### PR TITLE
Custom species, a survivable installer, and the example-mode design draft

### DIFF
--- a/PaintomicsClient/public_html/app/view/DataManagementViews/DM_MyDataView.js
+++ b/PaintomicsClient/public_html/app/view/DataManagementViews/DM_MyDataView.js
@@ -102,7 +102,7 @@ function DM_MyDataListView() {
 							'    <div class="po-account-row"><dt>User name</dt><dd>' + Ext.String.htmlEncode(Ext.util.Cookies.get('userName') || '—') + '</dd></div>' +
 							'    <div class="po-account-row"><dt>Email</dt><dd>' + Ext.String.htmlEncode(Ext.util.Cookies.get('lastEmail') || '—') + '</dd></div>' +
 							'  </dl>' +
-							'  <p class="formActionRow po-account-actions"><a class="button btn-default btn-form-action" href="javascript:void(0)" id="changePassButton"><i class="fa fa-key" aria-hidden="true"></i> Change password</a></p>' +
+							'  <p data-guides="ignore" class="formActionRow po-account-actions"><a class="button btn-default btn-form-action" href="javascript:void(0)" id="changePassButton"><i class="fa fa-key" aria-hidden="true"></i> Change password</a></p>' +
 							'</div>'
 						},
 						this.myDataSummaryPanel.getComponent()

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -1196,7 +1196,15 @@ function PA_Step1JobView() {
 		container.insert(1, {
 			xtype: "box",
 			itemId: "exampleFixedNote",
-			html: '<p style="margin:0 0 10px 0;padding:8px 12px;border-left:4px solid var(--pa-accent-blue);' +
+			/* 10px left and right, because .omicbox carries `margin: 5px 10px`:
+			   the note sits in the same column as the panels it describes, and
+			   with no left margin its blue bar started 10px left of every card
+			   edge below it - the one painted edge in the column off the rail
+			   the others share. */
+			/* data-guides="ignore" for the same reason as the column title
+			   above it: its rail-mates are the card edges below, which the
+			   overlay's groups cannot offer it as company. */
+			html: '<p data-guides="ignore" style="margin:0 10px 10px;padding:8px 12px;border-left:4px solid var(--pa-accent-blue);' +
 				'background:rgba(38,132,255,0.08);font-size:12px;line-height:1.5;">' +
 				'<b>This example dataset is fixed.</b> Its omics, organism and databases come from ' +
 				'the server&rsquo;s example catalogue' +
@@ -1390,7 +1398,10 @@ function PA_Step1JobView() {
 								// screen saying the same words about different things. This
 								// card is the whole of step 1, of which uploading is the
 								// fourth of five actions it lists.
-								'<h3>Upload and run</h3>' +
+								// data-guides="ignore": the heading is led by the 26px disc,
+								// so its text deliberately starts 37px right of the rail the
+								// card's copy sits on. The disc is the thing on the rail.
+								'<h3 data-guides="ignore">Upload and run</h3>' +
 							'</div>' +
 							/* Prose, not an <ol>. This card is numbered 1, and it used to
 							   hold a list numbered 1 to 5 inside it - so the screen showed
@@ -1412,7 +1423,7 @@ function PA_Step1JobView() {
 						'<div class="po-step-card">' +
 							'<div class="po-step-head">' +
 								'<div class="po-step-number">2</div>' +
-								'<h3>Identifier and name matching</h3>' +
+								'<h3 data-guides="ignore">Identifier and name matching</h3>' +
 							'</div>' +
 							/* The opening sentence was 32 words to carry two facts: those
 							   three databases are keyed on Entrez IDs, and PaintOmics does
@@ -1430,7 +1441,7 @@ function PA_Step1JobView() {
 						'<div class="po-step-card">' +
 							'<div class="po-step-head">' +
 								'<div class="po-step-number">3</div>' +
-								'<h3>Explore results</h3>' +
+								'<h3 data-guides="ignore">Explore results</h3>' +
 							'</div>' +
 							'<p>You get a Pathways summary, a classification, a network and an enrichment analysis. Paint any of the listed pathways with <a href="javascript:void(0)" class="button btn-inline btn-small btn-paint" title="Paint this pathway"><i class="fa fa-paint-brush"></i></a>, or ask for an <b>AI-powered pathway interpretation</b> with <a href="javascript:void(0)" class="button btn-inline btn-small btn-ai">' + getAIMark() + ' AI Interpret</a>. Read more about these analyses in <a href="https://paintomics.readthedocs.io/en/latest/" target="_blank">our documentation</a>.</p>' +
 							'<div class="po-step-art">' + PO_STEP_ART_EXPLORE + '</div>' +
@@ -1937,7 +1948,12 @@ function PA_Step1JobView() {
 							flex: 2,
 							layout: {type: 'vbox',align: "stretch"},
 							items: [
-								{xtype: 'box',html: '<h2 class="po-omics-col-title">Selected omics</h2>'},
+								// data-guides="ignore": the title's 10px padding lands its type
+								// on the omic cards' edges below - a relationship the overlay's
+								// column model cannot see (the cards stand as their own groups),
+								// so measured raw it reports 270px off the form rail while
+								// sitting exactly where it was tuned to sit.
+								{xtype: 'box',html: '<h2 class="po-omics-col-title" data-guides="ignore">Selected omics</h2>'},
 								{xtype: 'box',html: '<p class="dragHerePanel">Drag and drop here your selected <i>omics</i></p>'}
 							]
 						},

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -5019,6 +5019,20 @@ function initExpDesignDraft(box) {
 
 		var picked = collectPickedOmicFiles();
 		if (picked.length === 0) {
+			/* A loaded example has no browser-readable files: its pickers are
+			   disabled "[example dataset]" labels and the files live on the
+			   server. Naming the scenario lets the servlet read the same
+			   header rows there, instead of dead-ending the flagship demo in
+			   the "choose your files" warning below. */
+			var step1View = (typeof application !== "undefined" && application.getMainView)
+				? application.getMainView().getSubView("PA_Step1JobView")
+				: null;
+			if (step1View && step1View.isExampleMode && step1View.isExampleMode()) {
+				button.disabled = true;
+				setNote("working", "Reading the example dataset’s column names…");
+				send([], step1View.getExampleScenarioId() || "");
+				return;
+			}
 			/* The ask the user made explicitly: say so in a window rather than
 			   leaving the button to do nothing. Deliberately showWarningMessage
 			   and not confirm() -- a native modal blocks the page. */
@@ -5050,8 +5064,12 @@ function initExpDesignDraft(box) {
 		});
 	});
 
-	function send(omics) {
-		if (omics.length === 0) {
+	/* `exampleScenarioId` is only ever passed on the example path: any string
+	   (including "" for the server's default scenario) tells the servlet to
+	   read the headers from that scenario's own files. */
+	function send(omics, exampleScenarioId) {
+		var fromExample = (exampleScenarioId !== undefined);
+		if (omics.length === 0 && !fromExample) {
 			finish("error", "Could not read a header row from those files.");
 			return;
 		}
@@ -5063,13 +5081,19 @@ function initExpDesignDraft(box) {
 			? SERVER_URL_AI_GENERATE_EXP_DESIGN
 			: SERVER_URL + "ai_generate_exp_design";
 
+		var payload = {
+			aiConsent: "true",
+			organism: combo ? (combo.getValue() || "") : "",
+			omics: JSON.stringify(omics)
+		};
+		if (fromExample) {
+			payload.exampleMode = "true";
+			payload.exampleScenario = exampleScenarioId;
+		}
+
 		$.ajax({
 			type: "POST", url: url, dataType: "json",
-			data: {
-				aiConsent: "true",
-				organism: combo ? (combo.getValue() || "") : "",
-				omics: JSON.stringify(omics)
-			}
+			data: payload
 		}).done(function(response) {
 			if (!response || response.success !== true || !response.suggestion) {
 				finish("error", serverErrorText(response,

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
@@ -152,16 +152,21 @@ function PA_Step2JobView() {
 			'  <h2 >Data distribution summary <span class="helpTip" title=" "></h2>' +
 			'  <p>' +
 			'    By default, percentiles 10 and 90 set the reference range for the heatmap colours. You can change this in the pathway view: open <b>Settings</b> in the toolbar and edit <b>Reference values</b>.<br>' +
-			// settingsbutton.png was last regenerated in 2022 and shows the toolbar
-			// as it was then: a dark bar of coloured Bootstrap buttons reading
-			// "Go back / Show Pathway / Show Heatmap / Search / Settings", with a
-			// "Log out" above it. The step 4 toolbar it is meant to point at has
-			// been white pills in the reverse order since the chrome was rebuilt
-			// (98e5aa9d). The button's name is still "Settings", so the caption
-			// above is now accurate and the picture is the part that is out of
-			// date - it wants a fresh screenshot, which is not something to
-			// approximate by hand.
-			'		 <div style="margin: 15px auto;text-align:center;"><img src="resources/images/settingsbutton.png" width="400" height="73" /></div>' +
+			// This figure replaces settingsbutton.png, a 2022 screenshot of the
+			// old dark Bootstrap toolbar. It is not an image at all: it is the
+			// step-4 toolbar's own markup, styled by the same .button rules the
+			// real toolbar uses (extended to .paToolbarMiniature in main.css and
+			// dark.css), so it renders as vector text at any zoom, follows the
+			// theme, and cannot fall out of date when the toolbar is restyled.
+			// Order matches PA_Step4Views' secondTopToolbar; the ring marks the
+			// Settings button the caption above is pointing at.
+			'		 <div class="paToolbarMiniature" aria-hidden="true">' +
+			'			<span class="button btn-danger paMiniatureTarget"><i class="fa fa-wrench"></i> Settings</span>' +
+			'			<span class="button btn-info"><i class="fa fa-search"></i> Search</span>' +
+			'			<span class="button btn-secondary"><i class="fa fa-th"></i> Show Heatmap</span>' +
+			'			<span class="button btn-primary"><i class="fa fa-sitemap"></i> Show Pathway</span>' +
+			'			<span class="button btn-default"><i class="fa fa-arrow-left"></i> Go back</span>' +
+			'		 </div>' +
 			'  </p>' +
 			'</div>'
 		}];
@@ -295,7 +300,7 @@ function PA_Step2JobView() {
 					defaults: {labelAlign: "right", border: false},
 					items: numberOfClusters
 				}]
-			}, {xtype: 'container', html:'<div style="display: none;"></div>'});
+			}, {xtype: 'container', cls: 'paLayoutPad', html:'<div style="display: none;"></div>'});
 		}
 
 		if (databases.length > 1) {
@@ -337,7 +342,7 @@ function PA_Step2JobView() {
 			};
 
 			/* Add an empty container to restore "odd" position of next sibling elements */
-			omicSummaryPanelComponents.splice(2, 0, dbs_message, {xtype: 'container', html:'<div style="display: none;"></div>'});
+			omicSummaryPanelComponents.splice(2, 0, dbs_message, {xtype: 'container', cls: 'paLayoutPad', html:'<div style="display: none;"></div>'});
 		}
 
 		// Replicate-detection card — only renders when at least one omic has
@@ -353,7 +358,7 @@ function PA_Step2JobView() {
 				// container to keep the column-layout "odd/even" alignment
 				// consistent with the existing Step-2 cards.
 				omicSummaryPanelComponents.push(repComponent,
-					{xtype: 'container', html:'<div style="display: none;"></div>'});
+					{xtype: 'container', cls: 'paLayoutPad', html:'<div style="display: none;"></div>'});
 			}
 		}
 
@@ -389,7 +394,7 @@ function PA_Step2JobView() {
 					defaults: {labelAlign: "right", border: false},
 					items: thresholdMetaboliteClass
 				}]
-			}, {xtype: 'container', html:'<div style="display: none;"></div>'});
+			}, {xtype: 'container', cls: 'paLayoutPad', html:'<div style="display: none;"></div>'});
 		}
 
 		if (me.items.length > 0) {

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
@@ -531,12 +531,17 @@ function PA_Step3JobView() {
 		/********************************************************/
 		/* STEP 1: LOAD SUMMARY      		                    */
 		/********************************************************/
-		$("#jobIdField").html(this.getModel().getJobID());
-		$("#jobURL").html(window.location.href).attr('href', window.location.href);
+		$("#jobIdField").text(this.getModel().getJobID());
+		/* The anchor is a glyph button now; the URL is its target, not its text.
+		   Writing the href as text was what made the old card read as a
+		   paragraph about itself. */
+		$("#jobURL").attr('href', window.location.href);
 
-		// Update Job name (description) if available
+		// Update Job name (description) if available. Long names are clipped
+		// with an ellipsis by the stylesheet, so the full text rides the title.
 		if (this.getModel().getName()) {
-			$("#jobName").html('[' + this.getModel().getName() + ']').show();
+			$("#jobName").text(this.getModel().getName())
+				.attr('title', this.getModel().getName()).show();
 		}
 
 		/********************************************************/
@@ -617,8 +622,29 @@ function PA_Step3JobView() {
 			/*         (only if updating from categories panel)     */
 			/********************************************************/
 			this.pathwayTableView.updateVisiblePathways(true);
-			this.metaboliteView.updateVisiblePathways(true);
-			this.hubAnalysisView.updateObserver(true);
+			/* Guarded, because the metabolite view is only constructed when the
+			   job resolved compounds - see hasMetaboliteData() at the top of this
+			   file - and the hub view only when it has a result to show.
+
+			   Unguarded, this line threw `Cannot read properties of null` on
+			   every job without metabolomics, and it threw *here*: before the
+			   network refresh below it, before the summary counts, and before the
+			   cache write. So on a gene-only job, choosing categories and pressing
+			   Apply redrew the pie beside the filter - that happens earlier, in
+			   the classification view - and then silently did nothing else. The
+			   network kept every node you had just hidden and the Found/
+			   Significant counts kept their unfiltered totals, which is the one
+			   reading a user would take as "the filter did not work".
+
+			   Verified on this build before the guard: hide one KEGG category,
+			   Apply, and 94 of 364 pathways go unchecked while the network still
+			   reports "25 of 364" and the summary still reports 364. */
+			if (this.metaboliteView) {
+				this.metaboliteView.updateVisiblePathways(true);
+			}
+			if (this.hubAnalysisView) {
+				this.hubAnalysisView.updateObserver(true);
+			}
 		}
 		/********************************************************/
 		/* STEP 3. UPDATE THE pathwayNetworkView VIEW           */
@@ -670,7 +696,15 @@ function PA_Step3JobView() {
 		var me = this;
 		var model = me.getModel();
 		var userID = Ext.util.Cookies.get("userID");
-		var isOwner = (userID !== undefined && String(model.getUserID()) == String(userID));
+		// A job created without an account has no owner (userID null), so the
+		// server cannot tell "the owner came back" from "anyone arrived
+		// anonymously" and never enforces the flags saved here. String(null) ==
+		// String(null) used to make every anonymous visitor the owner of an
+		// ownerless job, offering a Read-only promise nobody keeps; those jobs
+		// belong in the explanatory branch below, which already names this case.
+		var jobOwner = model.getUserID();
+		var hasOwner = (jobOwner !== null && jobOwner !== undefined && String(jobOwner) !== "null" && String(jobOwner) !== "None");
+		var isOwner = (hasOwner && userID !== null && userID !== undefined && String(jobOwner) == String(userID));
 
 		var messageDialog = Ext.create('Ext.window.Window', {
 			title: "Sharing options",
@@ -714,9 +748,10 @@ function PA_Step3JobView() {
 				 {xtype: "box", html: "<br><div style='text-align: center;'><b>You are not the owner or the job does not have an owner account so sharing options cannot be modified.</b></div>"}
 				)
 			],
-			buttons: [
-				(isOwner ?
-				{
+			// An empty object here still renders as a button: a blank blue pill
+			// beside Close for everyone in the non-owner branch. Concat, so the
+			// Save button either exists whole or not at all.
+			buttons: (isOwner ? [{
 					text: 'Save options',
 					handler : function() {
 						var allowSharing = messageDialog.queryById('linksharing').getValue();
@@ -725,9 +760,9 @@ function PA_Step3JobView() {
 						messageDialog.close();
 						me.getController().updateSharingOptions(model, allowSharing, readOnly);
 					}
-				} : {}),
+				}] : []).concat([
 				{text: 'Close', handler : function() {messageDialog.close();}}
-			]
+			])
 		});
 
 		messageDialog.center();
@@ -820,10 +855,30 @@ function PA_Step3JobView() {
 		$.each(this.getModel().getDatabases(), (function(index, db) {
 			var tabDB = {
 				title: db,
-				items: [
-					this.pathwayClassificationViews[db].getComponent(),
-					this.pathwayNetworkViews[db].getComponent()
-				]
+				/* One card, not four.
+
+				   A database tab used to draw four separate bordered surfaces:
+				   "Pathways classification", "Pathways network", and the network's
+				   two 216px side panels, "Tools" and "Details". They are one
+				   activity - choose which pathways you are looking at, then look at
+				   them - and splitting the controls for it across four boxes meant
+				   that changing what the graph shows was a matter of finding which
+				   box the control was in. The category filter and the node filters
+				   in particular sit 900px apart on screen while doing the same job.
+
+				   They are one .contentbox now. That is also what the contents
+				   strip reads: paTocSections() takes one entry per card, so the
+				   sidebar lists one "Pathway explorer" per database rather than a
+				   classification entry and a network entry that scroll to the same
+				   card. */
+				items: [{
+					xtype: 'container',
+					cls: 'contentbox paExploreCard',
+					items: [
+						this.pathwayClassificationViews[db].getComponent(),
+						this.pathwayNetworkViews[db].getComponent()
+					]
+				}]
 			}
 
 			tabContent.push(tabDB)
@@ -856,72 +911,75 @@ function PA_Step3JobView() {
 					'<a href="javascript:void(0)" class="button btn-default btn-right" id="sharingButton"><i class="fa fa-share-alt"></i> Share</a>' +
 					'<a href="javascript:void(0)" class="button btn-info btn-right" id="aiInterpretButton" style="display:none;">' + getAIMark() + ' AI Interpret</a>' +
 					'<div id="warningMessage" style="display: none;"></div>'
-				},{ //THE SUMMARY PANEL
-					xtype: 'container', itemId: "pathwaysSummaryPanel",
-					layout: 'column', style: "max-width:1900px; margin: 5px 10px; margin-top:50px;", items: [
-						{
-							xtype: 'box', cls: "contentbox omicSummaryBox", html:
-							'<div id="about">' +
-							'  <h2>Pathways selection</h2>' +
-							'  <p>' +
-							'     We found the following Pathways for the provided data.<br>Each Pathway has a set of significance values for each submitted <i>omic data</i>,' +
-							'     those values are calculated based on the total number of features (compounds and genes) for each Pathway as well as the number of features from the input involved on that Pathway.<br>' +
-							'     Additionally, when the input includes 2 or more different omic types, we provide a Combined Significance Value, which allow us to identify those Pathways that are potentially more relevant.' +
-							'  </p>' +
-							'  <a id="paint_link"><i class="fa fa-paint-brush-o"></i> Choose the pathways below and  Paint!</a> ' +
-							'</div>'
-						}, {
-							xtype: 'box',
-							cls: "contentbox omicSummaryBox",
-							/* The job ID and the URL below it were one centred <h3> with
-							   an unclosed <span class="infoTip"> inside it, so a caption
-							   inherited heading styling and the whole block sat on a
-							   centre line that nothing else in the row shares - the card
-							   beside this one is left-aligned prose on the card inset.
-							   Two elements now, both taking the inset from
-							   `div.contentbox h3` / `div.contentbox p`, so the heading,
-							   the URL and the counts below all start on one rail. */
-							html: '<h2>Pathways summary</h2>' +
-							'<h3>Your Job ID is <b id="jobIdField">[JOB ID]</b><span id="jobName" style="display: none">[JOB NAME]</span></h3>' +
-							'<p class="po-job-url"><span class="infoTip">You can access this job using the URL: <a id="jobURL" target="_blank" href="#">[JOBURL]</a></span></p>' +
-							// The icons are decorative -- the label beside each count
-							// already names it -- so they are hidden from screen
-							// readers rather than read out as "star".
-							'<div class="po-pathway-stats">' +
-							'  <div class="po-pathway-stat">' +
-							'    <span class="po-pathway-icon" aria-hidden="true"><i class="fa fa-sitemap"></i></span>' +
-							'    <span class="po-pathway-figure">' +
-							'      <div id="foundPathwaysTag" class="odometer odometer-theme-default po-pathway-count">000</div>' +
-							'      <span class="po-pathway-label">Found Pathways</span>' +
-							'    </span>' +
-							'  </div>' +
-							'  <div class="po-pathway-stat">' +
-							'    <span class="po-pathway-icon is-significant" aria-hidden="true"><i class="fa fa-star"></i></span>' +
-							'    <span class="po-pathway-figure">' +
-							'      <div id="significantPathwaysTag" class="odometer odometer-theme-default po-pathway-count">000</div>' +
-							'      <span class="po-pathway-label">Significant</span>' +
-							'    </span>' +
-							'  </div>' +
-							'</div>'
-						}
-					]
-				},
-				((me.getModel().getDatabases().length < 2) ? null :
-				{
-					xtype: 'box', cls: "contentbox", style: "max-width:1900px; margin: 5px 10px; margin-top:20px;", html:
-					'<div id="multisource_msg">' +
-					'  <h2>Multiple databases used</h2>' +
-					'  <div class="multisource_body">' +
-					'    <div class="multisource_text">' +
-					'      <p>This species has pathway data in more than one database. The tabs below give you' +
-					' separate classification and network analysis for each one.</p>' +
-					'      <p>The pathway list shows every database at once by default. Use the checkboxes in the' +
-					' search bar to narrow it down &mdash; each row is labelled with the database it came from.</p>' +
-					'    </div>' +
-					'    <div id="multisource_summary"></div>' +
+				},{ //THE SUMMARY BAND
+					/* One band, not three cards.
+
+					   This region used to be two side-by-side cards ("Pathways
+					   selection" - four lines of prose about how significance is
+					   computed - and "Pathways summary" - job ID, the full URL
+					   written out, two counts) plus a third full-width card
+					   ("Multiple databases used" - two more paragraphs and a
+					   table). Roughly 700px of reading before the first real
+					   control, and almost none of it data: the prose never
+					   changes, the URL is the one in the address bar, and the
+					   paint link scrolled nowhere.
+
+					   Everything that varies by job now sits in one card: the
+					   counts, the per-database split, the job identity. The
+					   explanation of how significance is computed - true for
+					   every job - lives in the heading's tooltip, and the two
+					   paragraphs about database tabs became the one-line note
+					   beside the table they described. The IDs are unchanged
+					   on purpose: jobIdField/jobURL/jobName are filled by
+					   updateObserver, the two odometers by the summary refresh,
+					   and #multisource_summary by the per-database table built
+					   in afterrender. */
+					xtype: 'box', itemId: "pathwaysSummaryPanel",
+					cls: "contentbox po-band-card",
+					style: "max-width:1900px; margin: 5px 10px; margin-top:50px;",
+					html:
+					'<div class="po-band-head">' +
+					'  <h2>Pathways summary<span class="helpTip" title="Each pathway is scored per submitted omic type: its significance comes from how many of its features (genes and compounds) are present in your input, against the total the pathway contains. When two or more omic types are submitted, a Combined Significance Value ranks pathways across all of them."></span></h2>' +
+					'  <span id="jobName" class="po-job-name" style="display: none"></span>' +
+					'  <div class="po-band-actions">' +
+					'    <span class="po-job-chip">Job <b id="jobIdField">&mdash;</b>' +
+					// Two glyph buttons, labelled for readers since neither has text:
+					// open the shareable URL, and put it on the clipboard.
+					'      <a id="jobURL" target="_blank" href="#" title="Open the shareable link for this job" aria-label="Open the shareable link for this job"><i class="fa fa-external-link"></i></a>' +
+					'      <a id="copyJobURL" href="javascript:void(0)" title="Copy the shareable link" aria-label="Copy the shareable link"><i class="fa fa-clipboard"></i></a>' +
+					'    </span>' +
+					'    <a id="paint_link" class="button btn-info" href="javascript:void(0)"><i class="fa fa-paint-brush"></i> Pick pathways to paint</a>' +
 					'  </div>' +
+					'</div>' +
+					// The icons are decorative -- the label beside each count
+					// already names it -- so they are hidden from screen
+					// readers rather than read out as "star".
+					'<div class="po-band">' +
+					'  <div class="po-pathway-stat">' +
+					'    <span class="po-pathway-icon" aria-hidden="true"><i class="fa fa-sitemap"></i></span>' +
+					'    <span class="po-band-figure">' +
+					'      <div id="foundPathwaysTag" class="odometer odometer-theme-default po-pathway-count">000</div>' +
+					'      <span class="po-pathway-label">Pathways found</span>' +
+					'    </span>' +
+					'  </div>' +
+					'  <div class="po-pathway-stat">' +
+					'    <span class="po-pathway-icon is-significant" aria-hidden="true"><i class="fa fa-star"></i></span>' +
+					'    <span class="po-band-figure">' +
+					'      <div id="significantPathwaysTag" class="odometer odometer-theme-default po-pathway-count">000</div>' +
+					'      <span class="po-pathway-label">Significant</span>' +
+					'    </span>' +
+					'  </div>' +
+					((me.getModel().getDatabases().length < 2) ? '' :
+					'  <div class="po-band-dbs">' +
+					'    <div id="multisource_summary"></div>' +
+					// data-guides="ignore": a lone flex item beside a table whose
+					// cells key per-column - the guides overlay has no group that
+					// can hold both, so measured raw it reports against the card
+					// rail 400px to its left while sitting in the cell's own flow.
+					'    <p class="po-band-note" data-guides="ignore">One explorer tab per database below; the enrichment table lists all of them, filterable from its search bar.</p>' +
+					'  </div>') +
 					'</div>'
-				}),
+				},
 				me.statsView.getComponent(),
 				{
 						xtype: 'tabpanel', id: 'tabcontainer_network', plain: true,
@@ -942,10 +1000,28 @@ function PA_Step3JobView() {
 								   ended at 299 and "Reactome" began at 303, four pixels
 								   between two words that name different databases, so
 								   the strip read as the single phrase "KEGG Reactome"
-								   rather than as two controls. */
-								margin: '0 22 0 0'
+								   rather than as two controls.
+
+								   22px was the answer while the tabs were bare
+								   words. They are bookmark tabs now - see "The
+								   database tabs" in main.css - and a box does
+								   its own separating: at 22 the two read as
+								   unrelated buttons that happened to land side
+								   by side rather than as one control with two
+								   positions.
+
+								   4, not 6: tabs on a folder sit close enough
+								   that the sheets behind read as a stack. At 6
+								   they were still two objects with air between
+								   them. */
+								margin: '0 4 0 0'
 							},
-							height: 50,
+							/* The bar is exactly as tall as a tab. It was 50
+							   against a 38px tab, so the tabs floated in a
+							   12px band and could not meet the card below
+							   them - which is the whole of what a bookmark
+							   tab has to do. */
+							height: 36,
 						},
 						listeners: {
 							/* A card layout writes the width it measured onto its
@@ -995,8 +1071,16 @@ function PA_Step3JobView() {
 								}
 							},
 							tabchange: function(tabPanel, newCard, oldCard, eOpts) {
-								/* Fire event at network element (second position) */
-								newCard.items.getAt(1).fireEvent('tabchange');
+								/* Looked up by id rather than by position. The two views
+								   are wrapped in one card now, so the network is no longer
+								   the tab's second child - and a position that is wrong is
+								   silent here, because fireEvent on the classification box
+								   simply matches no listener and the network never draws
+								   itself on first switch. */
+								var networkCmp = Ext.getCmp('networkview_' + newCard.title.replace(' ', '__'));
+								if (networkCmp) {
+									networkCmp.fireEvent('tabchange');
+								}
 
 								// Rebuild the contents list for the database now
 								// showing. paTocSections() skips headings whose
@@ -1054,6 +1138,59 @@ function PA_Step3JobView() {
 					});
 					$("#sharingButton").click(function() {
 						me.shareHandler();
+					});
+
+					/* The old "Choose the pathways below and Paint!" anchor had
+					   no handler at all - an instruction dressed as a control.
+					   The button goes where the instruction pointed: the
+					   enrichment table, via the contents rail's own jump so the
+					   scroll animates inside the ExtJS scroller (a smooth
+					   scrollTo on that element is silently swallowed - see
+					   paTocJumpTo in Util.js). */
+					$("#paint_link").click(function() {
+						if (typeof paTocJumpTo === "function") {
+							paTocJumpTo("Pathway enrichment");
+						} else {
+							var section = document.getElementById("pathwayEnrichmentSection");
+							if (section && section.scrollIntoView) {
+								section.scrollIntoView({block: "start"});
+							}
+						}
+					});
+
+					/* Copy the shareable URL. The glyph is the feedback: a tick
+					   for a moment, then back - no dialog, because a modal here
+					   would block every later browser command in automated runs
+					   and interrupt a human for a success they can see. */
+					$("#copyJobURL").click(function() {
+						var link = $(this);
+						var url = window.location.href;
+						var showCopied = function() {
+							link.addClass("is-copied").find("i").attr("class", "fa fa-check");
+							window.setTimeout(function() {
+								link.removeClass("is-copied").find("i").attr("class", "fa fa-clipboard");
+							}, 1500);
+						};
+						/* execCommand path for the http:// deploys where the
+						   async clipboard API is withheld from the page. */
+						var fallbackCopy = function() {
+							var scratch = document.createElement("textarea");
+							scratch.value = url;
+							scratch.setAttribute("readonly", "");
+							scratch.style.position = "absolute";
+							scratch.style.left = "-9999px";
+							document.body.appendChild(scratch);
+							scratch.select();
+							try {
+								if (document.execCommand("copy")) { showCopied(); }
+							} catch (e) { /* the open-link button remains */ }
+							document.body.removeChild(scratch);
+						};
+						if (navigator.clipboard && navigator.clipboard.writeText) {
+							navigator.clipboard.writeText(url).then(showCopied, fallbackCopy);
+						} else {
+							fallbackCopy();
+						}
 					});
 
 					// AI widget lifecycle managed by refreshAIWidget() via updateObserver()
@@ -1491,9 +1628,21 @@ function PA_Step3PathwayClassificationView(db = "KEGG") {
 		var me = this;
 
 		this.component = Ext.widget({
-			xtype: 'box', cls: "contentbox",
+			/* No `contentbox` any more: this view and the network below it share
+			   one card, which the job view wraps around both. This is the half
+			   that carries the card's own <h2>. */
+			xtype: 'box', cls: "paExploreSection paExploreOverview",
 			maxWidth: 1900, html:
-			'<h2>Pathways classification (' + me.database + ' database)</h2>' +
+			'<h2>Pathway explorer (' + me.database + ' database)<span class="helpTip" title="Choose which pathways to keep by category, then explore how the ones that remain relate to each other. Every control on this card acts on the same set of pathways, and on the table at the foot of the page."></span></h2>' +
+			/* The classification block is foldable because it is the half of the
+			   card you set once. Folded, the network gets the whole card; the
+			   button says which state it is in rather than which state it will
+			   move to, so the row reads as a label with a control on it. */
+			'<div class="paExploreBand">' +
+			'  <h3>Pathway categories</h3>' +
+			'  <a href="javascript:void(0)" class="paExploreFold" id="foldClassificationButton_' + me.dbid + '"><i class="fa fa-chevron-up"></i> Hide</a>' +
+			'</div>' +
+			'<div class="paExploreFoldable" id="classificationBody_' + me.dbid + '">' +
 			/* The card's own inset, not 10px: "Category Distribution" is the
 			   first thing under the card's heading and started 16px left of
 			   it. */
@@ -1514,11 +1663,34 @@ function PA_Step3PathwayClassificationView(db = "KEGG") {
 			   anything else on the page uses, so it read as the button having
 			   come loose rather than as an inset. */
 			'  <a href="javascript:void(0)" class="button btn-success btn-right helpTip" id="applyClassificationSettingsButton_' + me.dbid + '" style="margin: 0px 0px 17px 0px;" title="Apply changes"><i class="fa fa-check"></i> Apply</a>' +
+			'</div>' +
 			'</div>',
 			listeners: {
 				boxready: function() {
 					$("#applyClassificationSettingsButton_" + me.dbid).click(function() {
 						me.applyVisualSettings();
+					});
+
+					$("#foldClassificationButton_" + me.dbid).click(function() {
+						var button = $(this);
+						var body = $("#classificationBody_" + me.dbid);
+						var folding = body.is(":visible");
+
+						body.slideToggle(200, function() {
+							/* Highcharts sizes itself against a container it can
+							   measure, and a container inside a hidden parent
+							   measures zero. Unfolding without this leaves the pie
+							   drawn at whatever width it had when it was last
+							   visible, which is the wrong one if the window has
+							   been resized in between. */
+							if (!folding && me.highcharts) {
+								me.highcharts.reflow();
+							}
+						});
+
+						button.html(folding
+							? '<i class="fa fa-chevron-down"></i> Show'
+							: '<i class="fa fa-chevron-up"></i> Hide');
 					});
 
 					initializeTooltips(".helpTip");
@@ -2223,15 +2395,178 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 	};
 
 	/**
+	* Show one of the two panes in the network's rail, and make sure the rail
+	* itself is on screen.
+	*
+	* The rail replaced two 216px panels that stood side by side and were shown
+	* and hidden independently - which meant the graph's width depended on how
+	* many of them happened to be open, and that "Configure" opened a second
+	* column rather than switching one.
+	*
+	* @chainable
+	* @param {String} pane, either "tools" or "details"
+	* @returns {PA_Step3PathwayNetworkView} the view
+	*/
+	this.showRailPane = function(pane) {
+		var me = this;
+		var isDetails = (pane === "details");
+
+		$("#networkview_" + me.dbid).removeClass("is-railHidden");
+		$("#networkDetailsPanel_" + me.dbid).toggle(isDetails);
+		$("#networkSettingsPanel_" + me.dbid).toggle(!isDetails);
+
+		$("#networkview_" + me.dbid + " .paNetRailTab").each(function() {
+			$(this).toggleClass("is-active", $(this).attr("data-pane") === pane);
+		});
+
+		/* The rail appearing, or the panes swapping, changes nothing about the
+		   canvas' box - but coming back from a hidden rail does, and that is the
+		   same call, so it is made unconditionally rather than guessed at. */
+		me.resizeNetwork();
+
+		return this;
+	};
+
+	/**
+	* Re-measure the canvas and redraw. sigma reads its container's size once, at
+	* construction, so every change to the space around the graph - the rail
+	* opening or closing, full screen, the resizer at the foot of the card - has
+	* to be followed by this or the drawing keeps the old dimensions and the graph
+	* sits in a corner of its own panel.
+	* @chainable
+	* @returns {PA_Step3PathwayNetworkView} the view
+	*/
+	this.resizeNetwork = function() {
+		var me = this;
+
+		if (!me.network) {
+			return me;
+		}
+
+		/* Deferred one frame: called from a click handler, the layout that the
+		   class change causes has not happened yet, so an immediate resize
+		   measures the box the graph is leaving rather than the one it is
+		   entering. */
+		paDeferFrame(function() {
+			if (!me.network) {
+				return;
+			}
+			me.network.renderers.forEach(function(renderer) {
+				if (renderer.resize) {
+					renderer.resize();
+				}
+			});
+			me.network.refresh();
+		});
+
+		return me;
+	};
+
+	/**
+	* Expand the network to fill the screen, or put it back into the page.
+	*
+	* The previous implementation handed sigma's fullScreen plugin the canvas
+	* `div` on its own, and two things followed from that. The canvas keeps the
+	* height it has in the page (--pa-net-canvas-height, 720px), so full screen
+	* showed a 720px band on a black backdrop rather than a filled screen. And the
+	* toolbar holding the button is a *sibling* of that canvas, not a child, so
+	* once the browser was showing the canvas alone there was nothing on screen
+	* left to click: Escape was the only way out, and nothing said so. That is the
+	* reported fault - full screen could not be exited.
+	*
+	* Expanding the whole panel fixes both at once: the toolbar comes with it, and
+	* the button in it now reads "Exit full screen". The native request is still
+	* made where the browser allows it, so the screen really is filled; where it is
+	* refused - no user gesture, a permissions policy, an embedded frame - the
+	* class alone still covers the viewport, so the control can never leave the
+	* user somewhere they cannot get back from. Escape is bound for the same
+	* reason.
+	*
+	* @chainable
+	* @param {Boolean} expand
+	* @returns {PA_Step3PathwayNetworkView} the view
+	*/
+	this.setFullScreenNetwork = function(expand) {
+		var me = this;
+		/* The whole area, graph and rail together - not the graph alone. Full
+		   screen is where you have the most room to adjust what you are looking
+		   at, and leaving the rail behind in the page would have left
+		   "Configure" in the expanded toolbar as a control that does nothing
+		   visible. */
+		var panel = $("#networkview_" + me.dbid);
+		var button = $("#fullscreenSettingsPanelButton_" + me.dbid);
+		var caption = expand
+			? "Put the network back into the page"
+			: "Expand the network to the whole window";
+
+		if (!panel.length) {
+			return me;
+		}
+
+		panel.toggleClass("paNetExpanded", expand);
+		button.html(expand
+			? '<i class="fa fa-compress"></i> Exit full screen'
+			: '<i class="fa fa-expand"></i> Full screen');
+		button.attr("title", caption);
+		/* tooltipster copies the title into its own store at initialisation and
+		   never looks at the attribute again, so without this the button says
+		   "Exit full screen" and its tooltip still offers to expand it. */
+		if (button.hasClass("tooltipstered")) {
+			button.tooltipster("content", caption);
+		}
+
+		if (expand) {
+			var element = panel[0];
+			var request = element.requestFullscreen || element.webkitRequestFullscreen || element.msRequestFullscreen;
+
+			if (request && !me.getFullScreenElement()) {
+				/* Both shapes of failure are swallowed: older engines throw, and
+				   current ones return a promise that rejects when the click was
+				   not a user gesture. Either way the class above has already done
+				   the visible work, and an unhandled rejection here would be the
+				   only thing the user ever saw of it. */
+				try {
+					var pending = request.call(element);
+					if (pending && pending.catch) {
+						pending.catch(function() {});
+					}
+				} catch (ignored) {}
+			}
+		} else if (me.getFullScreenElement()) {
+			var release = document.exitFullscreen || document.webkitExitFullscreen || document.msExitFullscreen;
+
+			if (release) {
+				try {
+					var leaving = release.call(document);
+					if (leaving && leaving.catch) {
+						leaving.catch(function() {});
+					}
+				} catch (ignored) {}
+			}
+		}
+
+		me.resizeNetwork();
+
+		return me;
+	};
+
+	/**
+	* The element the browser is currently showing full screen, across the vendor
+	* prefixes this application's browsers still answer to.
+	* @returns {Element|null}
+	*/
+	this.getFullScreenElement = function() {
+		return document.fullscreenElement || document.webkitFullscreenElement ||
+			document.mozFullScreenElement || document.msFullscreenElement || null;
+	};
+
+	/**
 	* This function activate the fullscreen mode for the network
 	* @chainable
 	* @returns {PA_Step3PathwayNetworkView} the view
 	*/
 	this.fullScreenNetwork = function() {
-		sigma.plugins.fullScreen({
-		  container: $("#pathwayNetworkBox_" + this.dbid)[0]
-		});
-		return this;
+		return this.setFullScreenNetwork(!$("#networkview_" + this.dbid).hasClass("paNetExpanded"));
 	};
 
 
@@ -2259,16 +2594,20 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 		}
 		this.pathwayDetailsView.updateObserver(omicNames, this.getModel().getDataDistributionSummaries(), this.getParent().getVisualOptions());
 
-		if(!$("#networkDetailsPanel_" + me.dbid).is(":visible")){
-			$("#networkSettingsPanel_" + me.dbid).hide();
-			$("#networkClustersContainer_" + me.dbid).hide();
-			$("#networkDetailsPanel_" + me.dbid).show(200, function(){
-				$("#patwaysDetailsWrapper_" + me.dbid).show();
-			});
-		}else{
-			$("#networkClustersContainer_" + me.dbid).slideUp(200,function(){
+		/* One rail, so clicking a node is a pane switch rather than a panel
+		   swap: bring Details to the front, then show the pathway inside it in
+		   place of the cluster summary. */
+		var wasShowing = $("#networkDetailsPanel_" + me.dbid).is(":visible");
+
+		this.showRailPane("details");
+
+		if (wasShowing) {
+			$("#networkClustersContainer_" + me.dbid).slideUp(200, function(){
 				$("#patwaysDetailsWrapper_" + me.dbid).slideDown();
 			});
+		} else {
+			$("#networkClustersContainer_" + me.dbid).hide();
+			$("#patwaysDetailsWrapper_" + me.dbid).show();
 		}
 
 		return this;
@@ -2769,6 +3108,14 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 
 		this.component = Ext.widget({
 			xtype: 'container', id: 'networkview_' + me.dbid,
+			/* `paNetArea` is the flex row: the graph on the left, one rail of
+			   controls on the right. It was two floated 216px panels before -
+			   "Tools" and "Details" side by side - which took 462px of a 1114px
+			   card for two columns that are never both being read, and left the
+			   diagram they annotate with less than half the space. One rail with
+			   two panes gives that back, and stretches to the graph's height on
+			   its own rather than through the 876px literal the floats needed. */
+			cls: 'paNetArea',
 			/*autoHeight: true,
 			layout:
 			{
@@ -2779,10 +3126,13 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 			items: [ {
 				xtype: 'box', id: 'networkDetailsPanel_' + me.dbid,
 				//autoHeight: true, flex: 1,
-				cls: "contentbox lateralOptionsPanel", html:
+				/* No `contentbox`, and no <h2> of its own: this is a pane inside
+				   the card's rail, and the rail's tab already names it. It keeps
+				   `lateralOptionsPanel` because that is what dresses the controls
+				   inside it - and what paTocSections() looks for when deciding
+				   that a heading in here titles a control, not an analysis. */
+				cls: "lateralOptionsPanel paNetRailPane", html:
 				//THE PANEL WITH THE CLUSTERS SUMMARY
-				'<div class="lateralOptionsPanel-toolbar"><a href="javascript:void(0)" class="toolbarOption helpTip hideOption" id="hideNetworkDetailsPanelButton_' + me.dbid + '" title="Hide this panel"><i class="fa fa-times"></i></a></div>'+
-				'<h2>Details</h2>' +
 				'<div id="networkClustersContainer_' + me.dbid + '">' +
 				'  <h4>TheName For AnOmic</h4><span class="infoTip">Click on each cluster to hide/show the nodes in the network</span>' +
 				'  <h5>N Clusters founds</h5>' +
@@ -2808,10 +3158,8 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 				// group labels rather than names and main.css tracks them out.
 				// Deliberately not on the Details panel beside it, whose h4 is
 				// whatever the network is currently coloured by.
-				cls: "contentbox lateralOptionsPanel paSettingsPanel", html:
+				cls: "lateralOptionsPanel paSettingsPanel paNetRailPane", html:
 				//THE PANEL WITH THE VISUAL OPTIONS
-				'<div class="lateralOptionsPanel-toolbar"><a href="javascript:void(0)" class="toolbarOption helpTip hideOption" id="hideNetworkSettingsPanelButton_' + me.dbid + '" title="Hide this panel"><i class="fa fa-times"></i></a></div>'+
-				'<h2>Tools<span class="helpTip" title="Some options may affect to the table below."></h2>' +
 				'<div id="pathwayNetworkToolsBox_' + me.dbid + '" style="overflow:hidden;">' +
 				'  <h4>Visual settings</h4>' +
 				'  <h5>Node coloring: <span class="helpTip" style="float:right;" title="Change the way in which nodes are colored."></span></h5>' +
@@ -2872,8 +3220,27 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 				'  <a href="javascript:void(0)" class="button btn-success btn-right helpTip" id="applyNetworkSettingsButton_' + me.dbid + '" style="margin-top: 20px;" title="Apply changes"><i class="fa fa-check"></i> Apply</a>' +
 				'</div>'
 			},{
-				xtype: 'box', cls: "contentbox",
+				/* The rail's own tab strip. The two panes above are placed into one
+				   grid cell by paNetArea, so exactly one is on screen at a time and
+				   this is what says which - and what names them, now that neither
+				   pane carries a heading of its own.
+
+				   A fourth sibling rather than a wrapper around the panes: this
+				   layout is a CSS grid precisely so that the rail can be assembled
+				   without nesting the two panes inside a container, which is a
+				   change that would have had to be made inside every id-addressed
+				   selector the network code already relies on. */
+				xtype: 'box', cls: "paNetRailTabs", html:
+				'<a href="javascript:void(0)" class="paNetRailTab is-active helpTip" data-pane="tools" title="Everything that changes what the graph shows. Some options also affect the table below."><i class="fa fa-sliders"></i> Tools</a>' +
+				'<a href="javascript:void(0)" class="paNetRailTab helpTip" data-pane="details" title="The colour legend, and the detail for whichever pathway you last clicked"><i class="fa fa-info-circle"></i> Details</a>' +
+				'<a href="javascript:void(0)" class="paNetRailHide helpTip" title="Hide this panel and give the graph the whole card"><i class="fa fa-times"></i></a>'
+			},{
+				xtype: 'box', id: 'networkPanel_' + me.dbid,
 				//autoHeight: true, flex: 4,
+				/* `paNetMain` is the graph half of the grid, and the element that
+				   full screen expands - see setFullScreenNetwork. No `contentbox`:
+				   the card around the whole explorer draws the only border here. */
+				cls: "paNetMain",
 				style: 'overflow: hidden; margin:0;', html:
 				//THE PANEL WITH THE NETWORK
 				/* One band, two groups. The controls that change what you are
@@ -2882,7 +3249,12 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 				   downloads that used to float over the title - sit right.
 				   Shapes and spacing come from .pa-net-tool in
 				   network-views.css, which the MORE network's buttons share. */
-				'<h2>Pathways network (' + me.database + ' database)<span class="helpTip" title="This Network represents the relationships between matched pathways."></h2>' +
+				/* h3, not h2. The card's one h2 is "Pathway explorer" a few hundred
+				   pixels above; this names the second block inside it. The contents
+				   strip counts h2s, so a second one here would have put the network
+				   in the sidebar as an analysis separate from the card it lives
+				   in. */
+				'<h3 class="paNetTitle">Pathways network<span class="helpTip" title="This Network represents the relationships between matched pathways."></span></h3>' +
 				'<div id="step3-network-toolbar_' + me.dbid + '" class="pa-net-toolbar">' +
 				' <div class="lateralOptionsPanel" id="reorderOptions_' + me.dbid + '" style="display:none;">' +
 				'  <div class="lateralOptionsPanel-toolbar">' +
@@ -3070,6 +3442,38 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 					$("#fullscreenSettingsPanelButton_" + me.dbid).click(function() {
 						me.fullScreenNetwork();
 					});
+
+					/* Two ways out of full screen that are not the button, both of
+					   which have to leave the panel and the button agreeing with
+					   each other:
+
+					     - the browser's own exit (Escape, or the notification bar
+					       Chrome shows), which fires fullscreenchange and would
+					       otherwise leave the panel still class-expanded over the
+					       page with a button reading "Exit full screen";
+					     - Escape when the native request was refused and only the
+					       class is holding the panel open, where no fullscreenchange
+					       ever comes.
+
+					   Namespaced per database and detached first: a job reload
+					   builds these views again, and document-level handlers from the
+					   previous one would otherwise accumulate and act on panels that
+					   no longer exist. */
+					var fullScreenEvents = "fullscreenchange.paNet" + me.dbid +
+						" webkitfullscreenchange.paNet" + me.dbid +
+						" msfullscreenchange.paNet" + me.dbid;
+
+					$(document).off(fullScreenEvents).on(fullScreenEvents, function() {
+						if (!me.getFullScreenElement() && $("#networkview_" + me.dbid).hasClass("paNetExpanded")) {
+							me.setFullScreenNetwork(false);
+						}
+					});
+
+					$(document).off("keydown.paNet" + me.dbid).on("keydown.paNet" + me.dbid, function(event) {
+						if (event.key === "Escape" && $("#networkview_" + me.dbid).hasClass("paNetExpanded")) {
+							me.setFullScreenNetwork(false);
+						}
+					});
 					$("#step3-network-toolbar-message_" + me.dbid).hover(function(){
 						$(this).fadeOut(100);
 					});
@@ -3081,8 +3485,22 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 					$("#step3-network-toolbar_" + me.dbid + " .submenuOption").click(function() {
 						$(this).parent(".menuBody").first().toggle();
 					});
+					/* Tools is the pane the card opens on. Both panes were visible at
+					   once before, side by side; one has to be chosen now, and it is
+					   the one that does something - Details is a legend until a node
+					   has been clicked, and clicking a node brings it forward
+					   itself. */
+					me.showRailPane("tools");
+
 					$("#showNetworkSettingsPanelButton_" + me.dbid).click(function() {
-						$("#networkSettingsPanel_" + me.dbid).show();
+						me.showRailPane("tools");
+					});
+					$("#networkview_" + me.dbid + " .paNetRailTab").click(function() {
+						me.showRailPane($(this).attr("data-pane"));
+					});
+					$("#networkview_" + me.dbid + " .paNetRailHide").click(function() {
+						$("#networkview_" + me.dbid).addClass("is-railHidden");
+						me.resizeNetwork();
 					});
 					$("#reorderOptions_" + me.dbid + " span i").click(function() {
 						var option = $("#reorderOptions_" + me.dbid + " h3:visible");
@@ -3123,14 +3541,25 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 							beforeresize: function(resizer, width, height){
 								resizer.prevHeight= height;
 							},
+							/* Only the canvas is sized here now, and it is addressed by
+							   its real id.
+
+							   Both of those were faults. The four ids in the list had
+							   no database suffix - `#pathwayNetworkBox` where the
+							   element is `pathwayNetworkBox_KEGG` - so every selector
+							   matched nothing and dragging the handle resized
+							   precisely one thing: the Ext panel's own frame, with
+							   the graph inside it unchanged. And the three side
+							   panels were in the list because floats had to be told
+							   each other's heights; the grid stretches the rail to
+							   the graph on its own, so telling it a height now is how
+							   the two get out of step. */
 							resize: function(resizer, width, height){
 								var diff = height - resizer.prevHeight;
-								var panels = ['pathwayNetworkBox', 'networkDetailsPanel', 'networkSettingsPanel', 'patwaysDetailsContainer'];
+								var canvas = $('#pathwayNetworkBox_' + me.dbid);
 
-								for(var i in panels){
-									var elem = $('#' + panels[i]);
-									elem.height(elem.height() + diff);
-								}
+								canvas.height(canvas.height() + diff);
+								me.resizeNetwork();
 							}
 						}
 					});
@@ -3409,8 +3838,13 @@ function PA_Step3PathwayDetailsView() {
 					/****************************************************************/
 					var pathwaySource = this.getModel().getSource();
 					var thumbnail_suffix = (pathwaySource == undefined || pathwaySource == 'KEGG') ? '_thumb' : '_' + pathwaySource + '_thumb'
-					pathwayPlotwrappers.html('<div class="step3ChartWrapper" style="background-image: url('/' + location.pathname + "kegg_data/" +  this.getModel().getID() + thumbnail_suffix + '/')"></div>');
-					this.getComponent().setHeight(200);
+					/* The quotes around the url() argument have to be escaped, not
+					   closed: written as url('/' + ... the leading string literal
+					   ended early and the whole expression parsed as a chain of
+					   divisions, handing jQuery a NaN. Colouring by classification
+					   is the default, so the panel came up blank every time. Same
+					   construction as the Step 4 thumbnails. */
+					pathwayPlotwrappers.html('<div class="step3ChartWrapper" style="background-image: url(\'' + location.pathname + "kegg_data/" + this.getModel().getID() + thumbnail_suffix + '\')"></div>');
 					break;
 				}else if (metagenes === undefined){
 					/****************************************************************/
@@ -3420,7 +3854,6 @@ function PA_Step3PathwayDetailsView() {
 						"<h4 style='color: #D16949;font-size: 13px;margin: 0;'>" + omicDataType[i] + "</h4>"+
 						"<b>No data for this pathway.</b>"
 					);
-					this.getComponent().setHeight(120);
 				}else{
 					/****************************************************************/
 					/* STEP 3.C UPDATE THE HEATMAP AND THE PLOT                     */
@@ -3429,7 +3862,7 @@ function PA_Step3PathwayDetailsView() {
 					pathwayPlotwrappers.append(
 						"<div>"+
 						"  <h4>" + omicDataType[i] + "</h4>"+
-						"  <span class='tooltipDetailsSpan'><i class='fa fa-info-circle'></i> " + metagenes.length + " major trends in this pathway.</span></br>"+
+						"  <span class='tooltipDetailsSpan'><i class='fa fa-info-circle'></i> " + metagenes.length + " major trend" + (metagenes.length === 1 ? "" : "s") + " in this pathway.</span></br>"+
 						"  <div class='twoOptionsButtonWrapper'>" +
 						'      <a href="javascript:void(0)" class="button twoOptionsButton" name="heatmap-chart">Heatmap</a>'+
 						'      <a href="javascript:void(0)" class="button twoOptionsButton selected" name="line-chart">Line chart</a>'+
@@ -3460,10 +3893,34 @@ function PA_Step3PathwayDetailsView() {
 				$(this).addClass("selected");
 				parent.siblings("div.step3-tooltip-plot-container.selected").removeClass("selected").toggle();
 				parent.siblings("div.step3-tooltip-plot-container[name="+ target + "]").addClass("selected").toggle();
+				/* The heatmap is 35px per trend, the line chart a flat 100px, so
+				   the panel is a different height on either side of this toggle. */
+				me.fitToContent();
 			});
 
-			this.getComponent().setHeight(230);
+			this.fitToContent();
 
+			return this;
+		};
+
+	/**
+	* Size the box to the content it actually holds.
+	*
+	* The three branches above used to pin it to 200/120/230px whatever they had
+	* just rendered. 230px is short of what a single omic needs (242px measured
+	* on a one-line pathway name), and the box does not clip, so the tail of the
+	* chart ran out of it and under the Show details / Paint row below. A second
+	* omic, a name that wraps to two lines or the taller heatmap made the overlap
+	* worse. Measure instead of guessing.
+	* @chainable
+	* @returns {PA_Step3PathwayDetailsView}
+	*/
+	this.fitToContent = function() {
+			var component = this.getComponent(), el = component.getEl();
+			var panel = (el != null) ? el.dom.querySelector(".mainInfoPanel") : null;
+			if (panel !== null) {
+				component.setHeight(panel.offsetHeight);
+			}
 			return this;
 		};
 
@@ -3623,6 +4080,24 @@ function PA_Step3PathwayDetailsView() {
 			maxVal = Math.ceil(Math.max(maxVal, 1));
 			minVal = Math.floor(Math.min(minVal, -1));
 
+			/* The three reference lines mark the +/-1 band that turns a point's
+			   marker orange. Their labels used to be unconditional, so on a
+			   pathway whose metagene range is wide (+/-6, +/-10) all three
+			   landed within a few pixels of each other in a 100px chart and
+			   piled up into an unreadable smudge on the right edge. Draw the
+			   lines either way; label the +/-1 pair only when the text has room
+			   to clear the zero label. */
+			var referenceLine = function(value, labelled) {
+				var line = {color: '#dedede', value: value, width: 1};
+				if (labelled) {
+					line.label = {
+						text: String(value), align: 'right', x: -3, y: -2,
+						style: {color: 'gray', fontSize: '9px'}
+					};
+				}
+				return line;
+			};
+
 			var plot = new Highcharts.Chart({
 				chart: {renderTo: targetID},
 				title: null,
@@ -3633,9 +4108,9 @@ function PA_Step3PathwayDetailsView() {
 					min: minVal,
 					max: maxVal,
 					plotLines: [
-						{label: {text: '-1',align: 'right', style: {color: 'gray'}},color: '#dedede',value: -1,width: 1},
-						{label: {text: '0',align: 'right', style: {color: 'gray'}},color: '#dedede',value: 0,width: 1},
-						{label: {text: '1',align: 'right', style: {color: 'gray'}},color: '#dedede',value: 1,width: 1}
+						referenceLine(-1, true),
+						referenceLine(0, true),
+						referenceLine(1, true)
 					]},
 					series: series,
 					legend: {
@@ -3659,6 +4134,20 @@ function PA_Step3PathwayDetailsView() {
 			);
 
 			plot.yAxis[0].setExtremes(minVal, maxVal);
+
+			/* Now that the axis has real pixel dimensions, drop the +/-1 labels
+			   if they would collide. 11px is the smallest gap at which the 9px
+			   label text still clears its neighbour. */
+			var yAxis0 = plot.yAxis[0];
+			if (Math.abs(yAxis0.toPixels(0) - yAxis0.toPixels(1)) < 11) {
+				yAxis0.update({
+					plotLines: [
+						referenceLine(-1, false),
+						referenceLine(0, true),
+						referenceLine(1, false)
+					]
+				}, true);
+			}
 
 			return plot;
 		};

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4Views.js
@@ -1008,7 +1008,7 @@ function PA_Step4KeggDiagramView() {
 			defaults: {border: false},
 			flex: 1, minWidth: 400, previousWidth: 400, width: 400,  height: ($("#mainViewCenterPanel").height() - 100),
 			html:
-			'<div class="lateralOptionsPanel-header">' +
+			'<div class="lateralOptionsPanel-header" data-guides="ignore">' +
 			'   <div class="lateralOptionsPanel-toolbar">' +
 			'    <a href="javascript:void(0)" class="toolbarOption btn-primary helpTip" id="hideDiagramPanelButton" title="Hide this panel"><i class="fa fa-times"></i></a>' +
 			'    <a href="javascript:void(0)" class="toolbarOption btn-primary helpTip" id="expandDiagramPanelButton" style="display:none;"  title="Expand this panel"><i class="fa fa-expand"></i></a>' +
@@ -2843,7 +2843,7 @@ function PA_Step4VisualOptionsView() {
 			items:[{
 				xtype: "box",
 				html:
-				"<div class='lateralOptionsPanel-header'>" +
+				"<div class='lateralOptionsPanel-header' data-guides='ignore'>" +
 				'  <div class="lateralOptionsPanel-toolbar">' +
 				'    <a href="javascript:void(0)" class="toolbarOption btn-danger helpTip" id="hideVisualSettingsPanelButton" title="Close this panel"><i class="fa fa-times"></i></a>' +
 				'  </div>' +
@@ -3070,7 +3070,7 @@ function PA_Step4FindFeaturesView() {
 				   is unreachable from any stylesheet, which is also why neither
 				   the light sheet nor dark.css could correct it: in dark mode
 				   this header stayed teal while everything around it moved. */
-				"<div class='lateralOptionsPanel-header'>" +
+				"<div class='lateralOptionsPanel-header' data-guides='ignore'>" +
 				'  <div class="lateralOptionsPanel-toolbar">' +
 				'    <a href="javascript:void(0)" class="toolbarOption btn-info helpTip" id="hideFindFeaturePanelButton" title="Close this panel"><i class="fa fa-times"></i></a>' +
 				'  </div>' +
@@ -3836,7 +3836,7 @@ function PA_Step4GlobalHeatmapView() {
 				}
 			},
 			previousWidth: 400, width: 400, minWidth: 400, html:
-			'<div class="lateralOptionsPanel-header" style="background: #2A8368;">' +
+			'<div class="lateralOptionsPanel-header" data-guides="ignore" style="background: #2A8368;">' +
 			'  <div class="lateralOptionsPanel-toolbar">' +
 			'    <a href="javascript:void(0)" class="toolbarOption btn-secondary helpTip" id="hideHeatmapPanelButton" title="Hide this panel"><i class="fa fa-times"></i></a>' +
 			'    <a href="javascript:void(0)" class="toolbarOption btn-secondary helpTip" id="configureHeatmapButton" title="Configure heatmap"><i class="fa fa-cogs"></i></a>' +
@@ -4388,7 +4388,7 @@ function PA_Step4DetailsView() {
 			},
 			items: [{
 				xtype: 'box', html:
-				'<div class="lateralOptionsPanel-header" style="background: #2A8368;">' +
+				'<div class="lateralOptionsPanel-header" data-guides="ignore" style="background: #2A8368;">' +
 				'  <div class="lateralOptionsPanel-toolbar">' +
 				'    <a class="toolbarOption btn-secondary helpTip" id="hideFeatureSetButton" title="Hide this panel"><i class="fa fa-times"></i></a>' +
 				'    <a class="toolbarOption btn-secondary helpTip" id="expandFeatureSetButton" title="Expand this panel"><i class="fa fa-expand"></i></a>' +

--- a/PaintomicsClient/public_html/app/view/UserManagementViews/UserViews.js
+++ b/PaintomicsClient/public_html/app/view/UserManagementViews/UserViews.js
@@ -282,7 +282,7 @@ function SignInPanel() {
                                       }},
                                   {xtype: "box", html:
                                               '<div class="formMessage" id="invalidUserPassMessage"></div>' +
-                                              '<p class="formActionRow"><a class="button btn-primary btn-form-action" href="javascript:void(0)" id="signInLink"><i class="fa fa-sign-in" aria-hidden="true"></i> Sign in</a></p>' +
+                                              '<p data-guides="ignore" class="formActionRow"><a class="button btn-primary btn-form-action" href="javascript:void(0)" id="signInLink"><i class="fa fa-sign-in" aria-hidden="true"></i> Sign in</a></p>' +
                                               '<p class="po-auth-links"><a id="forgotPassLink" href="javascript:void(0)">Forgot your password?</a></p>' +
                                               '<p class="po-auth-alt">New to PaintOmics? <a class="signUpLink" href="javascript:void(0)">Create an account</a></p>'
                                   }
@@ -292,7 +292,7 @@ function SignInPanel() {
                               '<div class="signInColumnDivider">' +
                               '  <h2>No account</h2>' +
                               '  <p>Your job is reachable only from the URL PaintOmics gives you when it starts, so save that URL. Without it the job cannot be recovered.</p>' +
-                              '  <p class="formActionRow"><a class="button btn-default btn-form-action" href="javascript:void(0)" id="noLoginButton"><i class="fa fa-arrow-right" aria-hidden="true"></i> Continue without an account</a></p>' +
+                              '  <p data-guides="ignore" class="formActionRow"><a class="button btn-default btn-form-action" href="javascript:void(0)" id="noLoginButton"><i class="fa fa-arrow-right" aria-hidden="true"></i> Continue without an account</a></p>' +
                               '</div>'
                   			}
                       ]
@@ -437,7 +437,7 @@ function SignUpPanel() {
 									'<iframe id="dataProtection" src="conditions_iframe.html" title="Basic information about data protection"></iframe>'},
 								{xtype: "checkboxfield", name: 'conditions', id: 'conditionsCheckbox', cls: 'po-auth-consent', allowBlank: false, submitValue: true, boxLabel: '<span>I have read the <a href="conditions.html" target="_blank" id="conditionsSignup">rules, conditions and privacy policy</a>.</span>'},
                                 {xtype: "box", html: '<div class="formMessage" id="invalidSignUpMessage"></div>' +
-                                            '<p class="formActionRow"><a class="button btn-primary btn-form-action" href="javascript:void(0)" id="signUpButton"><i class="fa fa-user-plus" aria-hidden="true"></i> Create account</a></p>' +
+                                            '<p data-guides="ignore" class="formActionRow"><a class="button btn-primary btn-form-action" href="javascript:void(0)" id="signUpButton"><i class="fa fa-user-plus" aria-hidden="true"></i> Create account</a></p>' +
                                             '<p class="po-auth-links"><a id="signUpBackLink" href="javascript:void(0)">Back to sign in</a></p>'
                                 }
                             ]
@@ -446,7 +446,7 @@ function SignUpPanel() {
                             items: [
                                 {xtype: "box", html: poAuthNotice('fa-envelope-o', 'Check your inbox', '')},
                                 {xtype: "box", flex: 1, itemId: "messageBox", html: ''},
-                                {xtype: "box", html: '<p class="formActionRow"><a class="button btn-default btn-form-action" href="javascript:void(0)" id="signUpCloseButton"><i class="fa fa-check-circle-o" aria-hidden="true"></i> Close</a></p>'}
+                                {xtype: "box", html: '<p data-guides="ignore" class="formActionRow"><a class="button btn-default btn-form-action" href="javascript:void(0)" id="signUpCloseButton"><i class="fa fa-check-circle-o" aria-hidden="true"></i> Close</a></p>'}
                             ]
                         }
                     ],
@@ -508,7 +508,7 @@ function ForgetPasswordPanel() {
                                   {
                                       xtype: "box",html:
                                               '<div class="formMessage" id="invalidEmailMessage"></div>' +
-                                              '<p class="formActionRow"><a class="button btn-primary btn-form-action" href="javascript:void(0)" id="resetPassLink"><i class="fa fa-envelope-o" aria-hidden="true"></i> Send instructions</a></p>' +
+                                              '<p data-guides="ignore" class="formActionRow"><a class="button btn-primary btn-form-action" href="javascript:void(0)" id="resetPassLink"><i class="fa fa-envelope-o" aria-hidden="true"></i> Send instructions</a></p>' +
                                               '<p class="po-auth-links"><a id="forgetPasswordBackLink" href="javascript:void(0)">Back to sign in</a></p>'
                                   }
                               ]
@@ -562,7 +562,7 @@ function GuestSessionPanel(email, p) {
                             '<h4><b>Password:</b> ' + me.p + '</h4>' +
                             '<p>Data, jobs and results belonging to guest users are kept for a maximum of <b>7 days</b>.</p>' +
                             '<p><a class="signUpLink" href="javascript:void(0)">Create an account</a> to keep them for longer. It takes a few seconds.</p>' +
-                            '<p class="formActionRow"><a class="button btn-primary btn-form-action" href="javascript:void(0)" id="continueButton"><i class="fa fa-arrow-right" aria-hidden="true"></i> Start working</a></p>' +
+                            '<p data-guides="ignore" class="formActionRow"><a class="button btn-primary btn-form-action" href="javascript:void(0)" id="continueButton"><i class="fa fa-arrow-right" aria-hidden="true"></i> Start working</a></p>' +
                             '</div>',
                     listeners: {
                         afterrender: function () {
@@ -606,7 +606,7 @@ function NoLoginSessionPanel(email, p) {
                             '<p>Write down your job ID. Without an account you have no data and jobs management area, so the ID is the only way back to your results.</p>' +
                             '<p>Data, jobs and results belonging to unregistered users are kept for a maximum of <b>7 days</b>.</p>' +
                             '<p><a class="signUpLink" href="javascript:void(0)">Create an account</a> to keep them for longer. It takes a few seconds.</p>' +
-                            '<p class="formActionRow"><a class="button btn-primary btn-form-action" href="javascript:void(0)" id="continueButton"><i class="fa fa-arrow-right" aria-hidden="true"></i> Start working</a></p>' +
+                            '<p data-guides="ignore" class="formActionRow"><a class="button btn-primary btn-form-action" href="javascript:void(0)" id="continueButton"><i class="fa fa-arrow-right" aria-hidden="true"></i> Start working</a></p>' +
                             '</div>',
                     listeners: {
                         afterrender: function () {
@@ -669,7 +669,7 @@ function ChangePasswordPanel() {
                                     return true;
                                 }
                             },
-                            {xtype: "box", html: '<p class="formActionRow"><a class="button btn-primary btn-form-action" href="javascript:void(0)" id="acceptNewPassButton"><i class="fa fa-check" aria-hidden="true"></i> Save new password</a></p>' +
+                            {xtype: "box", html: '<p data-guides="ignore" class="formActionRow"><a class="button btn-primary btn-form-action" href="javascript:void(0)" id="acceptNewPassButton"><i class="fa fa-check" aria-hidden="true"></i> Save new password</a></p>' +
                                         '<p class="po-auth-links"><a id="cancelNewPassButton" href="javascript:void(0)">Cancel</a></p>'
                             }
                         ],
@@ -678,7 +678,7 @@ function ChangePasswordPanel() {
                             items: [
                                 {xtype: "box", html: poAuthNotice('fa-check-circle', 'Password changed', 'Your password has been successfully updated.')},
                                 {xtype: "box", flex: 1, itemId: "messageBox", html: ''},
-                                {xtype: "box", html: '<p class="formActionRow"><a class="button btn-default btn-form-action" id="closeNewPassButton" href="javascript:void(0)"><i class="fa fa-arrow-circle-o-left" aria-hidden="true"></i> Close</a></p>'}
+                                {xtype: "box", html: '<p data-guides="ignore" class="formActionRow"><a class="button btn-default btn-form-action" id="closeNewPassButton" href="javascript:void(0)"><i class="fa fa-arrow-circle-o-left" aria-hidden="true"></i> Close</a></p>'}
                             ]
                     }
                 ],

--- a/PaintomicsClient/public_html/app/view/common/AlignmentGuides.js
+++ b/PaintomicsClient/public_html/app/view/common/AlignmentGuides.js
@@ -56,7 +56,12 @@
 	var SELECTOR = [
 		"h1", "h2", "h3", "h4", "h5", "h6",
 		"p", "li", "dt", "dd", "blockquote",
-		"a.button", "label", "figcaption", "th", "td",
+		/* a[class*='po-btn'] because the hero's actions are po-btn-primary /
+		   po-btn-outline / po-btn-quiet anchors, not a.button: the box-align
+		   rule below already expected them and the selector never admitted
+		   them, so the landing page's most prominent row of controls was
+		   invisible to this tool - a nudged button measured clean. */
+		"a.button", "a[class*='po-btn']", "label", "figcaption", "th", "td",
 		/* An ExtJS grid's column headers are divs, not <th>, so a selector of
 		   semantic elements cannot see them - and the tool reported the hub and
 		   metabolite-class grids as clean while every header in them sat 5px
@@ -138,14 +143,47 @@
 		var block = document.createRange();
 		block.selectNodeContents(el);
 		var union = block.getBoundingClientRect();
+		/* The first LINE's full extent, icons included. A centred action row
+		   is an icon and a label centred as one unit, but the unit's first
+		   text node starts after the icon - measuring the run alone put the
+		   sign-in button's centre 8px right of the box it is centred in
+		   exactly, half an icon of phantom misalignment on every icon-led
+		   centred line. Full-width rects are the boxes of block wrappers (a
+		   grid cell's inner div spans the cell whatever its text does) and
+		   are skipped, or every centred cell would report its own column's
+		   centre and the check would stop seeing ragged content. */
+		var elBox = el.getBoundingClientRect();
+		var rlist = block.getClientRects();
 		block.detach && block.detach();
 		var rect = (rects && rects.length) ? rects[0] : union;
 		range.detach && range.detach();
 		if (!(rect.width > 0)) { return null; }
+		var lineLeft = rect.left, lineRight = rect.right;
+		if (rlist && rlist.length) {
+			var topMin = Infinity, k;
+			for (k = 0; k < rlist.length; k++) {
+				if (rlist[k].width > 0 && Math.abs(rlist[k].width - elBox.width) >= 2 &&
+				    rlist[k].top < topMin) { topMin = rlist[k].top; }
+			}
+			if (isFinite(topMin)) {
+				var ll = Infinity, rr = -Infinity;
+				for (k = 0; k < rlist.length; k++) {
+					var rk = rlist[k];
+					if (!(rk.width > 0)) { continue; }
+					if (Math.abs(rk.width - elBox.width) < 2) { continue; }
+					if (rk.top < topMin + 4) {
+						if (rk.left < ll) { ll = rk.left; }
+						if (rk.right > rr) { rr = rk.right; }
+					}
+				}
+				if (isFinite(ll)) { lineLeft = ll; lineRight = rr; }
+			}
+		}
 		return {
 			left: rect.left, right: rect.right, top: rect.top,
 			bottom: rect.bottom, width: rect.width,
-			blockTop: union.top, blockBottom: union.bottom
+			blockTop: union.top, blockBottom: union.bottom,
+			lineLeft: lineLeft, lineRight: lineRight
 		};
 	}
 
@@ -190,6 +228,20 @@
 		for (var i = 0; i < nodes.length; i++) {
 			var el = nodes[i];
 			if (!isVisible(el)) { continue; }
+			/* A deliberate offset is declared, not detected: data-guides="ignore"
+			   on an element or an ancestor takes it out of the measurement
+			   entirely - rails, strays and baselines alike. The step cards'
+			   disc-led headings sit 37px right of the copy below them because a
+			   26px numbered disc leads them; that is the design, and no
+			   detection rule for "a heading after a small numbered thing" would
+			   earn the false negatives it risks elsewhere. */
+			if (el.closest && el.closest("[data-guides='ignore']")) { continue; }
+			/* The overlay must not measure itself. Its legend writes the
+			   faults as <li> items - elements this selector matches - and the
+			   moment any modal put enough text at body level for that group
+			   to reach quorum, the tool reported its own report as a fault
+			   1259px off a rail. */
+			if (el.closest && el.closest("#" + LAYER_ID)) { continue; }
 			if (isFlowContinuation(el)) { continue; }
 			/* ExtJS builds every form row as a table and wraps the label in a
 			   `td.x-field-label-cell`. That cell is a layout box, not a piece of
@@ -209,6 +261,18 @@
 			if ((el.tagName === "TD" || el.tagName === "TH") &&
 			    /(^|\s)x-(form|field)/.test(
 			        typeof el.className === "string" ? el.className : "")) {
+				continue;
+			}
+			/* Action-column cells hold a centred row of icon links, not data
+			   text. firstGlyphRect measures the FIRST link's run, which is a
+			   fragment of a centred line - the pathway grid's "External
+			   links" cells centre KEGG-plus-Reactome as one line whose middle
+			   is the column's middle, and the fragment read 24.6px off a
+			   header that is centred over them exactly. Fragments of centred
+			   lines are not measurable; drop the cells and let the header
+			   fall below quorum. */
+			if ((el.tagName === "TD" || el.tagName === "TH") &&
+			    /action-?col/i.test(typeof el.className === "string" ? el.className : "")) {
 				continue;
 			}
 			/* Right-anchored text has no left rail, but it does have a
@@ -241,6 +305,45 @@
 			   border box starts at the marker, which is the edge a reader
 			   actually sees line up. */
 			if (el.tagName === "LI") {
+				glyph = box;
+				boxAligned = true;
+			}
+			/* An ExtJS checkbox label is led by its box the way a list item is
+			   led by its bullet: the input sits on the rail and the words follow
+			   it, a checkbox and a gap further in. Judged on its own text edge,
+			   Step 1's consent label reported 46px off a rail its checkbox sits
+			   on exactly. The wrap cell starts where the checkbox does, which is
+			   the edge a reader actually sees line up. */
+			if (!boxAligned && el.tagName === "LABEL" &&
+			    el.classList.contains("x-form-cb-label")) {
+				var cbWrap = el.closest && el.closest("td.x-form-cb-wrap");
+				if (cbWrap) {
+					glyph = cbWrap.getBoundingClientRect();
+					boxAligned = true;
+				}
+			}
+			/* The same shape outside ExtJS: the network tools panel writes
+			   its rows as <div class=radio><input><label></label></div>, the
+			   control drawn in the label's own 23px padding. The row's box
+			   sits exactly on the panel's heading rail; measured by glyph,
+			   eleven correctly hung rows out-voted their own headings and
+			   reported them 23px off a rail that is really the indent. */
+			if (!boxAligned && el.tagName === "LABEL" &&
+			    el.previousElementSibling && el.previousElementSibling.tagName === "INPUT" &&
+			    /^(radio|checkbox)$/.test(el.previousElementSibling.type) &&
+			    el.parentElement) {
+				glyph = el.parentElement.getBoundingClientRect();
+				boxAligned = true;
+			}
+			/* An element that draws its own accent bar is aligned by that
+			   bar, like a button by its edge: the reader lines up the drawn
+			   edge, not the type behind it. The example-note callout paints a
+			   4px blue bar down its own left side with its text 16px in. Only
+			   a bar of 3px or more counts - grid cells and headers carry 1px
+			   hairlines that are borders of the lattice, not edges of the
+			   element, and box-aligning those would hide genuinely ragged
+			   cell text behind trivially aligned boxes. */
+			if (!boxAligned && parseFloat(window.getComputedStyle(el).borderLeftWidth) >= 3) {
 				glyph = box;
 				boxAligned = true;
 			}
@@ -311,14 +414,33 @@
 			var alignedRight = !boxAligned &&
 				(cs.textAlign === "right" || cs.textAlign === "end");
 			var alignedCentre = !boxAligned && (cs.textAlign === "center");
+			/* An ExtJS column header is judged on the horizontal axis only,
+			   and a centred one by its box, not its text run. Vertically,
+			   grouped headers centre a spanning header's text with 44px of
+			   padding while leaf headers sit in the lower row - framework
+			   arithmetic that read as three headers 10px off their row's
+			   baseline. Horizontally, a sort arrow or menu trigger reserves
+			   width beside the text, shifting the run's centre by half the
+			   reserve - the sorted column's header reported 8.5px off data
+			   it is centred over. The box's centre IS the column's centre,
+			   which is what a centred header has to agree with. */
+			var isExtHeader = el.classList && el.classList.contains("x-column-header-inner");
+			if (alignedCentre && isExtHeader) {
+				glyph = box;
+			}
 			var vMiddle = (el.tagName === "TD" || el.tagName === "TH") &&
 				cs.verticalAlign === "middle";
 			found.push({
 				el: el,
 				noLeftRail: noLeftRail,
 				edge: alignedRight ? "right" : (alignedCentre ? "centre" : "left"),
-				x: alignedRight ? glyph.right
-					: (alignedCentre ? (glyph.left + glyph.right) / 2 : glyph.left),
+				x: alignedRight
+					? (glyph.lineRight !== undefined ? glyph.lineRight : glyph.right)
+					: (alignedCentre
+						? (glyph.lineLeft !== undefined
+							? (glyph.lineLeft + glyph.lineRight) / 2
+							: (glyph.left + glyph.right) / 2)
+						: glyph.left),
 				top: glyph.top,
 				bottom: glyph.bottom,
 				/* A table cell set to `vertical-align: middle` is placed by the
@@ -331,9 +453,9 @@
 				   fault, and moving either one would break the centring that
 				   is actually right. */
 				vedge: vMiddle ? "middle" : "baseline",
-				baseline: vMiddle
+				baseline: isExtHeader ? NaN : (vMiddle
 					? (glyph.blockTop + glyph.blockBottom) / 2
-					: text.bottom - descentFor(el),
+					: text.bottom - descentFor(el)),
 				/* Two runs are peers when a reader would expect them to sit on
 				   one line: same element type, same size, same weight. A
 				   heading is not obliged to share a baseline with the caption
@@ -433,6 +555,17 @@
 			}
 		}
 		for (var n = el; n && n !== document.body; n = n.parentElement) {
+			/* An out-of-flow box is its own alignment context at keying time,
+			   not only as a fold barrier. ExtJS lays its box containers out
+			   with `position: absolute` wrappers, so the "Selected omics"
+			   column's title walked straight through its whole column to the
+			   bordered form body and was judged against a rail three hundred
+			   pixels to its left. The fold already refuses to cross these
+			   boundaries; keying across them asks the same wrong question. */
+			var ncs = window.getComputedStyle(n);
+			if (ncs.position === "absolute" || ncs.position === "fixed") {
+				return n;
+			}
 			var p = n.parentElement;
 			if (!p) { break; }
 			var ps = window.getComputedStyle(p);
@@ -485,6 +618,16 @@
 			   fills from its right edge, which makes its left edge a function
 			   of how wide the labels happen to be. */
 			if (s.display.indexOf("flex") >= 0 && s.flexDirection === "row-reverse") {
+				return true;
+			}
+			/* `justify-content: flex-end` packs a row from its right edge the
+			   same way row-reverse does. The example dialog's "Load this
+			   dataset" sits in a flex-end actions row at the card's bottom
+			   right; judged on its left edge it reported 544px off a rail no
+			   right-packed control could ever sit on - ten times, once per
+			   card. */
+			if (s.display.indexOf("flex") >= 0 &&
+			    /^(flex-end|end|right)$/.test(s.justifyContent)) {
 				return true;
 			}
 		}
@@ -643,6 +786,8 @@
 			return d;
 		}
 		var changed = true;
+		function foldToFixedPoint() {
+			changed = true;
 		while (changed) {
 			changed = false;
 			Array.from(groups.keys()).sort(function (a, b) {
@@ -651,6 +796,38 @@
 				var members = groups.get(key);
 				if (!members || key === root) { return; }
 				if (rowLeaders(members).length >= 2) { return; }
+				/* When a thin group dissolves out of a key that paints its own
+				   surface, what the parent column can judge is the surface's
+				   edge, not the type inset within it. The omics pills are
+				   painted boxes sitting exactly on the panel rail with their
+				   h4 10px inside; judged on the type, four correctly placed
+				   pills disagree with the title beside them, and judged not at
+				   all a drifted pill goes unreported. Fold them, but aligned
+				   to the box - the same argument that aligns a button by its
+				   edge. A member that is itself the key is already box-aligned
+				   by measure() and keeps its own x. */
+				if (key.nodeType === 1) {
+					var ks = window.getComputedStyle(key);
+					if (parseFloat(ks.borderLeftWidth) > 0 ||
+					    ks.backgroundImage !== "none" ||
+					    (ks.backgroundColor && ks.backgroundColor !== "rgba(0, 0, 0, 0)" &&
+					     ks.backgroundColor !== "transparent")) {
+						/* Unconditionally: a full-width pill (the omics chips
+						   stretch to their column below 1280px) still aligns by
+						   its painted edge, and no local geometry separates it
+						   from a panel's header band, whose type aligns to the
+						   body inset instead - both are flush painted children
+						   of their context. The one pattern where the box is
+						   the wrong reading, the lateralOptionsPanel header,
+						   declares itself data-guides="ignore" at its factory;
+						   a rule cannot know what only the design language
+						   does. */
+						var keyRect = key.getBoundingClientRect();
+						members.forEach(function (m) {
+							if (m.el !== key) { m.x = keyRect.left; }
+						});
+					}
+				}
 				for (var n = key.parentElement; n; n = n.parentElement) {
 					if (groups.has(n)) {
 						groups.get(n).push.apply(groups.get(n), members);
@@ -678,8 +855,19 @@
 					   to the panel; the fold then walked straight past the panel
 					   to the card and reported the panel's own paragraph as 22px
 					   off. Judged against the panel, it is exactly on it. */
+					/* A painted background bounds a surface as surely as a
+					   border draws one. Step 1's AI callout is a padded plate
+					   whose gradient starts exactly on the section rail and
+					   whose prose starts 22px inside it - columnKeyFor already
+					   keys that prose to the plate, but the fold walked out of
+					   it and reported the inset against the rail outside. A box
+					   that paints its own ground is its own alignment context,
+					   same as one that draws its own edge. */
 					if (n !== root && (ns.position === "fixed" || ns.position === "absolute" ||
-					    parseFloat(ns.borderLeftWidth) > 0)) {
+					    parseFloat(ns.borderLeftWidth) > 0 ||
+					    ns.backgroundImage !== "none" ||
+					    (ns.backgroundColor && ns.backgroundColor !== "rgba(0, 0, 0, 0)" &&
+					     ns.backgroundColor !== "transparent"))) {
 						groups.set(n, members);
 						groups.delete(key);
 						changed = true;
@@ -688,10 +876,67 @@
 				}
 			});
 		}
+		}
+		foldToFixedPoint();
+
+		/* Second pass: a standing surface's own edge joins its parent context.
+		   The contents of a painted card are judged inside it - that is what
+		   the groups above establish - but where the card ITSELF sits was
+		   never judged by anyone, and it is the card's edge, not its text,
+		   that a reader lines up against the column. The "Selected omics"
+		   title is padded 10px so its type lands exactly on the omic cards'
+		   edges below it; with the cards standing as their own groups the
+		   title was a loner, climbed out of its column, and reported 270px
+		   off the form rail while sitting precisely where it was designed
+		   to. The synthetic member carries no baseline - NaN drops it from
+		   the vertical check, which compares type, not boxes. */
+		var synth = [];
+		groups.forEach(function (members, key) {
+			if (!key || key.nodeType !== 1 || key === root) { return; }
+			if (rowLeaders(members).length < 2) { return; }
+			var ks = window.getComputedStyle(key);
+			var painted = parseFloat(ks.borderLeftWidth) > 0 ||
+				ks.backgroundImage !== "none" ||
+				(ks.backgroundColor && ks.backgroundColor !== "rgba(0, 0, 0, 0)" &&
+				 ks.backgroundColor !== "transparent");
+			if (!painted) { return; }
+			if (isRightAnchored(key)) { return; }
+			if (key.closest && key.closest("[data-guides='ignore']")) { return; }
+			var kr = key.getBoundingClientRect();
+			if (!(kr.width > 0)) { return; }
+			synth.push({ key: key, rect: kr });
+		});
+		synth.forEach(function (s) {
+			var pkey = s.key.parentElement ? columnKeyFor(s.key.parentElement) : root;
+			if (pkey === s.key) { return; }
+			/* A box corroborates a neighbourhood; it does not found one. With
+			   no group at its parent key the box has no designed rail-mates -
+			   the help panel's edge sits where the layout's column split puts
+			   it - and a synthetic member laddering out of an empty context
+			   reported that split as a 914px fault. */
+			if (!groups.has(pkey)) { return; }
+			groups.get(pkey).push({
+				el: s.key, noLeftRail: false, edge: "left",
+				x: s.rect.left, top: s.rect.top, bottom: s.rect.bottom,
+				vedge: "baseline", baseline: NaN, peer: "surface-box",
+				label: "[box] " + (s.key.id || (typeof s.key.className === "string" &&
+					s.key.className ? s.key.className.split(/\s+/)[0] : s.key.tagName.toLowerCase()))
+			});
+		});
+		foldToFixedPoint();
 
 		var columns = [];
 		groups.forEach(function (members, key) {
-			var leaders = rowLeaders(members);
+			/* Axes are only comparable within one edge family: a left edge, a
+			   centre and a right edge are three different questions, and one
+			   vote across them elected the sign-in dialog's rail from a mix
+			   of field edges and button centres - a number nothing in the
+			   dialog was designed against, with every centred row 50-160px
+			   "off" it. Each family gets its own rows, quorum and rail. */
+			["left", "centre", "right"].forEach(function (edgeKind) {
+			var fam = members.filter(function (m) { return m.edge === edgeKind; });
+			if (!fam.length) { return; }
+			var leaders = rowLeaders(fam);
 			/* One row is one thing, and one thing is always aligned with
 			   itself. Anything still thin after the fold above has no enclosing
 			   group to be judged against, so it is reported as neither a rail
@@ -708,6 +953,7 @@
 				onRail: rail.members.length,
 				rows: leaders.length,
 				strays: rails.slice(1).reduce(function (acc, r) { return acc.concat(r.members); }, [])
+			});
 			});
 		});
 		return columns;
@@ -933,6 +1179,22 @@
 		if (state.timer) { window.clearTimeout(state.timer); state.timer = 0; }
 	}
 
+	/* A one-line name for a column key, for report(). A stray is only
+	   diagnosable when the report says which column judged it: "22px off
+	   rail 140" reads as a page fault until the key shows the element was
+	   measured against the wrong neighbourhood, which is a tool fault. */
+	function keyDesc(key) {
+		if (!key) { return "?"; }
+		if (key.extColumn) { return "extcol:" + key.extColumn; }
+		if (key.table) { return "tablecol:" + (key.table.id || "anon") + ":" + key.column; }
+		if (key.nodeType === 1) {
+			return key.tagName.toLowerCase() + (key.id ? "#" + key.id : "") +
+				((typeof key.className === "string" && key.className)
+					? "." + key.className.split(/\s+/).slice(0, 2).join(".") : "");
+		}
+		return String(key);
+	}
+
 	var api = {
 		on: on,
 		off: off,
@@ -974,7 +1236,8 @@
 							rail: Math.round(col.rail * 10) / 10,
 							tag: m.el.tagName.toLowerCase(),
 							cls: (typeof m.el.className === "string" ? m.el.className : "").slice(0, 60),
-							label: m.label
+							label: m.label,
+							col: keyDesc(col.key)
 						});
 					});
 				});
@@ -993,6 +1256,10 @@
 				return {
 					viewport: window.innerWidth,
 					column: columnEdges(),
+					columns: (opts && opts.columns) ? columns.map(function (c) {
+						return { key: keyDesc(c.key), rail: Math.round(c.rail * 10) / 10,
+						         rows: c.rows, onRail: c.onRail, strays: c.strays.length };
+					}) : undefined,
 					measured: hits.length,
 					rails: columns.map(function (c) { return Math.round(c.rail); })
 						.filter(function (x, i, a) { return a.indexOf(x) === i; })

--- a/PaintomicsClient/public_html/app/view/common/Util.js
+++ b/PaintomicsClient/public_html/app/view/common/Util.js
@@ -587,7 +587,12 @@ function showMessage(title, data) {
         messageDialog = Ext.create('Ext.window.Window', {
             id: "messageDialog", header: false, closeAction: "hide",
             modal: true, closable: false,
-            html: "<div id='messageDialogPanel'>" +
+            /* data-guides="ignore": a centred floating dialog has no left rail
+               against the page - its x is half of whatever width the viewport
+               happens to have - and the guides overlay's column model cannot
+               hold a modal's contents together (they scatter to the body group
+               and report against a rail none of them could ever sit on). */
+            html: "<div id='messageDialogPanel' data-guides='ignore'>" +
                 " <h4 id='messageDialogTitle'></h4>" +
                 ' <div id="messageDialogBody"></div>' +
                 ' <div id="hiddenMessageDialogBody" style="display:none;"></div>' +

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,13 +39,13 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=0.98" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.01" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=0.6" />
 	<!-- Shared chrome for both of Step 3's graph surfaces. Before more-network.css,
 	     which layers this view's own legend and layout on top of it. -->
 	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=0.6" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
-	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.47" />
+	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.48" />
 
 	<!-- Theme, resolved before the first paint.
 	     Deliberately inline and here rather than in Util.js: the stylesheets

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,13 +39,13 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=0.77" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=0.98" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=0.6" />
 	<!-- Shared chrome for both of Step 3's graph surfaces. Before more-network.css,
 	     which layers this view's own legend and layout on top of it. -->
-	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=0.5" />
+	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=0.6" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
-	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.43" />
+	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.47" />
 
 	<!-- Theme, resolved before the first paint.
 	     Deliberately inline and here rather than in Util.js: the stylesheets
@@ -124,11 +124,11 @@
 	<!--SCRIPTS FOR SERVER CONNECTION CONFIGURATION-->
 	<script type="text/javascript" src="resources/ServerConfiguration.js?v=0.7"></script>
 	<!--CUSTOM SENCHA EXTENSIONS-->
-	<script type="text/javascript" src="app/view/common/Util.js?v=1.9"></script>
+	<script type="text/javascript" src="app/view/common/Util.js?v=2.0"></script>
 	<script type="text/javascript" src="app/view/common/ExtJS_extensions.js?v=0.7"></script>
 	<script type="text/javascript" src="app/view/common/upload/Panel.js?v=0.2"></script>
 	<!--LAYOUT DEBUG OVERLAY - inert until ctrl+alt+G or ?guides=1 -->
-	<script type="text/javascript" src="app/view/common/AlignmentGuides.js?v=2.6"></script>
+	<script type="text/javascript" src="app/view/common/AlignmentGuides.js?v=4.1"></script>
 
 	<!--MARKDOWN RENDERING LIBRARY -->
 	<script type="text/javascript" src="js/libs/marked/marked.min.js"></script>

--- a/PaintomicsClient/public_html/resources/css/dark.css
+++ b/PaintomicsClient/public_html/resources/css/dark.css
@@ -264,7 +264,8 @@
 /* Header and step-action controls. main.css states the ghost button's fill,
    ink and border literally, so all three are restated. */
 [data-theme="dark"] .mainTopToolbar .button,
-[data-theme="dark"] .secondTopToolbar .button {
+[data-theme="dark"] .secondTopToolbar .button,
+[data-theme="dark"] .paToolbarMiniature .button {
 	background-color: var(--pa-btn-default-bg);
 	color: var(--pa-btn-default-ink);
 	border-color: var(--pa-border-control);
@@ -284,10 +285,17 @@
 	background-color: var(--pa-btn-success-bg-hover);
 }
 [data-theme="dark"] .mainTopToolbar .button.btn-danger,
-[data-theme="dark"] .secondTopToolbar .button.btn-danger {
+[data-theme="dark"] .secondTopToolbar .button.btn-danger,
+[data-theme="dark"] .paToolbarMiniature .button.btn-danger {
 	background-color: transparent;
 	color: var(--pa-btn-ghost-danger-ink);
 	border-color: var(--pa-border-control);
+}
+/* The highlight ring on the miniature's Settings button: the light theme's
+   #B3261E measures poorly on the dark card, so use the same danger ink the
+   dark button itself carries. */
+[data-theme="dark"] .paToolbarMiniature .paMiniatureTarget {
+	box-shadow: 0 0 0 2px var(--pa-btn-ghost-danger-ink);
 }
 [data-theme="dark"] .mainTopToolbar .button.btn-danger:hover,
 [data-theme="dark"] .secondTopToolbar .button.btn-danger:hover {

--- a/PaintomicsClient/public_html/resources/css/dark.css
+++ b/PaintomicsClient/public_html/resources/css/dark.css
@@ -485,22 +485,82 @@
 [data-theme="dark"] .x-tab .x-tab-inner { color: var(--pa-ink-label); }
 [data-theme="dark"] .x-tab-active .x-tab-inner { color: var(--pa-ink-strong); }
 [data-theme="dark"] .x-tab-active { background-color: var(--pa-surface); }
-/* Step 3's database tabs are the one bar main.css rebuilds from scratch, as a
-   selected label over a 2px rule rather than a raised box - see the note there.
-   Its selected ink is a literal near-black, which is the correct colour for the
-   light theme and invisible here, and the rule under the label is the same
-   value. Both are stated by an id selector, so these have to carry it too.
+/* Step 3's database tabs are the one bar main.css rebuilds from scratch - as a
+   segmented control, two pills with the selected one filled, see the note
+   there. Every colour in that rebuild is a literal chosen against the ivory
+   page: `#1A1A18` for the selected fill, `#FFFFFF` for the label knocked out of
+   it, `rgba(24,24,27,0.20)` for the hover border. All three are stated by an id
+   selector, so these have to carry one too.
 
-   The rule is an inset box-shadow, not a border - main.css moved it there so
-   the selected and unselected labels keep the same line box - so it is the
-   whole shadow that has to be restated, not a colour. */
-[data-theme="dark"] div#tabcontainer_network .x-tab.x-active {
-	box-shadow: inset 0 -2px 0 var(--pa-ink-title);
-	background-color: transparent;
+   The selected pill inverts rather than dimming. In the light theme it is the
+   darkest thing on the page and that is what makes it read as chosen at a
+   glance; the same statement here is the lightest, so the fill takes the title
+   ink and the label takes the card underneath it. Filling it with a dark grey
+   instead - the literal translation - would put the selected pill *closer* to
+   the page than the unselected one, which is the one thing this control cannot
+   afford to get backwards. */
+/* The database tabs are bookmarks now, not pills - see "The database tabs" in
+   main.css. That changes what dark mode has to say about them: the selected tab
+   is no longer a filled shape to be inverted, it is the card's own surface
+   continuing upward, so it takes --pa-surface and the seam takes the same
+   colour. Left as it was, the selected tab stayed a near-white slab with dark
+   text sitting on a dark card - the one element on the page that had not been
+   told the lights were off. */
+[data-theme="dark"] div#tabcontainer_network .x-tab {
+	background: var(--pa-surface-sunken);
+	border-color: var(--pa-border) !important;
 }
-[data-theme="dark"] div#tabcontainer_network .x-tab.x-active .x-tab-inner,
-[data-theme="dark"] div#tabcontainer_network .x-tab:hover .x-tab-inner {
+[data-theme="dark"] div#tabcontainer_network .x-tab:not(.x-active):hover {
+	background: var(--pa-control-hover-bg);
+	border-color: var(--pa-border-hover) !important;
+}
+[data-theme="dark"] div#tabcontainer_network .x-tab.x-active {
+	background: var(--pa-surface);
+	border-color: var(--pa-border) !important;
+	box-shadow: 0 1px 0 0 var(--pa-surface);
+}
+[data-theme="dark"] div#tabcontainer_network .x-tab.x-active .x-tab-inner {
 	color: var(--pa-ink-title);
+}
+[data-theme="dark"] div#tabcontainer_network .x-tab:not(.x-active) .x-tab-inner {
+	color: var(--pa-ink-muted);
+}
+[data-theme="dark"] div#tabcontainer_network .x-tab:not(.x-active):hover .x-tab-inner {
+	color: var(--pa-ink-title);
+}
+
+/* The pathway explorer card ---------------------------------------------------
+   Its two controls - the fold on "Pathway categories" and the Tools/Details
+   tabs on the network's rail - are `a` elements, and `[data-theme="dark"] a`
+   here scores the same as main.css's `a.paNetRailTab` while loading after it.
+   So without these the tabs and the fold came out link-blue on a panel where
+   nothing else is a link, and the selected rail tab could not be told from the
+   other one by colour at all. */
+[data-theme="dark"] a.paExploreFold,
+[data-theme="dark"] a.paNetRailTab,
+[data-theme="dark"] a.paNetRailHide {
+	color: var(--pa-ink-muted);
+}
+[data-theme="dark"] a.paNetRailTab.is-active {
+	color: var(--pa-ink-title);
+	background: var(--pa-surface);
+}
+[data-theme="dark"] a.paExploreFold:hover,
+[data-theme="dark"] a.paNetRailTab:hover {
+	color: var(--pa-ink-title);
+}
+[data-theme="dark"] a.paNetRailHide:hover {
+	color: var(--pa-accent-orange);
+}
+/* main.css sets a bare `h4 { color: #27272A }` and dark.css answers it only in
+   the places that had been looked at - the AI bubbles, the omic boxes, the two
+   side panels. "Category Distribution" and "Filter by category" were not among
+   them, so they were near-black on a #1E1F23 card: present in the DOM, legible
+   nowhere. Scoped to this card rather than to `div.contentbox h4`, because
+   several cards colour their h4s deliberately and a blanket rule here would
+   overwrite those without anyone noticing which. */
+[data-theme="dark"] .paExploreCard h4 {
+	color: var(--pa-ink-label);
 }
 
 /* Form fields */
@@ -1003,31 +1063,29 @@
 	background-color: var(--pa-surface) !important;
 }
 
-/* The two summary tables - "Multiple databases used" on Step 2 and its Step 3
-   twin - are white cards with near-black ink. Both are restated together
-   because they are the same table written twice in main.css.
+/* The Step 2 "Multiple databases" table - a white card with near-black ink.
+   Its former Step 3 twin (#multisource_summary) is no longer restated here: it
+   lives inside the summary band now and its light rules are written on
+   --pa-ink-* tokens over a transparent ground, so the token block above is all
+   the theming it needs.
 
    The <dt> database names are included even though they are ink, not surface:
    at #27272A on the dark card they measured 1.4:1, which is the same defect
    seen from the other side. */
-[data-theme="dark"] #dbs_message table,
-[data-theme="dark"] div#multisource_summary table {
+[data-theme="dark"] #dbs_message table {
 	background-color: var(--pa-surface-sunken);
 	border-color: var(--pa-border);
 }
-[data-theme="dark"] #dbs_message table th,
-[data-theme="dark"] div#multisource_summary table th {
+[data-theme="dark"] #dbs_message table th {
 	background-color: var(--pa-grid-header-bg);
 	border-bottom-color: var(--pa-border);
 	color: var(--pa-grid-header-ink);
 }
-[data-theme="dark"] #dbs_message table td,
-[data-theme="dark"] div#multisource_summary table td {
+[data-theme="dark"] #dbs_message table td {
 	border-top-color: var(--pa-border-row);
 	color: var(--pa-ink-body);
 }
-[data-theme="dark"] #dbs_message dt,
-[data-theme="dark"] div#multisource_summary dt { color: var(--pa-ink-title); }
+[data-theme="dark"] #dbs_message dt { color: var(--pa-ink-title); }
 
 /* ---------------------------------------------------------------------------
    10. Highcharts
@@ -1049,6 +1107,14 @@
 [data-theme="dark"] .highcharts-axis-line,
 [data-theme="dark"] .highcharts-tick { stroke: var(--pa-chart-axis); }
 [data-theme="dark"] .highcharts-grid-line { stroke: var(--pa-chart-grid); }
+/* Except on a pie. Highcharts draws `.highcharts-plot-border` for every chart
+   and leaves it unstroked, so on a chart with axes the rule above turns it into
+   the frame the axes hang off - and on the classification pie, which has no
+   axes, it turns it into a bare 513x215 rectangle floating around the slices.
+   That box is in every dark screenshot of Step 3 and belongs to nothing. */
+[data-theme="dark"] div[id ^= "pathwayDistributionsContainer_"] .highcharts-plot-border {
+	stroke: none;
+}
 [data-theme="dark"] .highcharts-axis-labels text,
 [data-theme="dark"] .highcharts-legend-item text { fill: var(--pa-chart-ink-soft) !important; }
 [data-theme="dark"] .highcharts-axis-title,
@@ -1569,6 +1635,34 @@
 }
 [data-theme="dark"] .po-pathway-label {
 	color: var(--pa-ink-body);
+}
+/* The summary band's heading strip carries the card-heading treatment (white
+   fill, hairline) on a wrapper row rather than on the h2 itself - see "The
+   summary band" in main.css - so the same move `div.contentbox h2` makes
+   above is restated for the row here, and the h2 inside it stays transparent
+   against the dark heading rule, which outscores the light transparent one. */
+[data-theme="dark"] .po-band-head {
+	background-color: var(--pa-surface);
+	border-bottom-color: var(--pa-border);
+}
+[data-theme="dark"] .po-band-card .po-band-head h2 {
+	background: transparent;
+}
+/* The job chip's fill is --pa-surface-subtle in the light theme; this file
+   redefines that token to within two points of the card it sits on, so the
+   chip would arrive as an empty outline. --pa-surface-sunken is the token for
+   a well within a surface. The ID inside it opts back out of the blanket
+   `[data-theme="dark"] b` blue - it is an identifier, not emphasis - and the
+   glyph buttons' hover wash is restated from the dark accent, same as the
+   .po-pathway-icon tiles above. */
+[data-theme="dark"] .po-job-chip {
+	background: var(--pa-surface-sunken);
+}
+[data-theme="dark"] .po-job-chip > b {
+	color: var(--pa-ink-title);
+}
+[data-theme="dark"] .po-job-chip > a:hover {
+	background: rgba(107, 168, 240, 0.18);
 }
 
 /* ---------------------------------------------------------------------------

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -1042,9 +1042,13 @@ ul.submenu i.fa {
 	list-style: none;
 }
 /* 11px and tracked out: these name the columns, they are not read as content,
-   and at body size two of them would compete with the links underneath. */
+   and at body size two of them would compete with the links underneath.
+
+   No left margin: the 10px it carried parked each title between its list's
+   icon edge and its text start - on neither. The list items hang their icons
+   at the column's own edge, and that edge is the one rail the column has. */
 .navPanel-title {
-	margin: 0 0 6px 10px;
+	margin: 0 0 6px;
 	font-size: 11px;
 	font-weight: 600;
 	letter-spacing: 0.06em;
@@ -2633,6 +2637,70 @@ div.checkbox label, div.radio label {
 	padding-left: 0;
 }
 
+/* One rail for both controls, and a hanging indent for either ----------------
+   Two faults, one shape, and they were most visible in the network's Tools
+   column where radios and checkboxes are stacked in the same panel.
+
+   The first is that they did not share a left edge. The drawn box is an inline
+   `:before` at the start of the label's first line, so where the control lands
+   is whatever padding the label carries: 23px for a radio (the rule further up)
+   and 0 for a checkbox (the rule directly above). In the KEGG Tools panel that
+   put "Classification" and "Gene expression" 23px right of "Show all node
+   labels" and of every `h5` heading they sit under - a stagger with nothing
+   choosing it, in a column 214px wide.
+
+   The second is what happens when a label wraps. With the box in the first
+   line's flow, every line after the first starts at the label's content edge -
+   which is exactly where the box is - so "Linked biological / processes" put
+   "processes" underneath the radio, and "Calculate layout on / background",
+   "Always use combined p- / value" and "Shared biological / features" all did
+   the same. A wrapped line running under its own control is the one alignment
+   error a reader cannot read past, because it breaks the column that says which
+   words belong to which box.
+
+   `padding-left` plus a negative `text-indent` of the same size fixes both at
+   once: the first line is pulled back so the box sits on the container's rail,
+   and every line - first or wrapped - starts at the content edge just past it.
+   23px is the box (16px) and its gap (7px), from the `:before` rule above.
+
+   Deliberately not `display: flex` on the label, which would give the same two
+   columns without arithmetic: these labels also hold inline `<b>`/`<i>` runs,
+   and under flex each becomes its own flex item, which breaks the sentence into
+   separately-wrapping boxes. Deliberately not `position: absolute` on the box
+   either - inline is what keeps it on the first line's baseline through the
+   `vertical-align: -3px` above, at whatever font size the call site uses. */
+div.radio input[type='radio'] + label,
+div.checkbox:not(.nobox) input[type='checkbox'] + label {
+	display: block;
+	padding-left: 23px;
+	text-indent: -23px;
+}
+/* `viewbox` draws an eye glyph 23px wide and keeps the 7px gap, so its hang is
+   30px, not 23. Sharing the number would have left its wrapped lines 7px shy of
+   its first one - a smaller version of the same fault. */
+div.checkbox.viewbox input[type='checkbox'] + label {
+	padding-left: 30px;
+	text-indent: -30px;
+}
+/* `text-indent` is inherited and applies to the first line of every block box
+   inside, so a label's own block children would each be pulled 23px left. Three
+   of the checkboxes in the Tools panel carry their hint that way ("Disable the
+   auto-layout for network."), and without this reset the hint gained the
+   outdent that belongs to the control. Inline children need no reset - the
+   property does nothing to them. */
+div.radio > label > *,
+div.checkbox > label > * {
+	text-indent: 0;
+}
+/* The drawn box is itself an inline-block, so it inherits the outdent and
+   applies it to its own content. The plain checkbox and radio draw an empty
+   box and do not notice; `viewbox` draws a Font Awesome eye, which the outdent
+   would have carried 30px out of the control it belongs to. */
+div.checkbox input[type='checkbox'] + label:before,
+div.radio input[type='radio'] + label:before {
+	text-indent: 0;
+}
+
 /* Sliders ---------------------------------------------------------------------
    The seven sliders in the network's settings column, and the cluster-count one
    beside them, were jQuery UI's stock 2009 widget: a 1px #ddd frame around an
@@ -2943,7 +3011,7 @@ div.availableOmicsBox h4 {
    the vertical misalignment visible in the screenshots. inline-flex with
    `align-items: center` centres the two against each other and needs no magic
    number, so it stays right if either the icon or the label changes size. */
-#download_mapping_file, #paint_link {
+#download_mapping_file {
 	display: inline-flex;
 	align-items: center;
 	gap: 8px;
@@ -2955,7 +3023,7 @@ div.availableOmicsBox h4 {
 /* One step down and unbolded: the glyph is a cue for the label, not a second
    voice at the same weight. `line-height: 1` because Font Awesome's own is
    what would otherwise push it off the centre the flex box just established. */
-#download_mapping_file > i, #paint_link > i {
+#download_mapping_file > i {
 	font-size: 14px;
 	font-weight: 400;
 	line-height: 1;
@@ -2965,11 +3033,35 @@ div.availableOmicsBox h4 {
    is written inside the paragraph that introduces it, and `div.contentbox p`
    has already applied --pa-card-inset to that paragraph - so the margin landed
    on top of it and the link sat 52px in, 26px right of every other line in the
-   card. Measured: x=182.4 against a rail at 156.4. */
-div.contentbox p > #download_mapping_file,
-div.contentbox p > #paint_link {
+   card. Measured: x=182.4 against a rail at 156.4.
+
+   #paint_link is no longer in these rules: it is a real .button in the summary
+   band's heading row now (see "The summary band" further down). */
+div.contentbox p > #download_mapping_file {
 	margin-left: 0;
 	margin-right: 0;
+}
+/* The mapping-statistics section, revealed by "Show mapping" on Step 3.
+
+   Three faults in one card, all measured against its own contents: the ExtJS
+   vbox honors a 10px side margin every sibling section carries and this one
+   lacked, so its border sat 10px left of every other card on the page; and
+   its title and download link took --pa-card-inset (26px) while the omic
+   summary cards below them sit at the .omicbox margin (11px with the border).
+   A title over a stack of cards pads to the cards' edge - the same answer
+   "Selected omics" gives on the upload form - so the title and the link come
+   to the cards rather than four cards moving 15px for one line of type. */
+#statsViewContainer {
+	margin-left: 10px;
+	margin-right: 10px;
+}
+#statsViewContainer h2 {
+	padding-left: 11px;
+	padding-right: 11px;
+}
+#statsViewContainer > div > #download_mapping_file {
+	margin-left: 11px;
+	margin-right: 11px;
 }
 #dbs_message, #clusternumber_box, #threshold_box {
 	margin: 10px 0;
@@ -2998,7 +3090,12 @@ div.contentbox p > #paint_link {
    prose in these two cards sat 20px to the right of their own h2 and of every
    other paragraph on the page. */
 #clusternumber_box p, #threshold_box p {
-	margin: 20px 0;
+	/* 14px, not 20: the sibling "Multiple databases used" card leaves its
+	   first paragraph on the browser's default 1em margin, and the two
+	   cards' headings end on exactly the same line - so the 6px extra here
+	   was the whole reason these cards' opening lines sat on different
+	   baselines across one row. */
+	margin: 14px 0;
 }
 /* Each database gets a name, a paragraph about it, and the table of what
    matched in it. The table is the answer the card exists to give, so it is
@@ -3100,11 +3197,11 @@ div.contentbox p > #paint_link {
 	text-align: center;
 }
 
-div[id ^= "pathwayNetworkBox_"].fullscreen {
-	background-color: white;
-	width: 100%;
-	height: 100% !important;
-}
+/* `div[id^="pathwayNetworkBox_"].fullscreen` stood here and had never once
+   applied: nothing in the application adds a `fullscreen` class, and the old
+   full-screen path went through the native API, which sets a `:fullscreen`
+   pseudo-class instead. The rules that do the work now are `.paNetExpanded`,
+   further down this file with the rest of the network layout. */
 
 /* Column headers used to be rotated - 45 degrees for the p-value columns and a
    full 90 for the narrow count columns - because at the old width there was no
@@ -3216,22 +3313,287 @@ span.networkClusterImage.disabled > i {display:block;}
    what mmu and most of the example datasets produce. */
 div[id ^= "networkview_"] { max-width:1800px; margin: 5px 0; }
 div[id ^= "networkClustersContainer_"], div[id ^= "patwaysDetailsWrapper_"]{overflow-y:auto; overflow-x: hidden; padding: 2px 10px;}
-/* The Tools and Details columns beside the pathways network.
-   260px and 270px - two different widths for two panels standing side by side,
-   which is the kind of near-miss that reads as a mistake even when nobody can
-   say what is wrong. Together with their gutters they took 550px of a 1114px
-   row, so the graph they annotate got less than half the card it lives in.
 
-   216px each is the width of the MORE network's side panel one card below, so
-   the three annotation columns on this page are now one measurement, and the
-   diagram gets 662px instead of 564.
+/* The pathway explorer card ---------------------------------------------------
+   One card per database, holding what used to be four: the classification
+   panel, the network panel, and the network's "Tools" and "Details" panels. See
+   the note in PA_Step3JobView.initComponent for why they are one activity.
 
-   The height tracks the network beside it: 775px of canvas, plus the 34px
-   toolbar and the 33px status line above it. It is a literal because the
-   resizer at the foot of the panel sets these three heights together in JS -
-   see the Ext.resizer.Resizer in PA_Step3Views - so `auto` here would make one
-   of the three stop following the drag. */
-div[id ^= "networkSettingsPanel_"], div[id ^= "networkDetailsPanel_"] {width:216px; float:right; margin:0; margin-left:10px;height: 876px;overflow: auto;}
+   Nothing here draws a surface - the .contentbox the card also carries does
+   that. These rules only place the two blocks inside it and give the fold
+   control on the first one somewhere to sit. */
+.paExploreCard > .paExploreOverview {
+	/* Contains the two floated columns of the classification block, so that the
+	   network below starts under them rather than beside them. */
+	display: block;
+}
+.paExploreCard > .paExploreOverview::after,
+.paExploreFoldable::after {
+	content: "";
+	display: block;
+	clear: both;
+}
+/* The band that names the foldable block and carries its control. It is not an
+   h3 with a floated link, because a float would take the link out of the row's
+   height and the two would only line up by accident. */
+.paExploreBand {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	gap: 12px;
+	padding-right: var(--pa-card-inset);
+}
+.paExploreBand > h3 {
+	margin-bottom: 0;
+}
+a.paExploreFold {
+	flex: 0 0 auto;
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--pa-ink-muted, #6B6B66);
+	text-decoration: none;
+	white-space: nowrap;
+}
+a.paExploreFold:hover {
+	color: var(--pa-accent-orange, #AD5022);
+	text-decoration: none;
+}
+a.paExploreFold i {
+	margin-right: 5px;
+}
+/* jQuery's slideToggle writes `display` inline, so the folded state is not
+   expressed here - only the clearfix above, which has to survive it. */
+.paExploreFoldable {
+	border-bottom: 1px solid var(--pa-border);
+	padding-bottom: 8px;
+	margin-bottom: 4px;
+}
+
+/* The pathways network and its rail ------------------------------------------
+   Two floated 216px columns before, "Tools" and "Details", standing side by
+   side and shown or hidden independently. Three things were wrong with that and
+   all three are structural rather than cosmetic:
+
+     - the two are never both being read. Details holds the colour legend and
+       whatever pathway was last clicked; Tools holds every control. Showing
+       them together spent 462px of a 1114px card on annotation and left the
+       diagram it annotates with 662px;
+     - a float cannot take its height from the element beside it, so the panels
+       carried `height: 876px` as a literal and the resizer had to keep three
+       heights in step by hand. It did not - see the note on that resizer;
+     - "Configure" opened a *second* column rather than switching one, so how
+       wide the graph was depended on which panels happened to be open.
+
+   One grid: the graph in column 1 spanning both rows, the rail's tab strip and
+   whichever pane is showing in column 2. The rail is one 236px column whatever
+   is in it, the graph gets the rest, and neither has to be told a height. */
+/* No gutter, and no margin on the area. The graph panel runs to the card's own
+   left edge because the toolbar inside it derives its inset from
+   --pa-card-inset - so that the first tool's icon lands on the same rail as the
+   card's heading - and an inset on this container would charge that twice. The
+   rail is separated by its own left border instead of by a gap, and docks
+   against the card's right edge for the same reason: a bordered column floating
+   10px inside a bordered card is two frames where the eye expects one. */
+.paNetArea {
+	margin: 0;
+}
+/* The grid is declared two elements below the container, and it has to be.
+   ExtJS 4's auto layout renders a `display: table` span and a
+   `display: table-cell` div between a container and its items - both generated,
+   both carrying that display as an inline style, and neither reachable by the
+   `cls` config that named .paNetArea. So the row is declared on the inner
+   wrapper, addressed by the id ExtJS derives from the container's own, and the
+   outer one is unwrapped to a block so it stops shrink-wrapping the row.
+
+   `!important` beats the inline display and nothing else. Written without it
+   the container measured 948px against a 1184px card and both panes sat at full
+   width under the graph, which is the shape this replaced. */
+.paNetArea > [id$="-outerCt"] {
+	display: block !important;
+	width: 100%;
+}
+.paNetArea > [id$="-outerCt"] > [id$="-innerCt"] {
+	display: grid !important;
+	grid-template-columns: minmax(0, 1fr) 236px;
+	grid-template-rows: auto minmax(0, 1fr);
+	gap: 0;
+	align-items: stretch;
+	width: 100%;
+}
+.paNetArea .paNetMain {
+	grid-column: 1;
+	grid-row: 1 / span 2;
+	min-width: 0;
+}
+.paNetArea .paNetRailTabs {
+	grid-column: 2;
+	grid-row: 1;
+}
+.paNetArea .paNetRailPane {
+	grid-column: 2;
+	grid-row: 2;
+	margin: 0;
+	padding-bottom: 16px;
+	overflow-y: auto;
+	overflow-x: hidden;
+	background: var(--pa-surface, #fff);
+	border: none;
+	border-left: 1px solid var(--pa-border);
+	border-radius: 0;
+}
+/* With the rail hidden the graph takes the card. The canvas has to be told when
+   that happens - a sigma renderer sizes itself once - which is why every caller
+   of this class also calls resizeNetwork(). */
+.paNetArea.is-railHidden > [id$="-outerCt"] > [id$="-innerCt"] {
+	grid-template-columns: minmax(0, 1fr);
+}
+.paNetArea.is-railHidden .paNetRailTabs,
+.paNetArea.is-railHidden .paNetRailPane {
+	display: none !important;
+}
+
+/* Below the width where a 236px column and a graph can share a row, the rail
+   goes under the graph instead of squeezing it. 900px is the breakpoint
+   network-views.css already uses to shorten the canvas, so the two changes
+   happen together rather than at two widths a reader would have to discover
+   separately. */
+@media (max-width: 900px) {
+	.paNetArea > [id$="-outerCt"] > [id$="-innerCt"] {
+		grid-template-columns: minmax(0, 1fr);
+		grid-template-rows: auto auto auto;
+	}
+	.paNetArea .paNetMain {
+		grid-column: 1;
+		grid-row: 1;
+	}
+	.paNetArea .paNetRailTabs {
+		grid-column: 1;
+		grid-row: 2;
+		border-left: none;
+		border-top: 1px solid var(--pa-border);
+	}
+	.paNetArea .paNetRailPane {
+		grid-column: 1;
+		grid-row: 3;
+		border-left: none;
+		max-height: 420px;
+	}
+}
+
+/* The rail's tabs. Segmented, sitting on top of the pane and sharing its
+   border, so the strip and the pane below read as one object rather than as a
+   control that happens to be above a box. */
+.paNetRailTabs {
+	display: flex;
+	align-items: stretch;
+	gap: 0;
+	background: var(--pa-surface-sunken, #F5F4EF);
+	border: none;
+	border-left: 1px solid var(--pa-border);
+	border-radius: 0;
+	overflow: hidden;
+}
+a.paNetRailTab {
+	flex: 1 1 0;
+	min-width: 0;
+	padding: 9px 6px;
+	font-size: 12px;
+	font-weight: 600;
+	line-height: 1.2;
+	text-align: center;
+	color: var(--pa-ink-muted, #6B6B66);
+	background: transparent;
+	border: none;
+	border-bottom: 1px solid var(--pa-border);
+	text-decoration: none;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+a.paNetRailTab:hover {
+	color: var(--pa-ink-title, #1A1A18);
+	background: var(--pa-control-hover-bg, #FFFFFF);
+	text-decoration: none;
+}
+/* The active tab loses the bottom border so it runs into the pane below it -
+   the same join the database tabs make with the card. */
+a.paNetRailTab.is-active {
+	color: var(--pa-ink-title, #1A1A18);
+	background: var(--pa-surface, #fff);
+	border-bottom-color: transparent;
+}
+a.paNetRailTab i {
+	margin-right: 5px;
+	opacity: 0.75;
+}
+a.paNetRailHide {
+	flex: 0 0 auto;
+	padding: 9px 10px;
+	font-size: 12px;
+	color: var(--pa-ink-muted, #6B6B66);
+	border-bottom: 1px solid var(--pa-border);
+	text-decoration: none;
+}
+a.paNetRailHide:hover {
+	color: var(--pa-accent-orange, #AD5022);
+	background: var(--pa-control-hover-bg, #FFFFFF);
+	text-decoration: none;
+}
+
+/* Full screen ----------------------------------------------------------------
+   The class does the covering, not the Fullscreen API, so the panel is expanded
+   even where the native request is refused - and the toolbar inside it, holding
+   the button that comes back, is expanded with it. See setFullScreenNetwork in
+   PA_Step3Views for why that is the whole point.
+
+   `:fullscreen` is matched as well so that the same rules apply when the browser
+   *does* grant the request and paints its own black backdrop behind the
+   element. */
+.paNetArea.paNetExpanded,
+.paNetArea:fullscreen {
+	/* Three `!important`s, all against inline styles ExtJS writes onto this
+	   container itself: `position: relative` for the resizer that is pinned to
+	   it, and a measured width and height from the layout run. Without the first
+	   the class applies, the z-index resolves to 9500, and the panel does not
+	   move - which is the state this looked like on the first attempt. */
+	position: fixed !important;
+	inset: 0;
+	z-index: 9500;
+	margin: 0;
+	width: auto !important;
+	height: auto !important;
+	max-width: none !important;
+	background: var(--pa-surface, #fff);
+	overflow: hidden;
+}
+/* Both generated wrappers have to be given the height, or the grid inside them
+   shrink-wraps its content and the graph stays 720px tall on a screen-high
+   panel - which is what full screen looked like before. */
+.paNetArea.paNetExpanded > [id$="-outerCt"],
+.paNetArea:fullscreen > [id$="-outerCt"],
+.paNetArea.paNetExpanded > [id$="-outerCt"] > [id$="-innerCt"],
+.paNetArea:fullscreen > [id$="-outerCt"] > [id$="-innerCt"] {
+	height: 100% !important;
+}
+.paNetArea.paNetExpanded .paNetMain,
+.paNetArea:fullscreen .paNetMain {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+}
+/* The canvas takes the room the title, the toolbar and the status line leave. */
+.paNetArea.paNetExpanded .pa-net-canvas,
+.paNetArea:fullscreen .pa-net-canvas {
+	flex: 1 1 auto;
+	height: auto;
+	min-height: 0;
+}
+/* The resize handle is for a panel sitting in a page. Full screen has no page
+   under it to make room in. */
+.paNetArea.paNetExpanded > .x-resizable-handle,
+.paNetArea:fullscreen > .x-resizable-handle {
+	display: none;
+}
 
 /* Classification / database badge. The fill and the letter colour are set
    inline by classificationBadgeStyle() in Util.js - see the comment there for
@@ -3296,6 +3658,28 @@ i.classificationNameBox {
 	text-align: center;
 	font-weight: bold;
 	margin-bottom: 3px;
+	/* An inline-block is a block container, so it inherits `text-indent` and
+	   applies it to its own first line - and its own first line is the single
+	   letter this badge exists to centre. The hanging indent added below for the
+	   legend rows promptly pulled every letter 34px out of its circle and left a
+	   row of empty discs with a stray capital beside each. The badge's content is
+	   positioned by `text-align: center` and by nothing else. */
+	text-indent: 0;
+}
+/* The network's Details legend, one row per classification: a round badge and
+   the classification's name beside it. The badge is inline and the name is a
+   bare text node after it, so a name too long for the column wrapped back to
+   the row's left edge and its second line ran underneath the badge - "Genetic
+   Information / Processing" and "Environmental Information / Processing" both
+   did, in a panel 224px wide where they always will. The badge column and the
+   label column are then not columns at all.
+
+   Same hanging indent as the checkbox labels, and the same reasoning: the badge
+   keeps its place in the first line's flow, and every line starts past it.
+   34px is the badge (24px, border-box) and its 10px gap, from the rule above. */
+[id^="networkClustersContainer_"] > div > div {
+	padding-left: 34px;
+	text-indent: -34px;
 }
 div[id ^= "pathwayClassificationContainer"] {overflow-y: auto; overflow-x: hidden;}
 .step3ClassificationsWrapper{display: block;}
@@ -3415,10 +3799,49 @@ div[id ^= "step3-network-toolbar_"] div[id ^= "reorderOptions"]{
    "Reactome" a *thing you could press* was a 1px silver line under one of them.
    Two 23px orange words with a hairline between them is not a tab bar.
 
-   Rebuilt as one: 14px labels, the selected one near-black with a 2px accent
-   rule beneath it, the rest muted and colouring on hover. That is smaller than
-   the headings it sits above, which is correct - a tab is a control, and the
-   thing it reveals is what the reader came for.
+   Rebuilt first as one: 14px labels, the selected one near-black with a 2px
+   accent rule beneath it, the rest muted and colouring on hover. That is
+   smaller than the headings it sits above, which is correct - a tab is a
+   control, and the thing it reveals is what the reader came for.
+
+   That pass fixed what the labels said and left untouched what they *were*: a
+   word with no box around it. Measured, in this state: the KEGG tab's <a> was
+   33px wide and 38 tall - i.e. exactly as wide as the four letters, because the
+   only rule holding any horizontal padding named a `button` element (see the
+   note on .x-tab-inner below) that this ExtJS build does not render, so it
+   never applied to anything. Two bare words and a hairline still read as a
+   caption above the card, not as the switch between two databases; the whole
+   affordance rested on one of them being darker than the other.
+
+   So the labels get their boxes. Each database is a pill - a fill, a hairline,
+   a radius and a 18px hit area either side of the word - and the selected one
+   is filled near-black with a white label rather than merely being a darker
+   grey than its neighbour. The difference between "KEGG" and "Reactome" is now
+   figure/ground rather than two shades of ink, which is what a control that
+   changes the whole page below it should look like at a glance.
+
+   The gap between the tabs is set in JS, not here: see the note on
+   `defaults.margin` in PA_Step3Views.js. It was 22px, which was the distance
+   two undressed words needed to stop reading as one phrase; boxes carry their
+   own separation, and 22px between them made the pair read as two unrelated
+   buttons rather than as one control with two positions.
+
+   Last pass: bookmarks, not pills.
+
+   The pills were correct about weight and wrong about attachment. They floated
+   19px above the card they switch, so what the reader saw was two buttons and,
+   separately, a card - and nothing on the page said that pressing one of the
+   buttons was what put that card there. A pill is a button; a button's business
+   ends when you release it. What this control does is put a *different sheet*
+   in front of you, which is the one thing a bookmark tab says and a pill
+   cannot: the selected tab and the sheet are one surface, joined along an edge,
+   and the unselected one is another sheet behind it.
+
+   So: top-rounded tabs sitting directly on the card, the selected one filled in
+   the card's own surface and continuing into it across an unbroken seam, the
+   rest sunken and behind. The card gives up its top corners to receive them -
+   see the rule on .paExploreCard below - which is the price of the join and the
+   reason it reads as one object.
 
    The `!important`s below match Neptune's own on the same properties; the
    heights it hard-codes are what the strip and the tab boxes are measured from,
@@ -3427,136 +3850,155 @@ div#tabcontainer_network,
 div#tabcontainer_network .x-panel-body-default {
 	border-color: transparent;
 }
-/* The bar itself: a single hairline running the width of the block, which the
-   active tab's own rule then overpaints for its own width. */
+/* The bar's own hairline would run behind the tabs and out past the last one,
+   which is the one line a bookmark strip must not have: the edge belongs to the
+   sheet below, and the selected tab's job is to break it. */
 div#tabcontainer_network .x-tab-bar {
-	border-bottom: 1px solid var(--pa-border);
+	border-bottom: 0;
+	margin-bottom: 0;
 }
+/* One position of the control.
+
+   `margin-right` is not a typo for the gap and is deliberately absent: a tab bar
+   is an ExtJS box layout, which measures each tab and writes an absolute `left`
+   for the next one, so a margin from this stylesheet is both overwritten inline
+   and ignored by the arithmetic. The gap is a component config; this file cannot
+   set it.
+
+   No bottom border, and the radius only on the top two corners: a tab is open at
+   the edge it shares with its sheet. */
 div#tabcontainer_network .x-tab {
-	background: none;
-	border: 0 !important;
-	border-radius: 0;
-	margin-right: 4px;
-	padding: 0;
-	height: 38px !important;
-	transition: border-color var(--pa-transition);
+	background: var(--pa-surface-sunken, #F5F4EF);
+	border: 1px solid var(--pa-border) !important;
+	border-bottom: 0 !important;
+	border-radius: var(--pa-radius) var(--pa-radius) 0 0;
+	padding: 0 20px;
+	height: 36px !important;
+	transition: background-color var(--pa-transition),
+	            border-color var(--pa-transition);
 }
-div#tabcontainer_network .x-tab-inner {
+/* The label. This rule also absorbs what a `.x-tab button` selector further
+   down used to declare - `line-height: 36px !important; font-size: 14px;
+   padding: 0 14px` - and which never once applied: ExtJS 4.2.1 renders a tab as
+   `a.x-tab > span.x-tab-wrap > span.x-tab-button > span.x-tab-inner`, with no
+   `button` element anywhere in it. That dead rule is why the tabs had no
+   padding, and its 36px line-height is restated here, on the element that
+   exists: 38px of pill less its two 1px borders is a 36px content box, so the
+   label sits on the pill's centre line. */
+div#tabcontainer_network .x-tab .x-tab-inner {
 	color: var(--pa-ink-muted);
 	font-family: var(--pa-font-sans) !important;
 	font-size: 14px;
 	font-weight: 600 !important;
 	height: auto;
+	line-height: 35px;
 	transition: color var(--pa-transition);
 }
-div#tabcontainer_network .x-tab:hover .x-tab-inner {
+/* `:not(.x-active)` rather than letting source order settle it. The two
+   selectors score the same specificity, so the active pill would take the hover
+   background from whichever rule came last - and the point of the selected
+   state below is that it does not change under the cursor. */
+div#tabcontainer_network .x-tab:not(.x-active):hover {
+	background: var(--pa-control-hover-bg);
+	border-color: rgba(24, 24, 27, 0.20) !important;
+}
+div#tabcontainer_network .x-tab:not(.x-active):hover .x-tab-inner {
 	color: #27272A;
 }
-/* The selected state. A 2px rule sitting on the bar's own hairline, in the ink
-   of the label above it - so the mark and the thing it marks are one object.
+/* The selected state: the tab is the card.
 
-   An inset shadow rather than a `border-bottom`, and that is not a preference.
-   These tabs are sized `height: 38px` with Neptune's border-box, so a 2px
-   border comes out of the content box: the active tab's label had 36px of line
-   box to centre in and the inactive one had 38, which put "KEGG" one pixel
-   below "Reactome" on a strip whose whole job is to present them as the same
-   kind of thing. Measured: line-height 40px on the inactive tab, 38px on the
-   active. A shadow is painted inside the box without occupying it, so both
-   labels sit on one line whichever is selected. */
+   Same fill, same border, and a 1px shadow cast straight down that paints over
+   the card's own top border for exactly the width of the tab - which is the
+   seam. Without that one line the card's edge runs unbroken beneath every tab
+   and the selected one is merely a white box sitting on a box, which is what a
+   pill was.
+
+   No accent and no knocked-out label: the accents on this page encode data (the
+   significance tints, the database badges, the omic colours), and a control that
+   borrowed one would be claiming a meaning it does not have. Selection is
+   carried by the join, and by the label going from muted to full ink. */
 div#tabcontainer_network .x-tab.x-active {
-	border-bottom: 0 !important;
-	box-shadow: inset 0 -2px 0 #1A1A18;
+	background: var(--pa-surface, #FFFFFF);
+	border-color: var(--pa-border) !important;
+	position: relative;
+	z-index: 3;
+	box-shadow: 0 1px 0 0 var(--pa-surface, #FFFFFF);
 }
 div#tabcontainer_network .x-tab.x-active .x-tab-inner {
-	color: #1A1A18;
+	color: var(--pa-ink-title, #1A1A18);
 }
-/* Neptune's 1px filler strip under the bar. The bar draws its own border now,
-   so this would be a second line 40px below it. */
+/* The seam is a 1px overhang, so nothing between the tab and the card may clip
+   it. Neptune gives all three of these `overflow: hidden`. */
+div#tabcontainer_network .x-tab-bar,
+div#tabcontainer_network .x-tab-bar-body,
+div#tabcontainer_network .x-tab-bar .x-box-inner {
+	overflow: visible !important;
+}
+/* The card receives the tabs. Square across the top, and hard against the bar
+   above it: a rounded corner under a square-bottomed tab is the one detail that
+   gives away that these are two objects rather than one sheet. The bottom
+   corners keep the radius - that edge is the card's own.
+
+   A descendant selector, because ExtJS puts four generated wrappers between the
+   tab's panel and the card - a body, an outerCt, an innerCt, and the card's own
+   container - none of which a child combinator can be written against. */
+#tabcontainer_network .x-tabpanel-child .paExploreCard {
+	margin-top: 0;
+	border-top-left-radius: 0;
+	border-top-right-radius: 0;
+}
+/* Unless there are no tabs. A single-database organism hides the bar entirely
+   (see `tabBar.hidden` in PA_Step3Views), and a card squared off to receive
+   tabs that are not there is just a card with two corners missing - on the one
+   configuration where nobody can see why. */
+#tabcontainer_network.onedatabase .x-tabpanel-child .paExploreCard {
+	margin-top: 5px;
+	border-top-left-radius: var(--pa-radius);
+	border-top-right-radius: var(--pa-radius);
+}
+/* Neptune's 1px filler strip under the bar. Nothing draws a line there now, and
+   this would be the only one - 40px below the pills and attached to neither
+   them nor the card. */
 div#tabcontainer_network .x-tab-bar-strip {
 	display: none;
 }
 div#tabcontainer_network .x-tab-bar .x-tab-bar-body {
-	height: 38px !important;
+	height: 36px !important;
 	border: 0 !important;
 	padding: 0;
 }
 div#tabcontainer_network .x-tab-bar .x-tab-bar-body .x-box-inner {
-	height: 38px !important;
-}
-div#tabcontainer_network .x-tab-bar .x-tab-bar-body .x-box-inner .x-tab button {
-	line-height: 36px !important;
-	font-size: 14px;
-	padding: 0 14px;
+	height: 36px !important;
 }
 div#tabcontainer_network .x-tab-center {
 	margin-top: 0;
 }
-/* "Multiple databases used" card.
+/* The per-database split, inside the summary band.
 
-   The markup is master's: a .multisource_body wrapping the prose and the
-   per-database table, which replaced a layout that propped itself open with
-   min-height:200px. What changes here is the arrangement. Side by side used the
-   width but weighted the card to one side - the prose is ten times the table's
-   area and the two share no edge to align on - so they stack, prose first, with
-   the table centred underneath the text that introduces it. Symmetric at every
-   width, and no breakpoint needed.
-
-   The prose is deliberately not capped at a reading measure here: on a 1360px
-   card that leaves a column of text down one side with nothing opposite it,
-   which looks broken rather than composed. */
-div#multisource_msg .multisource_body {
-	display: block;
-	padding: 4px 0 0;
-}
-div#multisource_msg .multisource_text {
-	padding: 0 var(--pa-card-inset);
-}
-div#multisource_msg .multisource_text p {
-	margin: 0 0 12px;
-	padding: 0;
-	max-width: none;
-	line-height: 1.55;
-}
-div#multisource_msg .multisource_text p:last-child {
-	margin-bottom: 18px;
-}
-div#multisource_summary {
-	display: flex;
-	justify-content: center;
-	margin-bottom: 22px;
-}
-
-/* This was `1px solid black` - the only pure-black edge in the application, on
-   a table sitting inside an already-bordered card, so it read as a screenshot
-   pasted into the page. The cells also had no vertical padding, which is what
-   made the two database rows feel cramped against it. */
+   This table used to be the centrepiece of its own card, "Multiple databases
+   used" - two paragraphs of prose over a bordered, filled table. It sits in
+   the band's third cell now (see "The summary band" further down), where the
+   band's hairline separators already frame it, so a border and a fill of its
+   own would draw a box inside a box. Bare rows: tiny muted headers, the badge,
+   the name, two columns of lining figures. The ids on the count cells are
+   still what the pathway filters refresh, so the markup is untouched. */
 div#multisource_summary table {
-	border: 1px solid var(--pa-border);
-	border-radius: var(--pa-radius);
-	border-collapse: separate;
-	border-spacing: 0;
-	overflow: hidden;
-	background-color: #FFFFFF;
-	min-width: 320px;
+	border-collapse: collapse;
 }
 div#multisource_summary table th {
-	padding: 9px 16px;
-	border-bottom: 1px solid var(--pa-border);
-	background-color: #F9F8F4;
-	color: #52525B;
-	font-size: 11.5px;
+	padding: 0 12px 5px;
+	color: var(--pa-ink-muted, #595959);
+	font-size: 11px;
 	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
 	text-align: left;
 	white-space: nowrap;
 }
 div#multisource_summary table td {
-	padding: 10px 16px;
-	border-top: 1px solid #F1F1F3;
-	font-size: 12.5px;
-	color: #27272A;
-}
-div#multisource_summary table tr:first-child td {
-	border-top: 0;
+	padding: 4px 12px;
+	font-size: 13px;
+	color: var(--pa-ink-body, #27272A);
 }
 /* Counts read as a column of magnitudes, so they are right-aligned on lining
    figures - "368" over "520" should line up digit for digit. */
@@ -3566,24 +4008,10 @@ div#multisource_summary table td:nth-child(n+3) {
 	font-variant-numeric: tabular-nums;
 }
 /* The badge column carries no header and no label, only the coloured initial. */
-div#multisource_summary table th:first-child,
-div#multisource_summary table td:first-child {
-	width: 1%;
-	padding-right: 0;
-}
-
-/* Cell classes introduced with master's markup: the badge column carries no
-   label, the name column is the row's subject, and the significant count is
-   the number a reader is scanning for.
-
-   The rule above used to be left unclosed, so the browser's error recovery
-   swallowed this first selector as a bad declaration and `db_chip` never
-   applied - the badge column was sized by the `width: 1%` above instead. The
-   header cell is included now because the header row has a real cell for that
-   column rather than a colspan across it. */
 div#multisource_summary th.db_chip,
 div#multisource_summary td.db_chip {
 	width: 1px;                /* shrink to the chip */
+	padding-left: 0;
 	padding-right: 0;
 }
 div#multisource_summary td.db_name {
@@ -3591,7 +4019,10 @@ div#multisource_summary td.db_name {
 	font-weight: 600;
 	white-space: nowrap;
 }
-div#multisource_summary td.db_significant { color: #1a1a1a; font-weight: 600; }
+div#multisource_summary td.db_significant {
+	color: var(--pa-ink-title, #1a1a1a);
+	font-weight: 600;
+}
 
 div.onedatabase .x-panel-body-default {
 	border: none !important;
@@ -3612,11 +4043,16 @@ div.onedatabase div[id ^= "networkview_"] {
    KEGG and Reactome tabs, so "Pathways classification" and "Pathways network"
    started 1px right of the four cards outside the tabs - a hairline stagger
    down the page. Removed for one database already, via the rules above; the
-   side that had two databases is the side a reader normally sees. */
+   side that had two databases is the side a reader normally sees.
+
+   All four sides now, not just the two. There are two of these bodies nested,
+   each contributing a 1px top border, and together they held the card 2px below
+   the tab bar - which is 2px the selected tab's seam cannot reach across, and
+   the difference between a bookmark tab and a button sitting near a card.
+   Measured: tab bar bottom 127.9, card top 129.9. */
 #tabcontainer_network > .x-panel-body,
 #tabcontainer_network .x-tabpanel-child > .x-panel-body {
-	border-left-width: 0 !important;
-	border-right-width: 0 !important;
+	border-width: 0 !important;
 }
 
 /********************************************************************************
@@ -4925,24 +5361,6 @@ div.lateralOptionsPanel-header .toolbarOption.downloadTool:hover {
    glyph; the tile is a wash behind it, which is what keeps it from reading as
    a block. Both live here rather than inline so `dark.css` can reach them --
    an inline colour cannot be themed at all. */
-.po-pathway-stats {
-	display: flex;
-	align-items: center;
-	/* Was `center`. This card sits beside "Pathways selection", whose heading and
-	   every line of whose prose start on --pa-card-inset; a centred row inside it
-	   gave the pair of cards two different left edges and no shared one. The
-	   counts are the card's content, not a banner, so they start where its own
-	   heading starts. */
-	justify-content: flex-start;
-	flex-wrap: wrap;
-	gap: 20px 46px;
-	margin: 24px 0 4px;
-	padding: 0 var(--pa-card-inset);
-	/* The old container set line-height: 120px to fake vertical centring.
-	   Flex does it honestly, and the tall line-height was what pushed these
-	   counts so far from the job ID above them. */
-	line-height: 1;
-}
 .po-pathway-stat {
 	display: flex;
 	align-items: center;
@@ -4969,10 +5387,14 @@ div.lateralOptionsPanel-header .toolbarOption.downloadTool:hover {
 	background: rgba(173, 80, 34, 0.12);
 	color: var(--pa-accent-orange, #AD5022);
 }
-.po-pathway-figure {
+/* The figure stacks: numeral over label, both left-aligned, which is what
+   lets two figures of very different widths ("877" / "45") sit in cells of
+   the same height without the labels drifting to different baselines. */
+.po-band-figure {
 	display: flex;
-	align-items: baseline;
-	gap: 9px;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 8px;
 }
 /* Matches .po-stat-value, the design system's figure treatment, rather than
    inventing a second one. Tabular figures so the number does not jitter
@@ -5004,17 +5426,185 @@ div.lateralOptionsPanel-header .toolbarOption.downloadTool:hover {
 	font-family: inherit;
 	line-height: 1;
 }
-/* The URL caption under the job ID. A caption for the line above it, so it sits
-   tight against that line rather than a paragraph's distance from it. */
-.po-job-url {
-	margin: 0 0 2px;
-}
 /* A caption for the figure, so it sits below body copy (14px) rather than above
-   it. At 15px the label was larger than the prose in the card next door and
-   read as a second heading rather than as the unit of the number it follows. */
+   it. At 15px the label was larger than the prose around it and read as a
+   second heading rather than as the unit of the number it follows. */
 .po-pathway-label {
 	font-size: 13px;
 	color: var(--pa-ink-muted, #595959);
+}
+/* The summary band --------------------------------------------------------
+   One card where three used to be. The old top row was "Pathways selection" -
+   four lines of boilerplate about how significance is computed - beside
+   "Pathways summary", and a third card ("Multiple databases used") added two
+   more paragraphs over a table: ~700px of prose before the first control,
+   almost none of it varying by job. What varies now sits in a single band and
+   the boilerplate lives in the heading's tooltip; the markup comment in
+   PA_Step3Views.js tells the whole story.
+
+   Two rows. The head row is the card's heading strip - h2, the job's name,
+   then the job chip and the paint call-to-action on the right. The band under
+   it is one row of figures: the two totals, then the per-database split with
+   the one-line note that replaced the old paragraphs. Hairlines separate the
+   cells; the card's own border frames the whole, so nothing inside carries a
+   second box. */
+.po-band-head {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 10px 18px;
+	background-color: #FFFFFF;
+	border-bottom: 1px solid var(--pa-border);
+	border-radius: var(--pa-radius) var(--pa-radius) 0 0;
+	padding: 12px var(--pa-card-inset);
+}
+/* The heading's dress - white fill, hairline, inset - moved up onto the row so
+   the h2 can share a flex line with the chip and the button. Two classes and a
+   tag against `div.contentbox h2`'s one-and-two, so no !important. */
+.po-band-card .po-band-head h2 {
+	background: transparent;
+	border: 0;
+	border-radius: 0;
+	padding: 0;
+	flex: none;
+}
+/* The job's own description ("STATegra - real mouse Ikaros time course"),
+   clipped rather than wrapped: it is a subtitle, and a subtitle that can grow
+   a second line would push the actions strip off its row. The full text rides
+   the title attribute, set where the text is. */
+.po-job-name {
+	display: block;
+	flex: 1 1 160px;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 13px;
+	color: var(--pa-ink-muted, #595959);
+}
+.po-band-actions {
+	display: flex;
+	align-items: center;
+	gap: 14px;
+	margin-left: auto;
+}
+.po-band-actions .button {
+	margin: 0;
+}
+/* The job ID as a chip: the one piece of the old card people actually used -
+   the thing you paste into a mail - reduced to the ID plus two glyph buttons,
+   open and copy. The URL itself is no longer written out; it is the page's own
+   address, and the buttons hand it over without asking anyone to select text. */
+.po-job-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	padding: 4px 8px 4px 14px;
+	border: 1px solid var(--pa-border);
+	border-radius: 999px;
+	background: var(--pa-surface-subtle, #F9F8F4);
+	font-size: 13px;
+	color: var(--pa-ink-muted, #595959);
+	white-space: nowrap;
+}
+.po-job-chip > b {
+	font-weight: 600;
+	color: var(--pa-ink-title, #24252A);
+	letter-spacing: 0.02em;
+}
+.po-job-chip > a {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	border-radius: 50%;
+	color: var(--pa-accent-blue, #19589E);
+	font-size: 12px;
+}
+.po-job-chip > a:hover {
+	background: rgba(25, 88, 158, 0.10);
+}
+/* The moment of feedback after a copy: the glyph itself turns into a tick.
+   Green, because the tick reports success, not a link. */
+.po-job-chip > a.is-copied {
+	color: var(--pa-accent-green, #2A8368);
+}
+/* The band proper: one row of cells that together own the card's full width.
+   line-height 1 keeps the numerals from inheriting the page's paragraph
+   rhythm.
+
+   The cells grow, and that is the point of this block. Content-sized cells
+   packed left - the first version - left everything right of the database
+   table as one unbroken white field, roughly half the card at the widths a
+   desktop shows it: dead space with a shape, which reads as a card waiting
+   for content that never arrives. Growing cells put the same air *between*
+   the figures instead, each centred in its own share with a full-height
+   hairline marking the shares, so the width reads as composed rather than
+   unfilled. `stretch` is what lets those hairlines run the band's whole
+   height whatever cell happens to be tallest. */
+.po-band {
+	display: flex;
+	align-items: stretch;
+	flex-wrap: wrap;
+	gap: 16px 0;
+	padding: 20px var(--pa-card-inset) 22px;
+	line-height: 1;
+}
+.po-band .po-pathway-stat {
+	/* Equal shares, but `auto` basis: a zero basis hands "877" and its label
+	   exactly a third and lets min-width break the odometer across lines on a
+	   narrow card - the same defect the old figures panel documented. Content
+	   first, slack split evenly. */
+	flex: 1 1 auto;
+	justify-content: center;
+	padding: 0 24px;
+}
+.po-band .po-pathway-stat + .po-pathway-stat,
+.po-band .po-band-dbs {
+	border-left: 1px solid var(--pa-border);
+}
+/* The per-database cell: the mini table over its one-line note. Column, not
+   row - side by side the pair needed ~590px and pushed the band past the card
+   at the widths the contents rail leaves it. A slightly heavier share than
+   the totals, because its content is wider to begin with; its children are
+   centred individually, which the near-equal widths of the table and the
+   capped note keep from reading as ragged. */
+.po-band-dbs {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	flex: 1.4 1 auto;
+	gap: 10px;
+	padding: 0 24px;
+}
+/* Two classes, because `div.contentbox p` (0,1,2) would otherwise re-apply the
+   card inset and paragraph margins this note is opting out of. Centred text:
+   the note and the table above it are separately-centred blocks of different
+   widths, so left-aligned caption text put its edge ~30px outside the table's
+   and the pair read as misaligned rather than stacked. */
+.po-band .po-band-note {
+	margin: 0;
+	padding: 0;
+	max-width: 320px;
+	font-size: 12.5px;
+	line-height: 1.5;
+	text-align: center;
+	color: var(--pa-ink-muted, #595959);
+}
+/* When the band is too narrow for the split beside the totals - a narrow
+   window, or the contents rail taking its column - the database cell becomes
+   the band's second row, and its hairline turns horizontal with it. A viewport
+   query, not a container query: this card is a full-width box whose width
+   tracks the viewport, and ExtJS re-lays the page on window resize anyway. */
+@media (max-width: 1100px) {
+	.po-band .po-band-dbs {
+		flex-basis: 100%;
+		border-left: 0;
+		border-top: 1px solid var(--pa-border);
+		padding: 16px 0 0;
+	}
 }
 
 .omicSummaryBox, .metaboliteBox {
@@ -5655,7 +6245,13 @@ div.omicSummaryBox.expandedBox, div.metaboliteBox.expandedBox{
    single column of them made the card twice as tall as its own prose. */
 .po-example-tests ul {
 	margin: 0;
-	padding-left: 18px;
+	/* Hung markers, like every other list this design draws (the hero's AI
+	   panel is the pattern): the item's box starts on the card rail and the
+	   bullet is drawn inside the indent the text steps past. With the ul
+	   carrying padding-left instead, every item's box sat 18px right of the
+	   prose above it - one rail per card was the whole point of these cards. */
+	padding: 0;
+	list-style: none;
 	columns: 2;
 	column-gap: 28px;
 	font-size: 12.5px;
@@ -5664,6 +6260,20 @@ div.omicSummaryBox.expandedBox, div.metaboliteBox.expandedBox{
 }
 .po-example-tests li {
 	break-inside: avoid;
+	position: relative;
+	padding-left: 18px;
+}
+/* Drawn, not typed, for the reason the hero's squares are: a marker that is
+   not a character is not selected with the text and not read out loud. */
+.po-example-tests li::before {
+	content: "";
+	position: absolute;
+	left: 0;
+	top: 0.6em;
+	width: 5px;
+	height: 5px;
+	border-radius: 1px;
+	background: var(--pa-ink-muted, #595959);
 }
 .po-example-actions {
 	margin-top: 14px;

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -547,7 +547,8 @@ a:hover {color: var(--pa-link-hover);}
    boundary, while the neutral makes 3.59. Ink #24252A is 15.29 and the
    destructive #B3261E is 6.54. */
 .mainTopToolbar .button,
-.secondTopToolbar .button {
+.secondTopToolbar .button,
+.paToolbarMiniature .button {
 	display: inline-flex;
 	align-items: center;
 	gap: 6px;
@@ -580,7 +581,8 @@ a:hover {color: var(--pa-link-hover);}
 	color: #FFFFFF;
 }
 .mainTopToolbar .button.btn-danger,
-.secondTopToolbar .button.btn-danger {
+.secondTopToolbar .button.btn-danger,
+.paToolbarMiniature .button.btn-danger {
 	background-color: #FFFFFF;
 	color: #B3261E;
 	border-color: #878787;
@@ -5668,6 +5670,76 @@ div.omicSummaryBox.expandedBox, div.metaboliteBox.expandedBox{
 	width: 100%;
 }
 
+/* "Multiple databases used", "Configure the number of clusters" and the
+   metabolite-threshold card each take a full row of the step-2 flex layout.
+   They used to share a row under `align-items: stretch`, so the short config
+   card was stretched to the height of the two database tables beside it - a
+   column of white with four fields in its top corner. On its own row a card
+   is exactly as tall as its content. The id outranks the class shorthand's
+   `flex-basis` above; grow/shrink from that rule still apply. */
+#dbs_message, #clusternumber_box, #threshold_box {
+	flex-basis: 100%;
+}
+/* The empty "parity pad" containers Step 2 inserts after each full-width card
+   exist for one reason: browsers without :has() lay the cards out with the
+   odd/even floats, and the pads keep that parity intact. In the flex layout
+   they are actively harmful - a zero-width flex item still owns a 22px gap on
+   each side, so the row after the pads packed as [pad, pad, card] and the
+   card sat 44px off the left rail with its partner wrapped to the next row.
+   Hide them exactly where the flex layout applies: behind the same :has()
+   support gate. !important, because they are ExtJS containers and this must
+   win whatever the layout writes. */
+@supports selector(:has(*)) {
+	.x-column-layout-ct .paLayoutPad { display: none !important; }
+}
+/* The config fields inside the two full-width cards stay centred. The form
+   panel itself is stretched to the card by its vbox, and each field row is a
+   600px table that ExtJS positions with inline `left: 0; margin: 0` - the
+   config's `margin: 0 auto` never survives - so at full card width the fields
+   hugged the left edge. left:50% + translateX(-50%) centres each row under
+   any card width, and the !important is what lets a stylesheet outrank the
+   inline left. All rows share the same 600px width, so their labels still
+   align with each other. */
+#clusternumber_box .x-form-item,
+#threshold_box .x-form-item {
+	left: 50% !important;
+	transform: translateX(-50%);
+}
+/* ...and the 50% must resolve against the real card, not ExtJS's memory of it.
+   The panel body and box containers carry inline pixel widths measured before
+   the flex rules widened the card (815px inside a 1358px panel, observed), and
+   ExtJS does not re-measure on a CSS-driven size change. Stretching the chain
+   to 100% makes the centring above resolve against the card's true width. */
+#clusternumber_box .x-panel-body.divForm,
+#threshold_box .x-panel-body.divForm,
+#clusternumber_box .divForm .x-box-inner,
+#threshold_box .divForm .x-box-inner,
+#clusternumber_box .divForm .x-box-target,
+#threshold_box .divForm .x-box-target {
+	width: 100% !important;
+	margin-left: 0 !important;
+	margin-right: 0 !important;
+}
+
+/* The step-2 illustration of the pathway-view toolbar. It is drawn with the
+   toolbar's own markup and .button rules rather than a screenshot, so it
+   cannot fall out of date the way settingsbutton.png (2022) did - a restyle
+   of the real buttons restyles this figure in the same stroke. Not
+   interactive: it is a picture that happens to be made of markup. */
+.paToolbarMiniature {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	align-items: center;
+	gap: 8px;
+	margin: 15px auto 5px;
+	pointer-events: none;
+}
+/* The one button the caption is pointing at. */
+.paToolbarMiniature .paMiniatureTarget {
+	box-shadow: 0 0 0 2px #B3261E;
+}
+
 /********************************************************************************
 ** REGISTRATION FORM
 *********************************************************************************/
@@ -7216,14 +7288,25 @@ div.repDetectionCard h3 {
 	/* Keyed off the class buildAnalysisTOC sets, so the column is only reserved
 	   on views that actually have a contents list. The pathway view has none and
 	   gets the full width. */
+	/* One rail for the whole page. The TOC used to sit at --pa-gutter-railed
+	   (which bottoms out at 40px) while the header wordmark sits at --pa-gutter
+	   (~96-110px on laptops, and ~103px further right at every width) - two
+	   left edges that never coincided, directly under each other. The header's
+	   own comment states the contract ("the wordmark lines up with the left
+	   edge of the content beneath it"), so the wordmark's rail is the master:
+	   the TOC starts on it, the results column starts after gutter + rail, and
+	   the leftover space flows to the right - the docs-site grid. The cost is
+	   ~56-68px of empty margin at laptop widths, paid for a page where every
+	   left edge derives from one token. --pa-gutter-railed keeps its definition
+	   for anything external that read it, but nothing here does any more. */
 	#mainViewCenterPanel.pa-has-toc {
-		padding-left: calc(var(--pa-rail) + var(--pa-gutter-railed));
-		padding-right: var(--pa-gutter-railed);
+		padding-left: calc(var(--pa-gutter) + var(--pa-rail));
+		padding-right: max(40px, calc(100vw - var(--pa-gutter) - var(--pa-rail) - var(--pa-page-max)));
 	}
 	.pa-toc {
 		position: fixed;
 		top: 62px;
-		left: var(--pa-gutter-railed);
+		left: var(--pa-gutter);
 		width: 190px;
 		max-height: calc(100vh - 84px);
 		overflow-y: auto;

--- a/PaintomicsClient/public_html/resources/css/network-views.css
+++ b/PaintomicsClient/public_html/resources/css/network-views.css
@@ -49,7 +49,18 @@
 	flex-wrap: wrap;
 	align-items: center;
 	gap: 0;
-	padding: 6px 8px;
+	/* The bar's own inset is derived, not chosen, because what has to land on
+	   the card's rail is the first control's *icon* - not the bar, and not the
+	   control's box. A tool carries 1px of margin, 1px of transparent border and
+	   8px of padding before its icon starts, so the bar is inset by the card
+	   rail less those 10px and the icon comes out on 26px exactly. The same
+	   subtraction on the right puts the last control's icon on the right rail.
+
+	   Written as 8px this card stacked three different left edges: the `h2` on
+	   --pa-card-inset (26px, so x=293 on a 1440px window), the first tool's icon
+	   on 18px (285), and the status line under it on 12px (279). Three rails
+	   inside one card, none of them agreeing with the heading that names it. */
+	padding: 6px calc(var(--pa-card-inset, 26px) - 10px);
 	background: var(--pa-surface-toolbar, #F6F5F0);
 	border-bottom: 1px solid var(--pa-border);
 	font-size: 12px;
@@ -260,7 +271,11 @@
    now carry one. */
 .pa-net-subtitle,
 .more-net-subtitle {
-	padding: 7px 12px;
+	/* The card rail, so this line starts under the `h2` that names the panel and
+	   under the first tool's icon in the bar between them, rather than on a 12px
+	   inset of its own. It is prose, so its own edge is where its glyphs start -
+	   no subtraction needed here, unlike the toolbar above. */
+	padding: 7px var(--pa-card-inset, 26px);
 	font-size: 12px;
 	line-height: 1.5;
 	color: var(--pa-ink-muted, #595959);
@@ -310,7 +325,11 @@
 	.pa-net-toolbar,
 	.more-net-toolbar {
 		gap: 3px;
-		padding: 6px 8px;
+		/* Same derivation as the full-width rule, restated only because this
+		   block is changing `gap`. Writing the literal back here would undo the
+		   rail below 900px, which is where the wrapping makes a ragged left edge
+		   easiest to see. */
+		padding: 6px calc(var(--pa-card-inset, 26px) - 10px);
 	}
 
 	:root {

--- a/PaintomicsServer/src/AdminTools/DBManager.py
+++ b/PaintomicsServer/src/AdminTools/DBManager.py
@@ -31,6 +31,10 @@ from scripts.downloadReactome import *
 
 VERSION = 0.12
 
+# Degradations that did not stop an install, collected so the run ends with one
+# readable list instead of leaving them scattered through a multi-hour log.
+INSTALL_WARNINGS = []
+
 
 # ------------------------------------------------------------------------------------------
 # ------------------------------------------------------------------------------------------
@@ -352,19 +356,28 @@ def download_command(inputfile=None, specie=None, kegg=0, mapping=0, common=0, r
         exit(0)
 
 
-def install_command(inputfile=None, specie=None, common=0, hub=1):
+def install_command(inputfile=None, specie=None, species=None, common=0, hub=1, reinstall=0):
     """
     Install the information for given species
     Usage: AdminTools.py install <options>
     Examples:
               ./DBManager.py install --specie=mmu --common=0 --hub=1
+              ./DBManager.py install --species=hsa,mmu,ath --common=0 --hub=0
+              ./DBManager.py install --species=hsa,mmu --reinstall=1
 
     Keyword arguments:
-        from_file -- a file containing a list of a list of species IDs (one per line) to be installed
-        specie    -- a valid KEGG specie code e.g. mmu, hsa
+        inputfile -- a file containing a list of species IDs (one per line) to be installed
+        specie    -- a single valid KEGG specie code e.g. mmu, hsa
+        species   -- a comma-separated list of species codes, e.g. hsa,mmu,ath
         common    -- (optional) 1 if Pathways info (classification, PNG images...) should be reinstalled, 0 to keep from previous version. Default=0
+        hub       -- (optional) 1 to build the hub-analysis data. Default=1
+        reinstall -- (optional) 1 to rebuild from the data already in current/ without
+                     promoting anything from download/. Default=0
+
+    A species whose data is missing is skipped with a warning rather than ending the
+    run, so one absent organism cannot cost a batch the other nineteen.
     """
-    if inputfile == None and specie == None:
+    if inputfile == None and specie == None and species == None:
         print("Organisms not specified, please type ./DBManager.py install -h for help")
         exit(-1)
 
@@ -404,10 +417,22 @@ def install_command(inputfile=None, specie=None, common=0, hub=1):
 
     INSTALLED_SPECIES = []
     ERRONEOUS_SPECIES = []
+    SKIPPED_SPECIES = []
 
     SPECIES_INSTALL = None
     if inputfile != None:
         SPECIES_INSTALL = readFile(inputfile)  # THE IDS FOR THE SPECIES TO UPDATE
+    elif species != None:
+        # Comma-separated list. Order is preserved so a run reads the way it was asked
+        # for, and duplicates collapse rather than installing the same species twice.
+        SPECIES_INSTALL = {}
+        for code in str(species).split(","):
+            code = code.strip()
+            if code:
+                SPECIES_INSTALL[code] = 1
+        if not SPECIES_INSTALL:
+            print("No valid species found in --species=" + str(species))
+            exit(-1)
     else:
         SPECIES_INSTALL = {specie: 1}  # THE IDS FOR THE SPECIES TO UPDATE
 
@@ -435,19 +460,48 @@ def install_command(inputfile=None, specie=None, common=0, hub=1):
         downloadSpecieDir = os.path.join(downloadDir, specie_to_check)
         currentSpecieDir = os.path.join(currentDataDir, specie_to_check)
 
-        # Check if data exists in either download or current directory
+        # Check if data exists in either download or current directory.
+        #
+        # Skip, do not exit. Killing the whole run for one absent species means a batch
+        # of twenty loses the nineteen that were ready -- and with --inputfile or a
+        # comma-separated list that is the normal case, not an edge case. The species is
+        # dropped from this run and named again in the closing summary.
+        # --reinstall builds from current/ only, so that is the directory that has to
+        # exist; a staged download is irrelevant to it.
+        if reinstall and not os.path.isdir(currentSpecieDir):
+            msg = (f"'{specie_to_check}' is not installed ({currentSpecieDir} does not "
+                   f"exist), so there is nothing to reinstall -- run install first")
+            log("WARNING: " + msg)
+            summary.write(f"{specie_to_check}\tREINSTALL\tSKIPPED\tnot installed\n")
+            INSTALL_WARNINGS.append((specie_to_check, msg))
+            SKIPPED_SPECIES.append(specie_to_check)
+            continue
+
         if not os.path.isdir(downloadSpecieDir) and not os.path.isdir(currentSpecieDir):
-            error_msg = f"ERROR: Cannot find data for species '{specie_to_check}' in either download ({downloadSpecieDir}) or current ({currentSpecieDir}) directories. Please download the species data first using the download command."
-            log(error_msg)
-            summary.write(error_msg + '\n')
-            summary.close()
-            exit(1)
+            msg = (f"no data for '{specie_to_check}' in either {downloadSpecieDir} or "
+                   f"{currentSpecieDir} -- run the download command for it first")
+            log("WARNING: " + msg)
+            summary.write(f"{specie_to_check}\tINSTALL\tSKIPPED\tno downloaded data\n")
+            INSTALL_WARNINGS.append((specie_to_check, msg))
+            SKIPPED_SPECIES.append(specie_to_check)
+            continue
 
         # Log which directory will be used
-        if os.path.isdir(downloadSpecieDir):
+        if reinstall:
+            log(f"Species '{specie_to_check}': will rebuild in place from current/")
+        elif os.path.isdir(downloadSpecieDir):
             log(f"Species '{specie_to_check}': will use new data from download directory")
         else:
             log(f"Species '{specie_to_check}': will reinstall using existing data from current directory")
+
+    # Drop the skipped ones so the install loop below never sees them.
+    for skipped in SKIPPED_SPECIES:
+        SPECIES_INSTALL.pop(skipped, None)
+
+    if not SPECIES_INSTALL:
+        log("Nothing to install: every requested species is missing its downloaded data.")
+        summary.close()
+        exit(1)
 
     # **************************************************************************
     # STEP 2. INSTALLING KEGG GLOBAL/HUB DATA
@@ -559,16 +613,21 @@ def install_command(inputfile=None, specie=None, common=0, hub=1):
                 log("STEP EXTRA: [" + hubSpecie + "] Hub data staged in the download directory; "
                     "the species install below moves it into current/.")
     except Exception as e:
-        log("        FAILED WHILE INSTALLING HUB ANALYSIS INFORMATION. UNABLE TO CONTINUE. ABORTING!!")
-        summary.write('FAILED WHILE INSTALLING HUB ANALYSIS INFORMATION. UNABLE TO CONTINUE. ABORTING!!\n')
+        # Hub analysis is an optional panel, not the species. Aborting the whole install
+        # for it is why 170 runs in the production summary.log say "UNABLE TO CONTINUE"
+        # -- every one of those species could have been installed without it and simply
+        # shown no Hub Analysis section. Warn, drop the partial hub tree, carry on.
+        log("WARNING: hub analysis could not be built (" + str(e) + ")")
+        log("         -> the species installs WITHOUT hub data; the Hub Analysis panel "
+            "will be unavailable until it is rebuilt with --hub=1")
+        summary.write('HUB ANALYSIS SKIPPED (species still installed): ' + str(e) + '\n')
+        INSTALL_WARNINGS.append(("hub analysis", str(e)))
         # rmtree, not rmdir: rmdir cannot remove a non-empty directory, so a crash after
         # the first .RData was written left the partial tree in place and every later
         # run treated it as a finished install.
         if hubDir:
             shutil.rmtree(hubDir, ignore_errors=True)
         errorlog(e)
-        summary.close()
-        exit(1)
     # ********************************************************************************
     # STEP 2.A.1 IF WE CHOOSED TO DONWLOAD THE GENERAL DATA (PATHWAYS CLASSIFICATION, ETC.)
     # ********************************************************************************
@@ -620,27 +679,52 @@ def install_command(inputfile=None, specie=None, common=0, hub=1):
             # Lift it out, move the species, then put it back. The two are now independent:
             # the species move only ever sees real species data, and hub data cannot be
             # destroyed by it.
-            stagedHubDir = os.path.join(downloadDir, specie, "hubData")
-            heldHubDir = None
-            if hub_data_is_complete(stagedHubDir):
-                heldHubDir = os.path.join(downloadDir, "_hub_hold_" + specie)
-                if os.path.isdir(heldHubDir):
-                    shutil.rmtree(heldHubDir, ignore_errors=True)
-                shutil.move(stagedHubDir, heldHubDir)
-                # A download/<specie> left holding nothing must not trigger a move at all.
-                stagedSpecieDir = os.path.join(downloadDir, specie)
-                if os.path.isdir(stagedSpecieDir) and not os.listdir(stagedSpecieDir):
-                    os.rmdir(stagedSpecieDir)
+            # --reinstall rebuilds the database from what is already in current/ and
+            # touches no directories at all: nothing is promoted, archived, or moved.
+            # That is the whole point -- re-running a build after a code fix should not
+            # risk the installed data, and should not need the download tree to exist.
+            if reinstall:
+                log("        REINSTALL: rebuilding from " + dirNameAux + " (no species data is moved)")
+                # ...with one exception. The hub step above always stages into
+                # download/<specie>/hubData and relies on the species move to carry it
+                # across -- a move reinstall deliberately skips. Without this, a
+                # `reinstall --hub=1` builds the hub data, leaves all 1,637 files in
+                # download/, and reports SUCCESS with nothing installed.
+                stagedHubDir = os.path.join(downloadDir, specie, "hubData")
+                if hub_data_is_complete(stagedHubDir):
+                    installedHubDir = os.path.join(currentDataDir, specie, "hubData")
+                    if os.path.isdir(installedHubDir):
+                        shutil.rmtree(installedHubDir, ignore_errors=True)
+                    shutil.move(stagedHubDir, installedHubDir)
+                    log("        Hub analysis data installed into " + installedHubDir)
+            else:
+                stagedHubDir = os.path.join(downloadDir, specie, "hubData")
+                heldHubDir = None
+                if hub_data_is_complete(stagedHubDir):
+                    heldHubDir = os.path.join(downloadDir, "_hub_hold_" + specie)
+                    if os.path.isdir(heldHubDir):
+                        shutil.rmtree(heldHubDir, ignore_errors=True)
+                    shutil.move(stagedHubDir, heldHubDir)
+                    # A download/<specie> left holding nothing must not trigger a move at all.
+                    stagedSpecieDir = os.path.join(downloadDir, specie)
+                    if os.path.isdir(stagedSpecieDir) and not os.listdir(stagedSpecieDir):
+                        os.rmdir(stagedSpecieDir)
 
-            replaceNewVersionData(downloadDir, currentDataDir, specie, oldDataDir)
-
-            if heldHubDir:
-                installedHubDir = os.path.join(currentDataDir, specie, "hubData")
-                if os.path.isdir(installedHubDir):
-                    shutil.rmtree(installedHubDir, ignore_errors=True)
-                os.makedirs(os.path.dirname(installedHubDir), exist_ok=True)
-                shutil.move(heldHubDir, installedHubDir)
-                log("        Hub analysis data installed into " + installedHubDir)
+                # try/finally, because the restore has to happen on the failure path too.
+                # Without it, a promotion that raises between the two moves leaves the
+                # hub data orphaned in download/_hub_hold_<specie> and absent from
+                # current/ -- found as a real 60 MB directory stranded by an install that
+                # the guard had refused hours earlier.
+                try:
+                    replaceNewVersionData(downloadDir, currentDataDir, specie, oldDataDir)
+                finally:
+                    if heldHubDir and os.path.isdir(heldHubDir):
+                        installedHubDir = os.path.join(currentDataDir, specie, "hubData")
+                        if os.path.isdir(installedHubDir):
+                            shutil.rmtree(installedHubDir, ignore_errors=True)
+                        os.makedirs(os.path.dirname(installedHubDir), exist_ok=True)
+                        shutil.move(heldHubDir, installedHubDir)
+                        log("        Hub analysis data installed into " + installedHubDir)
 
             installSpecieData(specie, installLog, dirNameAux, str(step) + "/" + total,
                               ROOT_DIRECTORY + "AdminTools/scripts/")
@@ -675,6 +759,29 @@ def install_command(inputfile=None, specie=None, common=0, hub=1):
     # **************************************************************************
     log("")
     log("STEP " + str(currentStep) + ". CLOSING LOG FILES, GENERATING VERSION FILE")
+
+    # One readable block at the end. A multi-species run previously left the operator to
+    # reconstruct what happened by reading the whole log; the three lists below are the
+    # answer to "what do I have now, and what do I need to go back for".
+    # Assembled first, then emitted in one loop. log() derives its indentation from the
+    # source line's own indentation, so emitting these from inside an if/for staircases
+    # the output; building the lines up front keeps the block aligned.
+    summaryLines = ["", "=" * 62, "INSTALL SUMMARY", "=" * 62,
+                    "  installed : %d  %s" % (len(INSTALLED_SPECIES), " ".join(INSTALLED_SPECIES) or "-"),
+                    "  failed    : %d  %s" % (len(ERRONEOUS_SPECIES), " ".join(ERRONEOUS_SPECIES) or "-"),
+                    "  skipped   : %d  %s" % (len(SKIPPED_SPECIES), " ".join(SKIPPED_SPECIES) or "-")]
+
+    if INSTALL_WARNINGS:
+        summaryLines.append("  warnings  : %d (installed anyway)" % len(INSTALL_WARNINGS))
+        summaryLines.extend("      %s: %s" % (subject, detail) for subject, detail in INSTALL_WARNINGS)
+    else:
+        summaryLines.append("  warnings  : none")
+
+    summaryLines.append("=" * 62)
+
+    for summaryLine in summaryLines:
+        log(summaryLine)
+
     summary.close()
 
     version = open(currentDataDir + 'VERSION', 'a')
@@ -775,7 +882,11 @@ def replaceNewVersionData(origin, destination, dirname, backup_dir):
     if os.path.isdir(source_path) and os.path.isdir(dest_path):
         sourceFiles = set(os.listdir(source_path))
         destFiles = set(os.listdir(dest_path))
-        missing = destFiles - sourceFiles
+        # hubData is deliberately kept OUT of the download tree (see the species move
+        # below), so it is missing from every staged directory by design. Counting it
+        # here made this guard fire on every reinstall of a species that has hub data --
+        # 87 of the 105 installed species -- which blocked reinstalling any of them.
+        missing = destFiles - sourceFiles - {"hubData"}
         if missing:
             raise Exception(
                 "Refusing to install '" + dirname + "': the download directory is missing " +
@@ -789,6 +900,24 @@ def replaceNewVersionData(origin, destination, dirname, backup_dir):
     # Check if new data exists in download directory
     if os.path.isdir(source_path):
         # We have new data to install
+
+        # Carry hub data across the move.
+        #
+        # Exempting hubData from the guard above is only half the job: the promotion
+        # archives dest_path wholesale and moves source_path into its place, so an
+        # installed hubData that the download tree does not have would be left behind in
+        # old/ -- silently, since the guard no longer objects. Verified by doing exactly
+        # that to mmu: 1,869 files, 60 MB, gone from current/ and reported as SUCCESS.
+        #
+        # Hold it aside and put it back once the new tree is in place. It is moved, not
+        # copied, so this costs nothing on the same filesystem.
+        heldHubData = None
+        installedHubData = os.path.join(dest_path, "hubData")
+        if os.path.isdir(installedHubData) and not os.path.isdir(os.path.join(source_path, "hubData")):
+            heldHubData = os.path.join(os.path.dirname(dest_path), "_hubdata_hold_" + dirname)
+            if os.path.isdir(heldHubData):
+                shutil.rmtree(heldHubData, ignore_errors=True)
+            shutil.move(installedHubData, heldHubData)
 
         # 1. Handle Backup: If destination exists, move it to backup
         if os.path.exists(dest_path):
@@ -815,6 +944,12 @@ def replaceNewVersionData(origin, destination, dirname, backup_dir):
             
         # Move source to destination
         shutil.move(source_path, dest_path)
+
+        # Put the held hub data back into the freshly promoted tree.
+        if heldHubData:
+            shutil.move(heldHubData, os.path.join(dest_path, "hubData"))
+            log(f"Preserved existing hub data for {dirname} across the update")
+
         log(f"Installed new data for {dirname}")
         
     elif os.path.isdir(dest_path):
@@ -868,6 +1003,31 @@ def hub_data_is_complete(path):
             return False
 
     return any(entry.endswith(".RData") for entry in entries)
+
+
+def reinstall_command(species=None, specie=None, inputfile=None, common=0, hub=0):
+    """
+    Rebuild the database for species that are already installed, without downloading.
+    Usage: AdminTools.py reinstall <options>
+    Examples:
+              ./DBManager.py reinstall --species=hsa,mmu,ath
+              ./DBManager.py reinstall --specie=ath --hub=1
+              ./DBManager.py reinstall --inputfile=species.txt
+
+    Reads only from KEGG_DATA/current/<specie>/ and moves nothing: no promotion from
+    download/, no archiving under old/. Use it after fixing build code, or to pick up a
+    parser change, without re-fetching gigabytes that have not changed.
+
+    A species that is not installed is skipped with a warning; the rest still run.
+    `hub` defaults to 0 here because rebuilding hub data is the slow part and is rarely
+    what you want from a re-run -- pass --hub=1 to include it.
+    """
+    if species == None and specie == None and inputfile == None:
+        print("Organisms not specified, please type ./DBManager.py reinstall -h for help")
+        exit(-1)
+
+    return install_command(inputfile=inputfile, specie=specie, species=species,
+                           common=common, hub=hub, reinstall=1)
 
 
 def restorePreviousVersionData(origin, destination, dirname, backup_dir):
@@ -1198,10 +1358,34 @@ def getSpecieMappingData(specie, downloadLog, dirName, step, scriptsDir):
     return mapping_errors
 
 
+def collectBuildWarnings(specie):
+    """Pull the sources the species build had to do without into the run summary.
+
+    The build runs as a subprocess, so without this its warnings only ever reach
+    install.log -- which is precisely the multi-MB file nobody reads to the end.
+    """
+    handoff = "/tmp/build_warnings.tmp"
+    if not os.path.isfile(handoff):
+        return
+    try:
+        with open(handoff) as handle:
+            for line in handle:
+                parts = line.rstrip("\n").split("\t")
+                if len(parts) >= 4 and parts[0] == specie:
+                    INSTALL_WARNINGS.append((specie + " / " + parts[1], parts[2] + " -> " + parts[3]))
+                    log("       ! " + parts[1] + ": " + parts[3])
+        os.remove(handoff)
+    except Exception as readError:
+        errorlog("could not read build warnings for " + specie + ": " + str(readError))
+
+
 def installSpecieData(specie, downloadLog, dirName, step, scriptsDir):
     start_time = time()
     log("                 INSTALLING MAPPING DATA FOR " + specie + " (" + step + ")...")
     downloadLogFile = open(downloadLog, 'a')
+    # Never inherit a previous species' warnings.
+    if os.path.isfile("/tmp/build_warnings.tmp"):
+        os.remove("/tmp/build_warnings.tmp")
 
     try:
         if os.path.isfile(scriptsDir + specie + "_resources/build_database.py"):
@@ -1231,6 +1415,9 @@ def installSpecieData(specie, downloadLog, dirName, step, scriptsDir):
         raise ex
     finally:
         downloadLogFile.close()
+        # In `finally` so a species that failed still reports what it was missing --
+        # that list is usually the explanation for the failure.
+        collectBuildWarnings(specie)
     return True
 
 

--- a/PaintomicsServer/src/AdminTools/DBManager.py
+++ b/PaintomicsServer/src/AdminTools/DBManager.py
@@ -12,7 +12,7 @@ import os
 #     os.environ["PATH"] = os.path.join(VENV_DIR, "bin") + os.pathsep + os.environ.get("PATH", "")
 #     os.execv(VENV_PYTHON, [VENV_PYTHON] + sys.argv)
 
-import datetime, traceback, shutil, inspect
+import datetime, traceback, shutil, inspect, tempfile
 import logging
 import logging.config
 import requests
@@ -1358,34 +1358,58 @@ def getSpecieMappingData(specie, downloadLog, dirName, step, scriptsDir):
     return mapping_errors
 
 
-def collectBuildWarnings(specie):
+def newBuildWarningsHandoff():
+    """A private file for one species build to report its skipped sources in.
+
+    mkstemp rather than a fixed name, for three reasons. Two installs running at
+    once on the same machine wrote to the same path and read each other's
+    warnings. /tmp is world-writable and a predictable name there is a file
+    anyone can pre-create as a symlink onto something we then truncate. And a
+    fixed path has to be deleted before every build to avoid inheriting the
+    previous species' list -- a fresh file cannot be stale, so that step is gone.
+
+    Created 0600 by mkstemp and handed to the child through the environment;
+    the fd is closed immediately because only the subprocess writes to it.
+    """
+    handle, path = tempfile.mkstemp(prefix="paintomics_build_warnings_", suffix=".tsv")
+    os.close(handle)
+    return path
+
+
+def collectBuildWarnings(specie, handoffPath):
     """Pull the sources the species build had to do without into the run summary.
 
     The build runs as a subprocess, so without this its warnings only ever reach
     install.log -- which is precisely the multi-MB file nobody reads to the end.
     """
-    handoff = "/tmp/build_warnings.tmp"
-    if not os.path.isfile(handoff):
+    if not handoffPath or not os.path.isfile(handoffPath):
         return
     try:
-        with open(handoff) as handle:
+        with open(handoffPath) as handle:
             for line in handle:
                 parts = line.rstrip("\n").split("\t")
                 if len(parts) >= 4 and parts[0] == specie:
                     INSTALL_WARNINGS.append((specie + " / " + parts[1], parts[2] + " -> " + parts[3]))
                     log("       ! " + parts[1] + ": " + parts[3])
-        os.remove(handoff)
     except Exception as readError:
         errorlog("could not read build warnings for " + specie + ": " + str(readError))
+    finally:
+        # In `finally`: a read that throws half way must not leave the file behind.
+        # A long batch would otherwise leak one per species into /tmp.
+        try:
+            os.remove(handoffPath)
+        except OSError:
+            pass
 
 
 def installSpecieData(specie, downloadLog, dirName, step, scriptsDir):
     start_time = time()
     log("                 INSTALLING MAPPING DATA FOR " + specie + " (" + step + ")...")
     downloadLogFile = open(downloadLog, 'a')
-    # Never inherit a previous species' warnings.
-    if os.path.isfile("/tmp/build_warnings.tmp"):
-        os.remove("/tmp/build_warnings.tmp")
+    # Where this build reports what it had to do without. Named in the environment
+    # because check_call below passes no `env=`, so the child inherits ours.
+    handoffPath = newBuildWarningsHandoff()
+    os.environ["PAINTOMICS_BUILD_WARNINGS"] = handoffPath
 
     try:
         if os.path.isfile(scriptsDir + specie + "_resources/build_database.py"):
@@ -1415,9 +1439,12 @@ def installSpecieData(specie, downloadLog, dirName, step, scriptsDir):
         raise ex
     finally:
         downloadLogFile.close()
+        # Cleared before the read, so nothing downstream can inherit a pointer to a
+        # file collectBuildWarnings is about to delete.
+        os.environ.pop("PAINTOMICS_BUILD_WARNINGS", None)
         # In `finally` so a species that failed still reports what it was missing --
         # that list is usually the explanation for the failure.
-        collectBuildWarnings(specie)
+        collectBuildWarnings(specie, handoffPath)
     return True
 
 

--- a/PaintomicsServer/src/AdminTools/DBManager.py
+++ b/PaintomicsServer/src/AdminTools/DBManager.py
@@ -13,6 +13,7 @@ import os
 #     os.execv(VENV_PYTHON, [VENV_PYTHON] + sys.argv)
 
 import datetime, traceback, shutil, inspect, tempfile
+import json
 import logging
 import logging.config
 import requests
@@ -261,7 +262,32 @@ def download_command(inputfile=None, specie=None, kegg=0, mapping=0, common=0, r
 
             if reactome:
                 log("STEP " + str(currentStep) + " Extra. DOWNLOADING REACTOME Files...")
-                downloadReactome(specie)
+                try:
+                    downloadReactome(specie)
+                except Exception as reactomeError:
+                    # Coverage is a fact about Reactome's current release, not an
+                    # error in this run: ptr (chimpanzee) has zero rows in the
+                    # 2026 ReactomePathwaysRelation dump while 15 other species
+                    # keep theirs. A species Reactome no longer projects onto
+                    # installs KEGG-only (the build already fail-softs on the
+                    # missing reactome directory); everything else - network
+                    # failures mid-crawl included - still fails the species so a
+                    # transient error cannot silently strip Reactome from it.
+                    if "No pathway relations found" in str(reactomeError):
+                        log("        WARNING: " + str(reactomeError).splitlines()[0])
+                        log("        -> Reactome's current release does not cover this organism; continuing with KEGG data only.")
+                        # Record the drop in the staged tree itself. The
+                        # promotion guard reads this marker to let the install
+                        # retire the previously installed Reactome artifacts
+                        # (which this tree legitimately lacks) instead of
+                        # refusing the whole species -- without it, the
+                        # KEGG-only outcome promised above was unreachable for
+                        # any species previously installed WITH Reactome.
+                        with open(datadir + REACTOME_NOT_COVERED_MARKER, 'w') as marker:
+                            marker.write("# Reactome release does not cover this organism. Recorded: " +
+                                         strftime("%Y%m%d %H%M") + "\n")
+                    else:
+                        raise
 
             # STEP 2.B.1 IF USER SPECIFIED THAT KEGG DATA SHOULD BE DOWNLOADED, DOWNLOAD THE KEGG DATA, OTHERWISE COPY PREVIOUS DATA (IF EXISTS)
             # 2 = updateKegg, 3 = updateKegg && updateMapping
@@ -637,6 +663,16 @@ def install_command(inputfile=None, specie=None, species=None, common=0, hub=1, 
             replaceNewVersionData(downloadDir, currentDataDir, "common", oldDataDir)
             installCommonData(currentDataDir + "common/", ROOT_DIRECTORY + "AdminTools/scripts/")
             currentStep += 1
+    except PromotionRefused as e:
+        # The guard said no BEFORE anything moved: current/common and the
+        # database are untouched, so there is nothing to restore -- and the
+        # restore below would promote the stale old/common archive over the
+        # healthy installed one. Report the refusal and stop.
+        log("        REFUSED TO INSTALL COMMON INFORMATION -- the installed data was left untouched. ABORTING!!")
+        summary.write('REFUSED TO INSTALL COMMON INFORMATION (installed data left untouched): ' + str(e) + '\n')
+        errorlog(e)
+        summary.close()
+        exit(1)
     except Exception as e:
         # TODO: RESTORE
         restorePreviousVersionData(oldDataDir, currentDataDir, "common", downloadDir + "error/")
@@ -731,6 +767,18 @@ def install_command(inputfile=None, specie=None, species=None, common=0, hub=1, 
             INSTALLED_SPECIES.append(specie)
             summary.write(specie + '\tINSTALL\tSUCCESS\t' + str(SPECIES_INSTALL[specie]) + '\n')
             log("INSTALL  " + str(SPECIES_INSTALL[specie]) + " " + specie + "...SUCCESS\n")
+        except PromotionRefused as e:
+            # Nothing moved and Mongo was never touched: the species is exactly
+            # as installed. The rollback below would promote the stale
+            # old/<specie> archive over the intact installation and rebuild the
+            # database from it -- a silent one-version regression triggered by
+            # nothing more than a stale download directory -- so a refusal is
+            # reported and the installed data left alone.
+            summary.write(specie + '\tINSTALL\tREFUSED\t' + str(SPECIES_INSTALL[specie]) + '\n')
+            log("INSTALL  " + str(SPECIES_INSTALL[specie]) + " " + specie +
+                "...REFUSED (installed data left untouched)\n")
+            errorlog(e)
+            ERRONEOUS_SPECIES.append(specie)
         except Exception as e:
             restorePreviousVersionData(oldDataDir, currentDataDir, specie, downloadDir + "error/")
             installSpecieData(specie, installLog, dirNameAux, str(step) + "/" + total,
@@ -852,7 +900,24 @@ def findolder_command(nDays):
 # ---  AUXILIAR FUNCTIONS                                                               ----
 # ------------------------------------------------------------------------------------------
 
-def replaceNewVersionData(origin, destination, dirname, backup_dir):
+# Written into download/<specie>/ when the Reactome crawl discovers the current
+# release no longer projects onto the organism; read by the promotion guard below.
+REACTOME_NOT_COVERED_MARKER = "REACTOME_NOT_COVERED"
+
+
+class PromotionRefused(Exception):
+    """The never-lose-files guard vetoed a promotion BEFORE anything moved.
+
+    This must stay distinguishable from a failure that happened mid-install:
+    on a refusal, current/<dirname> and the imported database are exactly as
+    they were, so the install_command failure path has nothing to roll back --
+    and rolling back anyway would promote the stale old/<dirname> archive over
+    a healthy installation and rebuild Mongo from it, silently regressing the
+    species one version.
+    """
+
+
+def replaceNewVersionData(origin, destination, dirname, backup_dir, isRestore=False):
     """
     Replace data in destination with data from origin.
     If origin data doesn't exist, check if we're doing a reinstall (data already in destination).
@@ -879,16 +944,49 @@ def replaceNewVersionData(origin, destination, dirname, backup_dir):
     #
     # Refuse instead. Deleting a known-stale download to proceed is a decision an admin
     # can make in one command; recovering silently archived data is not.
-    if os.path.isdir(source_path) and os.path.isdir(dest_path):
+    if os.path.isdir(source_path) and os.path.isdir(dest_path) and not isRestore:
         sourceFiles = set(os.listdir(source_path))
         destFiles = set(os.listdir(dest_path))
         # hubData is deliberately kept OUT of the download tree (see the species move
         # below), so it is missing from every staged directory by design. Counting it
         # here made this guard fire on every reinstall of a species that has hub data --
         # 87 of the 105 installed species -- which blocked reinstalling any of them.
-        missing = destFiles - sourceFiles - {"hubData"}
+        #
+        # The named files below are in the same class for the same reason: they are
+        # GENERATED by the build that runs after this promotion (mergeNetworkFiles and
+        # the Reactome/MapMan pathway processing write them into current/<specie>), so
+        # no download directory ever contains them and comparing them here refused
+        # every reinstall of an installed species. Verified against a fresh
+        # `download --kegg=1 --mapping=1 --reactome=1` of sce on 2026-08-13: the run
+        # imported the new database, then this guard refused the file promotion and
+        # the species was reported FAILED with its fresh downloads stranded.
+        # The previous versions are not lost by exempting them: the promotion archives
+        # the whole installed directory under old/ before the build regenerates them.
+        GENERATED_AT_BUILD = {
+            "hubData",
+            "pathways_network.json",
+            "REACTOME_VERSION", "gene2pathway_reactome.list",
+            "pathways_network_Reactome.json",
+            "MAPMAN_VERSION", "MAPMAN_MAPPING", "gene2pathway_mapman.list",
+            "pathways_network_MapMan.json",
+        }
+        exempt = set(GENERATED_AT_BUILD)
+        # A download that discovered Reactome no longer covers this organism
+        # records the fact in its own staged tree (see download_command).
+        # Retiring the previously installed Reactome artifacts is then the
+        # POINT of the promotion, not a loss -- they are archived under old/
+        # with the rest of the tree. Without this, the coverage fail-soft was
+        # unreachable for any species previously installed WITH Reactome: the
+        # staged tree legitimately lacked reactome/ and this guard refused
+        # every install of it. The marker itself is per-download metadata, so
+        # an old marker left in the installed tree must never block a later,
+        # Reactome-carrying download either -- hence unconditionally exempt.
+        exempt.add(REACTOME_NOT_COVERED_MARKER)
+        if REACTOME_NOT_COVERED_MARKER in sourceFiles:
+            exempt |= {"reactome", "ReactomePathway.txt", "ReactomePathwayHierarchy.json"}
+        missing = destFiles - sourceFiles - exempt
         if missing:
-            raise Exception(
+            raise PromotionRefused(
                 "Refusing to install '" + dirname + "': the download directory is missing " +
                 str(len(missing)) + " file(s) that the installed one has, so promoting it "
                 "would delete them (" + ", ".join(sorted(missing)[:6]) +
@@ -1031,7 +1129,12 @@ def reinstall_command(species=None, specie=None, inputfile=None, common=0, hub=0
 
 
 def restorePreviousVersionData(origin, destination, dirname, backup_dir):
-    replaceNewVersionData(origin, destination, dirname, backup_dir)
+    # A restore intentionally rolls back to an OLDER tree, which may lack files
+    # the failed newer install had (pfa's pre-Reactome archive vs its fresh
+    # download, observed 2026-08-13: the never-lose-files guard vetoed the
+    # rollback and the failure path itself failed). Losing the newer files is
+    # the point of a rollback, so the guard does not apply here.
+    replaceNewVersionData(origin, destination, dirname, backup_dir, isRestore=True)
 
 def downloadKEGGOrganismList(message, logFile, dirName, fileName, delay, maxTries):
     """
@@ -1190,6 +1293,7 @@ def downloadKEGGFile(message, logFile, URL, dirName, fileName, delay, maxTries):
     log(message)
 
     nTry = 1
+    lastError = None
     while nTry <= maxTries:
         wait(delay)
         try:
@@ -1225,11 +1329,24 @@ def downloadKEGGFile(message, logFile, URL, dirName, fileName, delay, maxTries):
             with open(logFile, 'a') as log_file:
                 log_file.write(f"{strftime('%Y-%m-%d %H:%M:%S')} - Error downloading {fileName}: {str(e)}\n")
 
+            lastError = e
+            # A 400 is KEGG's contract answer -- "this list/conversion does not
+            # exist" -- not a transient fault, so retrying it can never succeed.
+            # Stop immediately and let the caller classify it; the retries were
+            # pure added latency on every organism KEGG does not fully cover.
+            status = getattr(getattr(e, "response", None), "status_code", None)
+            if status == 400:
+                break
             # Only log "Trying again" if we actually will try again
             if nTry < maxTries:
                 errorlog("FAIL! Trying again... " + str(nTry + 1) + " of " + str(maxTries))
             nTry += 1
-    raise Exception('Unable to retrieve ' + fileName + " from " + URL)
+    # The cause must ride in the exception text, not only in the log file:
+    # getSpecieMappingData decides whether a failure is permanent ("400 Client
+    # Error" = KEGG does not offer this conversion) by reading str(e), and the
+    # old bare message hid the status - bvu's 400 was retried and then failed
+    # the species even after the 400-as-absence handling landed.
+    raise Exception('Unable to retrieve ' + fileName + " from " + URL + ": " + str(lastError))
 
 
 def getSpecieKeggData(specie, downloadLog, dirName, step):
@@ -1313,40 +1430,55 @@ def getSpecieMappingData(specie, downloadLog, dirName, step, scriptsDir):
 
         # we tolerate that some of the files fail on download
         error_tolerance = 3
-        try:
-            downloadKEGGFile("             * KEGG TO NCBI GeneID", downloadLog,
-                             "https://rest.kegg.jp/conv/" + specie + "/ncbi-geneid", dirName, "ncbi-geneid2kegg.list",
-                             DOWNLOAD_DELAY_1, MAX_TRIES_1)
-        except Exception as e:
-            error_tolerance -= 1;
-            mapping_errors += " ncbi-geneid"
-            if error_tolerance == 0:
-                raise Exception(
-                    "Too many errors while downloading the KEGG mapping files for organism " + specie + ": " + mapping_errors)
-            log("                       Failed!! The download process will continue...")
 
-        try:
-            downloadKEGGFile("             * KEGG TO Uniprot", downloadLog,
-                             "https://rest.kegg.jp/conv/" + specie + "/uniprot", dirName, "uniprot2kegg.list",
-                             DOWNLOAD_DELAY_1, MAX_TRIES_1)
-        except Exception as e:
-            error_tolerance -= 1;
-            mapping_errors += " uniprot2kegg"
-            if error_tolerance == 0:
-                raise Exception(
-                    "Too many errors while downloading the KEGG mapping files for organism " + specie + ": " + mapping_errors)
-            log("                       Failed!! The download process will continue...")
+        # A mapping list KEGG does not offer for this organism answers HTTP 400.
+        # That is a contract answer, not a transient failure: dosa (rice, keyed
+        # by RAP-DB ids) gets 400 for /conv/dosa/ncbi-geneid on every attempt,
+        # and csau's pathways and KGML download fine while /list/csau answers
+        # 400 -- a per-endpoint coverage gap, not an invalid organism (that
+        # case fails the KEGG data phase minutes earlier). Counting it as a
+        # mapping error failed the whole species at the end of the download.
+        # The build side already tolerates the file's absence
+        # (processKEGGMappingData warns "Unable to find ... MAPPING file" and
+        # continues), so absence is the correct translation of a 400 here.
+        # Transient errors keep their old accounting: they are real failures
+        # and still fail the species.
+        def keggDoesNotOfferIt(exc):
+            return "400 Client Error" in str(exc)
 
-        try:
-            downloadKEGGFile("             * KEGG TO Gene Symbol", downloadLog, "https://rest.kegg.jp/list/" + specie,
-                             dirName, "kegg2genesymbol.list", DOWNLOAD_DELAY_1, MAX_TRIES_1)
-        except Exception as e:
-            error_tolerance -= 1;
-            mapping_errors += " kegg2genesymbol"
-            if error_tolerance == 0:
-                raise Exception(
-                    "Too many errors while downloading the KEGG mapping files for organism " + specie + ": " + mapping_errors)
-            log("                       Failed!! The download process will continue...")
+        # One body for the three endpoint downloads below. This logic was
+        # copy-pasted per endpoint and the copies had already drifted in
+        # wording; any change to the classification must hit all of them.
+        def downloadMappingList(message, url, fileName, errorKey, absenceNote):
+            nonlocal error_tolerance, mapping_errors
+            try:
+                downloadKEGGFile(message, downloadLog, url, dirName, fileName,
+                                 DOWNLOAD_DELAY_1, MAX_TRIES_1)
+            except Exception as e:
+                if keggDoesNotOfferIt(e):
+                    log("                       " + absenceNote)
+                else:
+                    error_tolerance -= 1
+                    mapping_errors += " " + errorKey
+                    if error_tolerance == 0:
+                        raise Exception(
+                            "Too many errors while downloading the KEGG mapping files for organism " + specie + ": " + mapping_errors)
+                    log("                       Failed!! The download process will continue...")
+
+        downloadMappingList("             * KEGG TO NCBI GeneID",
+                            "https://rest.kegg.jp/conv/" + specie + "/ncbi-geneid",
+                            "ncbi-geneid2kegg.list", "ncbi-geneid",
+                            "KEGG offers no ncbi-geneid conversion for " + specie + " (HTTP 400); continuing without it.")
+
+        downloadMappingList("             * KEGG TO Uniprot",
+                            "https://rest.kegg.jp/conv/" + specie + "/uniprot",
+                            "uniprot2kegg.list", "uniprot2kegg",
+                            "KEGG offers no uniprot conversion for " + specie + " (HTTP 400); continuing without it.")
+
+        downloadMappingList("             * KEGG TO Gene Symbol",
+                            "https://rest.kegg.jp/list/" + specie,
+                            "kegg2genesymbol.list", "kegg2genesymbol",
+                            "KEGG offers no gene list for " + specie + " (HTTP 400); continuing without gene symbols.")
 
         # downloadKEGGFile("             * KEGG TO NCBI GI", downloadLog,  "http://rest.kegg.jp/conv/"+ specie +"/ncbi-gi", dirName, "ncbi-gi2kegg.list",  DOWNLOAD_DELAY_1, MAX_TRIES_1)
 
@@ -1542,9 +1674,16 @@ def getCurrentInstalledSpecies():
                 downloaded = "downloading"
             else:
                 downloaded = False
-                # Erroneous download not removed --> remove
-                if os.path.isdir(KEGG_DATA_DIR + 'download/' + organism_code):
-                    shutil.rmtree(KEGG_DATA_DIR + 'download/' + organism_code)
+                # This used to rmtree the directory as an "erroneous download not
+                # removed". A getter must not delete: a parallel `download` process
+                # wipes and recreates download/<sp> BEFORE it writes the DOWNLOADING
+                # flag, and in that window this cleanup saw an unmarked directory and
+                # destroyed it under the running download. Observed 2026-08-13: an
+                # `install --specie=ath` deleted download/bta out from under bta's
+                # Reactome crawl (which then died on a vanished output path), and this
+                # rmtree itself crashed the whole ath install when bta's error handler
+                # moved the remains to error/ mid-delete. The download step wipes its
+                # own directory at start, so stale leftovers cost nothing by staying.
 
             databaseList.append({
                 "organism_name": organism_name,
@@ -1571,6 +1710,25 @@ def generateAvailableSpeciesFile(VALID_SPECIES, species_file, installed_species_
                 species[row[1]] = row[2]
         csvfile.close()
 
+        # Custom species (customSpeciesInstaller.py) register their display
+        # names in organisms_custom.list beside organisms_all.list, because the
+        # latter is re-downloaded from KEGG on a common refresh and would drop
+        # them. A code installed in Mongo but absent from this lookup takes the
+        # raise-branch below and aborts species.json for EVERY species, so the
+        # merge is what keeps one custom organism from poisoning every later
+        # standard install.
+        # quoting=csv.QUOTE_NONE: the display names are admin-supplied
+        # (customSpeciesInstaller validates --code but not --name), and the
+        # default dialect treats a leading double quote as a field delimiter --
+        # swallowing the tab and dropping the row, which re-triggers the
+        # every-species abort this merge exists to prevent.
+        custom_file = os.path.join(os.path.dirname(species_file), "organisms_custom.list")
+        if os.path.isfile(custom_file):
+            with open(custom_file) as fh:
+                for row in csv.reader(fh, delimiter='\t', quoting=csv.QUOTE_NONE):
+                    if len(row) >= 3:
+                        species[row[1]] = row[2]
+
         listAux = []
         for specie in VALID_SPECIES:
             if isinstance(specie, dict):
@@ -1588,7 +1746,12 @@ def generateAvailableSpeciesFile(VALID_SPECIES, species_file, installed_species_
         for i, specieCode in enumerate(VALID_SPECIES):
             name = species.get(specieCode, "")
             if name != "":
-                name = '\t{"name": "' + name + '", "value": "' + specieCode + '"}'
+                # json.dumps, not string concatenation: a quote or backslash in
+                # an admin-supplied custom species name would otherwise write an
+                # unparseable species.json and break the organism dropdown for
+                # every user (customSpeciesInstaller's own regenerate uses
+                # json.dumps for the same reason).
+                name = '\t{"name": ' + json.dumps(name) + ', "value": ' + json.dumps(specieCode) + '}'
                 if i < total - 1:
                     name += ","
                 file_content += name + '\n'

--- a/PaintomicsServer/src/AdminTools/customSpeciesInstaller.py
+++ b/PaintomicsServer/src/AdminTools/customSpeciesInstaller.py
@@ -1,0 +1,761 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Install a CUSTOM species from a gene→KO annotation table.
+
+Serves organisms KEGG does not cover (Nicotiana benthamiana, Trichoderma
+harzianum, ...). The user supplies a functional annotation produced by
+eggNOG-mapper, BlastKOALA/KAAS, or any tool that assigns KEGG Orthology (KO)
+identifiers to genes. This tool synthesizes everything the Paintomics runtime
+reads for a species, using KEGG's *reference* KO pathways (ko00010-style KGML,
+type="ortholog" entries) instead of per-organism pathway files.
+
+The runtime contract this satisfies (verified against the live code 2026-08-14):
+
+  * ``<code>-paintomics.kegg``     one doc per pathway; ``genes[].id`` is matched
+                                   case-insensitively against ``xref.display_id``
+                                   (PathwayAcquisitionJob.py:1751-1755). We store
+                                   bare KO ids ("K00001") on both sides.
+  * ``<code>-paintomics.xref``     identifier graph. Step 1 matches the user's
+                                   feature names on ``display_id`` (no dbname
+                                   filter), unwinds ``mates`` and keeps mates of
+                                   the target dbname (FeatureNamesToKeggIDsMapper
+                                   .py:114-143). Species without an organismDB
+                                   entry fall back to targets ``kegg_id`` +
+                                   ``kegg_gene_symbol`` — both dbname docs MUST
+                                   exist or the mapper's forked workers die
+                                   (FeatureNamesToKeggIDsMapper.py:209-210).
+  * ``<code>-paintomics.dbname``   the ID-type registry backing the above.
+  * ``<code>-paintomics.versions`` "KEGG" + "MAPPING" docs (AdminServlet.py:132
+                                   indexes [0] and 500s without them).
+  * ``current/<code>/gene2pathway.list``  read unconditionally by the metagenes
+                                   R script (generateMetaGenes.R:104); lines are
+                                   ``<code>:<featureID>\tpath:<code><number>``.
+  * ``current/common/organisms_all.list`` must contain the code or species.json
+                                   regeneration aborts (DBManager.py:1675-1680)
+                                   — including regeneration triggered by any
+                                   LATER standard install.
+  * ``current/species.json``       the organism dropdown.
+  * Pathway diagram PNGs are species-independent (current/common/png/map*.png);
+    only maps newer than the local common snapshot are fetched, with 300px
+    thumbnails to match the installed ones.
+
+Deliberately NOT produced (all degrade cleanly): ``hubData/`` (guards at
+PathwayAcquisitionJob.py:2296/2528), ``pathways_network.json`` (empty tab),
+Reactome/MapMan collections (source checkboxes simply absent).
+
+Usage:
+  python customSpeciesInstaller.py \
+      --code=nben --name="Nicotiana benthamiana" \
+      --lineage="Eukaryotes;Plants;Eudicots;Nightshade family" \
+      --annotation=/path/to/annotation.tsv \
+      --scope-organism=nta [--dry-run] [--verify-only]
+
+Annotation format (auto-detected):
+  * eggNOG-mapper ``.emapper.annotations`` (TSV, ``#query`` header line), or
+  * generic TSV with a header row: first column = feature id, plus a column
+    whose name contains ``ko`` (case-insensitive; cells like ``ko:K00001,ko:K00002``
+    or ``K00001``), optional ``name``/``description`` columns.
+  Feature ids ending in ``.<digits>`` are treated as transcripts and registered
+  both as-is and collapsed to their gene id.
+"""
+import argparse
+import gzip
+import json
+import os
+import random
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as XMLParser
+from collections import defaultdict
+from datetime import datetime
+
+KEGG_REST = "https://rest.kegg.jp"
+KO_RE = re.compile(r"^K\d{5}$")
+TRANSCRIPT_SUFFIX_RE = re.compile(r"\.\d+$")
+# Pathway classes whose reference maps make no sense outside their taxon when
+# no --scope-organism narrows the map set for us.
+DEFAULT_EXCLUDED_CLASSES = ("Human Diseases", "Drug Development")
+_ID_ALPHABET = "0123456789abcdefABCDEF"  # same alphabet the standard build mints
+
+
+# --------------------------------------------------------------------------- #
+#  Small utilities                                                            #
+# --------------------------------------------------------------------------- #
+
+def log(msg):
+    sys.stdout.write(msg + "\n")
+    sys.stdout.flush()
+
+
+def serverconf():
+    """Best-effort import of the app configuration (defensive: the tool must
+    stay usable on a build host where src/ is not importable)."""
+    try:
+        here = os.path.dirname(os.path.abspath(__file__))
+        src = os.path.dirname(here)
+        if src not in sys.path:
+            sys.path.insert(0, src)
+        from conf import serverconf as sc
+        return sc
+    except Exception:
+        return None
+
+
+class KeggCache(object):
+    """Cached, rate-limited KEGG REST fetcher. Files persist in cache_dir so a
+    re-run (or a second custom species) costs no repeat downloads."""
+
+    def __init__(self, cache_dir, min_interval=0.35):
+        self.cache_dir = cache_dir
+        self.min_interval = min_interval
+        self._last = 0.0
+        os.makedirs(cache_dir, exist_ok=True)
+
+    def fetch(self, path, cache_name, binary=False, optional=False):
+        target = os.path.join(self.cache_dir, cache_name)
+        if os.path.isfile(target) and os.path.getsize(target) > 0:
+            mode = "rb" if binary else "r"
+            with open(target, mode) as fh:
+                return fh.read()
+        wait = self.min_interval - (time.time() - self._last)
+        if wait > 0:
+            time.sleep(wait)
+        self._last = time.time()
+        url = KEGG_REST + path
+        try:
+            with urllib.request.urlopen(url, timeout=90) as resp:
+                payload = resp.read()
+        except urllib.error.HTTPError as ex:
+            if optional and ex.code in (400, 404):
+                return None
+            raise
+        tmp = target + ".part"
+        with open(tmp, "wb") as fh:
+            fh.write(payload)
+        os.replace(tmp, target)  # atomic: no truncated cache entries
+        return payload if binary else payload.decode("utf-8", "replace")
+
+
+def generate_random_id(used):
+    while True:
+        rid = "".join(random.choices(_ID_ALPHABET, k=24))
+        if rid not in used:
+            used.add(rid)
+            return rid
+
+
+# --------------------------------------------------------------------------- #
+#  Annotation parsing                                                         #
+# --------------------------------------------------------------------------- #
+
+def _extract_kos(cell):
+    kos = set()
+    for token in re.split(r"[,;\s]+", (cell or "").strip()):
+        token = token.strip().replace("ko:", "")
+        if KO_RE.match(token):
+            kos.add(token)
+    return kos
+
+
+def parse_annotation(path):
+    """Return (gene2ko, transcript2gene, gene_meta).
+
+    gene2ko: gene id -> set(KO); transcript2gene: transcript id -> gene id
+    (only where the two differ); gene_meta: gene id -> (name, description).
+    Handles eggNOG-mapper native output and generic TSV. Blank/'-'/'#' KO cells
+    mean "no assignment" and the feature is skipped (an unmapped feature and an
+    absent feature behave identically in Step 1).
+    """
+    opener = gzip.open if path.endswith(".gz") else open
+    gene2ko = defaultdict(set)
+    transcript2gene = {}
+    gene_meta = {}
+
+    def _columns_from(header):
+        lowered = [h.strip().lower() for h in header]
+        ko = next((i for i, h in enumerate(lowered)
+                   if "kegg_ko" in h or h == "ko"), None)
+        if ko is None:
+            ko = next((i for i, h in enumerate(lowered) if "ko" in h), 1)
+        name = next((i for i, h in enumerate(lowered)
+                     if "preferred_name" in h or h == "name"), None)
+        desc = next((i for i, h in enumerate(lowered) if "description" in h), None)
+        return ko, name, desc
+
+    with opener(path, "rt", encoding="utf-8-sig", errors="replace") as fh:
+        ko_col = None  # columns resolve on the first header/data line
+        name_col = desc_col = None
+        for raw in fh:
+            line = raw.rstrip("\n")
+            if not line or line.startswith("##"):
+                continue
+            if ko_col is None:
+                if line.startswith("#"):  # eggNOG-mapper '#query ...' header
+                    ko_col, name_col, desc_col = _columns_from(
+                        line.lstrip("#").split("\t"))
+                    continue
+                first = line.split("\t")
+                # A header row never carries a K-number outside column 0; if
+                # this first line already looks like data, fall back to the
+                # positional layout (id<TAB>ko) and process the line itself.
+                if any(_extract_kos(c) for c in first[1:]):
+                    ko_col, name_col, desc_col = 1, None, None
+                else:
+                    ko_col, name_col, desc_col = _columns_from(first)
+                    continue
+            cols = line.split("\t")
+            if len(cols) <= ko_col:
+                continue
+            qid = cols[0].strip()
+            if not qid:
+                continue
+            kos = _extract_kos(cols[ko_col])
+            gid = TRANSCRIPT_SUFFIX_RE.sub("", qid)
+            if gid != qid:
+                transcript2gene[qid] = gid
+            if not kos:
+                continue
+            gene2ko[gid].update(kos)
+            if gid not in gene_meta:
+                name = cols[name_col].strip() if name_col is not None and len(cols) > name_col else ""
+                desc = cols[desc_col].strip() if desc_col is not None and len(cols) > desc_col else ""
+                if name in ("-", "#", "nan"):
+                    name = ""
+                if desc in ("-", "#", "nan"):
+                    desc = ""
+                gene_meta[gid] = (name, desc[:300])
+    return gene2ko, transcript2gene, gene_meta
+
+
+# --------------------------------------------------------------------------- #
+#  KEGG reference data                                                        #
+# --------------------------------------------------------------------------- #
+
+def load_reference(cache, scope_organism):
+    """Fetch the small global tables: map list, KO->map links, KO names, BRITE
+    classes and (optionally) the scope organism's own pathway list."""
+    map_names = {}
+    for line in cache.fetch("/list/pathway", "list_pathway.tsv").splitlines():
+        if "\t" in line:
+            pid, name = line.split("\t", 1)
+            map_names[pid.replace("path:", "").strip()] = name.strip()
+
+    ko2maps = defaultdict(set)
+    for line in cache.fetch("/link/pathway/ko", "link_pathway_ko.tsv").splitlines():
+        if "\t" not in line:
+            continue
+        ko, path = line.split("\t")
+        ko = ko.replace("ko:", "").strip()
+        path = path.replace("path:", "").strip()
+        if path.startswith("map"):  # every link is duplicated in ko-space; keep one
+            ko2maps[ko].add(path)
+
+    ko_names = {}
+    for line in cache.fetch("/list/ko", "list_ko.tsv").splitlines():
+        if "\t" not in line:
+            continue
+        ko, name = line.split("\t", 1)
+        ko = ko.replace("ko:", "").strip()
+        symbol = name.split(";")[0].split(",")[0].strip()
+        ko_names[ko] = (symbol, name.strip()[:300])
+
+    classes = {}
+    cur_a, cur_b = "", ""
+    for line in cache.fetch("/get/br:br08901", "br08901.txt").splitlines():
+        if line.startswith("A"):
+            cur_a = line[1:].strip()
+        elif line.startswith("B  "):
+            cur_b = line[3:].strip()
+        elif line.startswith("C    "):
+            num = line[5:].split()[0]
+            classes["map" + num] = cur_a + ";" + cur_b
+
+    scope_maps = None
+    if scope_organism:
+        listing = cache.fetch("/list/pathway/" + scope_organism,
+                              "list_pathway_%s.tsv" % scope_organism)
+        scope_maps = set()
+        for line in listing.splitlines():
+            pid = line.split("\t")[0].strip()
+            num = re.sub(r"\D", "", pid)
+            if len(num) == 5:
+                scope_maps.add("map" + num)
+        if not scope_maps:
+            raise SystemExit("Scope organism '%s' returned no pathways — is the "
+                             "code right?" % scope_organism)
+    return map_names, ko2maps, ko_names, classes, scope_maps
+
+
+def select_maps(gene2ko, ko2maps, classes, scope_maps):
+    annotated_kos = set().union(*gene2ko.values()) if gene2ko else set()
+    hit = defaultdict(set)
+    for ko in annotated_kos:
+        for m in ko2maps.get(ko, ()):
+            hit[m].add(ko)
+    selected = {}
+    for m, kos in hit.items():
+        if scope_maps is not None:
+            if m not in scope_maps:
+                continue
+        else:
+            cls = classes.get(m, "")
+            if cls.split(";")[0] in DEFAULT_EXCLUDED_CLASSES:
+                continue
+        selected[m] = kos
+    return annotated_kos, selected
+
+
+def parse_ko_kgml(xml_bytes, annotated_kos):
+    """Flatten one reference KGML exactly the way the standard installer does
+    (common_build_database.py:2852-2911), with two deliberate differences:
+    entries are type="ortholog" (the reference-map flavour of "gene"), and only
+    KOs present in THIS organism's annotation are kept, so pathway gene sets —
+    and therefore the Step 2 enrichment universe — describe the organism, not
+    the whole reference map."""
+    genes, compounds, related = [], [], []
+    root = XMLParser.fromstring(xml_bytes)
+    own_number = re.sub(r"\D", "", root.get("name") or "")
+    for child in root:
+        entry_type = child.get("type")
+        if entry_type not in ("ortholog", "compound", "map"):
+            continue  # same silent skip as the standard build
+        graphic = child.find("graphics")
+        if graphic is None:
+            continue
+        box = {
+            "x": graphic.get("x"),
+            "y": graphic.get("y"),
+            "height": graphic.get("height"),
+            "width": graphic.get("width"),
+        }
+        if entry_type == "ortholog":
+            for token in (child.get("name") or "").split(" "):
+                ko = token.replace("ko:", "").strip()
+                if ko in annotated_kos:
+                    entry = dict(box)
+                    entry["id"] = ko
+                    genes.append(entry)
+        elif entry_type == "compound":
+            for token in (child.get("name") or "").split(" "):
+                entry = dict(box)
+                entry["id"] = token.replace("cpd:", "").strip()
+                compounds.append(entry)
+        else:  # map
+            number = re.sub(r"\D", "", child.get("name") or "")
+            if len(number) != 5 or number == own_number:
+                continue
+            entry = dict(box)
+            entry["id"] = number
+            entry["name"] = graphic.get("name")
+            related.append(entry)
+    return genes, compounds, related
+
+
+# --------------------------------------------------------------------------- #
+#  Assembly                                                                   #
+# --------------------------------------------------------------------------- #
+
+def build_pathway_docs(code, cache, selected, map_names, classes, annotated_kos):
+    docs = []
+    skipped = []
+    for m in sorted(selected):
+        number = m.replace("map", "")
+        raw = cache.fetch("/get/ko%s/kgml" % number, "ko%s.xml" % number,
+                          binary=True, optional=True)
+        if raw is None:
+            skipped.append(m + " (no reference KGML)")
+            continue
+        genes, compounds, related = parse_ko_kgml(raw, annotated_kos)
+        if not genes:
+            # The link table said the map is hit but the diagram carries none of
+            # our KOs (global overview maps can differ); nothing would paint.
+            skipped.append(m + " (no annotated KO on the diagram)")
+            continue
+        docs.append({
+            "ID": code + number,
+            "name": map_names.get(m, m),
+            "classification": classes.get(m, "Unclassified;Unclassified"),
+            "source": "KEGG",       # anything else is filtered out of the UI
+            "featureDB": "kegg_id",
+            "genes": genes,
+            "compounds": compounds,
+            "relatedPathways": related,
+        })
+    return docs, skipped
+
+
+def build_identifier_graph(gene2ko, transcript2gene, gene_meta, ko_names,
+                           annotated_kos):
+    """Create dbname/xref documents. Mate topology (mirrors what the standard
+    build's shared-transcript mechanism produces):
+
+        gene    <-> its KOs, plus itself
+        transcript (id form with .N) <-> the same KOs, plus itself
+        KO      <-> itself, every gene/transcript carrying it, and its symbol
+        symbol  <-> itself and its KO
+
+    Self-mates matter: they are what lets a user upload KO ids (or symbols)
+    directly and still resolve to the kegg_id target."""
+    used_ids = set()
+    dbnames = {}
+    for name in ("kegg_id", "kegg_gene_symbol",
+                 "external_gene_id", "external_transcript_id"):
+        dbnames[name] = {"_id": generate_random_id(used_ids), "dbname": name}
+
+    xrefs = {}
+
+    def new_xref(display_id, dbname, description):
+        rid = generate_random_id(used_ids)
+        xrefs[rid] = {"_id": rid, "display_id": display_id,
+                      "dbname_id": dbnames[dbname]["_id"],
+                      "description": description, "mates": {rid}}
+        return rid
+
+    # KO rows cover EVERY annotated KO, not just those placed on a diagram, so
+    # Step 1 reports genes as mapped even when their pathways are out of scope
+    # (native species likewise carry xrefs for genes that sit in no pathway).
+    ko_row = {}
+    for ko in sorted(annotated_kos):
+        symbol, definition = ko_names.get(ko, ("", "KEGG Orthology " + ko))
+        ko_row[ko] = new_xref(ko, "kegg_id", definition)
+        if symbol:
+            sid = new_xref(symbol, "kegg_gene_symbol", definition)
+            xrefs[sid]["mates"].add(ko_row[ko])
+            xrefs[ko_row[ko]]["mates"].add(sid)
+
+    linked_genes = 0
+    for gid in sorted(gene2ko):
+        kos = sorted(k for k in gene2ko[gid] if k in ko_row)
+        if not kos:
+            continue  # its KOs sit only on out-of-scope maps
+        linked_genes += 1
+        name, desc = gene_meta.get(gid, ("", ""))
+        grow = new_xref(gid, "external_gene_id", desc or name)
+        for ko in kos:
+            xrefs[grow]["mates"].add(ko_row[ko])
+            xrefs[ko_row[ko]]["mates"].add(grow)
+
+    linked_transcripts = 0
+    for tid, gid in sorted(transcript2gene.items()):
+        kos = sorted(k for k in gene2ko.get(gid, ()) if k in ko_row)
+        if not kos:
+            continue
+        linked_transcripts += 1
+        trow = new_xref(tid, "external_transcript_id", "transcript of " + gid)
+        for ko in kos:
+            xrefs[trow]["mates"].add(ko_row[ko])
+            xrefs[ko_row[ko]]["mates"].add(trow)
+
+    for doc in xrefs.values():
+        doc["mates"] = sorted(doc["mates"])
+    return (list(dbnames.values()), list(xrefs.values()),
+            linked_genes, linked_transcripts)
+
+
+# --------------------------------------------------------------------------- #
+#  Writers                                                                    #
+# --------------------------------------------------------------------------- #
+
+def write_mongo(code, dbname_docs, xref_docs, kegg_docs, mongo_host, mongo_port):
+    from pymongo import MongoClient, ASCENDING
+    client = MongoClient(mongo_host, mongo_port)
+    db = client[code + "-paintomics"]
+    for collection, docs in (("dbname", dbname_docs), ("xref", xref_docs),
+                             ("kegg", kegg_docs)):
+        db[collection].drop()
+        for i in range(0, len(docs), 5000):
+            db[collection].insert_many(docs[i:i + 5000])
+    stamp = datetime.now().strftime("%Y%m%d %H%M")
+    db["versions"].drop()
+    db["versions"].insert_many([{"name": "KEGG", "date": stamp},
+                                {"name": "MAPPING", "date": stamp}])
+    # Same two indexes the standard build creates (common_build_database.py:3254)
+    db.xref.create_index([("dbname_id", ASCENDING), ("_id", ASCENDING)])
+    db.xref.create_index([("display_id", ASCENDING)])
+    client.close()
+
+
+def write_gene2pathway(kegg_data_dir, code, kegg_docs):
+    """generateMetaGenes.R re-prefixes matched feature ids with '<code>:', so
+    the left column must be code-prefixed KO ids (verified: generateMetaGenes.R
+    :194-195, live mmu file 'mmu:103988\tpath:mmu00010')."""
+    specie_dir = os.path.join(kegg_data_dir, "current", code)
+    os.makedirs(specie_dir, exist_ok=True)
+    path = os.path.join(specie_dir, "gene2pathway.list")
+    lines = 0
+    with open(path, "w") as fh:
+        for doc in kegg_docs:
+            for ko in sorted({g["id"] for g in doc["genes"]}):
+                fh.write("%s:%s\tpath:%s\n" % (code, ko, doc["ID"]))
+                lines += 1
+    return path, lines
+
+
+def register_in_organisms_list(kegg_data_dir, code, name, lineage):
+    """Append (or replace) the species line; a code missing from this file
+    aborts species.json generation for EVERY later install (DBManager.py:1675)."""
+    path = os.path.join(kegg_data_dir, "current", "common", "organisms_all.list")
+    tnumber = "T9%04d" % (sum(ord(c) for c in code) % 10000)
+    newline = "%s\t%s\t%s\t%s" % (tnumber, code, name, lineage)
+    lines = []
+    if os.path.isfile(path):
+        with open(path) as fh:
+            lines = [l.rstrip("\n") for l in fh]
+    lines = [l for l in lines if l.split("\t")[1:2] != [code]]
+    lines.append(newline)
+    tmp = path + ".tmp"
+    with open(tmp, "w") as fh:
+        fh.write("\n".join(lines) + "\n")
+    os.replace(tmp, path)
+    return path
+
+
+def regenerate_species_json(kegg_data_dir, mongo_host, mongo_port):
+    """Rewrite current/species.json from installed *-paintomics DBs, the same
+    source of truth DBManager uses (dropdown format verified live)."""
+    from pymongo import MongoClient
+    client = MongoClient(mongo_host, mongo_port)
+    codes = sorted(n[:-len("-paintomics")] for n in client.list_database_names()
+                   if n.endswith("-paintomics") and n != "global-paintomics")
+    client.close()
+    names = {}
+    listing = os.path.join(kegg_data_dir, "current", "common", "organisms_all.list")
+    with open(listing) as fh:
+        for line in fh:
+            row = line.rstrip("\n").split("\t")
+            if len(row) >= 3:
+                names[row[1]] = row[2]
+    missing = [c for c in codes if not names.get(c)]
+    if missing:
+        raise SystemExit("These installed species are missing from "
+                         "organisms_all.list: %s" % ", ".join(missing))
+    target = os.path.join(kegg_data_dir, "current", "species.json")
+    if os.path.isfile(target):
+        import shutil
+        shutil.copy(target, target + "_prev")
+    entries = ",\n".join('\t{"name": %s, "value": %s}'
+                         % (json.dumps(names[c]), json.dumps(c)) for c in codes)
+    with open(target, "w") as fh:
+        fh.write('{"success": true, "species": [\n' + entries + '\n]}')
+    return target, len(codes)
+
+
+def ensure_diagrams(kegg_data_dir, cache, kegg_docs, code):
+    """The shared common/png snapshot may predate newer KEGG maps; fetch any
+    diagram a custom pathway needs, plus a 300px thumbnail like the installed
+    ones (verified 300x300 boxes)."""
+    png_dir = os.path.join(kegg_data_dir, "current", "common", "png")
+    thumb_dir = os.path.join(png_dir, "thumbnails")
+    os.makedirs(thumb_dir, exist_ok=True)
+    fetched = []
+    for doc in kegg_docs:
+        number = doc["ID"].replace(code, "", 1)
+        png = os.path.join(png_dir, "map%s.png" % number)
+        thumb = os.path.join(thumb_dir, "map%s_thumb.png" % number)
+        if not os.path.isfile(png):
+            payload = cache.fetch("/get/map%s/image" % number,
+                                  "map%s.png" % number, binary=True, optional=True)
+            if payload is None:
+                log("  WARNING: no diagram image for map%s" % number)
+                continue
+            with open(png, "wb") as fh:
+                fh.write(payload)
+            fetched.append("map" + number)
+        if not os.path.isfile(thumb):
+            try:
+                from PIL import Image
+                img = Image.open(png)
+                img.thumbnail((300, 300))
+                img.save(thumb)
+            except Exception as ex:
+                log("  WARNING: thumbnail for map%s failed: %s" % (number, ex))
+    return fetched
+
+
+# --------------------------------------------------------------------------- #
+#  Verification                                                               #
+# --------------------------------------------------------------------------- #
+
+def verify(code, kegg_data_dir, mongo_host, mongo_port, sample_genes):
+    """Prove the install satisfies the runtime by running the exact aggregation
+    Step 1 runs (FeatureNamesToKeggIDsMapper.py:114-143) plus structural checks.
+    Returns a list of problems (empty == pass)."""
+    from pymongo import MongoClient
+    problems = []
+    client = MongoClient(mongo_host, mongo_port)
+    db = client[code + "-paintomics"]
+
+    target = db.dbname.find_one({"dbname": "kegg_id"})
+    symbol_db = db.dbname.find_one({"dbname": "kegg_gene_symbol"})
+    if target is None or symbol_db is None:
+        problems.append("dbname docs kegg_id/kegg_gene_symbol missing "
+                        "(mapper workers would crash)")
+    for doc in db.kegg.find({}, {"ID": 1, "source": 1, "genes": 1}):
+        if "ID" not in doc:
+            problems.append("kegg doc without ID (organism load would KeyError)")
+            break
+        if doc.get("source") != "KEGG":
+            problems.append("%s: source != KEGG" % doc.get("ID"))
+            break
+    for name in ("KEGG", "MAPPING"):
+        if db.versions.find_one({"name": name}) is None:
+            problems.append("versions doc %s missing (admin page 500s)" % name)
+
+    if target is not None:
+        resolved = 0
+        for gid in sample_genes:
+            hits = list(db.xref.aggregate([
+                {"$match": {"display_id": {"$in": [gid]}}},
+                {"$unwind": "$mates"},
+                {"$lookup": {"from": "xref", "localField": "mates",
+                             "foreignField": "_id", "as": "unwind_mate"}},
+                {"$unwind": "$unwind_mate"},
+                {"$match": {"unwind_mate.dbname_id": target["_id"]}},
+                {"$project": {"display_id": "$unwind_mate.display_id"}},
+            ]))
+            if hits:
+                resolved += 1
+        if sample_genes and resolved == 0:
+            problems.append("no sample gene resolved to a KO through the "
+                            "Step 1 aggregation")
+        else:
+            log("  verify: %d/%d sample genes resolve to KOs"
+                % (resolved, len(sample_genes)))
+
+    g2p = os.path.join(kegg_data_dir, "current", code, "gene2pathway.list")
+    if not os.path.isfile(g2p) or os.path.getsize(g2p) == 0:
+        problems.append("gene2pathway.list missing/empty (metagenes would fail "
+                        "step 2)")
+    species_json = os.path.join(kegg_data_dir, "current", "species.json")
+    try:
+        with open(species_json) as fh:
+            entries = json.load(fh)["species"]
+        if not any(e.get("value") == code for e in entries):
+            problems.append("species.json does not list %s" % code)
+    except Exception as ex:
+        problems.append("species.json unreadable: %s" % ex)
+    client.close()
+    return problems
+
+
+# --------------------------------------------------------------------------- #
+#  Main                                                                       #
+# --------------------------------------------------------------------------- #
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument("--code", required=True,
+                        help="organism code (letters only, must not collide "
+                             "with a KEGG code — check rest.kegg.jp/list/genome)")
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--lineage", default="Eukaryotes;Custom",
+                        help="semicolon lineage shown in admin tools")
+    parser.add_argument("--annotation",
+                        help="gene→KO table (eggNOG-mapper output or TSV)")
+    parser.add_argument("--scope-organism", default=None,
+                        help="KEGG code of a relative; restricts pathways to "
+                             "the maps KEGG assigns that organism (recommended)")
+    parser.add_argument("--kegg-data-dir", default=None)
+    parser.add_argument("--mongo-host", default=None)
+    parser.add_argument("--mongo-port", default=None, type=int)
+    parser.add_argument("--cache-dir", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--verify-only", action="store_true")
+    args = parser.parse_args()
+
+    if not re.match(r"^[a-z]{3,6}$", args.code):
+        raise SystemExit("--code must be 3-6 lowercase letters (a digit-free "
+                         "code keeps pathwayID.replace(organism,'map') safe)")
+
+    sc = serverconf()
+    kegg_data_dir = args.kegg_data_dir or (sc and sc.KEGG_DATA_DIR)
+    mongo_host = args.mongo_host or (sc and getattr(sc, "MONGODB_HOST", "localhost")) or "localhost"
+    mongo_port = args.mongo_port or (sc and getattr(sc, "MONGODB_PORT", 27017)) or 27017
+    if not kegg_data_dir:
+        raise SystemExit("--kegg-data-dir required (serverconf not importable)")
+    cache_dir = args.cache_dir or os.path.join(kegg_data_dir, "download",
+                                               "custom_species_cache")
+    cache = KeggCache(cache_dir)
+
+    if args.verify_only:
+        problems = verify(args.code, kegg_data_dir, mongo_host, mongo_port, [])
+        for p in problems:
+            log("PROBLEM: " + p)
+        raise SystemExit(1 if problems else 0)
+
+    if not args.annotation:
+        raise SystemExit("--annotation is required for an install")
+
+    log("STEP 1. Parsing annotation %s" % args.annotation)
+    gene2ko, transcript2gene, gene_meta = parse_annotation(args.annotation)
+    if not gene2ko:
+        raise SystemExit("No gene→KO assignments found — nothing to install.")
+    log("  %d genes with KO, %d transcript ids, %d distinct KOs"
+        % (len(gene2ko), len(transcript2gene),
+           len(set().union(*gene2ko.values()))))
+
+    log("STEP 2. Loading KEGG reference tables (cache: %s)" % cache_dir)
+    map_names, ko2maps, ko_names, classes, scope_maps = load_reference(
+        cache, args.scope_organism)
+    annotated_kos, selected = select_maps(gene2ko, ko2maps, classes, scope_maps)
+    log("  %d annotated KOs hit %d pathway maps%s"
+        % (len(annotated_kos), len(selected),
+           " (scoped to %s)" % args.scope_organism if scope_maps else
+           " (class-filtered)"))
+    if not selected:
+        raise SystemExit("No pathway maps selected — check the annotation and "
+                         "the scope organism.")
+
+    log("STEP 3. Building pathway documents from reference KGML")
+    kegg_docs, skipped = build_pathway_docs(args.code, cache, selected,
+                                            map_names, classes, annotated_kos)
+    for s in skipped:
+        log("  skipped %s" % s)
+    kos_in_pathways = {g["id"] for doc in kegg_docs for g in doc["genes"]}
+    log("  %d pathways, %d distinct KOs placed on diagrams"
+        % (len(kegg_docs), len(kos_in_pathways)))
+
+    log("STEP 4. Building identifier graph")
+    dbname_docs, xref_docs, n_genes, n_transcripts = build_identifier_graph(
+        gene2ko, transcript2gene, gene_meta, ko_names, annotated_kos)
+    log("  %d xref rows (%d genes, %d transcripts linked)"
+        % (len(xref_docs), n_genes, n_transcripts))
+
+    if not kegg_docs or not n_genes:
+        raise SystemExit("Refusing to install an empty species.")
+    if args.dry_run:
+        log("DRY RUN — nothing written.")
+        return
+
+    log("STEP 5. Writing MongoDB %s-paintomics" % args.code)
+    write_mongo(args.code, dbname_docs, xref_docs, kegg_docs,
+                mongo_host, mongo_port)
+
+    log("STEP 6. Writing species files")
+    g2p_path, g2p_lines = write_gene2pathway(kegg_data_dir, args.code, kegg_docs)
+    log("  %s (%d lines)" % (g2p_path, g2p_lines))
+    register_in_organisms_list(kegg_data_dir, args.code, args.name, args.lineage)
+    fetched = ensure_diagrams(kegg_data_dir, cache, kegg_docs, args.code)
+    if fetched:
+        log("  fetched %d missing diagrams: %s" % (len(fetched), ", ".join(fetched)))
+    target, n_species = regenerate_species_json(kegg_data_dir, mongo_host,
+                                                mongo_port)
+    log("  %s now lists %d species" % (target, n_species))
+
+    log("STEP 7. Verifying against the runtime contract")
+    sample = [g for g in list(gene2ko)[:200]
+              if any(k in kos_in_pathways for k in gene2ko[g])][:5]
+    problems = verify(args.code, kegg_data_dir, mongo_host, mongo_port, sample)
+    if problems:
+        for p in problems:
+            log("PROBLEM: " + p)
+        raise SystemExit(1)
+    log("SUCCESS: %s installed. New jobs can use it immediately; the organism "
+        "dropdown reads species.json per page load." % args.code)
+
+
+if __name__ == "__main__":
+    main()

--- a/PaintomicsServer/src/AdminTools/customSpeciesInstaller.py
+++ b/PaintomicsServer/src/AdminTools/customSpeciesInstaller.py
@@ -401,9 +401,15 @@ def build_identifier_graph(gene2ko, transcript2gene, gene_meta, ko_names,
     directly and still resolve to the kegg_id target."""
     used_ids = set()
     dbnames = {}
+    labels = {"kegg_id": "KEGG Orthology", "kegg_gene_symbol": "Gene symbol",
+              "external_gene_id": "Gene ID", "external_transcript_id": "Transcript ID"}
     for name in ("kegg_id", "kegg_gene_symbol",
                  "external_gene_id", "external_transcript_id"):
-        dbnames[name] = {"_id": generate_random_id(used_ids), "dbname": name}
+        # Same doc shape the standard build dumps (display_label/dbname_type are
+        # what the admin tools show), so custom species read identically there.
+        dbnames[name] = {"_id": generate_random_id(used_ids), "dbname": name,
+                         "display_label": labels[name],
+                         "dbname_type": "Identifier"}
 
     xrefs = {}
 
@@ -495,22 +501,32 @@ def write_gene2pathway(kegg_data_dir, code, kegg_docs):
 
 
 def register_in_organisms_list(kegg_data_dir, code, name, lineage):
-    """Append (or replace) the species line; a code missing from this file
-    aborts species.json generation for EVERY later install (DBManager.py:1675)."""
-    path = os.path.join(kegg_data_dir, "current", "common", "organisms_all.list")
+    """Register the species name where species.json generation looks it up.
+
+    A code missing from organisms_all.list aborts species.json generation for
+    EVERY later install (DBManager.py:1675). But organisms_all.list is
+    re-downloaded from KEGG by `download --common=1`, which would silently drop
+    a custom row — so the durable registry is a sibling organisms_custom.list
+    (same 4-column format, one row per custom species) that survives common
+    refreshes, plus the row appended to organisms_all.list for everything that
+    reads it today. Re-running after a common refresh restores the row.
+    """
+    common_dir = os.path.join(kegg_data_dir, "current", "common")
     tnumber = "T9%04d" % (sum(ord(c) for c in code) % 10000)
     newline = "%s\t%s\t%s\t%s" % (tnumber, code, name, lineage)
-    lines = []
-    if os.path.isfile(path):
-        with open(path) as fh:
-            lines = [l.rstrip("\n") for l in fh]
-    lines = [l for l in lines if l.split("\t")[1:2] != [code]]
-    lines.append(newline)
-    tmp = path + ".tmp"
-    with open(tmp, "w") as fh:
-        fh.write("\n".join(lines) + "\n")
-    os.replace(tmp, path)
-    return path
+    for basename in ("organisms_all.list", "organisms_custom.list"):
+        path = os.path.join(common_dir, basename)
+        lines = []
+        if os.path.isfile(path):
+            with open(path) as fh:
+                lines = [l.rstrip("\n") for l in fh]
+        lines = [l for l in lines if l.split("\t")[1:2] != [code]]
+        lines.append(newline)
+        tmp = path + ".tmp"
+        with open(tmp, "w") as fh:
+            fh.write("\n".join(lines) + "\n")
+        os.replace(tmp, path)
+    return os.path.join(common_dir, "organisms_all.list")
 
 
 def regenerate_species_json(kegg_data_dir, mongo_host, mongo_port):
@@ -522,12 +538,18 @@ def regenerate_species_json(kegg_data_dir, mongo_host, mongo_port):
                    if n.endswith("-paintomics") and n != "global-paintomics")
     client.close()
     names = {}
-    listing = os.path.join(kegg_data_dir, "current", "common", "organisms_all.list")
-    with open(listing) as fh:
-        for line in fh:
-            row = line.rstrip("\n").split("\t")
-            if len(row) >= 3:
-                names[row[1]] = row[2]
+    common_dir = os.path.join(kegg_data_dir, "current", "common")
+    # organisms_custom.list second: custom rows win, and they survive the
+    # KEGG-refresh clobber of organisms_all.list.
+    for basename in ("organisms_all.list", "organisms_custom.list"):
+        listing = os.path.join(common_dir, basename)
+        if not os.path.isfile(listing):
+            continue
+        with open(listing) as fh:
+            for line in fh:
+                row = line.rstrip("\n").split("\t")
+                if len(row) >= 3:
+                    names[row[1]] = row[2]
     missing = [c for c in codes if not names.get(c)]
     if missing:
         raise SystemExit("These installed species are missing from "

--- a/PaintomicsServer/src/AdminTools/scripts/common_build_database.py
+++ b/PaintomicsServer/src/AdminTools/scripts/common_build_database.py
@@ -284,12 +284,28 @@ def summariseBuild():
     stderr.write("=" * 62 + "\n")
 
     # Hand the warnings back to DBManager, which runs this build as a subprocess and
-    # otherwise only sees an exit status. Written even when empty so a stale file from
-    # a previous species is never mistaken for this one's result.
+    # otherwise only sees an exit status.
+    #
+    # The destination is whatever DBManager named in PAINTOMICS_BUILD_WARNINGS: a
+    # fresh 0600 file per species, not a fixed /tmp path that two concurrent installs
+    # would both write to and read each other's warnings out of. When the variable is
+    # absent there is no parent listening -- a build run by hand from the shell --
+    # so nothing is written and the summary above is the whole report.
+    handoffPath = os.environ.get("PAINTOMICS_BUILD_WARNINGS")
+    if not handoffPath:
+        return
+
+    # Tab-separated, one record per line, so a reason carrying either character
+    # would split into fields the reader then drops. These strings are file paths
+    # and str(exception), neither of which is under our control.
+    def oneLine(value):
+        return " ".join(str(value).split())
+
     try:
-        with open("/tmp/build_warnings.tmp", "w") as handle:
+        with open(handoffPath, "w") as handle:
             for label, reason, consequence in SKIPPED_SOURCES:
-                handle.write("\t".join([str(SPECIE), label, reason, consequence]) + "\n")
+                handle.write("\t".join([oneLine(SPECIE), oneLine(label),
+                                        oneLine(reason), oneLine(consequence)]) + "\n")
     except Exception as writeError:
         stderr.write("  (could not write the warning hand-off file: %s)\n" % writeError)
 

--- a/PaintomicsServer/src/AdminTools/scripts/common_build_database.py
+++ b/PaintomicsServer/src/AdminTools/scripts/common_build_database.py
@@ -162,11 +162,136 @@ def showPercentage(n, total, prev, errorMessage):
     # The cost is operability, not speed -- it is only ~0.16s -- but it buries the one
     # exception an admin needs after a multi-hour failure under tens of MB with no
     # newlines. Emitting only on change drops it to 11 lines per file.
+    #
+    # Silent unless PAINTOMICS_INSTALL_VERBOSE=1. A progress bar is for a human watching
+    # a terminal; this output goes to a shared install.log that is read after the fact,
+    # where it only makes the real messages harder to find.
     percen = int(n/float(total)*10)
-    if percen == prev:
-        return prev
+    if percen == prev or not VERBOSE:
+        return percen
     stderr.write("0%[" + ("#"*percen) + (" "*(10 - percen)) + "]100% [" + str(n) + "/" + str(total) + "]\t"+ errorMessage + "\r" )
     return percen
+
+
+#**************************************************************************
+# FAIL-SOFT INPUT HANDLING
+#
+# A species is assembled from independent sources. Losing one of them costs the
+# identifier types it feeds and nothing else, so the build records what it lost and
+# carries on; only a result that cannot be used at all is worth refusing. The old
+# behaviour -- exit(1) the moment any input file was absent -- threw away organisms
+# that would have installed perfectly well with, say, no VEGA ids.
+#**************************************************************************
+def skipSource(label, reason, consequence):
+    """Record that an optional input is unusable and say what it costs."""
+    SKIPPED_SOURCES.append((label, reason, consequence))
+    stderr.write("\nWARNING [" + label + "] " + reason + "\n         -> " + consequence + "\n")
+
+
+def haveInputFile(label, fileName, consequence):
+    """True if fileName is usable; otherwise record the skip and return False.
+
+    Also rejects a file that exists but is empty, which is what a failed download
+    leaves behind and what used to be parsed into an empty identifier type.
+    """
+    if not fileName or not os.path.isfile(fileName):
+        skipSource(label, "input file not found: " + str(fileName), consequence)
+        return False
+    if os.path.getsize(fileName) == 0:
+        skipSource(label, "input file is empty: " + fileName, consequence)
+        return False
+    return True
+
+
+def assertInstallable():
+    """Refuse only a species that cannot answer a single query.
+
+    Two things make a species usable: at least one identifier the user can upload,
+    and at least one pathway to paint. Everything else is a degradation worth a
+    warning. Checked here rather than at each input so that a build missing four of
+    six sources still installs if the remaining two carry the species.
+    """
+    identifiers = sum(len(entries) for entries in xref.values())
+    pathways = len(ALL_PATHWAYS)
+
+    if identifiers == 0 or pathways == 0:
+        raise Exception(
+            "Refusing to install " + str(SPECIE) + ": the build produced " +
+            str(identifiers) + " identifier(s) and " + str(pathways) + " pathway(s), so "
+            "nothing a user uploads could ever match. Skipped sources: " +
+            (", ".join(label for label, _, _ in SKIPPED_SOURCES) or "none") +
+            ". This is the one case worth failing on -- every other missing source is "
+            "reported as a warning and installed anyway.")
+
+    return identifiers, pathways
+
+
+def countIdentifiersByType():
+    """Number of xref entries per identifier type, as the database will store them.
+
+    `xref` is keyed by SCOPE ('global'), not by identifier type -- grouping on its keys
+    reports one bucket called "global" and hides exactly what this summary exists to
+    show. The type lives on each entry as dbname_id, resolved through `dbname`.
+    """
+    perType = Counter()
+    for entries in xref.values():
+        for entry in entries.values():
+            label = dbname[entry.dbname_id].dbname if entry.dbname_id in dbname else str(entry.dbname_id)
+            perType[label] += 1
+    return perType
+
+
+def summariseBuild():
+    """One compact block per species: what was built, and what was lost."""
+    identifiers = sum(len(entries) for entries in xref.values())
+    byType = sorted(countIdentifiersByType().items())
+
+    stderr.write("\n" + "=" * 62 + "\n")
+    stderr.write("BUILD SUMMARY  " + str(SPECIE) + "\n")
+    stderr.write("=" * 62 + "\n")
+    stderr.write("  identifiers : %d across %d type(s)\n" % (identifiers, len(byType)))
+    for name, count in byType:
+        stderr.write("      %-32s %8d\n" % (name, count))
+    stderr.write("  pathways    : %d\n" % len(ALL_PATHWAYS))
+
+    dropped = {k: len(v) for k, v in FAILED_LINES.items() if v}
+    if dropped:
+        stderr.write("  rows dropped while parsing (per source):\n")
+        for k, v in sorted(dropped.items()):
+            stderr.write("      %-32s %8d\n" % (k, v))
+
+    if UNKNOWN_PATHWAY_PAIRS or PATHWAYS_WITHOUT_NODES:
+        stderr.write("  pathways missing from the shared KEGG reference:\n")
+        if UNKNOWN_PATHWAY_PAIRS:
+            unknown = sorted({p for pair in UNKNOWN_PATHWAY_PAIRS for p in pair})
+            stderr.write("      %-32s %8d  (e.g. %s)\n" % (
+                "unlinked pathway pairs", len(UNKNOWN_PATHWAY_PAIRS),
+                ", ".join(unknown[:5])))
+        if PATHWAYS_WITHOUT_NODES:
+            stderr.write("      %-32s %8d  (e.g. %s)\n" % (
+                "pathways with no node data", len(PATHWAYS_WITHOUT_NODES),
+                ", ".join(sorted(set(PATHWAYS_WITHOUT_NODES))[:5])))
+        stderr.write("      -> re-run the download with --common=1 to refresh "
+                     "pathways_all.list, then reinstall this species\n")
+
+    if SKIPPED_SOURCES:
+        stderr.write("  WARNINGS -- installed WITHOUT these sources:\n")
+        for label, reason, consequence in SKIPPED_SOURCES:
+            stderr.write("      %-20s %s\n" % (label, reason))
+            stderr.write("      %-20s -> %s\n" % ("", consequence))
+    else:
+        stderr.write("  warnings    : none\n")
+    stderr.write("=" * 62 + "\n")
+
+    # Hand the warnings back to DBManager, which runs this build as a subprocess and
+    # otherwise only sees an exit status. Written even when empty so a stale file from
+    # a previous species is never mistaken for this one's result.
+    try:
+        with open("/tmp/build_warnings.tmp", "w") as handle:
+            for label, reason, consequence in SKIPPED_SOURCES:
+                handle.write("\t".join([str(SPECIE), label, reason, consequence]) + "\n")
+    except Exception as writeError:
+        stderr.write("  (could not write the warning hand-off file: %s)\n" % writeError)
 
 #**************************************************************************
 #  ______ _   _  _____ ______ __  __ ____  _
@@ -224,9 +349,9 @@ def processEnsemblData():
 
     resource = EXTERNAL_RESOURCES.get("ensembl")[0]
     file_name= DATA_DIR + "mapping/" + resource.get("output")
-    if not os.path.isfile(file_name):
-        stderr.write("Unable to find the ENSEMBL MAPPING file: " + file_name)
-        exit(1)
+    if not haveInputFile("ENSEMBL", file_name,
+                         "Ensembl gene/transcript/protein identifiers will be absent for this species"):
+        return
 
     #Get line count (for percentage)
     total_lines = int(check_output(['wc', '-l', file_name]).decode('utf-8').split()[0])
@@ -310,9 +435,9 @@ def processRefSeqData():
     file_name= DATA_DIR + "mapping/" + resource.get("output")
 
     #Check if file exists
-    if not os.path.isfile(file_name):
-        stderr.write("Unable to find the REFSEQ MAPPING file: " + file_name)
-        exit(1)
+    if not haveInputFile("REFSEQ", file_name,
+                         "RefSeq RNA/protein accessions and EntrezGene ids will be absent for this species"):
+        return
 
     #Extract the file in a temporal directory
     stderr.write("  * EXTRACTING FILE...\n")
@@ -425,9 +550,9 @@ def processRefSeqGeneSymbolData():
     file_name= DATA_DIR + "mapping/" + resource.get("output")
 
     #Check if file exists
-    if not os.path.isfile(file_name):
-        stderr.write("Unable to find the REFSEQ GENE SYMBOL MAPPING file: " + file_name)
-        exit(1)
+    if not haveInputFile("REFSEQ GENE SYMBOL", file_name,
+                         "gene symbols and their synonyms will be absent -- users cannot upload by symbol"):
+        return
 
     #Extract the file in a temporal directory
     stderr.write("  * EXTRACTING FILE...\n")
@@ -595,9 +720,9 @@ def processUniProtData():
 
     resource = EXTERNAL_RESOURCES.get("uniprot")[0]
     file_name= DATA_DIR + "mapping/" + resource.get("output")
-    if not os.path.isfile(file_name):
-        stderr.write("\n\nUnable to find the UniProt MAPPING file: " + file_name + "\n")
-        exit(1)
+    if not haveInputFile("UNIPROT", file_name,
+                         "UniProt accessions and identifiers will be absent for this species"):
+        return
 
     #Extract the file in a temporal directory
     stderr.write("  * EXTRACTING FILE...\n")
@@ -703,9 +828,9 @@ def processVegaData():
     FAILED_LINES["VEGA"]=[]
     resource = EXTERNAL_RESOURCES.get("vega")[0]
     file_name= DATA_DIR + "mapping/" + resource.get("output")
-    if not os.path.isfile(file_name):
-        stderr.write("\n\nUnable to find the ENSEMBL VEGA MAPPING file: " + file_name + "\n")
-        exit(1)
+    if not haveInputFile("VEGA", file_name,
+                         "VEGA identifiers will be absent for this species"):
+        return
 
     #Get line count (for percentage)
     total_lines = int(check_output(['wc', '-l', file_name]).decode('utf-8').split()[0])
@@ -785,34 +910,53 @@ def processMapManMappingData():
     #STEP 2. READ THE UniProt 2 KEGG FILE but DO NOT process it as it will be done in "processKEGGMappingData
     # Instead, load the contents and keep as a link table to KEGG gene ids
     ncbi_file_name= DATA_DIR + "mapping/" + "ncbi-geneid2kegg.list"
-    if not os.path.isfile(ncbi_file_name):
-        stderr.write("\n\nUnable to find the NCBI 2 KEGG MAPPING file: " + ncbi_file_name + "\n")
-        exit(1)
+    if not haveInputFile("NCBI GENE ID 2 KEGG", ncbi_file_name,
+                         "NCBI gene ids will not be linked to KEGG features for this species"):
+        return
 
     # MapMan input files. Prefer the canonical DATA_DIR/mapping/<output> location
     # (populated by the download step) and fall back to the configured `url + file`
     # for legacy installs that keep MapMan source files outside DATA_DIR.
-    def _resolveMapManPath(resource, displayName):
+    # Returns None rather than exiting: the three MapMan inputs are independent, and
+    # only the gene-to-bin file is load-bearing. Losing the other two costs metabolites
+    # or the KEGG cross-link, which is a warning, not a reason to drop the organism.
+    def _resolveMapManPath(resource, displayName, consequence):
+        if resource is None:
+            skipSource(displayName, "no such resource declared for " + str(SPECIE), consequence)
+            return None
         candidate = DATA_DIR + "mapping/" + resource.get("output")
         if os.path.isfile(candidate):
             return candidate
         fallback = resource.get("url") + resource.get("file")
         if os.path.isfile(fallback):
             return fallback
-        stderr.write("\n\nUnable to find the " + displayName + " file in either " + candidate + " or " + fallback + "\n")
-        exit(1)
+        skipSource(displayName, "not found in either " + candidate + " or " + fallback, consequence)
+        return None
 
-    mapman_cpd_resource = EXTERNAL_RESOURCES.get("metabolites")[0]
-    mapman_cpd_file_name = _resolveMapManPath(mapman_cpd_resource, "MapMan Compound 2 MapMan ID MAPPING")
+    def _firstResource(name):
+        entries = EXTERNAL_RESOURCES.get(name)
+        return entries[0] if entries else None
 
-    mapman_resource = EXTERNAL_RESOURCES.get("mapman_gene")[0]
-    mapman_file_name = _resolveMapManPath(mapman_resource, "MapMan Gene 2 MapMan ID MAPPING")
+    mapman_cpd_file_name = _resolveMapManPath(
+        _firstResource("metabolites"), "MAPMAN METABOLITES",
+        "MapMan metabolite identifiers will be absent; genes are unaffected")
 
-    mapman_kegg_resource = EXTERNAL_RESOURCES.get("mapman_kegg")[0]
-    mapman_kegg_file_name = _resolveMapManPath(mapman_kegg_resource, "MapMan Gene to KEGG ID MAPPING")
+    mapman_file_name = _resolveMapManPath(
+        _firstResource("mapman_gene"), "MAPMAN GENE 2 BIN",
+        "no MapMan bins can be assigned, so MapMan diagrams will carry no features")
+
+    mapman_kegg_file_name = _resolveMapManPath(
+        _firstResource("mapman_kegg"), "MAPMAN GENE 2 KEGG",
+        "MapMan genes will not be cross-linked to KEGG ids")
+
+    # The gene-to-bin file IS the MapMan mapping. Without it there is nothing to build,
+    # so stop here and let the species install with its KEGG data only.
+    if mapman_file_name is None:
+        return
 
     # Insert compounds
-    processMapMan2CompoundSymbolMappingData(mapman_cpd_file_name)
+    if mapman_cpd_file_name is not None:
+        processMapMan2CompoundSymbolMappingData(mapman_cpd_file_name)
 
     # Initialize the mapping_dict NCBI Gene ID => [many possible KEGG_IDs]
     ncbi_mapping_dict = defaultdict(list)
@@ -836,14 +980,19 @@ def processMapManMappingData():
             for ontology_term in ontology_terms:
                 external_mapping[ontology_term].extend([mapping_entry["mapman_gene"]])
 
-    total_lines = int(check_output(['wc', '-l', mapman_kegg_file_name]).decode('utf-8').split()[0])
+    total_lines = 0
+    genes_present = set()
 
-    with open(mapman_kegg_file_name, 'r') as mapman_file:
+    # Only the cross-link to KEGG needs this file. Without it every MapMan gene still
+    # gets inserted below, just with its own transcript instead of a shared KEGG one.
+    if mapman_kegg_file_name is not None:
+      total_lines = int(check_output(['wc', '-l', mapman_kegg_file_name]).decode('utf-8').split()[0])
+
+      with open(mapman_kegg_file_name, 'r') as mapman_file:
         i = 0
         prev = -1
         errorMessage = ""
         file_reader = csv.reader(mapman_file, delimiter="\t")
-        genes_present = set()
 
         for mapping_entry in file_reader:
             i += 1
@@ -883,14 +1032,17 @@ def processMapManMappingData():
                     insertTR_XREF(external_gi, generateRandomID())
             except Exception as ex:
                 errorMessage = "FAILED WHILE PROCESSING " + mapman_kegg_file_name +" MAPPING FILE [line " + str(i) + "]: "+ str(ex)
+                FAILED_LINES.setdefault("MAPMAN GENE 2 KEGG", []).append([errorMessage])
 
-        # If we still have info about other genes not present in that file, add them
-        all_genes = set(list(itertools.chain.from_iterable(external_mapping.values())))
+    # Every MapMan gene not already linked above gets inserted with its own transcript.
+    # Dedented out of the `with` block on purpose: when the KEGG cross-link file is
+    # absent this loop is what still populates the MapMan identifiers.
+    all_genes = set(list(itertools.chain.from_iterable(external_mapping.values())))
 
-        for remaining_gene in all_genes.difference(genes_present):
-            gene_gi = insertXREF(XREF_Entry(remaining_gene, mapman_gene_db_id, mapman_gene_desc))
+    for remaining_gene in all_genes.difference(genes_present):
+        gene_gi = insertXREF(XREF_Entry(remaining_gene, mapman_gene_db_id, mapman_gene_desc))
 
-            insertTR_XREF(gene_gi, generateRandomID())
+        insertTR_XREF(gene_gi, generateRandomID())
 
     version = open(DATA_DIR + 'MAPMAN_MAPPING', 'w')
     version.write("# CREATION DATE:\t" + strftime("%Y%m%d %H%M"))
@@ -1247,8 +1399,9 @@ def processMapManPathwaysData():
     REVERSE_MAPMAN_CPD = {v: k for k, v in MAPMAN_COMPOUNDS.items()}
 
     if not len(external_mapping):
-        stderr.write("The MapMan dictionary is not filled. Mapping files must be processed first.")
-        exit(1)
+        skipSource("MAPMAN PATHWAYS", "no MapMan gene-to-bin mapping was loaded",
+                   "MapMan diagrams are skipped entirely; KEGG pathways are unaffected")
+        return
 
     # Check if classification file exists. Prefer DATA_DIR/mapping/<output>
     # (populated by the download step) and fall back to the configured
@@ -1261,8 +1414,10 @@ def processMapManPathwaysData():
         mapman_classification_file_name = mapman_classification_resource.get("url") + mapman_classification_resource.get("file")
 
     if not os.path.isfile(mapman_classification_file_name):
-        stderr.write("\n\nUnable to find the MapMan classification file in either " + _candidate + " or " + mapman_classification_file_name + "\n")
-        exit(1)
+        skipSource("MAPMAN CLASSIFICATION",
+                   "not found in either " + _candidate + " or " + mapman_classification_file_name,
+                   "MapMan diagrams are skipped entirely; KEGG pathways are unaffected")
+        return
 
     # MapMan pathways files are the same for each species, even the XML files.
     # The handful of species compatible with MapMan will specify to download the same dataset.
@@ -1291,8 +1446,9 @@ def processMapManPathwaysData():
     except Exception as e:
         if os.path.exists(MAPMAN_DIR):
             shutil.move(MAPMAN_DIR + ".bak", MAPMAN_DIR)
-        stderr.write("Failed extraction of MapMan pathways. Aborting.")
-        exit(1)
+        skipSource("MAPMAN PATHWAYS", "could not extract " + str(pathways_file_name) + ": " + str(e),
+                   "MapMan diagrams are skipped entirely; KEGG pathways are unaffected")
+        return
 
     # Make sure to create the thumbnail directory
     if not os.path.exists(os.path.dirname(MAPMAN_DIR + "/png/thumbnails/")):
@@ -1949,14 +2105,25 @@ def processReactomePathwaysData():
 
     REACTOME_PATHWAY = DATA_DIR + 'ReactomePathway.txt'
 
+    # Absent whenever the species was downloaded without --reactome=1, and for every
+    # organism Reactome does not curate. Neither is a reason to lose the KEGG pathways
+    # that were just built, so warn and return instead of raising FileNotFoundError.
+    if not haveInputFile("REACTOME PATHWAYS", REACTOME_PATHWAY,
+                         "Reactome pathways will be absent; KEGG pathways are unaffected. "
+                         "Re-run the download with --reactome=1 if this species is curated by Reactome"):
+        return
+
     with open( file=REACTOME_PATHWAY ) as pathwayList:
         for line in pathwayList:
             PATHWAY_ID.add(line.strip())
 
     def showPercentageSimple(n, total):
+        # Unconditional and once per pathway, so ~1,000 lines for human alone. Silent
+        # unless PAINTOMICS_INSTALL_VERBOSE=1, like the other progress writer.
         percen = int( n / float( total ) * 10 )
-        stderr.write(
-            "0%[" + ("#" * percen) + (" " * (10 - percen)) + "]100% [" + str( n ) + "/" + str( total ) + "]\t" )
+        if VERBOSE:
+            stderr.write(
+                "0%[" + ("#" * percen) + (" " * (10 - percen)) + "]100% [" + str( n ) + "/" + str( total ) + "]\t" )
         return percen
 
 
@@ -2810,7 +2977,12 @@ def generatePathwaysNetwork(ALL_PATHWAYS):
                     try:
                         pathways_matrix[other_path][current_path] += 1
                     except:
-                        stderr.write("Pathways " + current_path + " or " + other_path + " not found at pathways_all.list. Updating common KEGG information may solve this issue. Reinstall this specie after that.\n")
+                        # Counted, not printed. This fires once per pathway PAIR, so a
+                        # single species emitted 235 copies of the same 140-character
+                        # sentence -- 33 KB, and the largest single contributor to
+                        # install.log. The advice in it is identical every time; what an
+                        # operator needs is the count and one example.
+                        UNKNOWN_PATHWAY_PAIRS.append((current_path, other_path))
 
 
     # Free memory
@@ -2831,8 +3003,9 @@ def generatePathwaysNetwork(ALL_PATHWAYS):
                 try:
                     NODES[previous_pathway]["data"]["total_features"] += nGenes
                 except:
-                    stderr.write("No nodes information for Pathway " + previous_pathway + ".\n")
-                    stderr.write("Updating the installed common KEGG information may solve this issue. Reinstall this species after that.\n")
+                    # Same aggregation as above: one line per pathway, same advice each
+                    # time. Reported once, with a count, by summarisePathwayGaps().
+                    PATHWAYS_WITHOUT_NODES.append(previous_pathway)
                 nGenes=0
             nGenes+=1
             previous_pathway = path_id
@@ -2915,6 +3088,13 @@ def printResults():
         stderr.write("\nERRONEOUS in print result: " + str(key) )
 
 def dumpDatabase():
+    # Every species build funnels through here, so this is the one place that can
+    # decide whether what was assembled is worth installing. Both calls are cheap and
+    # neither touches the database -- assertInstallable raises before anything is
+    # written if the result would be unusable.
+    summariseBuild()
+    assertInstallable()
+
     #STEP1. GENERATE THE TABLE feature id --> [transcripts ids]
 
     # Remove the file if already exists to avoid adding
@@ -2925,8 +3105,11 @@ def dumpDatabase():
         os.remove(dump_xref_file)
 
     # To avoid depleting the ram completely, repeat the process for each database
+    orphanFeatures = 0
+
     for dbid, db_values in transcript2xref.items():
-        stderr.write("\nDumping database " + str(dbid))
+        if VERBOSE:
+            stderr.write("\nDumping database " + str(dbid))
 
         xref2xref = defaultdict(list)
 
@@ -2946,9 +3129,18 @@ def dumpDatabase():
             if(len(item["mates"])> 0):
                 file.write(json.dumps(item, separators=(',',':')) + "\n")
             else:
-                stderr.write("No transcripts detected for " + elem.display_id + " ["+ elem.description + "]\n")
+                # One line per unlinked feature was the single largest contributor to
+                # install.log. It is a normal outcome for tens of thousands of features,
+                # so count it and report the total once.
+                orphanFeatures += 1
+                if VERBOSE:
+                    stderr.write("No transcripts detected for " + elem.display_id + " ["+ elem.description + "]\n")
 
         file.close()
+
+    if orphanFeatures:
+        stderr.write("\n  note: %d feature(s) had no linked transcript and were not dumped "
+                     "(set PAINTOMICS_INSTALL_VERBOSE=1 to list them)\n" % orphanFeatures)
 
     #STEP 2. DUMP THE transcript2xref TABLE INTO A FILE
     file = open("/tmp/dbname.tmp", 'w')
@@ -3680,6 +3872,25 @@ MAPMAN_COMPOUNDS = {}
 #OTHER AUXILIAR TABLES OR VARIABLES
 TOTAL_FEATURES = {}
 FAILED_LINES = {}
+
+# Optional inputs that were absent or unusable. A species is built from a dozen
+# independent sources and most of them only contribute one identifier type, so a
+# missing one costs that type and nothing else -- it is not a reason to abandon an
+# organism that would otherwise install. Each skip is recorded here with the
+# consequence spelled out, reported in the build summary, and re-raised as a hard
+# failure ONLY if what survives is unusable (see assertInstallable).
+SKIPPED_SOURCES = []
+
+# Set PAINTOMICS_INSTALL_VERBOSE=1 to restore the per-row progress bars and the
+# per-feature "no transcripts" lines. The default is a summary: the old output was
+# tens of MB of carriage returns per species, which buried the few lines that matter.
+VERBOSE = os.environ.get("PAINTOMICS_INSTALL_VERBOSE", "0") == "1"
+
+# Pathways referenced by the species data but absent from the shared KEGG reference.
+# Both used to print a full sentence of identical advice per occurrence; they are
+# aggregated and reported once by summarisePathwayGaps().
+UNKNOWN_PATHWAY_PAIRS = []
+PATHWAYS_WITHOUT_NODES = []
 
 
 DATA_DIR = ""

--- a/PaintomicsServer/src/AdminTools/scripts/common_build_database.py
+++ b/PaintomicsServer/src/AdminTools/scripts/common_build_database.py
@@ -1899,7 +1899,7 @@ def buildReactomeHierarchyEdges(installedPathways, relationFile, speciesMarker,
 
 
 def loadReactomeMapping(filePath, keyColumn, valueColumns, minColumns,
-                        failedLines=None, specieLabel=""):
+                        failedLines=None, specieLabel="", allowEmpty=False):
     """
     Index a Reactome mapping TSV as {key: [tuple(row[c] for c in valueColumns), ...]}.
 
@@ -1912,9 +1912,15 @@ def loadReactomeMapping(filePath, keyColumn, valueColumns, minColumns,
     and shifts every identifier one field to the left, so entities map to the
     wrong genes rather than failing loudly.
 
-    Raises rather than returning an empty index: an empty mapping means the
-    upstream R step matched no rows for this species, and every downstream lookup
-    would quietly return nothing instead of reporting the real problem.
+    An empty file raises unless the caller passes allowEmpty=True. The split
+    exists because the callers' invariants differ: a per-species GENE mapping
+    can be legitimately empty (Reactome keys ddi/spo/pfa through NCBI and
+    UniProt but not Ensembl, and processReactomeData.R deliberately writes an
+    empty file for such a source -- the caller enforces the real invariant,
+    that not EVERY gene mapping is empty), while the common, all-species ChEBI
+    file has no legitimate empty state: zero rows there means a truncated
+    download, and every downstream lookup would quietly return nothing instead
+    of reporting the real problem.
     """
     if failedLines is None:
         failedLines = []
@@ -1941,10 +1947,16 @@ def loadReactomeMapping(filePath, keyColumn, valueColumns, minColumns,
             rowCount += 1
 
     if rowCount == 0:
-        raise Exception(
-            "Reactome mapping file is empty: " + filePath + "\n" +
-            "This usually means processReactomeData.R matched no rows for species '" +
-            str(specieLabel) + "'.")
+        if not allowEmpty:
+            raise Exception(
+                "Reactome mapping file is empty: " + filePath + "\n" +
+                "This file is not species-scoped, so zero rows means a truncated "
+                "or failed download (species being processed: '" +
+                str(specieLabel) + "').")
+        stderr.write("WARNING: no rows in {} for species '{}'; this identifier "
+                     "source contributes nothing.\n".format(
+                         os.path.basename(filePath), specieLabel))
+        return index
 
     stderr.write("Indexed {} rows from {} ({} distinct keys)\n".format(
         rowCount, os.path.basename(filePath), len(index)))
@@ -2026,6 +2038,19 @@ def processReactomePathwaysData():
 
 
 
+    # The ReactomePathway.txt check further down already fail-softs the KEGG
+    # build when Reactome was never downloaded - but the R script used to run
+    # BEFORE that check and die first. ptr made this real: Reactome dropped
+    # chimpanzee from its release, its download correctly skips Reactome, and
+    # the build then crashed in processReactomeData.R on three empty mappings.
+    # An absent download means "no Reactome for this species": take the same
+    # warn-and-return exit before anything Reactome-related runs.
+    if not haveInputFile("REACTOME PATHWAYS", DATA_DIR + 'ReactomePathway.txt',
+                         "Reactome was not downloaded for this species (not covered "
+                         "by the current Reactome release, or downloaded without "
+                         "--reactome=1); KEGG pathways are unaffected."):
+        return
+
     # The process will also insert information about compounds, thus discarding the previous database
     # and importing a new one, needing again the KEGG compounds.
     processKEGG2CompoundSymbolMappingData(DATA_DIR + "../common/compounds_all.list")
@@ -2042,10 +2067,24 @@ def processReactomePathwaysData():
         print(output)  # Print R script output
         print("Reactome R script completed successfully")
     except CalledProcessError as e:
+        rOutput = e.output if getattr(e, 'output', None) else ""
+        # The R script's aggregate zero-coverage stop is a fact about Reactome's
+        # release, not a build failure: every gene mapping came up empty, so
+        # there is nothing to attach genes to and installing Reactome would ship
+        # pathways with no gene mapped to anything. Take the same warn-and-return
+        # exit as a missing download -- the KEGG pathways just built are
+        # unaffected -- instead of failing the species with a misleading
+        # "check memory/R installation" error.
+        if "in any of Ensembl2Reactome, NCBI2Reactome or UniProt2Reactome" in rOutput:
+            print(rOutput)
+            print("WARNING: Reactome's current release has no gene mappings for "
+                  "species '" + str(SPECIE) + "'; skipping Reactome (KEGG "
+                  "pathways are unaffected).")
+            return
         print("ERROR: Reactome R script failed with exit code: " + str(e.returncode))
-        if hasattr(e, 'output') and e.output:
+        if rOutput:
             print("Output from R script:")
-            print(e.output)
+            print(rOutput)
         raise Exception("Failed to process Reactome data. Check memory usage and R installation.")
 
 
@@ -2067,15 +2106,28 @@ def processReactomePathwaysData():
     failedLines = FAILED_LINES["REACTOME PATHWAYS"]
 
     # stId -> [(ensembl_id, symbol), ...] and the NCBI / UniProt equivalents.
+    # allowEmpty on the three per-species gene mappings ONLY: any one of them
+    # can be legitimately empty (see loadReactomeMapping's docstring); the
+    # all-empty case is caught just below. The common ChEBI file further down
+    # keeps the raise -- empty there means a truncated download.
     ensemblByStId = loadReactomeMapping(
         mapReactomeDir + "Ensembl2Reactome.txt", keyColumn=1, valueColumns=(0, 2),
-        minColumns=3, failedLines=failedLines, specieLabel=SPECIE)
+        minColumns=3, failedLines=failedLines, specieLabel=SPECIE, allowEmpty=True)
     ncbiByStId = loadReactomeMapping(
         mapReactomeDir + "NCBI2Reactome.txt", keyColumn=1, valueColumns=(0, 2),
-        minColumns=3, failedLines=failedLines, specieLabel=SPECIE)
+        minColumns=3, failedLines=failedLines, specieLabel=SPECIE, allowEmpty=True)
     uniprotByStId = loadReactomeMapping(
         mapReactomeDir + "UniProt2Reactome.txt", keyColumn=1, valueColumns=(0, 2),
-        minColumns=3, failedLines=failedLines, specieLabel=SPECIE)
+        minColumns=3, failedLines=failedLines, specieLabel=SPECIE, allowEmpty=True)
+
+    # The invariant the old per-file check was reaching for: a species whose
+    # EVERY gene mapping is empty would install Reactome pathways with no gene
+    # attached to anything, which must fail loudly rather than ship.
+    if not ensemblByStId and not ncbiByStId and not uniprotByStId:
+        raise Exception(
+            "All three Reactome gene mappings (Ensembl, NCBI, UniProt) are "
+            "empty for species '" + str(SPECIE) + "'. Reactome does not cover "
+            "this organism; install it with --reactome=0.")
 
     # stId -> [chebi_id, ...]. This file is NOT species-filtered, so it is the
     # largest of the five and was the single worst offender in the old scan.

--- a/PaintomicsServer/src/AdminTools/scripts/pfa_resources/download_conf.py
+++ b/PaintomicsServer/src/AdminTools/scripts/pfa_resources/download_conf.py
@@ -5,13 +5,15 @@ EXTERNAL_RESOURCES = {
                     "file"          :   "gene2refseq.gz",
                     "output"        :   "refseq_gene2refseq.gz",
                     "description"   :   "Source: NCBI Gene. Downloaded from NCBI FTP. Tab-delimited one line per genomic/RNA/protein set of RefSeqs",
-                    "specie-code"   :   5833
+                    # NCBI keys P. falciparum rows by strain: 36329 (3D7). The species
+                    # taxid 5833 matches only 4 rows of gene_info.
+                    "specie-code"   :   36329
                     },{
                     "url"           :   "ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Protozoa/",
                     "file"          :   "Plasmodium_falciparum.gene_info.gz",
                     "output"        :   "refseq_gene2genesymbol.gz",
                     "description"   :   "Source: NCBI Gene. Downloaded from NCBI FTP. Tab-delimited one line per gene id/gene symbol/.../synonyms/... from RefSeqs",
-                    "specie-code"   :   5833
+                    "specie-code"   :   36329
                     }
                 ]
         }

--- a/PaintomicsServer/src/AdminTools/scripts/processReactomeData.R
+++ b/PaintomicsServer/src/AdminTools/scripts/processReactomeData.R
@@ -102,8 +102,27 @@ processFile <- function(fileName, outputName, specie, speciesName) {
     )
   }
 
+  # Before paying for the fallback, ask grep -q whether the species truly has
+  # zero rows here. A legitimately empty source (pfa/ddi/spo have no Ensembl
+  # rows) used to route through the whole-file read.delim below -- a
+  # several-GB, minutes-long parse of the largest tables just to confirm
+  # nothing matched, on what is now a designed success path. Exit status 1
+  # means "no match" with certainty; 0 (a match exists, so the pipe read above
+  # is what failed) and 2 (grep errored) both fall through to the full read.
+  zeroConfirmed <- FALSE
+  if ((is.null(filtered) || nrow(filtered) == 0) && !is.na(speciesName)) {
+    probeStatus <- suppressWarnings(
+      system2("grep", c("-qF", shQuote(speciesName), shQuote(inputPath))))
+    if (probeStatus == 1) {
+      zeroConfirmed <- TRUE
+      filtered <- data.frame(matrix(character(0), nrow = 0, ncol = 8),
+                             stringsAsFactors = FALSE)
+      colnames(filtered) <- paste0("V", 1:8)
+    }
+  }
+
   # Fallback: no species table entry, or grep produced nothing usable.
-  if (is.null(filtered) || nrow(filtered) == 0) {
+  if (!zeroConfirmed && (is.null(filtered) || nrow(filtered) == 0)) {
     inputData <- read.delim(inputPath, header = FALSE, quote = "",
                             comment.char = "", stringsAsFactors = FALSE)
     if (ncol(inputData) < 8) {
@@ -128,11 +147,17 @@ processFile <- function(fileName, outputName, specie, speciesName) {
   }
 
   if (nrow(filtered) == 0) {
-    stop(paste0("No rows matched species '", specie, "'",
-                if (!is.na(speciesName)) paste0(" ('", speciesName, "')") else "",
-                " in ", basename(inputPath), ".\n",
-                "Reactome does not cover every KEGG organism. Install this ",
-                "species with --reactome=0, or add it to KEGG_TO_REACTOME_SPECIES."))
+    # Not fatal on its own. Reactome does not key every organism through every
+    # identifier system: P. falciparum has 19k NCBI and 20k UniProt rows and
+    # ZERO Ensembl rows (its genes live in PlasmoDB, not Ensembl), and the old
+    # hard stop here failed the whole pfa build on the first file while the
+    # other two carried the actual mappings. Write the empty output - the
+    # Python side reads each mapping file independently and an empty one just
+    # contributes no identifiers - and let the caller decide below whether
+    # EVERY mapping came up empty, which is the real "not covered" case.
+    cat(paste0("  WARNING: no rows matched species '", specie, "'",
+               if (!is.na(speciesName)) paste0(" ('", speciesName, "')") else "",
+               " in ", basename(inputPath), "; writing an empty mapping.\n"))
   }
 
   # Column 3 is "<id> <description>"; downstream code wants only the identifier.
@@ -143,17 +168,29 @@ processFile <- function(fileName, outputName, specie, speciesName) {
               col.names = FALSE, quote = FALSE, sep = "\t")
   cat(paste0("  Wrote ", nrow(filtered), " rows for ", specie, " -> ", outputPath, "\n"))
 
+  rows <- nrow(filtered)
   rm(filtered)
   invisible(gc(verbose = FALSE))
+  rows
 }
 
 cat("STEP 1: Processing Ensembl2Reactome...\n")
-processFile("Ensembl2Reactome", "Ensembl2Reactome", specie, speciesName)
+ensemblRows <- processFile("Ensembl2Reactome", "Ensembl2Reactome", specie, speciesName)
 
 cat("STEP 2: Processing NCBI2Reactome...\n")
-processFile("NCBI2Reactome", "NCBI2Reactome", specie, speciesName)
+ncbiRows <- processFile("NCBI2Reactome", "NCBI2Reactome", specie, speciesName)
 
 cat("STEP 3: Processing UniProt2Reactome...\n")
-processFile("UniProt2Reactome", "UniProt2Reactome", specie, speciesName)
+uniprotRows <- processFile("UniProt2Reactome", "UniProt2Reactome", specie, speciesName)
+
+# Only every mapping being empty means Reactome truly does not cover the
+# organism; that still has to fail loudly rather than install a Reactome
+# database with no gene attached to anything.
+if (ensemblRows + ncbiRows + uniprotRows == 0) {
+  stop(paste0("No rows matched species '", specie, "' in any of ",
+              "Ensembl2Reactome, NCBI2Reactome or UniProt2Reactome.\n",
+              "Reactome does not cover every KEGG organism. Install this ",
+              "species with --reactome=0, or add it to KEGG_TO_REACTOME_SPECIES."))
+}
 
 cat("All Reactome data processing completed successfully.\n")

--- a/PaintomicsServer/src/AdminTools/scripts/sce_resources/download_conf.py
+++ b/PaintomicsServer/src/AdminTools/scripts/sce_resources/download_conf.py
@@ -14,13 +14,16 @@ EXTERNAL_RESOURCES = {
                     "file"          :   "gene2refseq.gz",
                     "output"        :   "refseq_gene2refseq.gz",
                     "description"   :   "Source: NCBI Gene. Downloaded from NCBI FTP. Tab-delimited one line per genomic/RNA/protein set of RefSeqs",
-                    "specie-code"   :   4932
+                    # NCBI keys S. cerevisiae rows by strain: 559292 (S288C), the same
+                    # organism id already in the UniProt filename below. The species
+                    # taxid 4932 matches only ~36 mitochondrial/placeholder rows.
+                    "specie-code"   :   559292
                     },{
                     "url"           :   "ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Fungi/",
                     "file"          :   "Saccharomyces_cerevisiae.gene_info.gz",
                     "output"        :   "refseq_gene2genesymbol.gz",
                     "description"   :   "Source: NCBI Gene. Downloaded from NCBI FTP. Tab-delimited one line per gene id/gene symbol/.../synonyms/... from RefSeqs",
-                    "specie-code"   :   4932
+                    "specie-code"   :   559292
                     }
                 ],
                  "uniprot"   :   [

--- a/PaintomicsServer/src/AdminTools/scripts/xtr_resources/download_conf.py
+++ b/PaintomicsServer/src/AdminTools/scripts/xtr_resources/download_conf.py
@@ -1,0 +1,38 @@
+# Xenopus tropicalis. This file was missing entirely: xtr_resources shipped a
+# download_others.py that loads <specie>_resources/download_conf.py by
+# convention, so every xtr download died at that import (FileNotFoundError,
+# observed on the 2026-08-14 full reinstall) and the species had never been
+# installable. Modeled on dre_resources (the other non-mammalian vertebrate
+# with the same build shape).
+#
+# Deliberately no "uniprot" section: UniProt's by_organism directory publishes
+# idmapping_selected.tab.gz for ~20 reference proteomes only and has no Xenopus
+# file (checked 2026-08-14), and xtr's build_database.py never had a UniProt
+# processing step to consume one. download_others.py reads only "ensembl" and
+# "refseq".
+EXTERNAL_RESOURCES = {
+                "ensembl"   :   [
+                    {
+                    "url"           :   "https://ftp.ensembl.org/pub/",
+                    "species-dir"   :   "xenopus_tropicalis",
+                    "division"      :   "vertebrates",
+                    "output"        :   "ensembl_mapping.list",
+                    "description"   :   "Source: Ensembl cross-reference TSV dumps. BioMart was retired (martservice answers HTTP 405), so the release/assembly and filename are resolved at run time rather than pinned here."
+                    }
+                ],
+                "refseq"   :  [
+                    {
+                    "url"           :   "ftp://ftp.ncbi.nih.gov/gene/DATA/",
+                    "file"          :   "gene2refseq.gz",
+                    "output"        :   "refseq_gene2refseq.gz",
+                    "description"   :   "Source: NCBI Gene. Downloaded from NCBI FTP. Tab-delimited one line per genomic/RNA/protein set of RefSeqs",
+                    "specie-code"   :   8364
+                    },{
+                    "url"           :   "ftp://ftp.ncbi.nih.gov/gene/DATA/GENE_INFO/Non-mammalian_vertebrates/",
+                    "file"          :   "Xenopus_tropicalis.gene_info.gz",
+                    "output"        :   "refseq_gene2genesymbol.gz",
+                    "description"   :   "Source: NCBI Gene. Downloaded from NCBI FTP. Tab-delimited one line per gene id/gene symbol/.../synonyms/... from RefSeqs",
+                    "specie-code"   :   8364
+                    }
+                ]
+        }

--- a/PaintomicsServer/src/classes/Job.py
+++ b/PaintomicsServer/src/classes/Job.py
@@ -45,8 +45,13 @@ from shutil import make_archive as shutil_make_archive
 class Job(Model):
     @staticmethod
     def detect_delimiter(filename):
-        """Auto-detect whether a file uses tab or comma as delimiter."""
-        with open(filename, 'r', encoding='utf-8-sig') as f:
+        """Auto-detect whether a file uses tab or comma as delimiter.
+
+        errors='replace': delimiter sniffing only needs to see tabs and commas,
+        and this helper runs on paths ensure_utf8 has not always covered yet —
+        it must never be the line that turns a bad byte into a crash.
+        """
+        with open(filename, 'r', encoding='utf-8-sig', errors='replace') as f:
             for line in f:
                 line = line.strip()
                 if line:
@@ -548,7 +553,15 @@ class Job(Model):
                     #*************************************************************************
                     # STEP 2.1 CHECK IF IT IS HEADER, IF SO, IGNORE LINE
                     #*************************************************************************
-                    if(nLine == 1 or len(line) == 0):
+                    if len(line) == 0:
+                        # A blank row used to fall into the header branch, where
+                        # float(line[1]) raised IndexError, was swallowed, and
+                        # `fileHeader = []` overwrote the real condition names.
+                        # Give back the row number too, so a leading blank line
+                        # does not consume the header slot.
+                        nLine = nLine - 1
+                        continue
+                    if nLine == 1:
                         try:
                             float(line[1])
                         except Exception:
@@ -727,8 +740,13 @@ class Job(Model):
 
             logging.info("PARSING USER GENE BASED FILE (" + omicName + ")... DONE" )
 
-            # Total unique mapped features. "Total" if there are more than one database
-            totalMapped = foundFeatures.get("Total", list(foundFeatures.values())[0])
+            # Total unique mapped features. "Total" if there are more than one database.
+            # The fallback must stay lazy: `.get(key, expr)` evaluates expr even
+            # when the key exists, and an empty mapper result (no databases
+            # resolved) made `list({}.values())[0]` abort the job.
+            totalMapped = foundFeatures.get("Total")
+            if totalMapped is None:
+                totalMapped = next(iter(foundFeatures.values()), 0)
 
             #   0        1       2    3    4    5     6,   7   8      9        10
             #[MAPPED, UNMAPPED, MIN, P10, Q1, MEDIAN, Q3, P90, MAX, MIN_IR, Max_IR]
@@ -784,7 +802,15 @@ class Job(Model):
                     #*************************************************************************
                     # STEP 2.1 CHECK IF IT IS HEADER, IF SO, IGNORE LINE
                     #*************************************************************************
-                    if(nLine == 1 or len(line) == 0):
+                    if len(line) == 0:
+                        # A blank row used to fall into the header branch, where
+                        # float(line[1]) raised IndexError, was swallowed, and
+                        # `fileHeader = []` overwrote the real condition names.
+                        # Give back the row number too, so a leading blank line
+                        # does not consume the header slot.
+                        nLine = nLine - 1
+                        continue
+                    if nLine == 1:
                         try:
                             float(line[1])
                         except Exception:
@@ -950,6 +976,9 @@ class Job(Model):
                 #   * Forced False after a plain condition-name header (e.g. `WT\tKO`),
                 #     which signals a genuine 2-condition relevance file.
                 legacyEligible = True
+                # One warning per file for rows wider than the declared width;
+                # a 40k-row export with row-names would otherwise log 40k lines.
+                raggedRowsWarned = False
                 for line in csv_reader(inputDataFile, delimiter=detected_delimiter):
                     # csv yields [] for an empty line, and a row of empty strings
                     # for one that is only separators, so `line[0]` raised
@@ -1039,7 +1068,11 @@ class Job(Model):
                         # eligible data row look like biological IDs — that's the structural
                         # difference from a true 2-condition file where the same ID typically
                         # appears in only one column at a time.
-                        if nConditions == 2 and not isBedFormat:
+                        # A shorter row cannot be the legacy pair — indexing
+                        # line[1] on a 1-column row raised IndexError and killed
+                        # the job, and a `#Cond<TAB>` header (blank second cell)
+                        # keeps legacyEligible True, so ordinary files reached it.
+                        if nConditions == 2 and not isBedFormat and len(line) > 1:
                              if legacyEligible and Job._row_looks_like_data([line[0]]) and Job._row_looks_like_data([line[1]]):
                                  # Both columns biological IDs → legacy format, not 2 conditions.
                                  featureID = ":::".join([line[0], line[1]]).lower()
@@ -1052,7 +1085,20 @@ class Job(Model):
 
                         # Multi-condition logic: Each column (from index 0 to n) contains IDs
                         if nConditions > 1 and not isBedFormat:
-                            for colIndex, featureID in enumerate(line):
+                            # The flag lists were sized from row 1, so a wider row
+                            # (R's write.table default emits header N / rows N+1)
+                            # wrote past the end and aborted the whole job. The
+                            # declared width wins; extra cells cannot belong to
+                            # any condition, so they are dropped, once, loudly.
+                            if len(line) > nConditions and not raggedRowsWarned:
+                                raggedRowsWarned = True
+                                logging.warning(
+                                    "PARSING RELEVANT FEATURES FILE (%s): row %d has %d "
+                                    "columns but the file declares %d condition(s); "
+                                    "ignoring the extra cells (R's write.table row-names "
+                                    "produce this shape).",
+                                    fileName, nLine, len(line), nConditions)
+                            for colIndex, featureID in enumerate(line[:nConditions]):
                                 if featureID.strip():
                                     fID = featureID.lower()
                                     if fID not in relevantFeatures:

--- a/PaintomicsServer/src/classes/JobInstances/Bed2GeneJob.py
+++ b/PaintomicsServer/src/classes/JobInstances/Bed2GeneJob.py
@@ -174,6 +174,30 @@ class Bed2GeneJob(Job):
         logging.info("VALIDATING REGION BASED FILES..." )
         nConditions, error = self.validateFile(self.geneBasedInputOmics[0], -1, error)
 
+        # The user-supplied annotation/GTF travels as a referenceInput and was
+        # never passed through the encoding pass, so a latin-1 byte in an
+        # attribute field crashed the association script instead of validating.
+        # Gzipped references are legitimate (the script gunzips them itself)
+        # and are not text, so they are left alone.
+        # getattr, not a direct call: jobs restored from older serialisations
+        # (and the validation tests' stubs) may not carry referenceInputs.
+        try:
+            referenceInputs = self.getReferenceInputs() or []
+        except AttributeError:
+            referenceInputs = []
+        for referenceInput in referenceInputs:
+            referenceFileName = referenceInput.get("inputDataFile", "") or ""
+            if not referenceFileName or referenceFileName.endswith(".gz"):
+                continue
+            referencePath = "{path}/{file}".format(
+                path=self.getInputDir(), file=referenceFileName)
+            if os_path.isfile(referencePath):
+                encodingError = ensure_utf8(referencePath)
+                if encodingError is not None:
+                    error += (" - Errors detected while processing " +
+                              os_path.basename(referenceFileName) + ": " +
+                              encodingError + ".\n")
+
         if error != "":
             raise Exception("Errors detected in input files, please fix the following issues and try again:" + error)
 
@@ -209,17 +233,24 @@ class Bed2GeneJob(Job):
         # out of a validation routine, reaching the user as an internal error
         # rather than a message about the file. A gene name with an accent in a
         # file saved from Excel is enough to do it.
+        encodingFailed = False
         for encodingTarget in (relevantFileName, valuesFileName):
             if os_path.isfile(encodingTarget):
                 encodingError = ensure_utf8(encodingTarget)
                 if encodingError is not None:
+                    encodingFailed = True
                     error += (" - Errors detected while processing " +
                               os_path.basename(encodingTarget) + ": " +
                               encodingError + ".\n")
+        # A recorded encoding failure means the file is still non-UTF-8 on
+        # disk: falling through to the readers below crashed with the very
+        # UnicodeDecodeError the message above was written to prevent.
+        if encodingFailed:
+            return nConditions, error
 
         logging.info("VALIDATING RELEVANT REGIONS FILE (" + omicName + ")..." )
         if os_path.isfile(relevantFileName):
-            with open(relevantFileName, 'r') as inputDataFile:
+            with open(relevantFileName, 'r', encoding='utf-8-sig') as inputDataFile:
                 nLine = -1
                 erroneousLines = {}
 
@@ -263,7 +294,7 @@ class Bed2GeneJob(Job):
 
         #IF THE USER UPLOADED VALUES FOR GENE EXPRESSION
         if os_path.isfile(valuesFileName):
-            with open(valuesFileName, 'r') as inputDataFile:
+            with open(valuesFileName, 'r', encoding='utf-8-sig') as inputDataFile:
                 nLine = -1
                 erroneousLines = {}
 

--- a/PaintomicsServer/src/classes/JobInstances/MiRNA2GeneJob.py
+++ b/PaintomicsServer/src/classes/JobInstances/MiRNA2GeneJob.py
@@ -156,17 +156,38 @@ class MiRNA2GeneJob(Job):
         # out of a validation routine, reaching the user as an internal error
         # rather than a message about the file. A gene name with an accent in a
         # file saved from Excel is enough to do it.
-        for encodingTarget in (relevantFileName, valuesFileName):
-            if os_path.isfile(encodingTarget):
+        # The association files (miRNA→gene reference and its relevant subset)
+        # are user uploads too, read later by detect_delimiter and the
+        # bioscripts with no encoding pass of their own — a latin-1 reference
+        # map crashed processFilesContent after validation had passed.
+        associationsFileName = inputOmic.get("associationsFile", "") or ""
+        relevantAssociationsFileName = inputOmic.get("relevantAssociationsFile", "") or ""
+        if associationsFileName:
+            associationsFileName = "{path}/{file}".format(
+                path=self.getInputDir(), file=associationsFileName)
+        if relevantAssociationsFileName:
+            relevantAssociationsFileName = "{path}/{file}".format(
+                path=self.getInputDir(), file=relevantAssociationsFileName)
+
+        encodingFailed = False
+        for encodingTarget in (relevantFileName, valuesFileName,
+                               associationsFileName, relevantAssociationsFileName):
+            if encodingTarget and os_path.isfile(encodingTarget):
                 encodingError = ensure_utf8(encodingTarget)
                 if encodingError is not None:
+                    encodingFailed = True
                     error += (" - Errors detected while processing " +
                               os_path.basename(encodingTarget) + ": " +
                               encodingError + ".\n")
+        # A recorded encoding failure means the file is still non-UTF-8 on
+        # disk: falling through to the readers below crashed with the very
+        # UnicodeDecodeError the message above was written to prevent.
+        if encodingFailed:
+            return nConditions, error
 
         logging.info("VALIDATING RELEVANT FEATURES FILE (" + omicName + ")..." )
         if os_path.isfile(relevantFileName):
-            f = open(relevantFileName, 'r')
+            f = open(relevantFileName, 'r', encoding='utf-8-sig')
             lines = f.readlines()
 
             if len(lines) > MAX_NUMBER_FEATURES:
@@ -185,7 +206,7 @@ class MiRNA2GeneJob(Job):
 
         #IF THE USER UPLOADED VALUES FOR GENE EXPRESSION
         if os_path.isfile(valuesFileName):
-            with open(valuesFileName, 'r') as inputDataFile:
+            with open(valuesFileName, 'r', encoding='utf-8-sig') as inputDataFile:
                 nLine = -1
                 erroneousLines = {}
 

--- a/PaintomicsServer/src/classes/JobInstances/PathwayAcquisitionJob.py
+++ b/PaintomicsServer/src/classes/JobInstances/PathwayAcquisitionJob.py
@@ -2112,9 +2112,16 @@ class PathwayAcquisitionJob(Job):
                         # metagene trend charts are an enhancement, so skip this
                         # omic/database pair instead of failing the whole of
                         # step 2 for a dataset that mapped a handful of genes.
-                        if "no available data for fitting" in error_detail:
+                        # "more cluster centers than distinct data points" is the
+                        # k-means flavour of the same situation (e.g. 2-condition
+                        # designs collapse every centred profile onto 2 points).
+                        degenerate_data_messages = (
+                            "no available data for fitting",
+                            "more cluster centers than distinct data points",
+                        )
+                        if any(m in error_detail for m in degenerate_data_messages):
                             logging.warning(
-                                "STEP2 - too few mapped features to cluster metagenes "
+                                "STEP2 - degenerate metagene geometry, cannot cluster "
                                 "for omic '%s' (%s); continuing without metagenes.",
                                 inputOmic.get("omicName"), dbname)
                             continue

--- a/PaintomicsServer/src/classes/JobInstances/PathwayAcquisitionJob.py
+++ b/PaintomicsServer/src/classes/JobInstances/PathwayAcquisitionJob.py
@@ -278,8 +278,14 @@ class PathwayAcquisitionJob(Job):
             # First position: dictionary with identifiers.
             # With multiple databases "Total" is the maximum
             # Compounds omics only have one value (no dict)
-            totalMapped = omicSummary[0].get("Total", list(omicSummary[0].values())[0]) if not isinstance(
-                omicSummary[0], (int)) else omicSummary[0]
+            # Lazy fallback: .get(key, expr) evaluates expr even when the key
+            # exists, and an empty dict made list({}.values())[0] raise.
+            if isinstance(omicSummary[0], int):
+                totalMapped = omicSummary[0]
+            else:
+                totalMapped = omicSummary[0].get("Total")
+                if totalMapped is None:
+                    totalMapped = next(iter(omicSummary[0].values()), 0)
 
             # Second position: considering total if it exists
             totalUnmapped = omicSummary[1]
@@ -418,7 +424,14 @@ class PathwayAcquisitionJob(Job):
 
         logging.info("VALIDATING RELEVANT ASSOCIATION FILE (" + omicName + ")...")
         if os_path.isfile(relevantAssociationsFileName):
-            ensure_utf8(relevantAssociationsFileName)
+            # This was the one call site that dropped the reason: an unreadable
+            # relevant-associations file then crashed two lines later inside
+            # detect_delimiter instead of becoming a validation message.
+            encodingError = ensure_utf8(relevantAssociationsFileName)
+            if encodingError is not None:
+                error += " - Errors detected while processing " + \
+                         inputOmic.get("relevantAssociationsFile", "") + ": " + encodingError + ".\n"
+                return nConditions, error
             nLine = -1
             rel_assoc_delimiter = Job.detect_delimiter(relevantAssociationsFileName)
             with open(relevantAssociationsFileName, 'r', encoding='utf-8-sig', newline='') as relevantAssociationDataFile:
@@ -2093,6 +2106,18 @@ class PathwayAcquisitionJob(Job):
                         error_detail = ex.output.decode('utf-8') if ex.output else str(ex)
                         logging.error("STEP2 - Error while generating metagenes information for " + inputOmic.get("omicName") + " db: " + str(dbname))
                         logging.error(f"Subprocess output: {error_detail}")
+                        # Too few mapped features for clustering is a property
+                        # of a small upload, not a broken server: mclust reports
+                        # "no available data for fitting" on numeric(0). The
+                        # metagene trend charts are an enhancement, so skip this
+                        # omic/database pair instead of failing the whole of
+                        # step 2 for a dataset that mapped a handful of genes.
+                        if "no available data for fitting" in error_detail:
+                            logging.warning(
+                                "STEP2 - too few mapped features to cluster metagenes "
+                                "for omic '%s' (%s); continuing without metagenes.",
+                                inputOmic.get("omicName"), dbname)
+                            continue
                         raise RuntimeError(f"Metagenes generation failed for omic '{inputOmic.get('omicName')}' and database '{dbname}'. Details: {error_detail}")
 
                     # STEP 2.2 PROCESS THE RESULTING FILE
@@ -2267,8 +2292,20 @@ class PathwayAcquisitionJob(Job):
         # hub analysis rendered as a heading with nothing under it.
         #
         # Unwrap until a dict falls out, so a file written either way loads.
-        with open(interactionJSONPath, 'r') as e:
-            compoundRegulateFeatures = json.loads(e.read())
+        #
+        # Not every installed species ships hubData (87 of ~97 on the
+        # production server; a fresh install may lack it entirely). That used
+        # to be a FileNotFoundError that killed the whole of step 2 for eco
+        # and every newly installed bacterium — the hub extras must degrade,
+        # not take the pathway results down with them.
+        if os.path.isfile(interactionJSONPath):
+            with open(interactionJSONPath, 'r') as e:
+                compoundRegulateFeatures = json.loads(e.read())
+        else:
+            logging.warning("HUB ANALYSIS - %s does not exist (species installed "
+                            "without hubData); metabolite neighbours will be "
+                            "unavailable.", interactionJSONPath)
+            compoundRegulateFeatures = {}
 
         for _ in range(4):
             if isinstance(compoundRegulateFeatures, dict):
@@ -2484,6 +2521,15 @@ class PathwayAcquisitionJob(Job):
         if not userDEfeatures:
             return False
 
+        # A species installed without hubData has nothing for the R script to
+        # read; the client already renders hubAnalysisResult=False as "no hub
+        # analysis", so degrade the same way instead of crashing step 2.
+        hubDataDir = KEGG_DATA_DIR + 'current/' + self.organism + '/hubData/'
+        if not os.path.isdir(hubDataDir):
+            logging.warning("HUB ANALYSIS - %s does not exist (species installed "
+                            "without hubData); skipping hub analysis.", hubDataDir)
+            return False
+
         import csv
         with open(self.outputDir + "userDataset.csv", 'w') as w:
             writer = csv.writer(w)
@@ -2493,20 +2539,28 @@ class PathwayAcquisitionJob(Job):
             writer = csv.writer(w)
             writer.writerow(userDEfeatures)
 
-        check_call(
-            [
-                ROOT_DIRECTORY + "common/bioscripts/hubAnalysis.R",
-                '--data_dir="' + self.outputDir + '"',
-                '--inputDir="' + KEGG_DATA_DIR + 'current/' + self.organism + '/hubData/' + '"'
-            ], stderr=STDOUT
-        )
+        # The hub analysis is an enhancement panel: a failure in the R script
+        # (partial hubData, missing R deps) must not take down the pathway
+        # results that step 2 exists to produce.
+        try:
+            check_call(
+                [
+                    ROOT_DIRECTORY + "common/bioscripts/hubAnalysis.R",
+                    '--data_dir="' + self.outputDir + '"',
+                    '--inputDir="' + hubDataDir + '"'
+                ], stderr=STDOUT
+            )
 
-        hubResult = {}
+            hubResult = {}
 
-        with open(self.outputDir + 'hub_result.csv', "r") as f:
-            reader = csv.reader(f, delimiter="\t")
-            for i, line in enumerate(reader):
-                hubResult[i] = line
+            with open(self.outputDir + 'hub_result.csv', "r") as f:
+                reader = csv.reader(f, delimiter="\t")
+                for i, line in enumerate(reader):
+                    hubResult[i] = line
+        except Exception as ex:
+            logging.warning("HUB ANALYSIS - failed for %s (%s); continuing "
+                            "without hub results.", self.organism, str(ex))
+            return False
 
         self.hubAnalysisResult = hubResult
 

--- a/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
+++ b/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
@@ -346,8 +346,12 @@ def mapFeatureIdentifiers(jobID, organism, databases, featureList,  matchedFeatu
                         # TODO: check why this is not always applied as there are some features without matching DB
                         featureClone.setMatchingDB(databaseConvertion_name)
 
-                        # For some IDs there might be more than one symbol, select the first one from the set
-                        featureName = cacheSymbolsIDS.get(featureID, [featureClone.getName()])[0]
+                        # For some IDs there might be more than one symbol, select the first
+                        # one from the set. A cached entry can legitimately be an empty
+                        # list (species installed with symbols=0), which indexed [0] and
+                        # aborted the whole mapping.
+                        cachedSymbols = cacheSymbolsIDS.get(featureID) or [featureClone.getName()]
+                        featureName = cachedSymbols[0]
 
                         featureClone.setName(featureName)
                         matchedFeatures.append(featureClone)
@@ -492,7 +496,8 @@ def mapFeatureNamesToKeggIDs(jobID, organism, databases, featureList, enrichment
     #***********************************************************************************
     #* STEP 4. RETURN THE RESULTS
     #***********************************************************************************
-    logging.info("FINISHED. " + str(sumFoundFeatures[list(sumFoundFeatures.keys())[0]]) + " uniquely matched features, " +  str(len(matchedFeatures)) + " features matched. " + str(len(notMatchedFeatures)) + " features not matched.")
+    logging.info("FINISHED. %s uniquely matched features, %d features matched. %d features not matched.",
+                 next(iter(sumFoundFeatures.values()), 0), len(matchedFeatures), len(notMatchedFeatures))
 
     # Materialise the proxies with ONE round trip each before returning them.
     # BaseListProxy exposes __getitem__/__len__ but not __iter__, so a caller's

--- a/PaintomicsServer/src/common/JobInformationManager.py
+++ b/PaintomicsServer/src/common/JobInformationManager.py
@@ -291,6 +291,23 @@ class JobInformationManager(metaclass=Singleton):
                 " was uploaded from.")
         return origin
 
+    @staticmethod
+    def _requiredFileLocation(formFields, fieldName, fileLabel):
+        """Return an upload's `*_filelocation` form field, or say which one is missing.
+
+        Same contract as _requiredOrigin: these fields are read whenever an
+        origin says the file was previously uploaded ('mydata', inbuilt GTF, or
+        a cross-omic reference). A missing field used to surface as
+        AttributeError: 'NoneType' object has no attribute 'replace'.
+        """
+        location = formFields.get(fieldName)
+        if location is None or str(location).strip() == "":
+            raise UserWarning(
+                "Malformed submission: the form field '" + fieldName +
+                "' is missing or empty, so PaintOmics cannot locate the " +
+                fileLabel + " it refers to.")
+        return str(location)
+
     def saveFiles(self, uploadedFiles, formFields, userID, jobInstance, CLIENT_TMP_DIR, EXAMPLE_FILES_DIR=""):
         nOthers = 1
         uploadedDataFile = None
@@ -315,6 +332,14 @@ class JobInformationManager(metaclass=Singleton):
                 # Default matching type: gene
                 matchingType = formFields.get(uploadedFileName.replace("file","match_type"), "gene")
                 omicType = formFields.get(uploadedFileName.replace("file","omic_name"))  ##GET THE OMIC NAME: "Gene Expression", "Metabolomics", "Proteomics", .... (or user name)
+                if omicType is None:
+                    # Concatenated into paths and log lines below; None used to
+                    # surface as an opaque TypeError instead of naming the field.
+                    raise UserWarning(
+                        "Malformed submission: the form field '" +
+                        uploadedFileName.replace("file", "omic_name") +
+                        "' is missing, so PaintOmics cannot tell which omic the "
+                        "file '" + uploadedFileName + "' belongs to.")
 
                 fields["omicType"] = omicType
                 fields["dataType"] =  formFields.get(uploadedFileName.replace("file","file_type")) ##GET THE FILE TYPE: GENE EXPRESSION, ETC.
@@ -372,11 +397,15 @@ class JobInformationManager(metaclass=Singleton):
                         savedFiles[dataOmicId] = dataFileName = saveFile(userID, dataFileName, fields, uploadedDataFile, CLIENT_TMP_DIR)
 
             elif(origin == 'mydata'):
-                dataFileName = formFields.get(uploadedFileName.replace("file","filelocation")).replace("[MyData]/","")
-                logging.info("SAVE FILES  - USING ALREADY SUBMITTED FILE (data file) " + dataFileName + " FOR  " + omicType)
+                dataFileName = self._requiredFileLocation(
+                    formFields, uploadedFileName.replace("file","filelocation"),
+                    "data file").replace("[MyData]/","")
+                logging.info("SAVE FILES  - USING ALREADY SUBMITTED FILE (data file) %s FOR %s", dataFileName, omicType)
             elif(origin == 'inbuilt_gtf'):
-                dataFileName = EXAMPLE_FILES_DIR + "GTF/" + formFields.get(uploadedFileName.replace("file","filelocation")).replace("[inbuilt GTF files]/","")
-                logging.info("SAVE FILES  - USING ALREADY INBUILT GTF FILE " + dataFileName + " FOR  " + omicType)
+                dataFileName = EXAMPLE_FILES_DIR + "GTF/" + self._requiredFileLocation(
+                    formFields, uploadedFileName.replace("file","filelocation"),
+                    "inbuilt GTF file").replace("[inbuilt GTF files]/","")
+                logging.info("SAVE FILES  - USING ALREADY INBUILT GTF FILE %s FOR %s", dataFileName, omicType)
             elif('filelocation' in origin):
                 # The omic references the file of another omic
                 originName = origin.split('_', 1)[0]
@@ -392,8 +421,11 @@ class JobInformationManager(metaclass=Singleton):
                     dataFileName = uploadedDataFile.filename
 
                     # If the file was previously saved, retrieve the final name.
+                    # Keyed by the form field name, exactly as it was stored:
+                    # looking it up by the FileStorage object always returned
+                    # None and registered the omic with inputDataFile: None.
                     if dataOmicId in savedFiles:
-                        dataFileName = savedFiles.get(uploadedDataFile)
+                        dataFileName = savedFiles.get(dataOmicId)
                     else:
                         if (dataFileName == ''):
                             logging.info("\tIGNORING " + omicType + ", EMPTY FILE OR NOT PROVIDED")
@@ -410,14 +442,21 @@ class JobInformationManager(metaclass=Singleton):
                             savedFiles[dataOmicId] = dataFileName = saveFile(userID, dataFileName, fields, uploadedDataFile, CLIENT_TMP_DIR)
 
                 else:
-                    dataFileName = formFields.get(originName +  "_filelocation").replace("[MyData]/", "")
+                    dataFileName = self._requiredFileLocation(
+                        formFields, originName + "_filelocation",
+                        "referenced data file").replace("[MyData]/", "")
             else:
                 logging.info("\tIGNORING " + omicType + ", EMPTY FILE OR NOT PROVIDED")
                 continue
 
             # TODO: move this to a loop? They are the same but changing file properties
             #SAVE THE ASSOCIATED RELEVANT FEATURED FILE (IF ANY)
-            if (uploadedRelevantFile is not None):
+            # An untouched <input type=file> still submits a part with
+            # filename="" — werkzeug classifies it as a file. Saving that
+            # empty name built '<inputData>//', which open()ed the directory
+            # itself (IsADirectoryError). Same guard as the data-file branch:
+            # empty means absent.
+            if (uploadedRelevantFile is not None and (uploadedRelevantFile.filename or "") != ""):
                 relevantFileName = uploadedRelevantFile.filename
                 origin = self._requiredOrigin(
                     formFields, uploadedFileName.replace("file", "relevant") + "_origin",
@@ -427,7 +466,7 @@ class JobInformationManager(metaclass=Singleton):
                 fieldsRelevant["dataType"]= formFields.get(uploadedFileName.replace("file","relevant_file_type")) ##GET THE FILE TYPE: GENE EXPRESSION, ETC.
                 fieldsRelevant["description"] =  formFields.get(uploadedFileName.replace("file","description"), "Uploaded using the submission form.")##GET THE FILE DESCRIPTION
 
-                logging.info("STEP1 - ORIGIN FOR " + uploadedFileName.replace("file","relevant") + " IS " + origin)
+                logging.info("STEP1 - ORIGIN FOR %s IS %s", uploadedFileName.replace("file","relevant"), origin)
                 if(origin == 'client'):
                     #TODO: GENERATE AUTOMATICALLY THE DATA TYPE (Gene exp, Gene list, etc.) AND THE DESCRIPTION
                     ##SAVE THE FILE, GET THE NEW NAME IF ALREADY EXISTS
@@ -437,13 +476,15 @@ class JobInformationManager(metaclass=Singleton):
 
                     relevantFileName = saveFile(userID, relevantFileName, fieldsRelevant, uploadedRelevantFile, CLIENT_TMP_DIR)
                 else:
-                    relevantFileName = formFields.get(uploadedFileName.replace("file","relevant_filelocation")).replace("[MyData]/","")
-                    logging.info("STEP1 - USING ALREADY SUBMITTED FILE (relevant features file) " + relevantFileName + " FOR  " + omicType)
+                    relevantFileName = self._requiredFileLocation(
+                        formFields, uploadedFileName.replace("file","relevant_filelocation"),
+                        "relevant features file").replace("[MyData]/","")
+                    logging.info("STEP1 - USING ALREADY SUBMITTED FILE (relevant features file) %s FOR %s", relevantFileName, omicType)
             else:
                 relevantFileName = None
 
             #SAVE THE ASSOCIATIONS FILE (IF ANY)
-            if uploadedAssociationDataFile is not None:
+            if uploadedAssociationDataFile is not None and (uploadedAssociationDataFile.filename or "") != "":
                 associationsFileName = uploadedAssociationDataFile.filename
                 origin = self._requiredOrigin(
                     formFields, uploadedFileName.replace("file", "associations") + "_origin",
@@ -463,12 +504,14 @@ class JobInformationManager(metaclass=Singleton):
 
                     associationsFileName = saveFile(userID, associationsFileName, fieldsAssociations, uploadedAssociationDataFile, CLIENT_TMP_DIR)
                 else:
-                    associationsFileName = formFields.get(uploadedFileName.replace("file","associations_filelocation")).replace("[MyData]/","")
-                    logging.info("STEP1 - USING ALREADY SUBMITTED FILE (associationss file) " + associationsFileName + " FOR  " + omicType)
+                    associationsFileName = self._requiredFileLocation(
+                        formFields, uploadedFileName.replace("file","associations_filelocation"),
+                        "associations file").replace("[MyData]/","")
+                    logging.info("STEP1 - USING ALREADY SUBMITTED FILE (associations file) %s FOR %s", associationsFileName, omicType)
 
                 # SAVE THE RELEVANT ASSOCIATIONS FILE (IF ANY)
                 # TODO: currently only if the associations file is present
-                if uploadedAssociationRelevantFile is not None and formFields.get(uploadedFileName.replace("file", "relevant_associations") + "_origin") is not None:
+                if uploadedAssociationRelevantFile is not None and (uploadedAssociationRelevantFile.filename or "") != "" and formFields.get(uploadedFileName.replace("file", "relevant_associations") + "_origin") is not None:
                     relevantAssociationsFileName = uploadedAssociationRelevantFile.filename
                     # The enclosing condition already established this field is
                     # present; going through the same helper as the other three
@@ -492,8 +535,10 @@ class JobInformationManager(metaclass=Singleton):
 
                         relevantAssociationsFileName = saveFile(userID, relevantAssociationsFileName, fieldsRelevantAssociations, uploadedAssociationRelevantFile, CLIENT_TMP_DIR)
                     else:
-                        relevantAssociationsFileName = formFields.get(uploadedFileName.replace("file", "relevant_associations_filelocation")).replace("[MyData]/", "")
-                        logging.info("STEP1 - USING ALREADY SUBMITTED FILE (relevant associations file) " + relevantAssociationsFileName + " FOR  " + omicType)
+                        relevantAssociationsFileName = self._requiredFileLocation(
+                            formFields, uploadedFileName.replace("file", "relevant_associations_filelocation"),
+                            "relevant associations file").replace("[MyData]/", "")
+                        logging.info("STEP1 - USING ALREADY SUBMITTED FILE (relevant associations file) %s FOR %s", relevantAssociationsFileName, omicType)
             else:
                 relevantAssociationsFileName = associationsFileName = None
 

--- a/PaintomicsServer/src/common/Util.py
+++ b/PaintomicsServer/src/common/Util.py
@@ -17,6 +17,10 @@
 #  More info http://bioinfo.cipf.es/paintomics
 #  Technical contact paintomics4@gmail.com
 #**************************************************************
+import codecs
+import os
+import tempfile
+
 from PIL.Image import open as image_open
 from chardet import detect # get the encoding of a file
 
@@ -244,6 +248,46 @@ def _decodes_as_utf8(sample, isPartial):
         return isPartial and exc.start >= len(sample) - 3
 
 
+# Containers and spreadsheets are not text in any encoding: transcoding them
+# "succeeds" under any single-byte codec and rewrites the archive as mojibake.
+# Sniffed by magic number so the user gets the message they actually need.
+_BINARY_MAGIC = (
+    (b"PK\x03\x04", "an Excel/zip file (.xlsx/.zip)"),
+    (b"\xd0\xcf\x11\xe0", "a legacy Excel file (.xls)"),
+    (b"\x1f\x8b", "a gzip-compressed file (.gz)"),
+    (b"%PDF", "a PDF document"),
+)
+
+
+def _binary_upload_reason(sample):
+    """A human-readable description when `sample` opens a known binary format.
+
+    NUL bytes are deliberately NOT treated as evidence here: UTF-16 text is
+    full of them and is a supported (transcoded) upload encoding. The NUL
+    check lives in ensure_utf8, after chardet has had the chance to call the
+    file UTF-16/32.
+    """
+    for magic, description in _BINARY_MAGIC:
+        if sample.startswith(magic):
+            return description
+    return None
+
+
+def _whole_file_is_utf8(filepath):
+    """Stream-decode the entire file as UTF-8, in bounded memory."""
+    decoder = codecs.getincrementaldecoder('utf-8-sig')()
+    try:
+        with open(filepath, 'rb') as handle:
+            while True:
+                chunk = handle.read(1 << 20)
+                if not chunk:
+                    decoder.decode(b'', final=True)
+                    return True
+                decoder.decode(chunk)
+    except UnicodeDecodeError:
+        return False
+
+
 def ensure_utf8(filepath):
     """Rewrite `filepath` as UTF-8 in place when it is in some other encoding.
 
@@ -256,6 +300,11 @@ def ensure_utf8(filepath):
     unsafe: single-byte codecs such as cp1252 accept *any* byte sequence, so a
     misdetected UTF-8 file would be silently rewritten into mojibake rather
     than left alone.
+
+    The prefix bounds only the chardet GUESS. The UTF-8 verdict must cover the
+    whole file, because every downstream reader decodes the whole file: a
+    multi-MB upload whose single bad byte sat past the sniff window used to
+    pass here and then raise UnicodeDecodeError in the csv loop.
     """
     with open(filepath, 'rb') as handle:
         sample = handle.read(_ENCODING_SNIFF_BYTES + 1)
@@ -264,24 +313,71 @@ def ensure_utf8(filepath):
     if not sample:
         return None
 
+    binaryReason = _binary_upload_reason(sample)
+    if binaryReason is not None:
+        return ("this looks like " + binaryReason +
+                ", not a text table; please export it as tab-delimited UTF-8 text")
+
     isPartial = len(sample) > _ENCODING_SNIFF_BYTES
     if _decodes_as_utf8(sample, isPartial):
-        return None
+        if not isPartial or _whole_file_is_utf8(filepath):
+            return None
+        # The prefix is clean UTF-8 but a later byte is not: fall through to
+        # chardet with the evidence we have, exactly as for a bad prefix.
 
     detected = detect(sample).get('encoding')
     if not detected:
+        if b"\x00" in sample:
+            return ("this looks like a binary file, not a text table; "
+                    "please export it as tab-delimited UTF-8 text")
         return "the character encoding could not be determined, please save the file as UTF-8"
 
-    try:
-        with open(filepath, 'rb') as handle:
-            text = handle.read().decode(detected)
-    except (UnicodeDecodeError, LookupError):
+    # NUL bytes in anything but a UTF-16/32 family file mean binary content:
+    # single-byte codecs would "decode" it happily and rewrite the upload as
+    # mojibake, moving the crash downstream to `_csv.Error: line contains NUL`.
+    if b"\x00" in sample and not detected.lower().replace("-", "").startswith(("utf16", "utf32")):
+        return ("this looks like a binary file, not a text table; "
+                "please export it as tab-delimited UTF-8 text")
+
+    # The guess came from the prefix, so it can be too narrow for the byte
+    # that actually offends (an all-ASCII prefix guesses 'ascii' even when a
+    # latin-1 byte sits at row 20,000). cp1252/latin-1 are the real-world
+    # superset codecs for that shape, so fall through to them before giving
+    # up; latin-1 accepts any byte, keeping the transcode total for text-ish
+    # files, while true binaries were already rejected above.
+    text = None
+    candidates = [detected]
+    for fallback in ("cp1252", "latin-1"):
+        if fallback not in [c.lower() for c in candidates]:
+            candidates.append(fallback)
+    with open(filepath, 'rb') as handle:
+        raw = handle.read()
+    for candidate in candidates:
+        try:
+            text = raw.decode(candidate)
+            break
+        except (UnicodeDecodeError, LookupError):
+            continue
+    del raw
+    if text is None:
         return ("the file could not be read as " + str(detected) +
                 ", please save it as UTF-8")
 
     # newline='' keeps the line endings exactly as decoded; the readers below
     # already cope with CRLF, and rewriting them here would be a silent edit of
-    # the user's file.
-    with open(filepath, 'w', encoding='utf-8', newline='') as handle:
-        handle.write(text)
+    # the user's file. Written to a sibling temp file and os.replace()d so a
+    # concurrent job referencing the same [MyData] file never observes a
+    # half-written table.
+    directory = os.path.dirname(filepath) or "."
+    fd, tmpPath = tempfile.mkstemp(prefix=".utf8_", dir=directory)
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8', newline='') as handle:
+            handle.write(text)
+        os.replace(tmpPath, filepath)
+    except BaseException:
+        try:
+            os.remove(tmpPath)
+        except OSError:
+            pass
+        raise
     return None

--- a/PaintomicsServer/src/common/bioscripts/DHS_exon_association.py
+++ b/PaintomicsServer/src/common/bioscripts/DHS_exon_association.py
@@ -838,7 +838,7 @@ def run(gtf, dhs, outputfile, match_table, options=None, managed_queue=None):
         # 1. First, we save all the genes with their positions
         inputGTF = None
         if gtf[-2:] == "gz":
-            aux = gzip.open(gtf, 'rb').read().decode()
+            aux = gzip.open(gtf, 'rb').read().decode(errors='replace')
             inputGTF = aux.split("\n")
         else:
             inputGTF = open(gtf, 'r')

--- a/PaintomicsServer/src/common/bioscripts/generateMetaGenes.R
+++ b/PaintomicsServer/src/common/bioscripts/generateMetaGenes.R
@@ -2,6 +2,12 @@
 
 #Functions
 getBestIndexBy2SlopeLesser1stQuartilSlope <- function(p) {
+  # A scan over k.max < 3 yields at most one slope, and the i/i+1 walk below
+  # then reads past the end of y (y[2] is NA -> "missing value where TRUE/FALSE
+  # needed", which aborts the script). With only k = 1..2 on the curve there is
+  # no elbow to pick; the largest scanned k is the only informative answer and
+  # the clamp after the caller bounds it by the distinct-point geometry anyway.
+  if (nrow(p$data) < 3) { return(nrow(p$data)) }
   v = 2:nrow(p$data)
   y = p$data$y[v]-p$data$y[v-1]
   firstQ = summary(y)[2]
@@ -370,7 +376,21 @@ if(is.null(args$kclusters) || args$kclusters == "dynamic") {
     k.max <- round(sqrt(length(row.names(dataScaled))/2)) + 1
     if (k.max < 2) k.max <- 2
 
-    if(args$cluster=="kmeans"){
+    # The elbow scan below runs kmeans for EVERY k up to k.max, so it aborts on
+    # "more cluster centers than distinct data points" long before the clamp
+    # after this block can help. The geometry matters with two conditions: the
+    # centred, unit-norm rows occupy exactly 2 distinct locations, so any
+    # k.max > 2 kills the scan. Bound the scan by the distinguishable points
+    # (same rounding rationale as the clamp below).
+    distinctPoints <- nrow(unique(round(dataForClustering, 10)))
+    if (is.finite(distinctPoints) && k.max > distinctPoints) k.max <- distinctPoints
+
+    if (k.max < 2) {
+      # A single distinguishable profile cannot be partitioned; fviz_nbclust
+      # and Mclust both require k.max >= 2, so decide directly.
+      cat("Only", distinctPoints, "distinct metagene profile(s); using 1 cluster. ")
+      args$kclusters <- 1
+    } else if(args$cluster=="kmeans"){
       # Check best cluster using WSS. Run the elbow over the same matrix the
       # final clustering uses -- it previously scanned dataScaled while the
       # clustering ran on the distance matrix, so the chosen k described a

--- a/PaintomicsServer/src/common/bioscripts/miRNA2Target.py
+++ b/PaintomicsServer/src/common/bioscripts/miRNA2Target.py
@@ -129,7 +129,7 @@ def run(referenceFile, relevantReferenceFile, dataFile, geneExpresion, corrOutpu
     #STEP 2. FILL THE TABLE WITH ALL THE TARGETS FOR EACH MIRNA
     print("STEP 2. Reading miRNA -> targets file...")
 
-    with open(referenceFile, 'r') as inputDataFile:
+    with open(referenceFile, 'r', encoding='utf-8-sig', errors='replace') as inputDataFile:
         for line in csv_reader(inputDataFile, delimiter="\t"):
             if line[0] in miRNAtable:
                 miRNAtable[line[0]]["targets"].append(line[1])

--- a/PaintomicsServer/src/paintomicsserver.py
+++ b/PaintomicsServer/src/paintomicsserver.py
@@ -602,7 +602,7 @@ class Application(object):
 
         @self.app.route(SERVER_SUBDOMAIN + '/ai_generate_exp_design', methods=['OPTIONS', 'POST'])
         def aiGenerateExpDesignHandler():
-            return aiGenerateExpDesign(request, Response()).getResponse()
+            return aiGenerateExpDesign(request, Response(), self.EXAMPLE_FILES_DIR).getResponse()
         #*******************************************************************************************
         # AI INTERPRETATION SERVLETS HANDLERS - END
         #############################################################################################

--- a/PaintomicsServer/src/resources/logging.cfg
+++ b/PaintomicsServer/src/resources/logging.cfg
@@ -24,7 +24,7 @@ args=(sys.stdout,)
 [handler_fileHandler]
 formatter=info
 class=handlers.RotatingFileHandler
-args=(os.path.join(sys.path[0],'log/application.log'),'a','maxBytes=31457280', 'backupCount=15')
+args=(os.path.join(sys.path[0],'log/application.log'),'a',31457280,15)
 
 [formatter_info]
 format=%(asctime)s - %(levelname)s - %(filename)s : %(funcName)s - %(message)s

--- a/PaintomicsServer/src/servlets/AIInterpretServlet.py
+++ b/PaintomicsServer/src/servlets/AIInterpretServlet.py
@@ -447,7 +447,82 @@ def _sanitizeColumnNames(rawColumns):
     return cleaned[:_EXPDESIGN_MAX_COLUMNS], dropped
 
 
-def aiGenerateExpDesign(REQUEST, RESPONSE):
+# Enough of a data file to be sure of catching its first newline; the same
+# bound the browser uses for an upload (EXP_DESIGN_HEADER_BYTES in
+# PA_Step1Views.js), so the two paths read the same amount.
+_EXPDESIGN_HEADER_BYTES = 262144
+
+
+def _looksLikeDataRow(columns):
+    """True when a file's first line is a measurement row, not a header.
+
+    Not every example file has a header: the default scenario's
+    mirna_values.tab opens directly with '<id>\\t-0.297...\\t...'. Sending that
+    line onward would put six measured values into the LLM prompt labelled as
+    column names -- exactly what the privacy contract promises never happens.
+    A header names its columns, so its labels do not parse as numbers; a data
+    row is numbers in every column after the identifier. Majority-numeric
+    decides, and the asymmetry is deliberate: wrongly skipping a header costs
+    the draft one omic's names, wrongly keeping a data row leaks values.
+    """
+    cells = [cell.strip() for cell in columns[1:] if cell.strip()]
+    if not cells:
+        return False
+    numeric = 0
+    for cell in cells:
+        try:
+            float(cell)
+            numeric += 1
+        except ValueError:
+            pass
+    return numeric * 2 >= len(cells)
+
+
+def _exampleHeaderOmics(exampleFilesDir, scenarioId):
+    """Column-header omics for an example scenario, read server-side.
+
+    The example flow disables the file pickers -- the files live in this
+    checkout, not in the browser -- so the client cannot read their header
+    rows the way it does for an upload. Reading them here keeps the privacy
+    contract unchanged: only the first row of each declared data file is
+    read, and only its column names go into the prompt; a headerless file
+    (first line already a data row) is skipped entirely.
+
+    A falsy scenarioId means the server's default scenario, exactly as the
+    bare /pa_step1/example route resolves it. An unknown id raises
+    ExampleDatasets.UnknownScenario, a UserWarning the interface renders
+    readably. A declared file that is missing or unreadable is skipped: one
+    absent omic should not cost the draft the other omics' headers.
+    """
+    from src.common import ExampleDatasets
+    scenario = ExampleDatasets.getScenario(exampleFilesDir, scenarioId or None)
+    omics = []
+    for omic in scenario.get("omics", []):
+        dataFile = omic.get("dataFile")
+        if not dataFile:
+            continue
+        path = ExampleDatasets.absolutePath(exampleFilesDir, dataFile)
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as handle:
+                line = handle.readline(_EXPDESIGN_HEADER_BYTES)
+        except OSError:
+            continue
+        line = line.rstrip("\r\n").strip()
+        # A leading '#' marks the header row in these files; it is not part
+        # of the first column's name. Same rule the browser applies.
+        if line.startswith("#"):
+            line = line[1:]
+        if not line.strip():
+            continue
+        columns = line.split("\t") if "\t" in line else line.split(",")
+        if _looksLikeDataRow(columns):
+            continue
+        omics.append({"omicName": omic.get("omicName") or "Omic",
+                      "columns": columns})
+    return omics
+
+
+def aiGenerateExpDesign(REQUEST, RESPONSE, EXAMPLE_FILES_DIR=None):
     """Draft an experiment design description from the column headers of the
     files the user has picked, before any job exists.
 
@@ -490,6 +565,15 @@ def aiGenerateExpDesign(REQUEST, RESPONSE):
             raise UserWarning("Could not read the column headers that were sent.")
         if not isinstance(omics, list):
             raise UserWarning("Could not read the column headers that were sent.")
+
+        # A loaded example has no browser-readable files -- its pickers are
+        # disabled labels -- so the request names the scenario instead and the
+        # headers are read here, from the same files the job itself would use.
+        if not omics and formFields.get("exampleMode") == "true":
+            if not EXAMPLE_FILES_DIR:
+                raise UserWarning("This server has no example datasets configured.")
+            omics = _exampleHeaderOmics(EXAMPLE_FILES_DIR,
+                                        (formFields.get("exampleScenario") or "").strip())
 
         # Organism is a hint for the wording, never a lookup key here, so an
         # unknown code degrades to itself rather than failing the request.

--- a/PaintomicsServer/src/servlets/DataManagementServlet.py
+++ b/PaintomicsServer/src/servlets/DataManagementServlet.py
@@ -408,6 +408,15 @@ def dataManagementDownloadFile(request, response):
 # FILES MANIPULATION
 #****************************************************************
 def saveFile(userID, uploadedFileName, options, uploadedFile, DESTINATION_DIR):
+    # An empty name would make file_path the directory itself, and the save
+    # below then open()s a directory (IsADirectoryError [Errno 21] with a
+    # trailing '//' in the path). Callers are expected to have skipped empty
+    # attachments already; this is the last line of defence.
+    if uploadedFileName is None or str(uploadedFileName).strip() == "":
+        raise UserWarning(
+            "Malformed submission: a file was attached without a filename, "
+            "so it cannot be saved.")
+
     #1. CREATE THE USER DATA DIRECTORY IF NOT EXISTS
     if(not os.path.isdir(DESTINATION_DIR)):
         os.makedirs(DESTINATION_DIR)

--- a/PaintomicsServer/src/servlets/PathwayAcquisitionServlet.py
+++ b/PaintomicsServer/src/servlets/PathwayAcquisitionServlet.py
@@ -184,7 +184,15 @@ def pathwayAcquisitionStep1_PART1(REQUEST, RESPONSE, QUEUE_INSTANCE, JOB_ID, EXA
             logging.info("STEP1 - FILE UPLOADING REQUEST RECEIVED")
             jobInstance.description=""
             jobInstance.setName(formFields.get("jobDescription", "")[:100])
-            specie = formFields.get("specie") #GET THE SPECIES NAME
+            specie = (formFields.get("specie") or "").strip() #GET THE SPECIES NAME
+            if not specie:
+                # Concatenated into the log below and stored on the job; a
+                # missing field used to be an opaque TypeError, and defaulting
+                # would silently run the job against the wrong database.
+                raise UserWarning(
+                    "Malformed submission: no organism was selected (the "
+                    "'specie' field is missing), so PaintOmics cannot choose "
+                    "a pathway database.")
             databases = REQUEST.form.getlist('databases[]')
             jobInstance.setOrganism(specie)
             # The submitted selection, filtered to what this server can actually
@@ -372,6 +380,19 @@ def pathwayAcquisitionStep1_PART2(jobInstance, userID, exampleMode, RESPONSE):
             "timestamp": int(time())
         })
 
+    except UnicodeDecodeError as ex:
+        jobInstance.cleanDirectories(remove_output=True)
+
+        # Last line of defence: every known read path normalises encodings
+        # first, but a bad byte that slips through must reach the user as
+        # advice about their file, not as a bare codec error.
+        handleException(
+            RESPONSE,
+            Exception("[b]One of the uploaded files is not UTF-8 encoded[/b]"
+                      "[br]Please save your files as UTF-8 text (in Excel: "
+                      "Save As → CSV UTF-8, then convert to tab-delimited) "
+                      "and submit again. (" + str(ex) + ")"),
+            __file__, "pathwayAcquisitionStep1_PART2", userID=userID)
     except Exception as ex:
         jobInstance.cleanDirectories(remove_output=True)
 

--- a/PaintomicsServer/src/servlets/PathwayAcquisitionServlet.py
+++ b/PaintomicsServer/src/servlets/PathwayAcquisitionServlet.py
@@ -1166,6 +1166,15 @@ def pathwayAcquisitionSaveSharingOptions(request, response):
         jobID = request.form.get("jobID")
         jobInstance = loadRequestedJob(jobID, "saving sharing options")
 
+        # An ownerless job ("nologin" mode stores userID None) has nobody who
+        # may hold sharing options on it: every visitor is equally anonymous,
+        # so the ownership comparison below would grant each of them ownership
+        # ('None' == 'None') of flags that pa_recover_job and the read-only
+        # guards never enforce for ownerless jobs anyway. The dialog no longer
+        # offers the controls for these jobs; this keeps direct POSTs honest.
+        if jobInstance.getUserID() is None or str(jobInstance.getUserID()) == 'None':
+            raise Exception("This job was created without an account, so it has no owner and its sharing options cannot be changed.")
+
         if str(jobInstance.getUserID()) != str(userID):
             raise Exception("Invalid user for this jobID")
 

--- a/PaintomicsServer/src/tests/test_build_warnings_handoff.py
+++ b/PaintomicsServer/src/tests/test_build_warnings_handoff.py
@@ -1,0 +1,185 @@
+"""The species build hands its skipped sources back through a private file.
+
+`common_build_database` runs as a subprocess of `DBManager`, so the only things
+that cross the boundary are an exit status and whatever the child writes down.
+That channel used to be a fixed `/tmp/build_warnings.tmp`, which had three
+problems worth keeping fixed:
+
+  * Two installs running at once on the same machine wrote to one path and read
+    each other's warnings, attributing one species' missing sources to another.
+  * /tmp is world-writable, so a predictable name there can be pre-created as a
+    symlink onto a file the build then truncates.
+  * A fixed path has to be deleted before every build so the previous species'
+    list is not inherited -- and that delete is one `finally` away from being
+    skipped on a failure path.
+
+A fresh mkstemp file per species answers all three: unique, 0600, and unable to
+be stale. The parent names it in PAINTOMICS_BUILD_WARNINGS; the child writes
+there or, when no parent is listening, writes nothing at all.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_build_warnings_handoff
+"""
+import os
+import sys
+import tempfile
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.abspath(os.path.join(_HERE, "../..")))
+sys.path.insert(0, os.path.abspath(os.path.join(_HERE, "../AdminTools")))
+sys.path.insert(0, os.path.abspath(os.path.join(_HERE, "../AdminTools/scripts")))
+
+import DBManager
+import common_build_database
+
+
+def _writeAsChild(path, specie, rows):
+    """Drive the real writer in common_build_database, not a replica of it."""
+    saved = (common_build_database.SPECIE, common_build_database.SKIPPED_SOURCES,
+             common_build_database.xref, common_build_database.dbname,
+             common_build_database.ALL_PATHWAYS, common_build_database.FAILED_LINES,
+             common_build_database.UNKNOWN_PATHWAY_PAIRS,
+             common_build_database.PATHWAYS_WITHOUT_NODES)
+    common_build_database.SPECIE = specie
+    common_build_database.SKIPPED_SOURCES = list(rows)
+    common_build_database.xref = {}
+    common_build_database.dbname = {}
+    common_build_database.ALL_PATHWAYS = {}
+    common_build_database.FAILED_LINES = {}
+    common_build_database.UNKNOWN_PATHWAY_PAIRS = []
+    common_build_database.PATHWAYS_WITHOUT_NODES = []
+    previous = os.environ.get("PAINTOMICS_BUILD_WARNINGS")
+    if path is None:
+        os.environ.pop("PAINTOMICS_BUILD_WARNINGS", None)
+    else:
+        os.environ["PAINTOMICS_BUILD_WARNINGS"] = path
+    try:
+        # summariseBuild also prints a human-readable block to stderr. That is the
+        # point of it; only the hand-off file is under test here.
+        stderr = common_build_database.stderr
+        common_build_database.stderr = open(os.devnull, "w")
+        try:
+            common_build_database.summariseBuild()
+        finally:
+            common_build_database.stderr.close()
+            common_build_database.stderr = stderr
+    finally:
+        if previous is None:
+            os.environ.pop("PAINTOMICS_BUILD_WARNINGS", None)
+        else:
+            os.environ["PAINTOMICS_BUILD_WARNINGS"] = previous
+        (common_build_database.SPECIE, common_build_database.SKIPPED_SOURCES,
+         common_build_database.xref, common_build_database.dbname,
+         common_build_database.ALL_PATHWAYS, common_build_database.FAILED_LINES,
+         common_build_database.UNKNOWN_PATHWAY_PAIRS,
+         common_build_database.PATHWAYS_WITHOUT_NODES) = saved
+
+
+class BuildWarningsHandoffTest(unittest.TestCase):
+
+    def setUp(self):
+        self._warnings = list(DBManager.INSTALL_WARNINGS)
+        DBManager.INSTALL_WARNINGS[:] = []
+
+    def tearDown(self):
+        DBManager.INSTALL_WARNINGS[:] = self._warnings
+
+    def test_each_build_gets_its_own_file(self):
+        """The whole point: two concurrent installs must not share a path."""
+        first = DBManager.newBuildWarningsHandoff()
+        second = DBManager.newBuildWarningsHandoff()
+        try:
+            self.assertNotEqual(first, second,
+                                "two builds were handed the same file, which is the "
+                                "collision this replaced a fixed /tmp path to avoid")
+            self.assertNotIn("build_warnings.tmp", first)
+        finally:
+            for path in (first, second):
+                if os.path.isfile(path):
+                    os.remove(path)
+
+    def test_the_file_is_private(self):
+        """0600. A world-readable name in /tmp is a name anyone can pre-create."""
+        path = DBManager.newBuildWarningsHandoff()
+        try:
+            self.assertEqual(oct(os.stat(path).st_mode)[-3:], "600")
+        finally:
+            os.remove(path)
+
+    def test_a_warning_survives_the_round_trip(self):
+        path = DBManager.newBuildWarningsHandoff()
+        _writeAsChild(path, "ath",
+                      [("VEGA", "input file not found: /data/vega.tsv",
+                        "VEGA identifiers will be absent for this species")])
+        DBManager.collectBuildWarnings("ath", path)
+
+        self.assertEqual(len(DBManager.INSTALL_WARNINGS), 1)
+        subject, detail = DBManager.INSTALL_WARNINGS[0]
+        self.assertIn("VEGA", subject)
+        self.assertIn("VEGA identifiers will be absent", detail)
+
+    def test_a_reason_carrying_tabs_or_newlines_stays_one_record(self):
+        """The fields are file paths and str(exception) -- not our text.
+
+        The reader splits on tab and needs four fields, so an unescaped tab or
+        newline in a path silently drops the warning it was trying to report.
+        """
+        path = DBManager.newBuildWarningsHandoff()
+        _writeAsChild(path, "ath",
+                      [("MAPMAN GENE 2 BIN", "not found in either\n/a/b\tc or /d/e",
+                        "no MapMan bins can be assigned")])
+
+        with open(path) as handle:
+            lines = [line for line in handle.read().splitlines() if line]
+        self.assertEqual(len(lines), 1, "the record was split across lines: %r" % lines)
+        self.assertEqual(len(lines[0].split("\t")), 4,
+                         "the record gained or lost fields: %r" % lines[0])
+
+        DBManager.collectBuildWarnings("ath", path)
+        self.assertEqual(len(DBManager.INSTALL_WARNINGS), 1)
+
+    def test_another_species_rows_are_not_claimed(self):
+        path = DBManager.newBuildWarningsHandoff()
+        _writeAsChild(path, "mmu", [("UNIPROT", "input file is empty", "UniProt absent")])
+        DBManager.collectBuildWarnings("ath", path)
+        self.assertEqual(DBManager.INSTALL_WARNINGS, [],
+                         "ath claimed mmu's warnings")
+
+    def test_the_file_is_removed_even_when_the_read_fails(self):
+        """Otherwise a long batch leaks one file per species into /tmp."""
+        path = DBManager.newBuildWarningsHandoff()
+        with open(path, "wb") as handle:
+            handle.write(b"\xff\xfe not utf-8 at all \xff\n")
+
+        DBManager.collectBuildWarnings("ath", path)
+        self.assertFalse(os.path.exists(path),
+                         "a read that raised left the hand-off file behind")
+
+    def test_the_file_is_removed_after_a_good_read(self):
+        path = DBManager.newBuildWarningsHandoff()
+        _writeAsChild(path, "ath", [("VEGA", "absent", "VEGA ids absent")])
+        DBManager.collectBuildWarnings("ath", path)
+        self.assertFalse(os.path.exists(path))
+
+    def test_a_missing_handoff_is_survivable(self):
+        """installSpecieData calls this from a `finally`, on the failure path too."""
+        DBManager.collectBuildWarnings("ath", None)
+        DBManager.collectBuildWarnings("ath", os.path.join(tempfile.gettempdir(), "nope.tsv"))
+        self.assertEqual(DBManager.INSTALL_WARNINGS, [])
+
+    def test_no_parent_means_nothing_is_written(self):
+        """A build run by hand has nobody listening, and no fixed path to fall back on."""
+        legacy = os.path.join(tempfile.gettempdir(), "build_warnings.tmp")
+        if os.path.exists(legacy):
+            os.remove(legacy)
+
+        _writeAsChild(None, "ath", [("VEGA", "absent", "VEGA ids absent")])
+
+        self.assertFalse(os.path.exists(legacy),
+                         "the build recreated the fixed path this change removed")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_crash_report_fixes.py
+++ b/PaintomicsServer/src/tests/test_crash_report_fixes.py
@@ -1,0 +1,184 @@
+"""Regression tests for the crash classes reported by users via email
+(Nov 2025 - Aug 2026) and fixed together on 2026-08-13.
+
+Each test names the production symptom it pins down:
+  * IndexError in step1 while parsing a ragged relevant-features file
+    (R's write.table row-names shape: header N columns, rows N+1).
+  * IndexError reading line[1] of a 1-column row under a `#Cond<TAB>` header.
+  * UnicodeDecodeError on a large upload whose only bad byte sits past the
+    256 KiB encoding sniff window.
+  * Binary uploads (.xlsx/.gz) being transcoded in place into mojibake.
+  * IsADirectoryError from an empty-filename file part ('untouched file
+    input' shape browsers submit).
+  * FileNotFoundError on <species>/hubData for species installed without it.
+
+Run:  PYTHONPATH=PaintomicsServer python3 PaintomicsServer/src/tests/test_crash_report_fixes.py
+"""
+import io
+import os
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.abspath(os.path.join(HERE, "..", "..")))
+
+from src.common.Util import ensure_utf8
+from src.classes.Job import Job
+
+
+def _parseRelevant(content):
+    """Run the real parser over an on-disk relevant-features file."""
+    job = object.__new__(Job)
+    job.conditionNames = []
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "relevant.tab")
+        with open(path, "w", encoding="utf-8", newline="") as handle:
+            handle.write(content)
+        return job.parseSignificativeFeaturesFile(path)
+
+
+class RaggedRelevantFileTest(unittest.TestCase):
+    def test_row_wider_than_header_is_clamped_not_crashed(self):
+        # R's write.table default: header has N names, rows N+1 fields.
+        features = _parseRelevant("Ctrl\tTreat\n1\tP12345\tP67890\n")
+        self.assertIn("p12345", features)
+        # The extra trailing cell is dropped, not written past the end.
+        for flags in features.values():
+            self.assertEqual(len(flags), 2)
+
+    def test_much_wider_row_is_also_safe(self):
+        features = _parseRelevant("Ctrl\tTreat\nP1\tP2\tP3\tP4\tP5\n")
+        self.assertTrue(all(len(flags) == 2 for flags in features.values()))
+
+    def test_one_column_row_under_comment_header_is_safe(self):
+        # `#Ctrl<TAB>` keeps legacy detection eligible; the single-column row
+        # used to be indexed at [1].
+        features = _parseRelevant("#Ctrl\t\nP12345\n")
+        self.assertIn("p12345", features)
+
+    def test_well_formed_multicondition_file_is_unchanged(self):
+        features = _parseRelevant("Ctrl\tTreat\nP1\tP2\nP3\t\n")
+        self.assertEqual(features["p1"], [True, False])
+        self.assertEqual(features["p2"], [False, True])
+        self.assertEqual(features["p3"], [True, False])
+
+
+class SniffWindowTest(unittest.TestCase):
+    def test_bad_byte_past_the_sniff_window_is_still_transcoded(self):
+        # 300 KiB of clean ASCII, then one latin-1 byte: the old prefix-only
+        # verdict said "UTF-8, fine" and the csv reader crashed later.
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "values.tab")
+            with open(path, "wb") as handle:
+                handle.write(b"gene\tlog2FC\n")
+                for i in range(30000):
+                    handle.write(("g%06d\t1.5\n" % i).encode("ascii"))
+                handle.write("Señal1\t2.0\n".encode("latin-1"))
+            self.assertIsNone(ensure_utf8(path))
+            # The whole file must now be readable the way the parsers read it.
+            with open(path, "r", encoding="utf-8-sig", newline="") as handle:
+                data = handle.read()
+            self.assertIn("Señal1", data)
+
+
+class BinaryUploadTest(unittest.TestCase):
+    def _reason(self, payload):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "upload.bin")
+            with open(path, "wb") as handle:
+                handle.write(payload)
+            reason = ensure_utf8(path)
+            with open(path, "rb") as handle:
+                after = handle.read()
+            return reason, payload == after
+
+    def test_xlsx_is_named_and_left_untouched(self):
+        reason, unchanged = self._reason(b"PK\x03\x04" + os.urandom(256))
+        self.assertIsNotNone(reason)
+        self.assertIn("Excel", reason)
+        self.assertTrue(unchanged, "a binary upload must never be rewritten")
+
+    def test_gzip_is_named_and_left_untouched(self):
+        import gzip
+        payload = gzip.compress(b"chr1\t100\t200\n")
+        reason, unchanged = self._reason(payload)
+        self.assertIsNotNone(reason)
+        self.assertIn("gzip", reason)
+        self.assertTrue(unchanged, "a .gz upload must never be rewritten")
+
+    def test_utf16_is_still_transcoded(self):
+        # UTF-16 is full of NULs and must keep working (existing behaviour).
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "values.tab")
+            with open(path, "wb") as handle:
+                handle.write("gene\tvalue\nAlb\t1.5\n".encode("utf-16"))
+            self.assertIsNone(ensure_utf8(path))
+
+
+class EmptyFilenamePartTest(unittest.TestCase):
+    def test_saveFile_refuses_an_empty_filename(self):
+        from src.servlets.DataManagementServlet import saveFile
+        with self.assertRaises(UserWarning):
+            saveFile("1", "", {}, None, "/tmp/nonexistent-dir/")
+
+    def test_saveFiles_skips_an_untouched_relevant_input(self):
+        # A part with filename="" is what browsers submit for an untouched
+        # <input type=file>; it used to reach saveFile and open() the
+        # directory itself.
+        from werkzeug.datastructures import FileStorage, MultiDict
+        from src.common.JobInformationManager import JobInformationManager
+
+        registered = {}
+
+        class _JobStub:
+            def getJobID(self):
+                return "TESTJOB"
+            def addGeneBasedInputOmic(self, omic):
+                registered.update(omic)
+            def addCompoundBasedInputOmic(self, omic):
+                registered.update(omic)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            files = MultiDict()
+            files.add("omic0_file", FileStorage(
+                stream=io.BytesIO(b"gene\tv\nAlb\t1.0\n"), filename="values.tab",
+                name="omic0_file"))
+            files.add("omic0_relevant_file", FileStorage(
+                stream=io.BytesIO(b""), filename="", name="omic0_relevant_file"))
+            fields = MultiDict({
+                "omic0_omic_name": "Gene expression",
+                "omic0_file_type": "Gene expression",
+                "omic0_match_type": "gene",
+                "omic0_origin": "client",
+                "omic0_relevant_origin": "client",
+            })
+            JobInformationManager().saveFiles(
+                files, fields, None, _JobStub(), tmp + "/")
+
+        self.assertEqual(registered.get("relevantFeaturesFile"), None)
+        self.assertTrue(str(registered.get("inputDataFile", "")).endswith("values.tab"))
+
+
+class MissingHubDataTest(unittest.TestCase):
+    def test_hubAnalysis_returns_False_when_hubData_is_absent(self):
+        from src.classes.JobInstances.PathwayAcquisitionJob import PathwayAcquisitionJob
+
+        class _OmicValue:
+            omicName = "Gene expression"
+            relevant = True
+            relevantAssociation = False
+
+        class _Gene:
+            omicsValues = [_OmicValue()]
+
+        job = object.__new__(PathwayAcquisitionJob)
+        job.organism = "no-such-species-xyz"
+        job.inputGenesData = {"g1": _Gene()}
+        job.inputCompoundsData = {}
+        result = job.hubAnalysis("/nonexistent-root/")
+        self.assertIs(result, False)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_exp_design_example_mode.py
+++ b/PaintomicsServer/src/tests/test_exp_design_example_mode.py
@@ -1,0 +1,78 @@
+"""The "Draft this for me" button must work for a loaded example.
+
+The example flow disables the file pickers -- its files live on the server --
+so the client cannot read their header rows the way it does for an upload
+(collectPickedOmicFiles finds no File objects and the button dead-ends in
+"Choose your data files first"). The servlet therefore reads the headers
+itself when the request names an example scenario.
+
+Run:  PYTHONPATH=PaintomicsServer python3 PaintomicsServer/src/tests/test_exp_design_example_mode.py
+"""
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.abspath(os.path.join(HERE, "..", "..")))
+
+from src.servlets.AIInterpretServlet import _exampleHeaderOmics
+
+EXAMPLE_FILES_DIR = os.path.abspath(os.path.join(HERE, "..", "examplefiles")) + os.sep
+
+failures = []
+
+
+def check(label, condition, detail=""):
+    if condition:
+        print("PASS  " + label)
+    else:
+        failures.append(label)
+        print("FAIL  " + label + ("  -- " + detail if detail else ""))
+
+
+# The default multi-omics scenario: every declared data file WITH a header
+# contributes its header row, under the omic name the manifest declares.
+omics = _exampleHeaderOmics(EXAMPLE_FILES_DIR, "stategra-multiomics")
+names = [entry["omicName"] for entry in omics]
+check("stategra-multiomics yields several omics", len(omics) >= 3, repr(names))
+check("Gene expression is among them", "Gene expression" in names, repr(names))
+
+# mirna_values.tab has NO header row -- its first line is a gene id plus six
+# measured values. That file must be skipped, not shipped: sending its first
+# line as "column names" put measurement values into the LLM prompt while the
+# UI asserted no values were sent.
+check("headerless miRNA-seq file is skipped", "miRNA-seq" not in names, repr(names))
+
+def columnsLeakValues(columns):
+    numeric = 0
+    for cell in columns[1:]:
+        try:
+            float(cell)
+            numeric += 1
+        except ValueError:
+            pass
+    return numeric > 0
+
+for entry in omics:
+    check("%s has multiple columns" % entry["omicName"], len(entry["columns"]) >= 2,
+          repr(entry["columns"][:5]))
+    check("%s header has no leading #" % entry["omicName"],
+          not entry["columns"][0].startswith("#"), repr(entry["columns"][0]))
+    check("%s columns carry no numeric values" % entry["omicName"],
+          not columnsLeakValues(entry["columns"]), repr(entry["columns"][:5]))
+
+# A falsy scenario id means the server's default scenario, same as /pa_step1/example.
+default_omics = _exampleHeaderOmics(EXAMPLE_FILES_DIR, None)
+check("default scenario resolves", len(default_omics) >= 1)
+
+# An unknown id must raise the readable UserWarning the interface shows.
+try:
+    _exampleHeaderOmics(EXAMPLE_FILES_DIR, "no-such-scenario")
+    check("unknown scenario raises", False)
+except UserWarning:
+    check("unknown scenario raises", True)
+
+print()
+if failures:
+    print("%d FAILURE(S): %s" % (len(failures), ", ".join(failures)))
+    sys.exit(1)
+print("ALL PASS")

--- a/PaintomicsServer/src/tests/test_logging_cfg_template.py
+++ b/PaintomicsServer/src/tests/test_logging_cfg_template.py
@@ -1,0 +1,125 @@
+"""
+The logging.cfg template must build the handlers it declares.
+
+Why this exists
+---------------
+``launch_server.py`` bootstraps a fresh checkout by copying
+``src/resources/logging.cfg`` over ``src/conf/logging.cfg`` whenever
+``serverconf.py`` is absent -- which is every from-source first launch,
+because serverconf.py is gitignored. For years the template passed
+``'maxBytes=31457280'`` and ``'backupCount=15'`` as *positional strings*,
+so RotatingFileHandler received ``maxBytes='maxBytes=31457280'`` and the
+first launch died with ``TypeError: '>' not supported between instances
+of 'str' and 'int'``.
+
+No developer machine ever saw it: an installed serverconf.py suppresses
+the bootstrap, and the tracked conf/logging.cfg was already correct. The
+Docker path writes serverconf.py before boot and never runs the bootstrap
+either. Only a genuinely fresh from-source install hit the broken file --
+the one audience that cannot debug it.
+
+So this test evaluates the handler args of BOTH tracked cfg files exactly
+the way ``logging.config.fileConfig`` does, instantiates the handler with
+them, and pins the template to the installed file so they cannot drift
+apart again.
+"""
+
+import configparser
+import logging
+import logging.handlers
+import os
+import sys
+import tempfile
+
+# PaintomicsServer/  <- src/  <- tests/  <- this file
+SERVER_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+CFG_FILES = (
+    os.path.join(SERVER_ROOT, "src", "conf", "logging.cfg"),
+    os.path.join(SERVER_ROOT, "src", "resources", "logging.cfg"),
+)
+
+_PASSED = []
+_FAILED = []
+
+
+def _check(name, fn):
+    import traceback
+    try:
+        fn()
+        _PASSED.append(name)
+        print("PASS  " + name)
+    except Exception:
+        _FAILED.append((name, traceback.format_exc()))
+        print("FAIL  " + name)
+
+
+def _file_handler_args(path):
+    """The evaluated args tuple, exactly as logging.config computes it."""
+    cp = configparser.ConfigParser()
+    read = cp.read(path)
+    assert read, "%s is missing or unreadable" % path
+    raw = cp.get("handler_fileHandler", "args")
+    # This mirrors logging/config.py _install_handlers: eval in the logging
+    # module's namespace, which is what makes os/sys/handlers resolvable.
+    return eval(raw, vars(logging))
+
+
+def test_file_handler_args_are_numeric():
+    """maxBytes and backupCount must arrive as ints, not decorative strings."""
+    for path in CFG_FILES:
+        args = _file_handler_args(path)
+        assert len(args) == 4, (
+            "%s: expected (filename, mode, maxBytes, backupCount), got %r"
+            % (path, args)
+        )
+        assert isinstance(args[2], int) and isinstance(args[3], int), (
+            "%s: maxBytes/backupCount evaluated to %r -- RotatingFileHandler "
+            "will refuse these on the first launch" % (path, args[2:])
+        )
+
+
+def test_file_handler_actually_constructs():
+    """Run the exact constructor call that crashed, against a temp file."""
+    for path in CFG_FILES:
+        args = _file_handler_args(path)
+        with tempfile.TemporaryDirectory() as tmp:
+            handler = logging.handlers.RotatingFileHandler(
+                os.path.join(tmp, "application.log"), *args[1:]
+            )
+            handler.close()
+
+
+def test_template_matches_installed_file():
+    """The bootstrap copies the template over conf/; divergence means a
+    fresh install boots a different logging setup than every dev checkout."""
+    installed = _file_handler_args(CFG_FILES[0])
+    template = _file_handler_args(CFG_FILES[1])
+    assert installed == template, (
+        "conf/logging.cfg and resources/logging.cfg disagree on the file "
+        "handler: %r vs %r" % (installed, template)
+    )
+
+
+def main():
+    print("logging.cfg template test")
+    print("server root: %s\n" % SERVER_ROOT)
+
+    tests = [
+        test_file_handler_args_are_numeric,
+        test_file_handler_actually_constructs,
+        test_template_matches_installed_file,
+    ]
+    for t in tests:
+        _check(t.__name__, t)
+
+    print()
+    print("Passed: %d / %d" % (len(_PASSED), len(_PASSED) + len(_FAILED)))
+    if _FAILED:
+        for name, msg in _FAILED:
+            print("\n--- %s ---\n%s" % (name, msg))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/PaintomicsServer/src/tests/test_organism_taxids_are_correct.py
+++ b/PaintomicsServer/src/tests/test_organism_taxids_are_correct.py
@@ -27,6 +27,12 @@ SCRIPTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
 
 # organism directory prefix -> NCBI taxonomy id, verified against the organism's own
 # gene_info.gz. Add a row here when a new organism is added; do not copy an existing one.
+#
+# NCBI keys some organisms' gene_info rows by STRAIN, not species: the species
+# taxid matches only a handful of placeholder rows there, so the strain id is
+# the correct value even though the NCBI taxonomy names the species one.
+# Verified 2026-08-14: sce 4932 matched ~36 mitochondrial/placeholder rows and
+# pfa 5833 only 4 -- both organisms shipped with almost no Entrez mapping.
 EXPECTED_TAXID = {
     "acs": 28377,   # Anolis carolinensis
     "ath": 3702,    # Arabidopsis thaliana
@@ -38,11 +44,12 @@ EXPECTED_TAXID = {
     "gga": 9031,    # Gallus gallus
     "hsa": 9606,    # Homo sapiens
     "mmu": 10090,   # Mus musculus
-    "pfa": 5833,    # Plasmodium falciparum
+    "pfa": 36329,   # Plasmodium falciparum 3D7 (strain; species id 5833 matches 4 rows)
     "ptr": 9598,    # Pan troglodytes
     "rno": 10116,   # Rattus norvegicus
-    "sce": 4932,    # Saccharomyces cerevisiae
+    "sce": 559292,  # Saccharomyces cerevisiae S288C (strain; species id 4932 matches ~36 rows)
     "ssc": 9823,    # Sus scrofa
+    "xtr": 8364,    # Xenopus tropicalis
 }
 
 TAXID_PATTERN = re.compile(r'"specie-code"\s*:\s*(\d+)')
@@ -60,18 +67,20 @@ class OrganismTaxidTest(unittest.TestCase):
 
     def test_each_organism_declares_its_own_taxid(self):
         for organism, expected in sorted(EXPECTED_TAXID.items()):
-            declared = declaredTaxids(organism)
-            if declared is None:
-                continue  # organism directory not present in this checkout
-            self.assertTrue(
-                declared,
-                organism + "_resources/download_conf.py declares no specie-code")
-            self.assertEqual(
-                declared, {expected},
-                organism + " declares specie-code " + str(sorted(declared)) +
-                " but its NCBI taxonomy id is " + str(expected) +
-                ". A wrong taxid silently yields ZERO Entrez/RefSeq mappings for this "
-                "organism -- the awk filter matches no row of its own gene_info file.")
+            # subTest, so the first mismatching organism cannot hide the rest.
+            with self.subTest(organism=organism):
+                declared = declaredTaxids(organism)
+                if declared is None:
+                    continue  # organism directory not present in this checkout
+                self.assertTrue(
+                    declared,
+                    organism + "_resources/download_conf.py declares no specie-code")
+                self.assertEqual(
+                    declared, {expected},
+                    organism + " declares specie-code " + str(sorted(declared)) +
+                    " but its NCBI taxonomy id is " + str(expected) +
+                    ". A wrong taxid silently yields ZERO Entrez/RefSeq mappings for this "
+                    "organism -- the awk filter matches no row of its own gene_info file.")
 
     def test_no_two_organisms_share_a_taxid(self):
         """The original bug was a copy-paste, and this is its signature."""

--- a/PaintomicsServer/src/tests/test_reactome_install.py
+++ b/PaintomicsServer/src/tests/test_reactome_install.py
@@ -142,7 +142,12 @@ def test_missing_file_raises_with_species_in_message():
 
 
 def test_empty_file_raises_instead_of_silently_succeeding():
-    """The R step writes nothing when it matches no species. That must be loud."""
+    """An empty mapping raises by default -- the contract for the common ChEBI
+    file, whose only empty state is a truncated download. Per-species gene
+    mappings opt out with allowEmpty=True, because Reactome legitimately keys
+    some organisms through only a subset of the identifier systems (pfa has no
+    Ensembl rows at all); the build enforces the real invariant separately,
+    that not EVERY gene mapping is empty."""
     tmp = tempfile.mkdtemp()
     try:
         path = _writeTsv(tmp, "Ensembl2Reactome.txt", [])
@@ -154,6 +159,12 @@ def test_empty_file_raises_instead_of_silently_succeeding():
             message = str(exc)
             assert "empty" in message.lower(), f"unhelpful message: {message}"
             assert "mmu" in message, f"species missing from message: {message}"
+
+        # The tolerated path: empty is a coverage fact, and the caller gets an
+        # empty index to combine with the other identifier sources.
+        index = loadReactomeMapping(path, keyColumn=1, valueColumns=(0, 2), minColumns=3,
+                                    specieLabel="pfa", allowEmpty=True)
+        assert len(index) == 0, f"allowEmpty must return an empty index, got {dict(index)}"
     finally:
         shutil.rmtree(tmp)
 
@@ -354,7 +365,13 @@ def test_r_script_extracts_requested_species_only():
 
 
 def test_r_script_fails_loudly_for_species_reactome_lacks():
-    """Silent success was the bug: no output, exit 0, confusing failure later."""
+    """Silent success was the bug: no output, exit 0, confusing failure later.
+
+    The failure is now AGGREGATE: one empty mapping is a per-source coverage
+    fact and deliberately writes an empty output file, and only all three gene
+    mappings coming up empty stops the script. The stop message is load-bearing:
+    the Python wrapper recognises it and downgrades the species to KEGG-only
+    instead of failing the install."""
     if not shutil.which("Rscript"):
         print("      (skipped: Rscript not installed)")
         return
@@ -372,9 +389,17 @@ def test_r_script_fails_loudly_for_species_reactome_lacks():
         combined = result.stdout + result.stderr
         assert "No rows matched species 'sot'" in combined, \
             f"unhelpful failure output: {combined}"
-        assert not os.path.isfile(
-            os.path.join(tmp, "sot", "mapping", "reactome", "Ensembl2Reactome.txt")), \
-            "a partial output file was left behind"
+        # The exact phrase common_build_database.py keys the KEGG-only
+        # downgrade on; reword both together or uncovered species fail hard.
+        assert "in any of Ensembl2Reactome, NCBI2Reactome or UniProt2Reactome" in combined, \
+            f"aggregate stop message changed; the Python-side downgrade will not match: {combined}"
+
+        # The per-source empty outputs are deliberate now, not debris: the
+        # Python side reads each one independently.
+        outPath = os.path.join(tmp, "sot", "mapping", "reactome", "Ensembl2Reactome.txt")
+        assert os.path.isfile(outPath), "the empty mapping file should still be written"
+        with open(outPath) as handle:
+            assert handle.read().strip() == "", "expected an EMPTY mapping for an uncovered species"
     finally:
         shutil.rmtree(tmp)
 

--- a/PaintomicsServer/src/tests/test_release_hygiene.py
+++ b/PaintomicsServer/src/tests/test_release_hygiene.py
@@ -16,6 +16,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import traceback
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
@@ -25,6 +26,30 @@ _FAILED = []
 
 _REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
     os.path.dirname(os.path.abspath(__file__)))))
+
+
+def _execTemplate(templatePath):
+    """Execute the template the way an import would, but in isolation.
+
+    A real import always defines ``__file__`` -- the template's dotenv loader
+    depends on it -- so a bare ``exec`` into an empty namespace misrepresents
+    module semantics and dies with NameError. But handing it the *real* path
+    is no better: the loader would then find the developer's own .env and
+    setdefault live keys into a test that exists to prove the template works
+    with nothing set. So: a copy of the source, buried in a temp directory
+    where the .env probe paths resolve to nothing.
+    """
+    with open(templatePath) as handle:
+        source = handle.read()
+    with tempfile.TemporaryDirectory() as tmp:
+        isolatedDir = os.path.join(tmp, "isolated", "src", "resources")
+        os.makedirs(isolatedDir)
+        isolatedPath = os.path.join(isolatedDir, "example_serverconf.py")
+        with open(isolatedPath, "w") as handle:
+            handle.write(source)
+        namespace = {"__file__": isolatedPath}
+        exec(compile(source, isolatedPath, "exec"), namespace)
+    return namespace
 
 
 def _check(name, fn):
@@ -156,8 +181,7 @@ def test_template_covers_every_setting_the_app_imports():
 
     templatePath = os.path.join(
         _REPO_ROOT, "PaintomicsServer", "src", "resources", "example_serverconf.py")
-    namespace = {}
-    exec(compile(open(templatePath).read(), templatePath, "exec"), namespace)
+    namespace = _execTemplate(templatePath)
 
     missing = sorted(name for name in required if name not in namespace)
     assert not missing, \
@@ -175,8 +199,7 @@ def test_template_is_importable_with_no_environment_set():
         for key in list(os.environ):
             if key.startswith(("AI_", "SMTP_", "PAINTOMICS_", "MONGODB_", "SERVER_", "EMAIL_")):
                 del os.environ[key]
-        namespace = {}
-        exec(compile(open(templatePath).read(), templatePath, "exec"), namespace)
+        namespace = _execTemplate(templatePath)
     finally:
         os.environ.clear()
         os.environ.update(saved)

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -80,7 +80,7 @@ INDEX_HTML = os.path.join(CLIENT_ROOT, "index.html")
 # year, and recording a digest for a 300KB minified bundle only creates churn.
 PUBLISHED = {
     "app/view/common/Util.js": (
-        "1.9", "ebb2c218742ba5f0bbc7a530056b8a5673123ad9365b89e80bbd75ce82a494db"),
+        "2.0", "284b8be3fd6f8e746730408b7bacc37c9385e4ce6e76743885c3a11dae6c3ecd"),
     "app/view/common/ExtJS_extensions.js": (
         "0.7", "f1e68f670cc56064fc15649d259004ccbd96f49181ced049cffbe62c29bf1d80"),
     "app/view/common/upload/Panel.js": (
@@ -90,11 +90,11 @@ PUBLISHED = {
     # it with an unbumped marker leaves returning browsers running the old
     # copy exactly as it would for view code.
     "app/view/common/AlignmentGuides.js": (
-        "2.6", "e8132149237c69b9d53f7902c3f0fe12caccaba14ec7ff6a598988de9a25a96f"),
+        "4.1", "db648a4f47fc2a11db95275e9467cc323e6036e87b69fc3cf37646ec745aa3ff"),
     "app/view/PathwayAcquisitionViews/PA_AIInterpretView.js": (
         "0.4", "7db83c339d465cafb9bdd319ad267660d4e7bbcca4eb3fcd250736f59d5d8c6d"),
     "app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js": (
-        "0.5", "aa30804fc4b62b84e0c8ad9e9db71c0a8f478b322cc51bd4e78162cca06a1d68"),
+        "0.7", "b135712a9564f8ae0eac94daf9c567ef275c4c748dbc270fdbdeb7d25fc79e34"),
     "resources/ServerConfiguration.js": (
         "0.7", "da64ff7cfeeecef7c6c9fb8ec125199b40200988d638951e9d7817eef13da754"),
     "js/libs/linkurious/sigma.min.js": ("0.1", None),

--- a/README.md
+++ b/README.md
@@ -1,74 +1,275 @@
-<div class="imageContainer" style="" >
-    <img src="docs/img/paintomics_150x690.png" height="50" title="STATegra EMS LOGO."/>
-</div>
+<p align="center">
+  <img src="PaintomicsClient/public_html/resources/images/paintomics-mark.svg" alt="PaintOmics" height="72">
+</p>
 
-# Paintomics, integrative visualization of multiple *omic* data                                    
-For any question on **PaintOmics 4**, users can send a mail to [paintomics4@gmail.com](mailto:paintomics4@gmail.com).
+<h1 align="center">PaintOmics AI</h1>
 
-**PaintOmics 4** official instance: [https://paintomics.uv.es](https://paintomics.uv.es/)
+<p align="center">
+  <b>Integrative visualization and analysis of multi-omics data on KEGG, Reactome and MapMan pathways —<br>
+  now with an interpretation agent that reads the results and writes up the biology with citations you can check.</b>
+</p>
 
-## Welcome to PaintOmics 4 documentation.
+<p align="center">
+  <a href="https://paintomics.uv.es/"><img alt="Live instance" src="https://img.shields.io/badge/try%20it-paintomics.uv.es-2E7D9A"></a>
+  <a href="https://paintomics.readthedocs.io/en/latest/"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-8CA1AF"></a>
+  <a href="https://doi.org/10.1093/nar/gkac352"><img alt="DOI" src="https://img.shields.io/badge/DOI-10.1093%2Fnar%2Fgkac352-B31B1B"></a>
+  <img alt="Python" src="https://img.shields.io/badge/python-3.11-3776AB">
+  <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-GPLv3-blue"></a>
+</p>
 
-**PaintOmics 4** is a web tool for the integrative visualization of multiple *omic* datasets onto [KEGG](https://www.genome.jp/kegg/), [Reactome](https://reactome.org/), and [MapMan](http://www.gomapman.org/) pathways.
+---
 
-**PaintOmics 4** consists of three simple steps:
+## Overview
 
-* **Data uploading**: typically data matrices, containing, for example, gene expression, metabolite levels, and metabolite levels for the same set of samples.
-* **Identifier and Name Matching and Metabolite assignment**: as PaintOmics requires Entrez IDs for working with KEGG pathways, the tool will try to convert the names and identifiers from different sources and databases for the input data. Additionally, it's necessary to specify metabolite assignments in ambiguous cases.
-* **Results:** Pathways summary, Pathways classification, Pathways network, Metabolite hub analysis, Metabolite class enrichment, Pathways enrichment, Pathways visualization (by clicking for any of the displayed pathways in the Pathways enrichment section). Understand more about these analyses in [our documentation](http://paintomics.readthedocs.io/en/latest/) or [video tutorial](https://www.youtube.com/channel/UCSoQ3LSli9ZxOQTX56_WJeA).
+PaintOmics takes several *omic* measurements from the same experiment —
+transcriptomics, proteomics, metabolomics, region-based assays such as ChIP-seq
+or Methyl-seq, and regulatory layers such as miRNA or transcription factors —
+and paints them together onto biological pathways, so that the layers can be
+read against each other rather than one at a time.
 
-Currently, **PaintOmics 4** supports integrated visualization of multiple species of different biological kingdoms and allows users to request any other organism present in the [KEGG](https://www.genome.jp/kegg/), [Reactome](https://reactome.org/), and [MapMan](http://www.gomapman.org/) databases.
+It supports [KEGG](https://www.genome.jp/kegg/),
+[Reactome](https://reactome.org/) and [MapMan](http://www.gomapman.org/)
+pathways for organisms across all biological kingdoms, and any other organism
+present in those databases can be installed on request.
 
-**PaintOmics 4** application is distributed under **GNU General Public License, Version 3**.
+**PaintOmics AI is the current release, and the successor to PaintOmics 4**
+([*Nucleic Acids Research*, 2022](https://doi.org/10.1093/nar/gkac352)). It
+keeps everything PaintOmics 4 does and adds the AI interpretation agent, the
+MORE regulatory model, multi-condition designs, and a rebuilt interface — see
+[What's new](#whats-new-in-paintomics-ai). The public instance runs on
+[Supercomputador Drago](https://aic.csic.es/supercomputador-drago/) (CSIC).
 
-<div class="imageContainer" style="text-align:center; font-size:10px; color:#898989" >
-    <img src="docs/img/gplv3-127x51.png" title="GNU GENERAL PUBLIC LICENSE Version 3 logo."/>
-</div>
+**Try it without installing anything:** [https://paintomics.uv.es](https://paintomics.uv.es/)
 
-**Paintomics 4** is part of the [STATegra Project](https://cordis.europa.eu/project/id/306000/reporting) and was developed by the [Genomics of Gene Expression Lab](http://conesalab.org/) at [Príncipe Felipe Research Centre](http://www.cipf.es/).
+## What's new in PaintOmics AI
 
-## Video tutorial 
+| Area | What changed |
+|---|---|
+| **AI interpretation** | New. An agent reads your ranked pathways, searches PubMed for supporting work, and drafts the biology with numbered, checkable citations — per pathway, across the whole analysis, and as follow-up questions. Opt-in per job. [Details below](#the-ai-interpretation-agent). |
+| **MORE regulatory model** | Regulatory Omics gained the [MORE](https://github.com/BiostatOmics/MORE) model behind a method chooser, with three engines: PLS1 on a Rust port (default, measured byte-identical to R and several hundred times faster), PLS1 on R, and MLR on R. A job predicted not to fit inside the queue's budget is refused at submit time instead of being killed at the end. |
+| **Regulator–target network** | New Step 3 panel drawing regulators against their targets with Cytoscape.js — free layout, per-condition colouring, search, spotlight, exports, and a "Find in pathways" hand-off into the pathway view. Regulation-per-condition tables sit alongside it. |
+| **Multi-condition designs** | Analyses run across any number of conditions, not two. Per-condition significance stars in the Step 4 heatmaps, in Metabolite Hub and in Class Activity; columns labelled with your condition names; a Stouffer weights panel; and the combined-p-value statistics checked against SciPy. |
+| **Replicate aggregation** | Replicates collapse onto the conditions you declare, in both the pathway visualization and MORE, and the experiment design is drafted from your column headers before a job exists. |
+| **Rebuilt interface** | Navigation moved into the header and the left rail is gone; one token-based design system for surfaces, shapes and type; WCAG AA contrast throughout; a dark theme with a header toggle; a redrawn landing page and mark; a contents sidebar on the results page; and modernized dialogs, tables and upload controls. |
+| **Examples for every pipeline** | Bundled, manifest-driven example datasets built from a seeded generator, with the pathways the enrichment should recover listed alongside the files. **Load example** now works for Regions2Genes, miRNA2Genes and MORE too, not only pathway acquisition. |
+| **Container deployment** | A Docker Compose stack (nginx/TLS → app → MongoDB), a post-deployment smoke test that fails on the mistakes that are expensive to find in production, an operator runbook, and species installation from the command line. |
+| **Platform** | Python 3.11, Flask 3, pymongo 4 against MongoDB 7, and the imaging and HTTP stacks upgraded onto versions that carry their security fixes. One pip manifest, pinned. |
+| **Security** | Path traversal through job and file names closed; forgeable identity (`userID=0` and ID reuse) fixed; session and password-reset tokens drawn from `secrets`; per-request authorisation guards on job, image and admin routes; password hashes no longer sent to the admin panel; AI consent enforced server-side. |
+| **Statistics and correctness** | Enrichment counting, an independent denominator for the hub scorer, BH applied across the whole p-value vector, non-finite p-values dropped before FDR, reproducible metagene clustering, and the R drop-to-vector bug that silently killed metagenes for whole omic/database pairs. |
+| **Installers** | KEGG and Reactome download paths repaired (KEGG retired `/list/organism`; Reactome cached error bodies as data), every step made idempotent so reruns skip finished work, and an install that can no longer lose files it does not replace. |
+| **Tests** | 135 test scripts, including an end-to-end run against a real installed species, the real R backend rather than a double, an import smoke test over every tracked module, and a check that edited assets get their cache marker bumped. |
 
-**PaintOmics concepts tutorial**
+## The AI interpretation agent
 
-The PaintOmics concepts tutorial helps you understand why and how we conduct different analysis methods and functionalities in PaintOmics.
+It turns your ranked pathways into a written interpretation: it reads the
+cross-omic patterns, finds the supporting literature, and drafts the biology
+with citations you can check.
 
-1. [0:00](https://www.youtube.com/watch?v=brvToUmL1n4&t=0s) Introduction of **PaintOmics 4**
-2. [2:24](https://www.youtube.com/watch?v=brvToUmL1n4&t=144s) Pathway Enrichment Analysis 
-3. [4:16](https://www.youtube.com/watch?v=brvToUmL1n4&t=256s) Metabolite Hub Analysis 
-4. [6:30](https://www.youtube.com/watch?v=brvToUmL1n4&t=390s) Metabolite Class Activity Analysis  
-5. [8:13](https://www.youtube.com/watch?v=brvToUmL1n4&t=493s) Metagenes 
-6. [10:09](https://www.youtube.com/watch?v=brvToUmL1n4&t=609s) Pathway Interactions Network 
-7. [13:00](https://www.youtube.com/watch?v=brvToUmL1n4&t=780s) Regulatory Omics
+The pipeline runs in six phases — triage the pathways worth reading, plan the
+literature searches, retrieve papers from PubMed, interpret each batch, synthesize
+one report, then verify it. **Verification is not cosmetic:** every claim and
+quotation is checked back against the retrieved sources, and what cannot be
+grounded is redacted rather than published. References are rendered from the
+retrieved records, in the order the citations are numbered, and each `[n]` links
+to PubMed.
 
-check the full [PaintOmics concepts tutorial](https://youtu.be/brvToUmL1n4)
+It is off unless you ask for it. The consent box in Step 1 says what leaves the
+server — your pathway results and the values of the matched features — and names
+the service that receives them; the server re-checks that consent before every
+request it sends, and refuses the job up front if no LLM token is configured.
+The provider is any OpenAI-compatible endpoint, and a deployment can switch the
+feature off entirely with `AI_INTERPRETATION_ENABLED=false`.
 
-**PaintOmics step-by-step tutorial**
+## How it works
 
-The PaintOmics step-by-step tutorial helps you learn how to analyze different data types supported by PaintOmics step-by-step. 
+| Step | What happens |
+|---|---|
+| **1 · Upload** | Pick an organism and the pathway databases to explore, decide whether to enable the AI interpretation, then upload one data matrix per omic — or load a bundled example. |
+| **2 · Match** | Identifiers are converted to the ones the pathway databases use, and ambiguous metabolite names are resolved by you. The screen reports how many features mapped. |
+| **3 · Explore** | Enrichment, classification, networks, hub and class analyses, metagenes, regulator–target networks, and pathway diagrams painted with every omic at once. |
 
-1. [0:00](https://www.youtube.com/watch?v=4XxPKqAubsA&t=0s) Introduction of **PaintOmics 4**
-2. [0:59](https://www.youtube.com/watch?v=4XxPKqAubsA&t=59s) Overview of the video
-3. [3:34](https://www.youtube.com/watch?v=4XxPKqAubsA&t=214s) How to analyze gene/metabolomics data 
-4. [16:11](https://www.youtube.com/watch?v=4XxPKqAubsA&t=971s) How to analyze region-based omics data
-5. [19:20](https://www.youtube.com/watch?v=4XxPKqAubsA&t=1160s) How to analyze regulatory omics analysis
+## Analyses
 
-check the full [PaintOmics step-by-step tutorial](https://youtu.be/4XxPKqAubsA)
+| Analysis | What it answers |
+|---|---|
+| [Pathway enrichment](https://paintomics.readthedocs.io/en/latest/4_1_pathway_enrichment/) | Which pathways are significantly affected, per omic and combined |
+| [Pathway classification](https://paintomics.readthedocs.io/en/latest/4_2_kegg_categories/) | Where the affected pathways sit in the database hierarchy |
+| [Pathway interaction network](https://paintomics.readthedocs.io/en/latest/4_3_pathways_network/) | How the enriched pathways connect through shared features |
+| [Metabolite hub analysis](https://paintomics.readthedocs.io/en/latest/4_4_metabolite_hub_analysis/) | Which metabolites act as hubs for the observed changes |
+| [Metabolite class activity](https://paintomics.readthedocs.io/en/latest/4_5_metabolite_class_activity_analysis/) | Which chemical classes of metabolites move as a group |
+| [Regulatory omics](https://paintomics.readthedocs.io/en/latest/4_6_Regulatory_omics/) (incl. MORE) | Which trans-acting regulators (miRNA, TF, SF, RBP…) drive the changes |
+| [Metagenes](https://paintomics.readthedocs.io/en/latest/4_7_Metagenes/) | The dominant expression trends inside a pathway |
+| [Pathway visualisation](https://paintomics.readthedocs.io/en/latest/5_1_browsing_pathways/) | All omics painted on one diagram, with per-feature heatmaps |
+| **AI interpretation** | What the ranked pathways mean biologically, with literature to back it |
 
-## Contact
+Two supporting tools convert data into a usable input format: **Regions to
+Genes** (RGmatch, for region-based assays) and **miRNA to Genes**.
 
-**Tian-Yuan Liu**, Main Developer.
+## Deploy your own instance
 
-**Ana Conesa, Ph.D.**, Head Genomics of Gene Expression Lab.
+### With Docker (recommended)
 
-For any question on STATegraEMS, users can send a mail to [paintomics4@gmail.com](mailto:paintomics4@gmail.com).
+```bash
+git clone https://github.com/ConesaLab/paintomics4.git
+cd paintomics4
 
+cp deploy/env.example deploy/.env
+$EDITOR deploy/.env                        # PAINTOMICS_BASE_URL is mandatory
+./deploy/make-cert.sh <your-hostname-or-ip>
 
-<div class="imageContainer" style="text-align:center; font-size:10px; color:#898989" >
-    <img src="docs/img/stategra_logo.png" title="The STATegra Project logo."/>
-    <img src="docs/img/stategra_logo2.png" title="7th FRAMEWORK PROGRAMME, EUROPEAN COMMISSION"/>
-</div>
+docker compose -f deploy/compose.yaml up -d --build
+./deploy/smoke-test.sh
+```
 
-<div class="imageContainer" style="margin-top:50px; text-align:center; font-size:10px; color:#898989" >
-    <img src="docs/img/stategra_partners_logo.jpg" title="The STATegra Consorcium."/>
-</div>
+Three containers: nginx (TLS) → app (Flask + uWSGI + in-process job queue) →
+MongoDB. The first build takes 15–30 minutes, most of it R packages. See
+[`deploy/README.md`](deploy/README.md) for configuration, backups, certificates,
+and the two constraints that must not be relaxed.
+
+AI interpretation needs an OpenAI-compatible endpoint and its key in
+`deploy/.env`; without one the rest of the application runs normally and the
+feature refuses jobs, or set `AI_INTERPRETATION_ENABLED=false` to hide it.
+
+### From source (development)
+
+Requires **Python 3.11**, **MongoDB**, **R**, and the `libcairo2` shared library.
+
+```bash
+git clone https://github.com/ConesaLab/paintomics4.git
+cd paintomics4
+
+python3.11 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+
+# R packages used by hub analysis, metagenes and regulatory omics
+Rscript -e 'install.packages(c("purrr","amap","cluster","factoextra","mclust","optparse"))'
+
+cd PaintomicsServer
+python src/launch_server.py                # http://localhost:8000
+```
+
+The first launch copies `src/resources/example_serverconf.py` to
+`src/conf/serverconf.py`; edit that file (or the environment variables it reads)
+to set paths, MongoDB host, SMTP, quotas and the AI and MORE backends.
+`./start_server.sh` does the same through a conda environment and starts MongoDB
+if it is not already running.
+
+MORE's PLS1 runs on the Rust port whenever a `more-rs` binary is discoverable —
+beside `runMORE.R` or on `PATH` — and falls back to R when it is not, so a host
+that has never heard of the port behaves exactly as before. Set
+`PAINTOMICS_MORE_RS=off` to force R for every job; MLR always runs on R.
+
+### Load pathway data
+
+A fresh instance has an empty database — install each organism explicitly:
+
+```bash
+cd PaintomicsServer
+python src/AdminTools/DBManager.py download --specie=mmu --kegg=1 --mapping=1 --common=1 --reactome=1
+python src/AdminTools/DBManager.py install  --specie=mmu
+```
+
+Use `--common=0` for every species after the first: the common step re-downloads
+shared KEGG reference data and dominates the runtime. Reactome curates human and
+infers about twenty other species — use `--reactome=0` for the rest.
+
+### Tests
+
+Tests are standalone scripts, run from `PaintomicsServer`:
+
+```bash
+cd PaintomicsServer
+python -m src.tests.test_release_hygiene     # no secret is committed
+python -m src.tests.test_pymongo4_compat     # no removed pymongo API is used
+python -m src.tests.test_bug_fixes           # multi-condition statistics
+```
+
+## Documentation
+
+Full user guide: **[paintomics.readthedocs.io](https://paintomics.readthedocs.io/en/latest/)**
+— including [accepted input formats](https://paintomics.readthedocs.io/en/latest/2_1_accepted_input/),
+a [step-by-step guide](https://paintomics.readthedocs.io/en/latest/8_step_by_step/)
+and the [FAQ](https://paintomics.readthedocs.io/en/latest/9_faq/).
+The sources live in [`docs/`](docs) and build with `mkdocs`.
+
+## Video tutorials
+
+<details>
+<summary><b>Concepts tutorial</b> — why and how each analysis works (<a href="https://youtu.be/brvToUmL1n4">watch</a>)</summary>
+
+| Time | Topic |
+|---|---|
+| [0:00](https://www.youtube.com/watch?v=brvToUmL1n4&t=0s) | Introduction to PaintOmics |
+| [2:24](https://www.youtube.com/watch?v=brvToUmL1n4&t=144s) | Pathway enrichment analysis |
+| [4:16](https://www.youtube.com/watch?v=brvToUmL1n4&t=256s) | Metabolite hub analysis |
+| [6:30](https://www.youtube.com/watch?v=brvToUmL1n4&t=390s) | Metabolite class activity analysis |
+| [8:13](https://www.youtube.com/watch?v=brvToUmL1n4&t=493s) | Metagenes |
+| [10:09](https://www.youtube.com/watch?v=brvToUmL1n4&t=609s) | Pathway interactions network |
+| [13:00](https://www.youtube.com/watch?v=brvToUmL1n4&t=780s) | Regulatory omics |
+
+</details>
+
+<details>
+<summary><b>Step-by-step tutorial</b> — analysing each data type (<a href="https://youtu.be/4XxPKqAubsA">watch</a>)</summary>
+
+| Time | Topic |
+|---|---|
+| [0:00](https://www.youtube.com/watch?v=4XxPKqAubsA&t=0s) | Introduction to PaintOmics |
+| [0:59](https://www.youtube.com/watch?v=4XxPKqAubsA&t=59s) | Overview of the video |
+| [3:34](https://www.youtube.com/watch?v=4XxPKqAubsA&t=214s) | Gene expression and metabolomics data |
+| [16:11](https://www.youtube.com/watch?v=4XxPKqAubsA&t=971s) | Region-based omics data |
+| [19:20](https://www.youtube.com/watch?v=4XxPKqAubsA&t=1160s) | Regulatory omics analysis |
+
+</details>
+
+These cover the analyses as released in PaintOmics 4; the pipeline they describe
+is unchanged. More on the
+[PaintOmics YouTube channel](https://www.youtube.com/channel/UCSoQ3LSli9ZxOQTX56_WJeA).
+
+## Citation
+
+If PaintOmics contributed to your work, please cite:
+
+> **PaintOmics 4**: new tools for the integrative analysis of multi-omics
+> datasets supported by multiple pathway databases.
+> *Nucleic Acids Research* (2022). [10.1093/nar/gkac352](https://doi.org/10.1093/nar/gkac352)
+
+<details>
+<summary>Earlier releases and related tools</summary>
+
+- **PaintOmics 3** — *Nucleic Acids Research* (2018), [10.1093/nar/gky466](https://doi.org/10.1093/nar/gky466)
+- **PaintOmics 2** — *Bioinformatics* (2011), [10.1093/bioinformatics/btq594](https://doi.org/10.1093/bioinformatics/btq594)
+- **RGmatch** — *BMC Bioinformatics* (2016), [10.1186/s12859-016-1293-1](https://doi.org/10.1186/s12859-016-1293-1)
+- **MORE** — the regulatory model behind the Regulatory Omics option, [BiostatOmics/MORE](https://github.com/BiostatOmics/MORE)
+
+BibTeX records are available from the **More → Cite PaintOmics** menu in the
+application.
+
+</details>
+
+## Contact and contributing
+
+Questions, bug reports and organism requests: [paintomics4@gmail.com](mailto:paintomics4@gmail.com)
+or an [issue](https://github.com/ConesaLab/paintomics4/issues) on this
+repository. Pull requests are welcome.
+
+## License
+
+Distributed under the **GNU General Public License, Version 3** — see
+[`LICENSE`](LICENSE).
+
+## Acknowledgements
+
+PaintOmics is developed by the [Genomics of Gene Expression Lab](http://conesalab.org/)
+and originated in the [STATegra Project](https://cordis.europa.eu/project/id/306000/reporting),
+funded by the European Commission's 7th Framework Programme.
+
+<p align="center">
+  <img src="docs/img/stategra_logo.png" alt="STATegra" height="44">
+  &nbsp;&nbsp;
+  <img src="docs/img/stategra_logo2.png" alt="7th Framework Programme, European Commission" height="44">
+</p>
+
+<p align="center">
+  <img src="docs/img/stategra_partners_logo.jpg" alt="The STATegra consortium" width="640">
+</p>


### PR DESCRIPTION
Everything on the branch since the last merge (14 commits), in four strands:

## Installer robustness (reviewed, then hardened)
The 2026-08 full-reinstall fixes: Reactome coverage drops (ptr) fail-soft to a KEGG-only install; per-source empty Reactome gene mappings are tolerated while all-three-empty still fails loudly; KEGG's HTTP 400 "not offered" answers are treated as absence instead of retried into a species failure; pfa/sce declare their strain taxids (36329, 559292 — the species ids matched almost no gene_info rows); xtr gains the download_conf it always tried to import, making the species installable for the first time.

A multi-agent review of the diff then surfaced — and this PR fixes — the regressions those changes would have introduced:
- a promotion **refusal** no longer triggers the rollback path, which silently regressed an intact species one version (typed `PromotionRefused`);
- the KEGG-only fail-soft is actually reachable for species previously installed with Reactome (a `REACTOME_NOT_COVERED` marker the guard reads);
- the common ChEBI mapping keeps its empty-file raise (empty there = truncated download, the curl-without--f class);
- custom species names go through `json.dumps`, so a quote in a display name cannot poison species.json for every organism;
- permanent 400s stop being retried, the zero-coverage R path no longer re-parses the 874MB all-species table, and the three copy-pasted mapping downloads collapsed into one helper.

## Custom (non-KEGG) species
Install any organism from a gene-to-KO annotation table (`customSpeciesInstaller.py`), with display names that survive a common refresh.

## AI example-mode design draft
"Draft this for me" now works for a loaded example: the client names the scenario and the servlet reads the header rows server-side. A majority-numeric check skips headerless files (the STATegra miRNA table opens with measured values), keeping the "no values were sent" contract true. Verified in Chrome: drafted from 28 column names across the four headered omics.

## Crash fixes and UI
The five crash classes users had been mailing in since November; first-launch bootstrap/logging-config fixes; the step-2 toolbar figure drawn from the toolbar's own markup instead of a 2022 screenshot; step-2 full-width cards on their own flex rows; one shared left rail for the results page.

## Verification
- `test_reactome_install` 25/25, `test_organism_taxids_are_correct` 3/3, `test_exp_design_example_mode` all pass — also from a clean `git archive` checkout, plus the servlet import gate on that archive.
- 16 related standalone suites green; the one failure (`test_dependencies_declared`) reproduces identically on the pre-existing HEAD and is unrelated.
- Example-draft flow exercised end-to-end in Chrome against the running server.

Known follow-ups (documented, not fixed here): stale unflagged `download/<sp>` debris now persists until an admin removes it (the guard refuses it cleanly instead of rolling back); `GENERATED_AT_BUILD` is a second source of truth for build outputs; the 400-as-absence classification is substring-based; the browser-side upload path has the same headerless-file exposure for user-picked files, under the user's own consent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)