### PR TITLE
Render the AI report's markdown, show dark selection states, align th…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,3 +70,11 @@ Before verifying:
   repaint and re-measure both.
 * **Never trigger `alert`/`confirm`/`prompt`** — a modal dialog blocks every subsequent browser
   command. Use `console.log` plus `read_console_messages` instead.
+
+## 6. Redline / alignment QA
+
+Dev-only overlay at scripts/alignment-guides.js: red rails + HUD listing
+off-rail elements. Enable with ?guides=1 or Ctrl+Alt+G.
+After any layout/spacing/CSS change: open the page with guides on,
+screenshot it, fix every off-rail element in the HUD (except ones marked
+data-guides="ignore"), and repeat until the HUD shows 0 off-rail.

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_AIInterpretView.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_AIInterpretView.js
@@ -248,6 +248,28 @@ function PA_AIInterpretView() {
     };
 
     this._preprocessMarkdown = function(text) {
+        /* The model routinely writes a SPACE where a newline belongs, gluing a
+           structure token to the tail of the previous sentence:
+               "...hepatic response [3, 6]. - **All ten pathways..."
+               "...perturbs bile secretion. ---"
+               "...biosynthetic response. ### The Flat Temporal Pattern..."
+           A glued token is not markdown at all - marked renders it literally,
+           which is how "---" and "###" ended up visible in reports. Recover the
+           newline first; the blank-line rules below then finish the job.
+           Verified against every report stored locally (see git history). */
+        // Headings glued after prose ("prose. ### Title" / "prose. #### Title")
+        text = text.replace(/([^\n])[ \t]+(#{1,6} )/g, "$1\n\n$2");
+        // Horizontal rules glued after prose, when the --- ends its line.
+        // [^\n-] keeps this off spaced em-dashes ("text --- text" stays prose
+        // because the lookahead requires end-of-line).
+        text = text.replace(/([^\n-])[ \t]+(-{3,})[ \t]*(?=\n|$)/g, "$1\n\n$2");
+        // Bullets glued after a sentence. Fires when the bullet text opens with
+        // emphasis ("- **") or a capital ("- The SPLIS feedback model...") -
+        // every glued bullet in the stored reports is one of the two, while a
+        // dash inside prose continues lowercase and is left alone.
+        text = text.replace(/([.!?:\])\*])[ \t]+- (?=\*|[A-Z])/g, "$1\n- ");
+        // Numbered items glued after a sentence ("...changes. 2. **Systematic")
+        text = text.replace(/([.!?:\])\*])[ \t]+(\d{1,2}\. )(?=\*|[A-Z])/g, "$1\n$2");
         // Ensure blank line before headings (required by CommonMark)
         text = text.replace(/([^\n])\n(#{1,6}\s)/g, "$1\n\n$2");
         // Ensure blank line before horizontal rules

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -1717,7 +1717,12 @@ function PA_Step1JobView() {
 									   with --pa-ai-consent-warn -- a token it already declared for
 									   exactly this and had no way to apply. Same fix, same reason, as
 									   .formMessage. */
-									boxLabel: 'Enable AI pathway interpretation (<span class="ai-consent-warn">sends your pathway results and the values of the matched features to <span id="aiProviderName">an external AI service</span></span>) ' +
+									/* "sends your results to X", not "your pathway results and the
+									   values of the matched features to X": the long form wrapped the
+									   label to three lines and buried the recipient. The enumeration
+									   of exactly which fields leave the server belongs to - and stays
+									   in - the (i) notice this label links to. */
+									boxLabel: 'Enable AI pathway interpretation (<span class="ai-consent-warn">sends your results to <span id="aiProviderName">an external AI service</span></span>) ' +
 										'<i class="fa fa-exclamation-circle ai-gdpr-info-icon" id="aiGdprInfoIcon" title="Data privacy &amp; compliance \u2014 click to learn what data is sent"></i>',
 									name: 'aiConsent', inputValue: 'true', uncheckedValue: 'false',
 									/* Off everywhere but a local instance -- a pre-ticked consent

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
@@ -3723,17 +3723,27 @@ function PA_Step3PathwayDetailsView() {
 		/* STEP 1. Update the name of the pathway and the classification */
 		/*****************************************************************/
 		$(componentID + " .pathwayNameLabel h4").text(this.getModel().getName());
-		$(componentID + " .pathwayClassificationLabel").html(
-			"<b>Classification:</b>"+
-			"<ul style='margin: 0;'>" +
-			"  <li>" + this.getModel().getClassification().replace(";","</li><li>") + "</li>" +
-			"</ul>");
+		/* Chips instead of a bulleted list: the two classification levels are
+		   tags, not sentences, and a <ul> spent two full lines and bullet
+		   glyphs saying so. Built with .text() per chip so a classification
+		   name can never be read as markup. */
+		var classificationChips = $("<div class='pa-details-chips'></div>");
+		this.getModel().getClassification().split(";").forEach(function(levelName) {
+			levelName = levelName.trim();
+			if (levelName !== "") {
+				classificationChips.append($("<span class='pa-details-chip'></span>").text(levelName));
+			}
+		});
+		$(componentID + " .pathwayClassificationLabel")
+			.empty()
+			.append("<span class='pa-details-label'>Classification</span>")
+			.append(classificationChips);
 
 			/*******************************************************************/
 			/* STEP 2. Fill the information about matched features and p-values*/
 			/*******************************************************************/
 			if(this.getParent().getName() !== "PA_Step3PathwayNetworkTooltipView"){
-				var htmlCode = '<thead><tr><th></th><th>Matched<br>features</th><th>p-value (Global)</th><th></th></tr></thead><tbody>';
+				var htmlCode = '<thead><tr><th></th><th title="Matched features (relevant)">Matched</th><th title="Global p-value">p-value</th><th></th></tr></thead><tbody>';
 				var significanceValues = this.getModel().getSignificanceValues();
 				var globalOmicPvalues = this.getModel().getGlobalOmicPvalues() || {};
 				var jobView = this.getParent("PA_Step3JobView") || this.getParent("PA_Step4JobView");
@@ -3748,30 +3758,31 @@ function PA_Step3PathwayDetailsView() {
 					
 					var omicID = omicName.replace(/ /g, "_");
 					
-					htmlCode += '<tr class="omic-row" data-omic="' + omicID + '"><td>' + omicName + '</td><td>' + significanceValues[omicName][0][0] + ' (' + significanceValues[omicName][0][1] + ')</td><td>' + renderedGlobalP + '</td>' +
-					            '<td class="whiteBackground">' + 
-					            '<i class="fa fa-chevron-right expandConditions" title="Show per-condition p-values" data-omic="' + omicID + '"></i> ' +
-					            (! Ext.Object.isEmpty(foundFeatures[omicName]) ? '<i class="fa fa-plus-square-o expandMatched" data-id="' + omicID + '"></i>' : '') + 
+					htmlCode += '<tr class="omic-row" data-omic="' + omicID + '"><td class="pa-details-omic">' + omicName + '</td><td class="pa-details-num">' + significanceValues[omicName][0][0] + ' (' + significanceValues[omicName][0][1] + ')</td><td class="pa-details-num">' + renderedGlobalP + '</td>' +
+					            '<td class="pa-details-actions">' +
+					            '<i class="fa fa-chevron-right expandConditions" title="Show per-condition p-values" data-omic="' + omicID + '"></i>' +
+					            (! Ext.Object.isEmpty(foundFeatures[omicName]) ? '<i class="fa fa-plus-square-o expandMatched" title="Show matched features" data-id="' + omicID + '"></i>' : '') +
 					            '</td></tr>';
-					
-					// Add per-condition rows (hidden by default)
+
+					// Add per-condition rows (hidden by default). Styled by class,
+					// not inline: an inline background is unreachable by dark.css.
 					for (var c = 0; c < significanceValues[omicName].length; c++) {
 						var condP = significanceValues[omicName][c][2];
 						var renderedCondP = (condP > 0.001 || condP === 0) ? parseFloat(condP).toFixed(6) : parseFloat(condP).toExponential(4);
 						var condName = conditionNames[c] || ("Condition " + (c+1));
-						
-						htmlCode += '<tr class="condition-row cond-row-' + omicID + '" style="display:none; background-color: #f9f9f9; font-size: 0.9em;">' +
-						            '<td style="padding-left: 20px;"><i>' + condName + '</i></td>' +
-						            '<td>' + significanceValues[omicName][c][0] + ' (' + significanceValues[omicName][c][1] + ')</td>' +
-						            '<td>' + renderedCondP + '</td><td></td></tr>';
+
+						htmlCode += '<tr class="condition-row cond-row-' + omicID + '" style="display:none;">' +
+						            '<td class="pa-details-cond">' + condName + '</td>' +
+						            '<td class="pa-details-num">' + significanceValues[omicName][c][0] + ' (' + significanceValues[omicName][c][1] + ')</td>' +
+						            '<td class="pa-details-num">' + renderedCondP + '</td><td></td></tr>';
 					}
 				}
 				htmlCode+='</tbody>';
-				$(componentID + " .pathwaySummaryTable").html('<table class="table table-condensed" style="padding: 10px;text-align: center;">'+ htmlCode + '</table>');
+				$(componentID + " .pathwaySummaryTable").html('<table class="pa-details-table">'+ htmlCode + '</table>');
 
 				var detailedHTMLcode = '';
 				Object.keys(foundFeatures).forEach(function(omicName) {
-					detailedHTMLcode += '<div id="matchedlist_' + omicName.replace(/ /g, "_") + '" style="display: none;"><h5>Matched features: ' + omicName + '</h5>';
+					detailedHTMLcode += '<div id="matchedlist_' + omicName.replace(/ /g, "_") + '" class="pa-details-matchedlist" style="display: none;"><h5>Matched features: ' + omicName + '</h5>';
 
 					if (! Ext.Object.isEmpty(foundFeatures[omicName])) {
 						// Sort alphabetically

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4Views.js
@@ -3079,16 +3079,18 @@ function PA_Step4FindFeaturesView() {
 				"<div class='lateralOptionsPanel-body findFeaturesContainer'>" +
 				'  <div>'+
 				'    <h4>Search in this pathway</h4>' +
-				'    <div class="findFeaturesInput input" style="width:170px; display:inline-block;"><input type="text" style="width:160px;"></div>'+
-				/* `margin-right: 0`, not the 5px `.button` gives every button: that
-				   5px is the gutter between two buttons sitting side by side, and
-				   this one is alone on its line. It floats right, so the gutter
-				   simply stopped it 5px short of the edge the panel's heading,
-				   its "Search in this pathway" label and every field below it are
-				   squared to - x=1301 against a rail at 1306. Written here rather
-				   than in the stylesheet because the margin is inline, and inline
-				   beats any rule that is not !important. */
-				'    <a class="button btn-info findFeatureButton helpTip" style="margin: 20px 0 20px 5px" title="Find features"><i class="fa fa-search"></i> Search</a>' +
+				/* One flex row (.findFeaturesRow, main.css) instead of an
+				   inline-block input next to a floated button: `.button` carries
+				   `float: right`, so the button dropped below the input and hung
+				   off the right edge on its own line - the field and its one
+				   action read as two unrelated controls. Flex ignores floats on
+				   its items, which is what actually pins the two to one line and
+				   one baseline; the stylesheet owns the geometry so dark.css can
+				   reach every part of it. */
+				'    <div class="findFeaturesRow">' +
+				'      <div class="findFeaturesInput input"><input type="text" placeholder="Gene, metabolite..."></div>'+
+				'      <a class="button btn-info findFeatureButton helpTip" title="Find features"><i class="fa fa-search"></i> Search</a>' +
+				'    </div>' +
 				'    <div class="applyWaitMessage" style="color:#4c4c4c; margin: 10px; display:none;"> Searching...<i class="fa fa-cog fa-spin" style=" float: left; margin-right: 10px; "></i></div>' +
 				'  </div>'+
 				'  <div class="patwaysDetailsContainer"></div>'+
@@ -3111,16 +3113,27 @@ function PA_Step4FindFeaturesView() {
 				el.find("#hideFindFeaturePanelButton").click(function() {
 					me.toggle(false);
 				});
+				/* Looked up from the container, not with `.next()`: the button
+				   now lives inside .findFeaturesRow and the wait message is the
+				   row's sibling, so a sibling walk from the button finds nothing
+				   and the search silently never ran. */
 				el.find(".findFeatureButton").click(function() {
-					$(this).next(".applyWaitMessage").fadeIn(400, function() {
+					var waitMessage = el.find(".applyWaitMessage");
+					waitMessage.fadeIn(400, function() {
 						el.find(".patwaysDetailsContainer").hide();
 						me.searchFeatures(el.find(".findFeaturesInput > input").val());
-						$(this).hide();
+						waitMessage.hide();
 					});
 				});
 				el.find(".findFeaturesInput > input").autocomplete({
 					source: availableTags,
 					minLength: 2
+				}).on("keydown", function(event) {
+					/* Enter searches. A lone text field whose Enter does nothing
+					   reads as broken, and the button is the only other way in. */
+					if (event.keyCode === 13) {
+						el.find(".findFeatureButton").click();
+					}
 				});
 
 				el.find(".backToPathwayDetailsButton").click(function() {

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,13 +39,13 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.01" />
-	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=0.6" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.02" />
+	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=0.7" />
 	<!-- Shared chrome for both of Step 3's graph surfaces. Before more-network.css,
 	     which layers this view's own legend and layout on top of it. -->
 	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=0.6" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
-	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.48" />
+	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.50" />
 
 	<!-- Theme, resolved before the first paint.
 	     Deliberately inline and here rather than in Util.js: the stylesheets
@@ -133,7 +133,7 @@
 	<!--MARKDOWN RENDERING LIBRARY -->
 	<script type="text/javascript" src="js/libs/marked/marked.min.js"></script>
 	<!--AI INTERPRETATION VIEW -->
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_AIInterpretView.js?v=0.4"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_AIInterpretView.js?v=0.5"></script>
 	<!--MORE REGULATOR–TARGET NETWORK VIEW -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js?v=0.7"></script>
 

--- a/PaintomicsClient/public_html/resources/css/ai-interpret.css
+++ b/PaintomicsClient/public_html/resources/css/ai-interpret.css
@@ -70,8 +70,24 @@
     transform: scale(1.1);
     box-shadow: 0 4px 16px rgba(74, 144, 217, 0.6);
 }
+/* Working state. The old treatment was the fabPulse glow alone, which at
+   2s/40% opacity read as a decorative shimmer, not as "the analysis is
+   running" - users reported not being able to tell. Three signals now run
+   together: a rotating spinner ring around the launcher (the universally
+   read "busy" symbol), a faster and much wider glow pulse, and a gentle
+   breathing scale on the button itself. */
 .ai-widget-fab.is-processing {
-    animation: fabPulse 2s ease-in-out infinite;
+    animation: fabGlowPulse 1.4s ease-in-out infinite,
+               fabBreathe 1.4s ease-in-out infinite;
+}
+.ai-widget-fab.is-processing::before {
+    content: "";
+    position: absolute;
+    inset: -6px;
+    border-radius: 50%;
+    border: 3px solid rgba(74, 144, 217, 0.25);
+    border-top-color: #4a90d9;
+    animation: fabSpin 0.9s linear infinite;
 }
 .ai-widget-fab-badge {
     width: 18px;
@@ -213,16 +229,32 @@
     margin-bottom: 4px;
 }
 .ai-progress-track {
-    height: 4px;
+    height: 6px;
     background: #dde8f0;
-    border-radius: 2px;
+    border-radius: 3px;
     overflow: hidden;
 }
 .ai-progress-fill {
     height: 100%;
     background: linear-gradient(90deg, #4a90d9, #67b8f7);
-    border-radius: 2px;
+    border-radius: 3px;
     transition: width 0.5s ease;
+    position: relative;
+    overflow: hidden;
+}
+/* A sheen sweeping the filled part keeps the bar visibly alive between the
+   coarse percent updates - a static fill at 40% for a minute reads as hung. */
+.ai-progress-fill::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.55), transparent);
+    animation: progressSheen 1.2s linear infinite;
+}
+.ai-widget-progress.is-done .ai-progress-fill::after,
+.ai-widget-progress.is-error .ai-progress-fill::after {
+    animation: none;
+    content: none;
 }
 .ai-widget-progress.is-done {
     background: #e8f5e9;
@@ -628,10 +660,20 @@
     from { opacity: 0; transform: translateY(5px); }
     to { opacity: 1; transform: translateY(0); }
 }
-@keyframes fabPulse {
-    0% { box-shadow: 0 2px 8px rgba(74, 144, 217, 0.4); }
-    50% { box-shadow: 0 2px 20px rgba(74, 144, 217, 0.8); }
-    100% { box-shadow: 0 2px 8px rgba(74, 144, 217, 0.4); }
+@keyframes fabGlowPulse {
+    0%, 100% { box-shadow: 0 2px 10px rgba(74, 144, 217, 0.45); }
+    50% { box-shadow: 0 2px 28px 6px rgba(74, 144, 217, 0.85); }
+}
+@keyframes fabBreathe {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.06); }
+}
+@keyframes fabSpin {
+    to { transform: rotate(360deg); }
+}
+@keyframes progressSheen {
+    from { transform: translateX(-100%); }
+    to { transform: translateX(100%); }
 }
 @keyframes dotPulse {
     0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }

--- a/PaintomicsClient/public_html/resources/css/dark.css
+++ b/PaintomicsClient/public_html/resources/css/dark.css
@@ -571,8 +571,17 @@
 	color: var(--pa-ink-label);
 }
 
-/* Form fields */
-[data-theme="dark"] .x-form-field,
+/* Form fields.
+
+   `.x-form-field` also sits on every ExtJS checkbox and radio
+   (class="x-form-field x-form-checkbox ..."), and this blanket's !important
+   background pair beat the checkbox rules further down, which are not
+   !important: the checked box lost both its --pa-accent-blue fill and its
+   background-image tick, so a checked control rendered pixel-identical to an
+   unchecked one - on the enrichment toolbar there was no way to see whether
+   KEGG or Reactome was selected. Checkboxes and radios are excluded here so
+   the dedicated rules below can draw their two states. */
+[data-theme="dark"] .x-form-field:not(.x-form-checkbox):not(.x-form-radio),
 [data-theme="dark"] .x-form-text,
 [data-theme="dark"] .x-form-textarea,
 [data-theme="dark"] .x-form-trigger-wrap {
@@ -656,6 +665,28 @@
 	border-color: var(--pa-border);
 	color: var(--pa-ink-body);
 }
+/* The sentence in a MessageBox does not inherit the body colour above, because
+ * it is not text -- it is a form field. `Ext.window.MessageBox` builds its
+ * `msg` out of `Ext.form.field.Display`, so the element that actually carries
+ * "Are you sure you want to exit the current job?" is `.x-form-display-field`,
+ * and Neptune ships `.x-form-display-field { color: black }` for it.
+ *
+ * Neither of the two rules that look like they should have covered this does.
+ * `.x-window-body` sets an inherited colour, which stops the moment a
+ * descendant declares its own. The `.x-form-field` block near the top of this
+ * file is `!important` and would have won -- but a display field never carries
+ * that class: `x-form-field` is on the <input>, and a display field renders a
+ * <div> instead precisely because it has no input.
+ *
+ * Measured on a rendered confirm dialog: rgb(0, 0, 0) on --pa-surface #1E1F23,
+ * 1.28:1. Every alert(), confirm() and prompt() in the app was a black sentence
+ * on a black card -- the buttons and the title were correct, which is why it
+ * read as a dialog with its question missing rather than as a broken theme.
+ *
+ * Not scoped to `.x-message-box`: the leak is Neptune's default for the field
+ * type, so any display field this app grows later would arrive black too.
+ */
+[data-theme="dark"] .x-form-display-field { color: var(--pa-ink-body); }
 /* Window headers need the SURFACE as well as the text colour.
  *
  * This block used to set `color` only, which produced light text on the
@@ -1216,7 +1247,9 @@
 [data-theme="dark"] .paWeightsTip .x-tip-header,
 [data-theme="dark"] .paWeightsTip .x-tip-header-default { background: var(--pa-surface-quiet); }
 
-[data-theme="dark"] .pathwaySummaryTable tr:nth-child(even) { background: var(--pa-grid-row-alt); }
+/* The details table lost its zebra (main.css: hairline separators carry the
+   structure now, in .pa-details-table tokens that dark redefines), so the
+   even-row repaint that mirrored it is gone too. */
 /* Disabled classification chips grey out to #E8E8E8 with !important. */
 [data-theme="dark"] .step3ClassificationsTitle.disabled > i.classificationNameBox {
 	background-color: var(--pa-surface-quiet) !important;

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -3782,10 +3782,113 @@ div[id ^= "step3-network-toolbar_"] div[id ^= "reorderOptions"]{
 		min-height: auto !important;
  }
 
-.pathwaySummaryTable tr:nth-child(even) {
-	background: #e2eff8;
-	padding: 0;
-	margin: 0;
+/* The pathway details panel (Step 3 details card, Step 4 sidebar) ------------
+   Replaces the blue zebra table (#e2eff8 on even rows) and the bulleted
+   classification list. Zebra striping earned nothing here - three rows do not
+   need tracking help - and once the hidden per-condition rows toggle open the
+   stripes landed on arbitrary rows anyway. Hairline separators carry the
+   structure; numbers right-align in tabular figures so magnitudes line up. */
+.pa-details-label {
+	display: block;
+	font-size: 10px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--pa-ink-muted, #595959);
+	margin: 6px 0 4px;
+}
+.pa-details-chips {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 4px;
+}
+.pa-details-chip {
+	font-size: 11px;
+	line-height: 1.4;
+	padding: 2px 9px;
+	border-radius: 999px;
+	background: var(--pa-surface-quiet, #F3F2ED);
+	border: 1px solid var(--pa-border, rgba(24, 24, 27, 0.10));
+	color: var(--pa-ink-control, #3F3F46);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 100%;
+}
+.pa-details-table {
+	width: 100%;
+	border-collapse: collapse;
+	margin: 8px 0 4px;
+	font-size: 12px;
+}
+.pa-details-table th {
+	font-size: 10px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var(--pa-ink-muted, #595959);
+	text-align: right;
+	padding: 3px 6px;
+	border-bottom: 1px solid var(--pa-border, rgba(24, 24, 27, 0.10));
+}
+.pa-details-table th:first-child {
+	text-align: left;
+}
+.pa-details-table td {
+	padding: 5px 6px;
+	border-bottom: 1px solid var(--pa-border, rgba(24, 24, 27, 0.10));
+	vertical-align: middle;
+}
+.pa-details-table tbody tr:last-child td {
+	border-bottom: none;
+}
+.pa-details-omic {
+	text-align: left;
+	font-weight: 600;
+	color: var(--pa-ink, #18181B);
+}
+.pa-details-num {
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+	white-space: nowrap;
+	color: var(--pa-ink-control, #3F3F46);
+}
+.pa-details-actions {
+	text-align: right;
+	white-space: nowrap;
+}
+.pa-details-actions i {
+	cursor: pointer;
+	padding: 4px 5px;
+	border-radius: var(--pa-radius-sm, 6px);
+	color: var(--pa-ink-muted, #595959);
+}
+.pa-details-actions i:hover {
+	background: var(--pa-surface-quiet, #F3F2ED);
+	color: var(--pa-ink, #18181B);
+}
+.pa-details-table tr.condition-row td {
+	border-bottom: none;
+	background: var(--pa-surface-subtle, #F9F8F4);
+	font-size: 11px;
+	color: var(--pa-ink-muted, #595959);
+}
+.pa-details-table tr.condition-row td.pa-details-cond {
+	padding-left: 16px;
+	font-style: italic;
+}
+.pa-details-matchedlist h5 {
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var(--pa-ink-muted, #595959);
+	margin: 8px 0 2px;
+}
+.pa-details-matchedlist ul {
+	margin: 0 0 8px;
+	padding-left: 18px;
+	font-size: 12px;
 }
 
 /* The database tabs -----------------------------------------------------------
@@ -4470,6 +4573,46 @@ div[id ^= "sliderClusterNumberContainer_"] {
 div[id ^= "pathwayNetworkToolsBox_"] > a.button.btn-right,
 .findFeaturesContainer a.button {
 	margin-right: 0;
+}
+/* The search field and its button share one flex row. `.button` floats right,
+   which is what used to push "Search" onto its own line below the field; a
+   flex container ignores floats on its items, so declaring the row is also
+   what cancels the float. The input stretches, the button keeps its size, and
+   both are as tall as each other - align-items: stretch - so the pair reads
+   as one control squared to the panel rail. */
+.findFeaturesRow {
+	display: flex;
+	align-items: stretch;
+	gap: 6px;
+	margin: 6px 0 10px;
+}
+.findFeaturesRow .findFeaturesInput {
+	flex: 1;
+	min-width: 0;
+}
+.findFeaturesRow .findFeaturesInput input {
+	width: 100%;
+	height: 100%;
+	box-sizing: border-box;
+	margin: 0;
+	padding: 6px 10px;
+	font-family: var(--pa-font-sans);
+	font-size: 13px;
+	color: var(--pa-ink, #27272A);
+	background: var(--pa-surface, #FFFFFF);
+	border: 1px solid var(--pa-border, #D4D4D8);
+	border-radius: var(--pa-radius-sm, 6px);
+}
+.findFeaturesRow .findFeaturesInput input:focus {
+	outline: none;
+	border-color: var(--pa-focus-ring, #0A84FF);
+}
+.findFeaturesRow a.button.findFeatureButton {
+	float: none;
+	margin: 0;
+	display: flex;
+	align-items: center;
+	gap: 5px;
 }
 .lateralOptionsPanel-header h2 {
 	color: #27272A;
@@ -5738,6 +5881,41 @@ div.omicSummaryBox.expandedBox, div.metaboliteBox.expandedBox{
 /* The one button the caption is pointing at. */
 .paToolbarMiniature .paMiniatureTarget {
 	box-shadow: 0 0 0 2px #B3261E;
+}
+/* The row's spacing is the flex gap alone. `.button` brings `margin: 0 5px`
+   from the shared rule, and five buttons' worth of those margins (50px) is
+   exactly what pushed "Go back" onto a second row at laptop card widths while
+   every width sum said the row fit. */
+.paToolbarMiniature .button {
+	margin: 0;
+}
+/* The figure must stay one row: the real toolbar it depicts is one row, and
+   "Go back" wrapping underneath on a narrow laptop turned the picture into a
+   layout it was never illustrating. The row needs ~500px at full size, so on
+   a narrower card the buttons shrink typographically - smaller type, tighter
+   padding - long before the wrap fallback above could fire. Sized by the
+   card, not the viewport: the summary cards reflow between one and two
+   columns, so viewport width says nothing about the space this figure has.
+   inline-size containment only, on the card itself - the same recipe as the
+   MORE toolbar column fix - so ExtJS keeps control of the height. */
+.omicSummaryBox {
+	container-type: inline-size;
+}
+@container (max-width: 560px) {
+	.paToolbarMiniature { gap: 4px; }
+	.paToolbarMiniature .button {
+		height: 26px;
+		padding: 0 8px;
+		gap: 4px;
+		font-size: 11px;
+	}
+}
+@container (max-width: 430px) {
+	.paToolbarMiniature .button {
+		height: 24px;
+		padding: 0 6px;
+		font-size: 10px;
+	}
 }
 
 /********************************************************************************
@@ -7302,6 +7480,20 @@ div.repDetectionCard h3 {
 	#mainViewCenterPanel.pa-has-toc {
 		padding-left: calc(var(--pa-gutter) + var(--pa-rail));
 		padding-right: max(40px, calc(100vw - var(--pa-gutter) - var(--pa-rail) - var(--pa-page-max)));
+	}
+	/* The header follows the column it sits above. On these railed pages the
+	   results column's right edge comes from the leftover-space formula above,
+	   not from --pa-gutter, so the header's utility corner (and the step
+	   actions anchored to its left) ended 48px shy of the cards directly
+	   beneath it at laptop widths - "the top button is misaligned with the
+	   body". The +20 is the inset the ExtJS step containers still add between
+	   the column edge and a card's border (two stacked 10px paddings), i.e.
+	   the edge the reader actually sees. The left side needs no counterpart:
+	   the wordmark and the TOC both already sit on --pa-gutter. fitHeaderNav's
+	   body observer re-measures --pa-header-utilities when pa-has-toc lands,
+	   so the step actions follow this padding without new script. */
+	body:has(#mainViewCenterPanel.pa-has-toc) .mainTopToolbar {
+		padding-right: calc(max(40px, 100vw - var(--pa-gutter) - var(--pa-rail) - var(--pa-page-max)) + 20px);
 	}
 	.pa-toc {
 		position: fixed;


### PR DESCRIPTION
…e header

Six user-reported defects on the results pages, verified end-to-end in the browser against three stored example jobs, in both themes:

- The AI model writes a space where a newline belongs, gluing '---', '###' and '- ' bullets to the tail of the previous sentence, so reports showed literal markdown and ran as one paragraph. _preprocessMarkdown now recovers those newlines; all 40 stored reports render with zero residual tokens (old pipeline: 19 of 40 bad, 247 literal headings, 81 literal rules).
- A checked ExtJS checkbox in dark mode rendered pixel-identical to an unchecked one: the blanket [data-theme] .x-form-field !important background pair also matched .x-form-checkbox and erased the checked fill and tick. Checkboxes and radios are excluded from the blanket.
- The pathway sidebar's Search button floated onto its own line below the field; the pair is now one flex row squared to the panel rail, and Enter searches.
- The details panel's classification bullets and blue-zebra table are now chips and a hairline table in the design tokens, class-styled so dark.css can reach every part (the per-condition rows' background was inline).
- The AI consent label said twice what leaves the server; it now names the recipient once and leaves the enumeration to the (i) notice it links to.
- The 'AI is running' state was a faint glow; it is now a rotating ring, a wider pulse and a breathing scale on the launcher, plus a sheen on the progress fill so a static percent does not read as hung.

Also from this pass: the header's right cluster now lands on the railed column's card edge on TOC'd pages (it ended 48px shy at laptop widths), and the step-2 toolbar figure keeps to one row - .button margins, not chip widths, were what pushed 'Go back' onto a second line.