### PR TITLE
Example catalogue, chained-example significance, AI citations and full text, header-railed layout

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_AIInterpretView.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_AIInterpretView.js
@@ -648,7 +648,12 @@ function PA_AIInterpretView() {
             var refLabel = p.ref_index ? '[' + p.ref_index + '] ' : '';
             listHtml += '<div class="ai-citation-item" data-pmid="' + (p.pmid || "") + '">';
             listHtml += '  <div class="ai-citation-title"><span class="ai-citation-ref">' + refLabel + '</span>' + (p.title || "Untitled") + '</div>';
-            listHtml += '  <div class="ai-citation-meta">' + (p.first_author || "") + ' et al., ' + (p.journal || "") + ' (' + (p.year || "") + ')</div>';
+            /* What the agent actually read for this paper. The pipeline stores
+               full_text_available per paper; older jobs predate the field, so
+               its absence renders nothing rather than a wrong claim. */
+            var sourceRead = (p.full_text_available === true) ? ' &middot; full text read'
+                : (p.full_text_available === false) ? ' &middot; abstract read' : '';
+            listHtml += '  <div class="ai-citation-meta">' + (p.first_author || "") + ' et al., ' + (p.journal || "") + ' (' + (p.year || "") + ')' + sourceRead + '</div>';
             listHtml += '  <div class="ai-citation-pmid">PMID: ' + (p.pmid || "N/A") + '</div>';
             listHtml += '</div>';
         }

--- a/PaintomicsClient/public_html/app/view/common/AlignmentGuides.js
+++ b/PaintomicsClient/public_html/app/view/common/AlignmentGuides.js
@@ -631,6 +631,32 @@
 				return true;
 			}
 		}
+		/* A stretching sibling earlier in a flex row decides where everything
+		   after it starts. The pathway panel's search row is an input with
+		   flex:1 and its button after it, so the button's left edge is
+		   wherever the input chose to stop - a function of the panel's width,
+		   not a rail any stylesheet placed. Judged on that edge it reported
+		   1.9px off a rail it was never aimed at, on every pathway a user
+		   painted.
+
+		   Deliberately checked on the element itself and NOT on its
+		   ancestors: a *container* placed after a stretcher can still have a
+		   deterministic width and real rails inside it, and walking this test
+		   up the tree would silently drop everything in it from measurement -
+		   the exact regression class the probe battery exists to catch. */
+		var flexParent = el.parentElement;
+		if (flexParent) {
+			var fp = window.getComputedStyle(flexParent);
+			if (fp.display.indexOf("flex") >= 0 &&
+			    fp.flexDirection.indexOf("row") === 0) {
+				for (var sib = el.previousElementSibling; sib;
+				     sib = sib.previousElementSibling) {
+					if (parseFloat(window.getComputedStyle(sib).flexGrow) > 0) {
+						return true;
+					}
+				}
+			}
+		}
 		return false;
 	}
 

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.02" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.03" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=0.7" />
 	<!-- Shared chrome for both of Step 3's graph surfaces. Before more-network.css,
 	     which layers this view's own legend and layout on top of it. -->
@@ -128,12 +128,12 @@
 	<script type="text/javascript" src="app/view/common/ExtJS_extensions.js?v=0.7"></script>
 	<script type="text/javascript" src="app/view/common/upload/Panel.js?v=0.2"></script>
 	<!--LAYOUT DEBUG OVERLAY - inert until ctrl+alt+G or ?guides=1 -->
-	<script type="text/javascript" src="app/view/common/AlignmentGuides.js?v=4.1"></script>
+	<script type="text/javascript" src="app/view/common/AlignmentGuides.js?v=4.2"></script>
 
 	<!--MARKDOWN RENDERING LIBRARY -->
 	<script type="text/javascript" src="js/libs/marked/marked.min.js"></script>
 	<!--AI INTERPRETATION VIEW -->
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_AIInterpretView.js?v=0.5"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_AIInterpretView.js?v=0.6"></script>
 	<!--MORE REGULATOR–TARGET NETWORK VIEW -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js?v=0.7"></script>
 

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -306,7 +306,17 @@ root {
      The gutter is `max()` so nothing changes below the cap - this only does
      work on displays wide enough to have the problem. */
   --pa-page-max: 1400px;
-  --pa-rail: 206px;
+
+  /* The rail is sized so the results column's visible edge lands on the
+     header's "Job view" pill, the same way the TOC's width is the wordmark's:
+     the header is the ruler for everything under it. The pill starts 166px
+     right of the gutter (147px of wordmark + 19px of menu margin, both
+     constants), and the ExtJS step containers add 20px of their own inset
+     between the column edge and a card's border, so 146 + 20 puts the card
+     exactly under the pill at every viewport width. Was 206, which left the
+     cards 60px right of anything else in the header - a rail nothing above
+     it shared. */
+  --pa-rail: 146px;
 
   /* The gutter was `max(40px, (100vw - 1400px) / 2)`, which on the 1440-1512px
      laptops this is mostly read on resolved to the 40px floor or a little over
@@ -4656,8 +4666,13 @@ div[id ^= "pathwayNetworkToolsBox_"] > a.button.btn-right,
 .step4_plotwrappers{display: inline-block;}
 
 /* These were 18px with a 2px border and steel-blue ink - roughly twice the size
-   of every other control on the page, in a panel that sits beside it. */
-div.lateralOptionsPanel input[type="text"]:not([id^=numberfield]) {
+   of every other control on the page, in a panel that sits beside it.
+
+   The find-features field opts out: it lives in a flex row that owns its
+   geometry (.findFeaturesRow above), and this rule's `margin: 6px 0` outranks
+   that row's `margin: 0` - 6px of top margin inside an align-items: stretch
+   row pushed the field below the button it shares the line with. */
+div.lateralOptionsPanel input[type="text"]:not([id^=numberfield]):not(.findFeaturesInput input) {
 	margin: 6px 0;
 	width: 100%;
 	max-width: 250px;
@@ -7499,7 +7514,12 @@ div.repDetectionCard h3 {
 		position: fixed;
 		top: 62px;
 		left: var(--pa-gutter);
-		width: 190px;
+		/* The wordmark's own width, so the column under "PaintOmics AI" ends
+		   where the wordmark does and the results column starts at the next
+		   thing in the header - the "Job view" pill (see --pa-rail). Names
+		   wrap one line earlier than they did at 190px, which the column has
+		   the vertical room for. */
+		width: 147px;
 		max-height: calc(100vh - 84px);
 		overflow-y: auto;
 		margin: 0;

--- a/PaintomicsServer/src/AdminTools/scripts/exampledata/scenarios.py
+++ b/PaintomicsServer/src/AdminTools/scripts/exampledata/scenarios.py
@@ -339,6 +339,7 @@ def buildGeneMultiCondition(context):
         "databases": ["KEGG", "Reactome"],
         "conditions": TIME_COURSE,
         "simulated": True,
+        "supersededBy": "stategra-multiomics",
         "omics": [{
             "omicName": "Gene expression",
             "omicType": "gene",
@@ -605,6 +606,7 @@ def buildMultiomics(context):
         "databases": ["KEGG", "Reactome"],
         "conditions": TIME_COURSE,
         "simulated": True,
+        "supersededBy": "stategra-multiomics",
         "omics": omics,
         "references": [],
         "extraFiles": [{
@@ -749,6 +751,7 @@ def buildRegulatoryMirna(context):
         "databases": ["KEGG"],
         "conditions": TIME_COURSE,
         "simulated": True,
+        "supersededBy": "stategra-mirna",
         "omics": [
             {
                 "omicName": "miRNA-seq",
@@ -1082,6 +1085,7 @@ def buildRegulatoryMore(context):
         "databases": ["KEGG"],
         "conditions": MORE_GROUPS,
         "simulated": True,
+        "supersededBy": "stategra-more",
         "samples": sampleNames,
         "target": {
             "omicName": "Gene expression",
@@ -1248,6 +1252,7 @@ def buildRegionBased(context):
         "databases": ["KEGG"],
         "conditions": TIME_COURSE,
         "simulated": True,
+        "supersededBy": "stategra-regions",
         "omics": [{
             "omicName": "DNase-seq",
             "omicType": "region",

--- a/PaintomicsServer/src/classes/AIInterpret/pipeline.py
+++ b/PaintomicsServer/src/classes/AIInterpret/pipeline.py
@@ -16,7 +16,7 @@ from src.classes.AIInterpret.verification import (
     verify_report, redact_unverified,
     verify_report_v2, redact_unverified_v2, parse_references_section,
     render_references_section,
-    renumber_citations, sort_references_section,
+    renumber_citations, sort_references_section, normalize_citation_markers,
     # Reused so a quote is held to the same matching rule that will later judge
     # it; a private import beats a second, subtly different matcher.
     _fuzzy_contains, _normalize_text,
@@ -462,6 +462,13 @@ def run_ai_pipeline(job_id, experiment_design, RESPONSE):
         if _cancel_flags.get(job_id):
             raise InterruptedError("Cancelled")
 
+        # "[17, 18]" -> "[17], [18]" before anything reads a marker: quote
+        # collection, rendering, verification and renumbering all match single
+        # "[N]" markers, and an unsplit multi-citation is invisible to every
+        # one of them -- the shipped report then cites entries its References
+        # section does not carry.
+        report = normalize_citation_markers(report)
+
         # Rebuild the References section from ground truth before anything tries
         # to read it. Asking the model to hit the parser's format by instruction
         # failed in 5 of 6 measured runs -- no heading, or unquoted Cited Text,
@@ -579,7 +586,9 @@ def run_ai_pipeline(job_id, experiment_design, RESPONSE):
             # which is why the loop could check 6 citations on iteration 1 and
             # then finish with ref_accuracy 0.0. Re-render after every rewrite,
             # carrying forward the quotes already gathered so surviving
-            # citations are not re-queried.
+            # citations are not re-queried. A rewrite also reintroduces
+            # "[17, 18]" markers, so they are re-split first.
+            report = normalize_citation_markers(report)
             _quotes.update(_collect_cited_quotes(llm, report, paper_index, job_id,
                                                  known=_quotes))
             report, _rendered = render_references_section(report, paper_index, _quotes)

--- a/PaintomicsServer/src/classes/AIInterpret/pubmed_client.py
+++ b/PaintomicsServer/src/classes/AIInterpret/pubmed_client.py
@@ -148,7 +148,12 @@ class PubMedClient:
     # ------------------------------------------------------------------
 
     def convert_pmids_to_pmcids(self, pmids):
-        """Batch PMID -> PMCID via NCBI ID Converter API. Returns {pmid: pmcid_or_None}."""
+        """Batch PMID -> PMCID via NCBI ID Converter API. Returns {pmid: pmcid_or_None}.
+
+        Keys are always strings, whatever the caller or the API supplied --
+        see the coercion below for what mixing the two silently cost.
+        """
+        pmids = [str(p) for p in pmids]
         result = {p: None for p in pmids}
         if not pmids:
             return result
@@ -164,7 +169,14 @@ class PubMedClient:
                 r.raise_for_status()
                 data = r.json()
                 for rec in data.get("records", []):
-                    pmid = rec.get("pmid", "")
+                    # The converter answers "pmid" as a JSON *number*. The
+                    # result dict is keyed by the caller's string PMIDs, so an
+                    # unconverted assignment added an integer key beside the
+                    # string key it was meant to update -- and every lookup in
+                    # fetch_papers then found None. Measured effect: 0 papers
+                    # with full text across every AI job ever stored here; the
+                    # whole three-tier fetch below this was unreachable.
+                    pmid = str(rec.get("pmid") or "")
                     pmcid = rec.get("pmcid")
                     if pmid and pmcid:
                         result[pmid] = pmcid

--- a/PaintomicsServer/src/classes/AIInterpret/verification.py
+++ b/PaintomicsServer/src/classes/AIInterpret/verification.py
@@ -89,6 +89,44 @@ _REFERENCE_ENTRY_RE = re.compile(r'^\[(\d+)\]', re.MULTILINE)
 # report, not to whichever entry happens to be printed last.
 _TRAILING_NOTE_RE = re.compile(r'^>\s*\*\*Note:\*\*', re.MULTILINE)
 
+# Multi-citation markers, the academic style the model falls back into no
+# matter what the prompt says: "[17, 18]", "[17;18]", "[17-19]". Every reader
+# in this module matches single "[N]" markers, so an unnormalised multi-marker
+# is invisible to all of them at once: render_references_section drops refs 17
+# and 18 from the section ("not cited"), redaction cannot remove the sentence,
+# renumbering skips the marker, and the shipped report ends with a body
+# citation pointing at entries that are not there -- which the reader sees and
+# no check does. Numbers are capped at two digits so a span of years
+# ("[2010-2015]") or any other bracketed figure is left alone, and a marker
+# directly followed by "(" is a Markdown link, not a citation.
+_MULTI_CITATION_RE = re.compile(r'\[(\d{1,2}(?:\s*[,;]\s*\d{1,2})+)\](?!\()')
+_RANGE_CITATION_RE = re.compile(r'\[(\d{1,2})\s*[-–—]\s*(\d{1,2})\](?!\()')
+
+
+def normalize_citation_markers(text):
+    """Split "[17, 18]" and "[17-19]" into "[17], [18](, [19])".
+
+    Idempotent -- single markers are untouched -- so it is applied at the
+    entry of every function that reads citation markers rather than trusting
+    each call site to remember it.
+    """
+    if not text:
+        return text
+
+    def _split_range(match):
+        start, stop = int(match.group(1)), int(match.group(2))
+        # An inverted or implausibly wide "range" is a figure, not a citation.
+        if stop <= start or stop - start > 20:
+            return match.group(0)
+        return ", ".join("[%d]" % n for n in range(start, stop + 1))
+
+    def _split_list(match):
+        numbers = re.split(r'\s*[,;]\s*', match.group(1))
+        return ", ".join("[%s]" % n for n in numbers)
+
+    text = _RANGE_CITATION_RE.sub(_split_range, text)
+    return _MULTI_CITATION_RE.sub(_split_list, text)
+
 def verify_report_v2(report_text, gene_whitelist, unique_papers, job_instance):
     """Verify a report using [N] citation format.
 
@@ -99,6 +137,7 @@ def verify_report_v2(report_text, gene_whitelist, unique_papers, job_instance):
         "ref_accuracy": float,
     }
     """
+    report_text = normalize_citation_markers(report_text)
     paper_index = {p["ref_index"]: p for p in unique_papers}
     valid_ref_indices = set(paper_index.keys())
 
@@ -200,6 +239,7 @@ def redact_unverified_v2(report_text, failed_citations):
 
     Returns (cleaned_report, removed_count).
     """
+    report_text = normalize_citation_markers(report_text)
     if not failed_citations:
         return report_text, 0
 
@@ -268,6 +308,7 @@ def renumber_citations(report_text):
 
     Returns (renumbered_report, old_to_new_mapping).
     """
+    report_text = normalize_citation_markers(report_text)
     # 1. Collect all [N] indices used in the report (body + references), in order of first appearance
     all_indices = []
     seen = set()
@@ -365,6 +406,7 @@ def parse_references_section(report_text):
         "title": str,
     }
     """
+    report_text = normalize_citation_markers(report_text)
     # Find References section.
     #
     # This used to require exactly "### References". The model writes
@@ -453,8 +495,15 @@ def render_references_section(report_text, paper_index, quotes):
     not invented: a reference to a paper we never retrieved cannot be verified,
     and emitting it would manufacture the appearance of support.
 
+    Each entry also names what its quote was found in -- "abstract" or a
+    full-text section -- so a reader can tell a citation grounded in a
+    paper's Results from one grounded in the two sentences of its abstract.
+    The label is computed here, where the quote and the paper's sections are
+    both at hand, rather than asked of the model.
+
     Returns (new_report_text, rendered_ref_indices).
     """
+    report_text = normalize_citation_markers(report_text)
     if not paper_index:
         return report_text, []
 
@@ -496,9 +545,31 @@ def render_references_section(report_text, paper_index, quotes):
         quote = re.sub(r'\s+', ' ', str(quote)).replace('"', "'").strip()
         if quote:
             lines.append('    **Cited Text:** "%s"' % quote)
+            lines.append('    *Cited from: %s*' % _quote_source(paper, quote))
         lines.append("")
 
     return body + "\n" + "\n".join(lines), cited
+
+
+def _quote_source(paper, quote):
+    """Where a quote was found: "abstract" or "full text (results)".
+
+    Located by matching rather than recorded at extraction time, because the
+    quote may have been carried forward across a correction rewrite and the
+    paper's sections are the one ground truth both stages share. When the
+    quote matches nowhere -- verification will flag it -- the label falls back
+    to what was available to search, which is still true.
+    """
+    sections = paper.get("sections") or {}
+    abstract = sections.get("abstract") or paper.get("abstract") or ""
+    if quote and abstract and _fuzzy_contains(abstract, quote):
+        return "abstract"
+    for name, text in sections.items():
+        if name == "abstract" or not text:
+            continue
+        if quote and _fuzzy_contains(text, quote):
+            return "full text (%s)" % name
+    return "full text" if paper.get("full_text_available") else "abstract"
 
 
 # ---------------------------------------------------------------------------

--- a/PaintomicsServer/src/common/ExampleDatasets.py
+++ b/PaintomicsServer/src/common/ExampleDatasets.py
@@ -281,7 +281,7 @@ def scenarioOrder(scenario):
     return UNORDERED_SCENARIO
 
 
-def listScenarios(exampleFilesDir, pipeline=None):
+def listScenarios(exampleFilesDir, pipeline=None, includeSuperseded=False):
     """Scenarios whose files are all present, optionally filtered by pipeline.
 
     Presence is checked rather than assumed because two scenarios legitimately
@@ -289,11 +289,27 @@ def listScenarios(exampleFilesDir, pipeline=None):
     full mouse GTF, which a manual deploy step fetches. Offering it and failing
     is worse than not offering it.
 
-    Returned in teaching order (see `scenarioOrder`), which is what the picker
-    and every per-pipeline default read.
+    A simulated stand-in hides behind its real counterpart: most simulated
+    scenarios duplicate the shape of a real STATegra scenario, so offering
+    both shows every pipeline twice. A scenario whose `supersededBy` names
+    another offered scenario of the same pipeline is omitted -- and comes back
+    the moment the counterpart's files are missing, which keeps the failure
+    policy intact (a checkout without the mouse GTF still gets a region
+    example). Supersession is honoured only within one pipeline so a
+    misconfigured mapping can never empty an entry point's offer, and it trims
+    only the *offer*: `includeSuperseded=True` is for callers that must
+    recognise every loadable scenario (chained-conversion matching), because a
+    hidden scenario is still reachable by deep link and its conversion output
+    still arrives.
+
+    Real data leads: the published STATegra scenarios are the reason to trust
+    the tool, so they are offered before the simulated lessons rather than
+    after them. Within each block the teaching order holds (see
+    `scenarioOrder`) -- one condition before six, six before per-condition
+    relevance. This is what the picker and every per-pipeline default read.
     """
     manifest = loadManifest(exampleFilesDir)
-    available = []
+    candidates = []
     for scenario in manifest["scenarios"]:
         if pipeline and scenario.get("pipeline") != pipeline:
             continue
@@ -302,9 +318,26 @@ def listScenarios(exampleFilesDir, pipeline=None):
             logging.info("EXAMPLE DATASETS - '%s' not offered, %d file(s) absent "
                          "(first: %s)", scenario.get("id"), len(missing), missing[0])
             continue
-        available.append(scenario)
+        candidates.append(scenario)
 
-    available.sort(key=lambda entry: (scenarioOrder(entry),
+    if includeSuperseded:
+        available = candidates
+    else:
+        offeredPipelines = {entry.get("id"): entry.get("pipeline")
+                            for entry in candidates}
+        available = []
+        for scenario in candidates:
+            counterpart = scenario.get("supersededBy")
+            if (counterpart and counterpart != scenario.get("id")
+                    and counterpart in offeredPipelines
+                    and offeredPipelines[counterpart] == scenario.get("pipeline")):
+                logging.info("EXAMPLE DATASETS - '%s' not offered, superseded "
+                             "by '%s'", scenario.get("id"), counterpart)
+                continue
+            available.append(scenario)
+
+    available.sort(key=lambda entry: (bool(entry.get("simulated")),
+                                      scenarioOrder(entry),
                                       str(entry.get("id") or "")))
     return available
 
@@ -616,7 +649,10 @@ def _chainedScenarioFor(exampleFilesDir, inputOmic):
     if not configOptions:
         return None
 
-    for scenario in listScenarios(exampleFilesDir):
+    # includeSuperseded: a scenario hidden from the picker behind its real
+    # counterpart is still loadable by deep link, so its conversion output
+    # must still be recognised here or its target omic is silently dropped.
+    for scenario in listScenarios(exampleFilesDir, includeSuperseded=True):
         if scenario.get("pipeline") not in CHAINED_TARGET_PIPELINES:
             continue
         fingerprint = _chainedFingerprint(scenario)

--- a/PaintomicsServer/src/common/JobInformationManager.py
+++ b/PaintomicsServer/src/common/JobInformationManager.py
@@ -308,6 +308,25 @@ class JobInformationManager(metaclass=Singleton):
                 fileLabel + " it refers to.")
         return str(location)
 
+    @staticmethod
+    def _fileByReference(formFields, uploadedFileName, suffix):
+        """Whether a secondary file arrives by reference instead of as an upload.
+
+        "Use a file from My Data" and every chained conversion (regions,
+        miRNA, MORE) submit a secondary file as `<omic>_<suffix>_filelocation`
+        plus a non-client `<omic>_<suffix>_origin`, with the matching
+        `<input type=file>` part legitimately empty. Such a file is present
+        and must be registered; judging presence by the upload part alone
+        silently dropped it (measured: the region example's relevant-features
+        list, and with it every significant pathway in the job).
+        """
+        origin = formFields.get(uploadedFileName.replace("file", suffix) + "_origin")
+        if origin in (None, "", "client"):
+            return False
+        location = formFields.get(
+            uploadedFileName.replace("file", suffix + "_filelocation"))
+        return location is not None and str(location).strip() != ""
+
     def saveFiles(self, uploadedFiles, formFields, userID, jobInstance, CLIENT_TMP_DIR, EXAMPLE_FILES_DIR=""):
         nOthers = 1
         uploadedDataFile = None
@@ -456,8 +475,18 @@ class JobInformationManager(metaclass=Singleton):
             # empty name built '<inputData>//', which open()ed the directory
             # itself (IsADirectoryError). Same guard as the data-file branch:
             # empty means absent.
-            if (uploadedRelevantFile is not None and (uploadedRelevantFile.filename or "") != ""):
-                relevantFileName = uploadedRelevantFile.filename
+            #
+            # Absent as an UPLOAD is not absent as a FILE, though: a secondary
+            # file can also arrive by reference ("_filelocation" + a non-client
+            # "_origin"), with the file part legitimately empty — that is what
+            # "Use a file from My Data" posts, and what every chained
+            # conversion (regions, miRNA) posts for its own outputs. Gating on
+            # the part alone dropped those silently: the region example
+            # registered relevantFeaturesFile: None and reported 829 pathways
+            # with 0 significant on data with a planted signal.
+            if (uploadedRelevantFile is not None and (uploadedRelevantFile.filename or "") != "") \
+                    or self._fileByReference(formFields, uploadedFileName, "relevant"):
+                relevantFileName = uploadedRelevantFile.filename if uploadedRelevantFile is not None else ""
                 origin = self._requiredOrigin(
                     formFields, uploadedFileName.replace("file", "relevant") + "_origin",
                     "relevant features file") ##GET THE ORIGIN OF THE FILE. IF CLIENT -> SAVE THE FILE
@@ -484,8 +513,12 @@ class JobInformationManager(metaclass=Singleton):
                 relevantFileName = None
 
             #SAVE THE ASSOCIATIONS FILE (IF ANY)
-            if uploadedAssociationDataFile is not None and (uploadedAssociationDataFile.filename or "") != "":
-                associationsFileName = uploadedAssociationDataFile.filename
+            # Same shape as the relevant-features branch above: an empty part
+            # with a "_filelocation" reference is a present file, not an
+            # absent one.
+            if (uploadedAssociationDataFile is not None and (uploadedAssociationDataFile.filename or "") != "") \
+                    or self._fileByReference(formFields, uploadedFileName, "associations"):
+                associationsFileName = uploadedAssociationDataFile.filename if uploadedAssociationDataFile is not None else ""
                 origin = self._requiredOrigin(
                     formFields, uploadedFileName.replace("file", "associations") + "_origin",
                     "associations file") ##GET THE ORIGIN OF THE FILE. IF CLIENT -> SAVE THE FILE
@@ -511,8 +544,10 @@ class JobInformationManager(metaclass=Singleton):
 
                 # SAVE THE RELEVANT ASSOCIATIONS FILE (IF ANY)
                 # TODO: currently only if the associations file is present
-                if uploadedAssociationRelevantFile is not None and (uploadedAssociationRelevantFile.filename or "") != "" and formFields.get(uploadedFileName.replace("file", "relevant_associations") + "_origin") is not None:
-                    relevantAssociationsFileName = uploadedAssociationRelevantFile.filename
+                if ((uploadedAssociationRelevantFile is not None and (uploadedAssociationRelevantFile.filename or "") != ""
+                        and formFields.get(uploadedFileName.replace("file", "relevant_associations") + "_origin") is not None)
+                        or self._fileByReference(formFields, uploadedFileName, "relevant_associations")):
+                    relevantAssociationsFileName = uploadedAssociationRelevantFile.filename if uploadedAssociationRelevantFile is not None else ""
                     # The enclosing condition already established this field is
                     # present; going through the same helper as the other three
                     # keeps every origin lookup uniform rather than leaving one

--- a/PaintomicsServer/src/examplefiles/datasets/manifest.json
+++ b/PaintomicsServer/src/examplefiles/datasets/manifest.json
@@ -102,6 +102,7 @@
       "references": [],
       "simulated": true,
       "summary": "A six-point time course with one relevance list shared by every condition \u2014 the ordinary shape of a time-course submission, and the closest simulated counterpart to the real STATegra example.",
+      "supersededBy": "stategra-multiomics",
       "tests": [
         "Multi-condition heatmaps",
         "Per-condition pathway colouring",
@@ -277,6 +278,7 @@
       "references": [],
       "simulated": true,
       "summary": "Transcriptomics, proteomics, transcription factors, metabolomics and miRNA over the same six time points, sharing one planted signal so the layers agree.",
+      "supersededBy": "stategra-multiomics",
       "tests": [
         "Multi-omic pathway enrichment",
         "Compound matching",
@@ -350,6 +352,7 @@
       ],
       "simulated": true,
       "summary": "miRNA quantification plus a target-prediction table. The Regulatory Omics step pairs each miRNA with its targets and hands GENE:::miRNA rows on to the pathway analysis.",
+      "supersededBy": "stategra-mirna",
       "tests": [
         "miRNA-to-gene association",
         "Regulator/target pairing",
@@ -444,6 +447,7 @@
       ],
       "simulated": true,
       "summary": "Per-sample expression with three replicates per group, an experimental design matrix, and two candidate regulatory omics with association files. Each target is a noisy linear function of one known regulator, so what MORE should find is written down.",
+      "supersededBy": "stategra-more",
       "target": {
         "dataFile": "datasets/06-regulatory-more/data/gene_expression_targets.tab",
         "omicName": "Gene expression"
@@ -512,6 +516,7 @@
       ],
       "simulated": true,
       "summary": "Genomic regions in BED-like form with a matching synthetic GTF, so region-to-gene assignment runs without the large mouse annotation a fresh checkout does not have. Signal regions sit in promoters; 200 intergenic decoys do not.",
+      "supersededBy": "stategra-regions",
       "tests": [
         "RGmatch region-to-gene assignment",
         "Promoter/TSS area rules",

--- a/PaintomicsServer/src/servlets/AIInterpretServlet.py
+++ b/PaintomicsServer/src/servlets/AIInterpretServlet.py
@@ -8,6 +8,7 @@ from src.common.UserSessionManager import UserSessionManager
 from src.common.DAO.AIInterpretDAO import AIInterpretDAO
 from src.common.JobInformationManager import JobInformationManager
 from src.classes.AIInterpret.pipeline import run_ai_pipeline, _cancel_flags
+from src.classes.AIInterpret.verification import normalize_citation_markers
 from src.common.PySiQ import JobStatus
 from src.classes.AIInterpret.llm_client import LLMClient, MissingAPIKeyError
 from src.classes.AIInterpret.prompts import (SYSTEM_PROMPT_CHAT,
@@ -733,6 +734,9 @@ def aiInterpretPathway(REQUEST, RESPONSE):
             max_tokens=1500,
             temperature=AI_TEMPERATURE,
         )
+        # "[3, 5]" -> "[3], [5]": the client linkifies single [N] markers only,
+        # so an unsplit multi-citation stays plain text instead of two links.
+        report = normalize_citation_markers(report)
 
         citedPapers = [
             {k: v for k, v in p.items() if k != "sections"} for p in papers

--- a/PaintomicsServer/src/tests/test_citation_marker_normalization.py
+++ b/PaintomicsServer/src/tests/test_citation_marker_normalization.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Multi-citation markers must be visible to every citation reader.
+
+The model writes "[17, 18]" however firmly the prompt asks for single
+markers, and every reader in verification.py matches "[N]" alone. An unsplit
+multi-marker was therefore invisible to all of them at once:
+render_references_section dropped refs 17 and 18 from the References section
+("not cited"), redaction could not remove the sentence, renumbering skipped
+the marker -- and the shipped report ended with a body citation pointing at
+entries that were not there. Seen on a real report: "...coupling [17, 18]."
+with no [17] or [18] in its References.
+
+normalize_citation_markers splits those markers, and is applied inside every
+reader so no call site can forget it. These tests pin the splitting rules and
+the end-to-end behaviour through render/verify/redact/renumber.
+
+Also pinned here: each rendered reference names what its quote was found in
+("abstract" or a full-text section), which is the reader-facing half of the
+full-text pipeline.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_citation_marker_normalization
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from src.classes.AIInterpret.verification import (
+    normalize_citation_markers, render_references_section,
+    parse_references_section, redact_unverified_v2, renumber_citations,
+)
+
+
+class SplitRulesTest(unittest.TestCase):
+
+    def test_comma_list_is_split(self):
+        self.assertEqual(normalize_citation_markers("coupling [17, 18]."),
+                         "coupling [17], [18].")
+
+    def test_semicolon_and_tight_lists_split_too(self):
+        self.assertEqual(normalize_citation_markers("x [3;4] y [5,6,7]"),
+                         "x [3], [4] y [5], [6], [7]")
+
+    def test_a_range_is_expanded(self):
+        self.assertEqual(normalize_citation_markers("shown [17-19]."),
+                         "shown [17], [18], [19].")
+
+    def test_a_span_of_years_is_not_a_citation(self):
+        text = "between [2010-2015] the cohort grew"
+        self.assertEqual(normalize_citation_markers(text), text)
+
+    def test_inverted_and_implausibly_wide_ranges_are_left_alone(self):
+        for text in ("[9-2]", "[1-40]"):
+            self.assertEqual(normalize_citation_markers(text), text)
+
+    def test_single_markers_and_idempotency(self):
+        text = "as reported [17], later [18]."
+        once = normalize_citation_markers(text)
+        self.assertEqual(once, text)
+        self.assertEqual(normalize_citation_markers(once), once)
+
+    def test_a_markdown_link_is_not_split(self):
+        text = "see [3, 4](https://example.org/figure)"
+        self.assertEqual(normalize_citation_markers(text), text)
+
+
+def _paper(idx, abstract="", results=""):
+    sections = {}
+    if abstract:
+        sections["abstract"] = abstract
+    if results:
+        sections["results"] = results
+    return {
+        "ref_index": idx,
+        "pmid": str(30000000 + idx),
+        "title": "Paper %d" % idx,
+        "first_author": "Author%d" % idx,
+        "journal": "J Test",
+        "year": "2024",
+        "abstract": abstract,
+        "sections": sections,
+        "full_text_available": bool(results),
+    }
+
+
+class RenderKeepsMultiCitedEntriesTest(unittest.TestCase):
+    """The exact shipped symptom: [17, 18] in the body, nothing in References."""
+
+    def test_both_references_of_a_multi_marker_are_rendered(self):
+        body = "PPP flux rises with G6pd coupling [17, 18].\n"
+        papers = {17: _paper(17, abstract="G6pd drives PPP flux."),
+                  18: _paper(18, abstract="Coupling of PPP enzymes rises.")}
+        quotes = {17: "G6pd drives PPP flux.",
+                  18: "Coupling of PPP enzymes rises."}
+        report, rendered = render_references_section(body, papers, quotes)
+        self.assertEqual(rendered, [17, 18])
+        self.assertIn("[17] Author17", report)
+        self.assertIn("[18] Author18", report)
+        # And the body marker is now two markers the client can linkify.
+        self.assertIn("coupling [17], [18].", report)
+
+    def test_redaction_removes_a_multi_cited_sentence(self):
+        body = ("A first claim [1]. A second claim [2, 3].\n\n"
+                "### References\n\n"
+                "[1] A \"P1.\" J, 2024. PMID: 1\n"
+                "[2] B \"P2.\" J, 2024. PMID: 2\n"
+                "[3] C \"P3.\" J, 2024. PMID: 3\n")
+        cleaned, removed = redact_unverified_v2(
+            body, [{"ref_index": 3, "reason": "no support",
+                    "cited_text": "", "claim_sentence": ""}])
+        self.assertNotIn("[3]", cleaned.split("### References")[0])
+        self.assertIn("A first claim [1].", cleaned)
+        self.assertGreater(removed, 0)
+
+    def test_renumbering_sees_split_markers(self):
+        text = "One [7]. Two [9, 11]."
+        renumbered, mapping = renumber_citations(text)
+        self.assertEqual(renumbered, "One [1]. Two [2], [3].")
+        self.assertEqual(mapping, {7: 1, 9: 2, 11: 3})
+
+
+class QuoteProvenanceTest(unittest.TestCase):
+
+    def _entry_for(self, report, idx):
+        block = [line for line in report.split("\n")
+                 if line.strip().startswith("*Cited from:")]
+        return "\n".join(block)
+
+    def test_a_quote_found_in_the_abstract_is_labelled_abstract(self):
+        body = "A claim [1]."
+        papers = {1: _paper(1, abstract="The abstract states the finding.")}
+        report, _ = render_references_section(
+            body, papers, {1: "The abstract states the finding."})
+        self.assertIn("*Cited from: abstract*", report)
+
+    def test_a_quote_found_in_results_is_labelled_full_text(self):
+        body = "A claim [1]."
+        papers = {1: _paper(1, abstract="Short summary.",
+                            results="The results section carries the exact supporting sentence.")}
+        report, _ = render_references_section(
+            body, papers,
+            {1: "The results section carries the exact supporting sentence."})
+        self.assertIn("*Cited from: full text (results)*", report)
+
+    def test_the_label_does_not_break_reference_parsing(self):
+        body = "A claim [1]."
+        papers = {1: _paper(1, abstract="The abstract states the finding.")}
+        report, _ = render_references_section(
+            body, papers, {1: "The abstract states the finding."})
+        parsed = parse_references_section(report)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["cited_text"],
+                         "The abstract states the finding.")
+
+    def test_redaction_also_removes_the_label_line(self):
+        body = "A claim [1]. Another [2]."
+        papers = {1: _paper(1, abstract="Alpha finding."),
+                  2: _paper(2, abstract="Beta finding.")}
+        report, _ = render_references_section(
+            body, papers, {1: "Alpha finding.", 2: "Beta finding."})
+        cleaned, _ = redact_unverified_v2(
+            report, [{"ref_index": 2, "reason": "x",
+                      "cited_text": "", "claim_sentence": ""}])
+        refs = cleaned.split("### References")[1]
+        self.assertNotIn("Beta finding", refs)
+        self.assertEqual(refs.count("*Cited from:"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_example_scenario_ordering.py
+++ b/PaintomicsServer/src/tests/test_example_scenario_ordering.py
@@ -1,20 +1,32 @@
 #!/usr/bin/env python3
-"""The example picker offers the datasets in the order they were numbered.
+"""The example picker offers real data first, and no duplicated lessons.
 
-The dataset directories are 01-..10- because they teach in that order: one
-condition, then six, then per-condition relevance, then multi-omic, and so on.
-The manifest was written sorted by *id*, so the picker offered
+Three rules, in precedence order:
 
-    Gene expression — six conditions        (02-gene-multi-condition)
-    Gene expression — per-condition relevance
-    Gene expression — single condition      (01-gene-single-condition)
+1. **A superseded lesson hides behind its real counterpart.** Most simulated
+   scenarios were written as stand-ins for a real STATegra scenario of the
+   same shape, so offering both shows every pipeline twice. A scenario whose
+   `supersededBy` names an offered scenario of the same pipeline is omitted --
+   and comes back the moment the counterpart's files are missing, so a fresh
+   checkout without the mouse GTF still gets a region example.
+2. **Real before simulated.** The published STATegra scenarios are the reason
+   to trust the tool, so they lead the picker instead of trailing the
+   simulated lessons.
+3. **Teaching order within each block.** The dataset directories are numbered
+   01-..11- because they teach in that order: one condition, then six, then
+   per-condition relevance, then multi-omic, and so on. The manifest was once
+   written sorted by *id*, so the picker offered
 
-which is lesson two before lesson one.
+       Gene expression — six conditions        (02-gene-multi-condition)
+       Gene expression — per-condition relevance
+       Gene expression — single condition      (01-gene-single-condition)
 
-The order is derived in `listScenarios` from the directory number rather than
-only from an `order` field, because the manifest that is already committed has
-to sort correctly without being regenerated -- regeneration needs a KEGG
-snapshot and a mouse GTF a fresh checkout does not have.
+   which is lesson two before lesson one.
+
+The number is derived in `listScenarios` from the directory rather than only
+from an `order` field, because the manifest that is already committed has to
+sort correctly without being regenerated -- regeneration needs a KEGG snapshot
+and a mouse GTF a fresh checkout does not have.
 
 Usage:
     cd PaintomicsServer
@@ -48,6 +60,35 @@ EXPECTED_ORDER = [
     (10, "stategra-mirna"),
     (11, "stategra-more"),
 ]
+
+# What the picker offers: the real block (directories 08-11) ahead of the
+# simulated lessons (01-07), teaching order inside each block. Entries hidden
+# by SUPERSEDED below appear here so the order still holds wherever one IS
+# offered (its counterpart's files missing on that deploy).
+EXPECTED_OFFER = [
+    "stategra-multiomics",
+    "stategra-regions",
+    "stategra-mirna",
+    "stategra-more",
+    "gene-single-condition",
+    "gene-multi-condition",
+    "gene-multi-condition-relevance",
+    "multiomics-integration",
+    "regulatory-mirna",
+    "regulatory-more",
+    "region-based",
+]
+
+# Simulated stand-ins and the real scenario each one duplicates. Offered only
+# while the counterpart cannot be; otherwise the picker shows every pipeline
+# twice, which is the duplication this was reported as.
+SUPERSEDED = {
+    "gene-multi-condition": "stategra-multiomics",
+    "multiomics-integration": "stategra-multiomics",
+    "regulatory-mirna": "stategra-mirna",
+    "regulatory-more": "stategra-more",
+    "region-based": "stategra-regions",
+}
 
 
 class ScenarioOrderTest(unittest.TestCase):
@@ -91,27 +132,158 @@ class ShippedCatalogueTest(unittest.TestCase):
             self.assertEqual(ExampleDatasets.scenarioOrder(byId[scenarioId]),
                              expected, scenarioId)
 
-    def test_listScenarios_returns_them_in_teaching_order(self):
+    def test_listScenarios_offers_real_first_then_teaching_order(self):
         offered = [entry["id"] for entry in
                    ExampleDatasets.listScenarios(EXAMPLE_DIR)]
         # stategra-regions needs the full mouse GTF, which a fresh checkout
         # does not have, so it is legitimately absent from the offer.
-        expected = [scenarioId for _, scenarioId in EXPECTED_ORDER
+        expected = [scenarioId for scenarioId in EXPECTED_OFFER
                     if scenarioId in offered]
         self.assertEqual(offered, expected)
 
-    def test_the_single_condition_lesson_comes_before_the_six_condition_one(self):
-        """The symptom this was reported as."""
+    def test_every_real_scenario_precedes_every_simulated_one(self):
+        """The symptom this was reported as: the real STATegra data sat below
+        seven simulated lessons."""
+        offered = ExampleDatasets.listScenarios(EXAMPLE_DIR)
+        flags = [bool(entry.get("simulated")) for entry in offered]
+        self.assertIn(False, flags, "no real scenario is offered at all")
+        firstSimulated = flags.index(True)
+        self.assertNotIn(False, flags[firstSimulated:],
+                         "a real scenario sorted below a simulated one")
+
+    def test_the_single_condition_lesson_comes_before_per_condition_relevance(self):
+        """The ordering symptom this was first reported as -- lesson two before
+        lesson one -- asserted on the two gene lessons that are still offered
+        (gene-multi-condition now hides behind the real STATegra time course).
+        """
         offered = [entry["id"] for entry in
                    ExampleDatasets.listScenarios(EXAMPLE_DIR)]
         self.assertLess(offered.index("gene-single-condition"),
-                        offered.index("gene-multi-condition"))
+                        offered.index("gene-multi-condition-relevance"))
+
+    def test_superseded_lessons_are_not_offered_next_to_their_counterpart(self):
+        """The duplication symptom: each pipeline group offered a real entry
+        and its simulated clone side by side."""
+        offered = {entry["id"] for entry in
+                   ExampleDatasets.listScenarios(EXAMPLE_DIR)}
+        for simulated, real in SUPERSEDED.items():
+            if real in offered:
+                self.assertNotIn(
+                    simulated, offered,
+                    "%s is offered although %s is" % (simulated, real))
+
+    def test_the_shipped_manifest_declares_the_supersessions(self):
+        """The committed manifest carries the mapping, so a regenerated one
+        must too (the generator writes the same field)."""
+        with open(MANIFEST_PATH, encoding="utf-8") as handle:
+            scenarios = json.load(handle)["scenarios"]
+        byId = {entry["id"]: entry for entry in scenarios}
+        for simulated, real in SUPERSEDED.items():
+            self.assertEqual(byId[simulated].get("supersededBy"), real,
+                             simulated)
+        for scenarioId, entry in byId.items():
+            if scenarioId not in SUPERSEDED:
+                self.assertNotIn("supersededBy", entry, scenarioId)
+
+    def test_superseded_lessons_remain_loadable_by_id(self):
+        """Hiding a lesson from the picker must not break a deep link to it."""
+        for simulated in SUPERSEDED:
+            self.assertEqual(
+                ExampleDatasets.getScenario(EXAMPLE_DIR, simulated)["id"],
+                simulated)
 
     def test_the_picker_sees_the_same_order(self):
         catalogue = ExampleDatasets.catalogueForClient(EXAMPLE_DIR)
         self.assertEqual([entry["id"] for entry in catalogue["scenarios"]],
                          [entry["id"] for entry in
                           ExampleDatasets.listScenarios(EXAMPLE_DIR)])
+
+
+class SupersessionFallbackTest(unittest.TestCase):
+    """The stand-in comes back the moment its counterpart cannot be offered.
+
+    Exercised on a synthetic catalogue because the shipped one always has the
+    STATegra files: the deploy where they are missing is exactly the deploy
+    that cannot run this suite.
+    """
+
+    def setUp(self):
+        import tempfile
+        self.root = tempfile.mkdtemp(prefix="example_supersession_") + os.sep
+        self.addCleanup(self.cleanRoot)
+
+    def cleanRoot(self):
+        import shutil
+        shutil.rmtree(self.root, ignore_errors=True)
+        ExampleDatasets.clearCache()
+
+    def writeCatalogue(self, scenarios, presentFiles):
+        datasetsDir = os.path.join(self.root, "datasets")
+        os.makedirs(datasetsDir, exist_ok=True)
+        with open(os.path.join(datasetsDir, "manifest.json"), "w",
+                  encoding="utf-8") as handle:
+            json.dump({"version": ExampleDatasets.SUPPORTED_VERSION,
+                       "defaultScenario": scenarios[0]["id"],
+                       "scenarios": scenarios}, handle)
+        for relative in presentFiles:
+            path = os.path.join(self.root, relative)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write("x\n")
+        ExampleDatasets.clearCache()
+
+    @staticmethod
+    def scenario(scenarioId, number, **extra):
+        entry = {"id": scenarioId, "pipeline": "pathway-acquisition",
+                 "omics": [{"omicName": "Gene expression", "omicType": "gene",
+                            "dataFile": "datasets/%02d-%s/data/values.tab"
+                                        % (number, scenarioId)}]}
+        entry.update(extra)
+        return entry
+
+    def test_hidden_while_the_counterpart_is_offered(self):
+        real = self.scenario("real-lesson", 2, simulated=False)
+        standIn = self.scenario("sim-lesson", 1, simulated=True,
+                                supersededBy="real-lesson")
+        self.writeCatalogue([real, standIn],
+                            ["datasets/02-real-lesson/data/values.tab",
+                             "datasets/01-sim-lesson/data/values.tab"])
+        self.assertEqual([entry["id"] for entry in
+                          ExampleDatasets.listScenarios(self.root)],
+                         ["real-lesson"])
+
+    def test_offered_again_when_the_counterpart_files_are_missing(self):
+        real = self.scenario("real-lesson", 2, simulated=False)
+        standIn = self.scenario("sim-lesson", 1, simulated=True,
+                                supersededBy="real-lesson")
+        self.writeCatalogue([real, standIn],
+                            ["datasets/01-sim-lesson/data/values.tab"])
+        self.assertEqual([entry["id"] for entry in
+                          ExampleDatasets.listScenarios(self.root)],
+                         ["sim-lesson"])
+
+    def test_a_cross_pipeline_supersession_does_not_fire(self):
+        """Defensive: hiding a pipeline's only example behind a scenario the
+        pipeline-filtered list cannot contain would empty that entry point."""
+        real = self.scenario("real-lesson", 2, simulated=False)
+        standIn = self.scenario("sim-lesson", 1, simulated=True,
+                                pipeline="regions2genes",
+                                supersededBy="real-lesson")
+        self.writeCatalogue([real, standIn],
+                            ["datasets/02-real-lesson/data/values.tab",
+                             "datasets/01-sim-lesson/data/values.tab"])
+        offered = [entry["id"] for entry in
+                   ExampleDatasets.listScenarios(self.root)]
+        self.assertIn("sim-lesson", offered)
+
+    def test_a_self_supersession_does_not_hide_the_scenario(self):
+        broken = self.scenario("sim-lesson", 1, simulated=True,
+                               supersededBy="sim-lesson")
+        self.writeCatalogue([broken],
+                            ["datasets/01-sim-lesson/data/values.tab"])
+        self.assertEqual([entry["id"] for entry in
+                          ExampleDatasets.listScenarios(self.root)],
+                         ["sim-lesson"])
 
 
 class DefaultsAreUnchangedTest(unittest.TestCase):

--- a/PaintomicsServer/src/tests/test_pubmed_pmcid_conversion.py
+++ b/PaintomicsServer/src/tests/test_pubmed_pmcid_conversion.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""PMID -> PMCID conversion must survive the API answering with integers.
+
+Measured across every stored AI job on this machine: 0 papers with full text
+out of hundreds retrieved, on a pipeline that carries a three-tier full-text
+fetch. The tiers were fine; nothing ever reached them. The NCBI ID Converter
+returns each record's "pmid" as a JSON *number*, and convert_pmids_to_pmcids
+seeded its result dict with the caller's *string* PMIDs -- so the assignment
+added a new integer key beside the string key it was meant to update:
+
+    {'32015508': None, 32015508: 'PMC7094943'}
+
+fetch_papers then looked the string up, found None, and logged
+"Tier 3 (abstract only) -- no PMCID" for every paper ever fetched. The AI
+therefore only ever read abstracts, exactly as reported.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_pubmed_pmcid_conversion
+"""
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from src.classes.AIInterpret.pubmed_client import PubMedClient
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+        self.status_code = 200
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+class PmcidConversionTest(unittest.TestCase):
+
+    def _client_answering(self, records):
+        client = PubMedClient()
+        client._request_with_retry = (
+            lambda *args, **kwargs: _FakeResponse({"records": records}))
+        return client
+
+    def test_integer_pmids_in_the_response_update_the_string_keys(self):
+        client = self._client_answering(
+            [{"pmid": 32015508, "pmcid": "PMC7094943"}])
+        result = client.convert_pmids_to_pmcids(["32015508"])
+        self.assertEqual(result, {"32015508": "PMC7094943"})
+
+    def test_string_pmids_in_the_response_still_work(self):
+        client = self._client_answering(
+            [{"pmid": "26509449", "pmcid": "PMC4624794"}])
+        result = client.convert_pmids_to_pmcids(["26509449"])
+        self.assertEqual(result, {"26509449": "PMC4624794"})
+
+    def test_a_paper_without_a_pmc_deposit_stays_none(self):
+        client = self._client_answering(
+            [{"pmid": 11111111}, {"pmid": 22222222, "pmcid": "PMC2"}])
+        result = client.convert_pmids_to_pmcids(["11111111", "22222222"])
+        self.assertEqual(result, {"11111111": None, "22222222": "PMC2"})
+
+    def test_no_stray_integer_keys_are_left_behind(self):
+        client = self._client_answering(
+            [{"pmid": 32015508, "pmcid": "PMC7094943"}])
+        result = client.convert_pmids_to_pmcids(["32015508"])
+        self.assertTrue(all(isinstance(k, str) for k in result))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_secondary_files_by_reference.py
+++ b/PaintomicsServer/src/tests/test_secondary_files_by_reference.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Secondary files passed by reference must register, not silently vanish.
+
+Measured on job 66khe0vtr3 (and reproduced on kW4oCH3eV7): the region-based
+example converts its regions with RGmatch, the conversion writes
+B2G_output_<date>.tab AND B2G_relevant_<date>.tab, and the client then submits
+step 1 with both files *by reference*:
+
+    omic0_origin=mydata                omic0_filelocation=[MyData]/B2G_output_...
+    omic0_relevant_origin=mydata       omic0_relevant_filelocation=[MyData]/B2G_relevant_...
+
+An untouched <input type=file> still submits a part with filename="" for
+omic0_relevant_file, and saveFiles gated the whole relevant-features branch on
+that part being non-empty -- so the mydata path inside it was unreachable, the
+omic registered relevantFeaturesFile: None, and every Fisher test in the job
+degenerated to p=1.0: 829 pathways found, 0 significant, on a dataset with a
+planted signal and six expected target pathways.
+
+The data-file branch does not have this defect because it checks the origin
+first; these tests pin the same shape onto the three secondary files (relevant
+features, associations, relevant associations).
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_secondary_files_by_reference
+"""
+import io
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from werkzeug.datastructures import FileStorage, MultiDict
+
+from src.common.JobInformationManager import JobInformationManager
+
+
+class _JobStub:
+    def __init__(self):
+        self.registered = {}
+
+    def getJobID(self):
+        return "TESTJOB"
+
+    def addGeneBasedInputOmic(self, omic):
+        self.registered.update(omic)
+
+    def addCompoundBasedInputOmic(self, omic):
+        self.registered.update(omic)
+
+
+def _emptyPart(name):
+    """What a browser submits for an untouched <input type=file>."""
+    return FileStorage(stream=io.BytesIO(b""), filename="", name=name)
+
+
+def _run(files, fields):
+    job = _JobStub()
+    with tempfile.TemporaryDirectory() as tmp:
+        JobInformationManager().saveFiles(files, fields, None, job, tmp + "/")
+    return job.registered
+
+
+class RelevantByReferenceTest(unittest.TestCase):
+    """The exact shape the chained region example submits."""
+
+    def submit(self):
+        files = MultiDict()
+        files.add("omic0_file", _emptyPart("omic0_file"))
+        files.add("omic0_relevant_file", _emptyPart("omic0_relevant_file"))
+        fields = MultiDict({
+            "omic0_omic_name": "DNase-seq",
+            "omic0_file_type": "Bed file (regions mapped to Genes)",
+            "omic0_match_type": "gene",
+            "omic0_origin": "mydata",
+            "omic0_filelocation": "[MyData]/B2G_output_x.tab",
+            "omic0_relevant_origin": "mydata",
+            "omic0_relevant_filelocation": "[MyData]/B2G_relevant_x.tab",
+        })
+        return _run(files, fields)
+
+    def test_the_data_file_registers(self):
+        """The half that always worked; pinned so the fix cannot break it."""
+        self.assertEqual(self.submit().get("inputDataFile"), "B2G_output_x.tab")
+
+    def test_the_relevant_file_registers_too(self):
+        """The defect: this was None, which turns every p-value into 1.0."""
+        self.assertEqual(self.submit().get("relevantFeaturesFile"),
+                         "B2G_relevant_x.tab")
+
+
+class AssociationsByReferenceTest(unittest.TestCase):
+    """The same shape for the pairwise-regulatory (miRNA) conversion, whose
+    output is four files: values, relevant, associations, relevant
+    associations."""
+
+    def submit(self):
+        files = MultiDict()
+        for part in ("omic0_file", "omic0_relevant_file",
+                     "omic0_associations_file",
+                     "omic0_relevant_associations_file"):
+            files.add(part, _emptyPart(part))
+        fields = MultiDict({
+            "omic0_omic_name": "miRNA-seq",
+            "omic0_file_type": "miRNA-Seq quatification",
+            "omic0_match_type": "gene",
+            "omic0_origin": "mydata",
+            "omic0_filelocation": "[MyData]/output.tab",
+            "omic0_relevant_origin": "mydata",
+            "omic0_relevant_filelocation": "[MyData]/relevant.tab",
+            "omic0_associations_origin": "mydata",
+            "omic0_associations_filelocation": "[MyData]/associations.tab",
+            "omic0_relevant_associations_origin": "mydata",
+            "omic0_relevant_associations_filelocation":
+                "[MyData]/relevant_associations.tab",
+        })
+        return _run(files, fields)
+
+    def test_the_associations_file_registers(self):
+        self.assertEqual(self.submit().get("associationsFile"),
+                         "associations.tab")
+
+    def test_the_relevant_associations_file_registers(self):
+        self.assertEqual(self.submit().get("relevantAssociationsFile"),
+                         "relevant_associations.tab")
+
+
+class UntouchedInputsStillSkipTest(unittest.TestCase):
+    """The guard the gate was written for (IsADirectoryError on filename="")
+    must survive the fix: no location, no upload -> no file, no crash."""
+
+    def test_untouched_secondary_inputs_register_none(self):
+        files = MultiDict()
+        files.add("omic0_file", FileStorage(
+            stream=io.BytesIO(b"gene\tv\nAlb\t1.0\n"), filename="values.tab",
+            name="omic0_file"))
+        for part in ("omic0_relevant_file", "omic0_associations_file",
+                     "omic0_relevant_associations_file"):
+            files.add(part, _emptyPart(part))
+        fields = MultiDict({
+            "omic0_omic_name": "Gene expression",
+            "omic0_file_type": "Gene expression",
+            "omic0_match_type": "gene",
+            "omic0_origin": "client",
+            "omic0_relevant_origin": "client",
+        })
+        registered = _run(files, fields)
+        self.assertIsNone(registered.get("relevantFeaturesFile"))
+        self.assertIsNone(registered.get("associationsFile"))
+        self.assertIsNone(registered.get("relevantAssociationsFile"))
+        self.assertTrue(str(registered.get("inputDataFile", ""))
+                        .endswith("values.tab"))
+
+    def test_an_uploaded_relevant_file_is_still_saved(self):
+        files = MultiDict()
+        files.add("omic0_file", FileStorage(
+            stream=io.BytesIO(b"gene\tv\nAlb\t1.0\n"), filename="values.tab",
+            name="omic0_file"))
+        files.add("omic0_relevant_file", FileStorage(
+            stream=io.BytesIO(b"Alb\n"), filename="relevant.tab",
+            name="omic0_relevant_file"))
+        fields = MultiDict({
+            "omic0_omic_name": "Gene expression",
+            "omic0_file_type": "Gene expression",
+            "omic0_match_type": "gene",
+            "omic0_origin": "client",
+            "omic0_relevant_origin": "client",
+        })
+        registered = _run(files, fields)
+        self.assertTrue(str(registered.get("relevantFeaturesFile", ""))
+                        .endswith("relevant.tab"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What this branch delivers

The tail of the release-hardening line (README, first-launch bootstrap, crash-report fixes, custom-species installer, example-scenario ordering) plus four fixes verified end-to-end in Chrome today:

### Example picker offers each pipeline once
Seven simulated lessons duplicated the four real STATegra scenarios card-for-card. Simulated stand-ins now declare `supersededBy` and hide while their real counterpart is offered — and return automatically wherever the counterpart's files are missing (a fresh checkout without the mouse GTF keeps its region example). Deep links and chained-conversion matching still see hidden scenarios.

### Chained examples get their significance back
`saveFiles` judged a secondary file present by its *upload part*, so any file passed by reference (`_filelocation` + `mydata` origin — which is what every chained conversion posts for its own outputs, and what "Use a file from My Data" posts) was silently dropped. The region example ran with 0 relevant features and reported **829 pathways, 0 significant** on data with a planted signal. Fixed by judging presence by origin, like the data-file branch always did: the same run now reports **83 significant** with the planted targets ranked first (p≈1e-75).

### AI reports: citations you can trust, full text actually read
- `[17, 18]`-style markers were invisible to every citation reader (render/verify/redact/renumber), shipping body citations that pointed at nothing — measured in 14 of 42 stored reports. They are now normalised to `[17], [18]` inside each reader.
- Full text was **never** fetched (0 papers across all stored jobs): the NCBI ID Converter returns `pmid` as a JSON number and the lookup dict was string-keyed, so every paper fell to the abstract tier. One `str()` later, 7 of 15 papers on the verification job carry full Results/Discussion, and the citation-verification pass went from 5-of-12 failing to 13-of-13 passing.
- Every References entry now states its provenance (`*Cited from: abstract*` / `*Cited from: full text (results)*`) and the citations list labels each paper "full text read" / "abstract read".

### Layout squared to the header
The pathway panel's search field sat 6px below its own button (a panel-wide input normaliser outranked the row's reset); the TOC now spans exactly the wordmark's width and the results column starts under the "Job view" pill (measured 275.4 vs 275.6), widening the analysis box by ~60px. The alignment-guides overlay learned that a button after a flex-stretching sibling has no left rail.

## Verification
- New test suites: `test_secondary_files_by_reference` (6), `test_citation_marker_normalization` (14), `test_pubmed_pmcid_conversion` (4); all example/AI suites green.
- Clean-checkout import gate passed (all servlets + core modules import from a bare `git archive`).
- Chrome-verified on the running app: trimmed picker, aligned search row (guides overlay 0 off-rail), 83-significant region run, and a full AI pipeline run showing provenance labels and read-source chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)