### PR TITLE
A modern cookie consent card the design system can reach

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -4628,40 +4628,6 @@ function MORESubmittingPanel(nElem, options) {
 }
 MORESubmittingPanel.prototype = new DefaultSubmittingPanel;
 
-
-window.cookieconsent.initialise({
-	container: document.getElementById("content"),
-	palette: {
-		popup: {background: "#f6f6f6"},
-		button: {background: "#2684ff"},
-	},
-	revokable: true,
-	onStatusChange: function (status) {
-		console.log(this.hasConsented() ?
-			'enable cookies' : 'disable cookies');
-	},
-	law: {
-		regionalLaw: false,
-	},
-	location: true,
-	content: {
-		header: 'Cookies used on the website!',
-		message: 'This website uses cookies to improve your experience.',
-		dismiss: 'Got it!',
-		allow: 'Allow cookies',
-		deny: 'Decline',
-		link: 'Learn more',
-		href: 'https://paintomics.uv.es/conditions.html',
-		close: '&#x274c;',
-		policy: 'Cookie Policy',
-		target: '_blank',
-	},
-	position:"bottom-left",
-	elements: {
-		link: '<a aria-label="learn more about cookies" tabindex="0" class="cc-link" href="" target="_blank"></a>'
-	}
-});
-
 /*********************************************************************
  * AI PROVENANCE                                    ******************
  *********************************************************************

--- a/PaintomicsClient/public_html/app/view/common/CookieConsent.js
+++ b/PaintomicsClient/public_html/app/view/common/CookieConsent.js
@@ -1,0 +1,132 @@
+/*********************************************************************
+ * COOKIE CONSENT                                   ******************
+ *********************************************************************
+ * The consent card in the corner, self-contained.
+ *
+ * This replaces the cookieconsent@3 CDN bundle. That library is
+ * unmaintained, painted a grey banner no design token could reach, and
+ * its `location: true` option asked a third-party geo-IP service where
+ * the visitor was before the visitor had consented to anything. Nothing
+ * in the product ever read its status beyond a console.log, so all it
+ * owed a replacement was: show a notice, remember the answer.
+ *
+ * Storage is one localStorage key, with a cookie fallback for private
+ * windows where localStorage throws. The old library stored its answer
+ * in a `cookieconsent_status` cookie; that is read once and migrated so
+ * returning visitors are not asked again for a choice they already made.
+ *
+ * Markup and styling live apart on purpose: this file injects the card
+ * (see resources/css/cookie-consent.css for its look), and the card is
+ * `data-guides="ignore"` because a floating overlay is off the layout
+ * rails by design.
+ *********************************************************************/
+(function () {
+	"use strict";
+
+	var STORAGE_KEY = "pa-cookie-consent";
+	var LEGACY_COOKIE = "cookieconsent_status";
+	var ACCEPTED = "accepted";
+	var DECLINED = "declined";
+
+	function readCookie(name) {
+		var match = document.cookie.match(new RegExp("(?:^|;\\s*)" + name + "=([^;]*)"));
+		return match ? decodeURIComponent(match[1]) : null;
+	}
+
+	function readChoice() {
+		var value = null;
+		try { value = window.localStorage.getItem(STORAGE_KEY); } catch (e) { /* private mode */ }
+		return value || readCookie(STORAGE_KEY) || null;
+	}
+
+	function storeChoice(value) {
+		try { window.localStorage.setItem(STORAGE_KEY, value); } catch (e) { /* private mode */ }
+		document.cookie = STORAGE_KEY + "=" + value + ";path=/;max-age=" + (60 * 60 * 24 * 365) + ";SameSite=Lax";
+	}
+
+	/* What cookieconsent@3 recorded, translated. Its "dismiss" was the only
+	 * button most visitors ever saw ("Got it!"), so it counts as accepted. */
+	function legacyChoice() {
+		var value = readCookie(LEGACY_COOKIE);
+		if (value === "deny") { return DECLINED; }
+		if (value === "allow" || value === "dismiss") { return ACCEPTED; }
+		return null;
+	}
+
+	function currentStatus() {
+		var choice = readChoice();
+		if (choice) { return choice; }
+		var migrated = legacyChoice();
+		if (migrated) { storeChoice(migrated); }
+		return migrated;
+	}
+
+	function dismiss(card, choice) {
+		storeChoice(choice);
+		try {
+			window.dispatchEvent(new CustomEvent("pa:cookie-consent", { detail: { status: choice } }));
+		} catch (e) { /* CustomEvent missing: nobody to tell, nothing lost */ }
+		card.classList.add("pa-cookie-card--leaving");
+		window.setTimeout(function () {
+			if (card.parentNode) { card.parentNode.removeChild(card); }
+		}, 220);
+	}
+
+	function show() {
+		if (document.getElementById("paCookieConsent")) { return; }
+
+		var card = document.createElement("aside");
+		card.id = "paCookieConsent";
+		card.className = "pa-cookie-card";
+		card.setAttribute("role", "region");
+		card.setAttribute("aria-label", "Cookies notice");
+		card.setAttribute("data-guides", "ignore");
+		card.innerHTML =
+			'<div class="pa-cookie-card__icon" aria-hidden="true">' +
+				'<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">' +
+					'<path d="M12 2a10 10 0 1 0 10 10 4 4 0 0 1-5-5 4 4 0 0 1-5-5"/>' +
+					'<path d="M8.5 8.5v.01"/><path d="M16 15.5v.01"/><path d="M12 12v.01"/>' +
+					'<path d="M11 17v.01"/><path d="M7 14v.01"/>' +
+				'</svg>' +
+			'</div>' +
+			'<div class="pa-cookie-card__body">' +
+				'<h2 class="pa-cookie-card__title">Cookies on PaintOmics</h2>' +
+				'<p class="pa-cookie-card__text">We use cookies to keep your session and remember your preferences between visits. ' +
+					'<a href="conditions.html" target="_blank" rel="noopener">Learn more</a></p>' +
+			'</div>' +
+			'<div class="pa-cookie-card__actions">' +
+				'<button type="button" class="pa-cookie-card__btn pa-cookie-card__btn--quiet">Decline</button>' +
+				'<button type="button" class="pa-cookie-card__btn pa-cookie-card__btn--primary">Accept</button>' +
+			'</div>';
+
+		card.querySelector(".pa-cookie-card__btn--quiet").addEventListener("click", function () {
+			dismiss(card, DECLINED);
+		});
+		card.querySelector(".pa-cookie-card__btn--primary").addEventListener("click", function () {
+			dismiss(card, ACCEPTED);
+		});
+
+		document.body.appendChild(card);
+	}
+
+	function init() {
+		if (!currentStatus()) { show(); }
+	}
+
+	window.paCookieConsent = {
+		status: currentStatus,
+		hasConsented: function () { return currentStatus() === ACCEPTED; },
+		reset: function () {
+			try { window.localStorage.removeItem(STORAGE_KEY); } catch (e) { /* private mode */ }
+			document.cookie = STORAGE_KEY + "=;path=/;max-age=0";
+			document.cookie = LEGACY_COOKIE + "=;path=/;max-age=0";
+			show();
+		}
+	};
+
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", init);
+	} else {
+		init();
+	}
+})();

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -45,7 +45,7 @@
 	     which layers this view's own legend and layout on top of it. -->
 	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=0.6" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
-	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.50" />
+	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.51" />
 
 	<!-- Theme, resolved before the first paint.
 	     Deliberately inline and here rather than in Util.js: the stylesheets

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -67,8 +67,8 @@
 	</script>
 
 	<!--Cookies consent -->
-	<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.css" />
-	<script src="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.js" data-cfasync="false"></script>
+	<link rel="stylesheet" type="text/css" href="resources/css/cookie-consent.css?v=1.0" />
+	<script src="app/view/common/CookieConsent.js?v=1.0"></script>
 
 	<!--Math-->
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjs/10.4.2/math.js" data-cfasync="false"></script>

--- a/PaintomicsClient/public_html/resources/css/cookie-consent.css
+++ b/PaintomicsClient/public_html/resources/css/cookie-consent.css
@@ -1,0 +1,143 @@
+/* Cookie consent card ---------------------------------------------------------
+   Styles for the card app/view/common/CookieConsent.js injects. It replaced the
+   cookieconsent@3 CDN stylesheet, which knew nothing of this product's palette.
+
+   Every colour is written as var(--pa-*, light-value): the light :root defines
+   only a few of these tokens, so the fallback IS the light theme, and dark.css
+   [data-theme="dark"] token block restyles the card without a single rule here
+   naming dark. Keep it that way — a literal colour with no token wrapper is a
+   colour dark mode cannot reach.
+
+   The card floats above everything, so it carries its own elevation shadow
+   (stronger than --pa-shadow, which is for in-flow panels) and a rounder radius
+   than --pa-radius, which is sized for inline cards, not floating surfaces. */
+
+.pa-cookie-card {
+	position: fixed;
+	left: 20px;
+	bottom: 20px;
+	z-index: 99990;
+	width: min(400px, calc(100vw - 40px));
+	box-sizing: border-box;
+	display: grid;
+	grid-template-columns: auto 1fr;
+	column-gap: 14px;
+	row-gap: 14px;
+	padding: 18px 20px 16px;
+	background: var(--pa-surface, #FFFFFF);
+	color: var(--pa-ink, #18181B);
+	border: 1px solid var(--pa-border, rgba(24, 24, 27, 0.12));
+	border-radius: 12px;
+	box-shadow: 0 16px 40px rgba(0, 0, 0, 0.18), 0 3px 10px rgba(0, 0, 0, 0.10);
+	font-family: var(--pa-font-sans, 'SourceSansPro', 'Source Sans Pro', 'Segoe UI', system-ui, sans-serif);
+	animation: pa-cookie-in 240ms ease-out;
+}
+
+.pa-cookie-card--leaving {
+	opacity: 0;
+	transform: translateY(8px);
+	transition: opacity 200ms ease-in, transform 200ms ease-in;
+}
+
+@keyframes pa-cookie-in {
+	from { opacity: 0; transform: translateY(12px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.pa-cookie-card { animation: none; }
+	.pa-cookie-card--leaving { transition: none; }
+}
+
+.pa-cookie-card__icon {
+	width: 36px;
+	height: 36px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	border-radius: 50%;
+	color: var(--pa-accent-orange, #AD5022);
+	/* A 12% wash of the light accent reads as a warm chip on both themes. */
+	background: rgba(173, 80, 34, 0.12);
+}
+
+.pa-cookie-card__icon svg {
+	width: 22px;
+	height: 22px;
+}
+
+.pa-cookie-card__body {
+	align-self: center;
+	min-width: 0;
+}
+
+.pa-cookie-card__title {
+	margin: 0 0 4px;
+	font-size: 15px;
+	font-weight: 700;
+	line-height: 1.3;
+	color: var(--pa-ink, #18181B);
+}
+
+.pa-cookie-card__text {
+	margin: 0;
+	font-size: 13.5px;
+	line-height: 1.5;
+	color: var(--pa-ink-label, #52525B);
+}
+
+.pa-cookie-card__text a {
+	color: var(--pa-link, #006ACC);
+	text-decoration: underline;
+	text-underline-offset: 2px;
+}
+
+.pa-cookie-card__text a:hover {
+	color: var(--pa-link-hover, #24785D);
+}
+
+.pa-cookie-card__actions {
+	grid-column: 1 / -1;
+	display: flex;
+	justify-content: flex-end;
+	gap: 10px;
+}
+
+.pa-cookie-card__btn {
+	appearance: none;
+	margin: 0;
+	padding: 8px 18px;
+	border-radius: var(--pa-radius-sm, 6px);
+	font-family: inherit;
+	font-size: 14px;
+	font-weight: 600;
+	line-height: 1.2;
+	cursor: pointer;
+	transition: background-color 120ms ease, border-color 120ms ease;
+}
+
+.pa-cookie-card__btn:focus-visible {
+	outline: 2px solid var(--pa-focus-ring, #0A84FF);
+	outline-offset: 2px;
+}
+
+.pa-cookie-card__btn--primary {
+	background: var(--pa-btn-primary-bg, #337AB7);
+	border: 1px solid var(--pa-btn-primary-border, #2E6DA4);
+	color: #FFFFFF;
+}
+
+.pa-cookie-card__btn--primary:hover {
+	background: var(--pa-btn-primary-bg-hover, #2E6DA4);
+	border-color: var(--pa-btn-primary-border-hover, #285F8C);
+}
+
+.pa-cookie-card__btn--quiet {
+	background: transparent;
+	border: 1px solid var(--pa-border-control, #C6C4BD);
+	color: var(--pa-ink-control, #3F3F46);
+}
+
+.pa-cookie-card__btn--quiet:hover {
+	background: var(--pa-control-active-bg, #EEEDE7);
+	border-color: var(--pa-border-control-hover, #A9A79F);
+}

--- a/PaintomicsClient/public_html/resources/css/dark.css
+++ b/PaintomicsClient/public_html/resources/css/dark.css
@@ -1022,13 +1022,6 @@
 [data-theme="dark"] #mainViewCenterPanel .content span { color: var(--pa-ink-body); }
 [data-theme="dark"] #mainViewCenterPanel .content h5 { color: var(--pa-ink-title); }
 
-/* The cookie-consent widget ships its own light palette. */
-[data-theme="dark"] .cc-revoke,
-[data-theme="dark"] .cc-window {
-	background: var(--pa-surface-quiet) !important;
-	color: var(--pa-ink-body) !important;
-}
-
 /* ---------------------------------------------------------------------------
    7. Prose that has no class of its own
 

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -92,9 +92,9 @@ PUBLISHED = {
     # it with an unbumped marker leaves returning browsers running the old
     # copy exactly as it would for view code.
     "app/view/common/AlignmentGuides.js": (
-        "4.1", "db648a4f47fc2a11db95275e9467cc323e6036e87b69fc3cf37646ec745aa3ff"),
+        "4.2", "ce2ba85063e8059eb2cc4c8e1992744854a14ad0db6f866213b8df1136650a59"),
     "app/view/PathwayAcquisitionViews/PA_AIInterpretView.js": (
-        "0.4", "7db83c339d465cafb9bdd319ad267660d4e7bbcca4eb3fcd250736f59d5d8c6d"),
+        "0.6", "220aaea6269eafd08b10f8e6f9f0fefca952b7412cfc7c76c53617e383f65572"),
     "app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js": (
         "0.7", "b135712a9564f8ae0eac94daf9c567ef275c4c748dbc270fdbdeb7d25fc79e34"),
     "resources/ServerConfiguration.js": (

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -83,6 +83,8 @@ PUBLISHED = {
         "2.0", "284b8be3fd6f8e746730408b7bacc37c9385e4ce6e76743885c3a11dae6c3ecd"),
     "app/view/common/ExtJS_extensions.js": (
         "0.7", "f1e68f670cc56064fc15649d259004ccbd96f49181ced049cffbe62c29bf1d80"),
+    "app/view/common/CookieConsent.js": (
+        "1.0", "e170c539dea089b0d88e090becd968d43a699aa319dbd02e681b75384a57f403"),
     "app/view/common/upload/Panel.js": (
         "0.2", "34264cdec6faef81e46d28982f348003180b2e06d0af696f815f1b5b2a7a7458"),
     # A development overlay, inert until ctrl+alt+G, and still recorded here:


### PR DESCRIPTION
## What

Replaces the cookie consent banner — the unmaintained `cookieconsent@3` CDN bundle (grey bar, hard-coded palette, "Got it!") — with a self-contained consent card styled by the product's own design tokens.

| | Before | After |
|---|---|---|
| UI | Stock grey CDN banner, one hard-coded blue button | Floating bottom-left card: cookie icon, title, Accept / Decline, Learn more |
| Dark mode | Chased with `!important` overrides in dark.css | Free — every colour is `var(--pa-*, light-fallback)`, so the token block restyles it; the old `.cc-window` overrides are deleted |
| Privacy | `location: true` asked a third-party geo-IP service where the visitor was, before any consent | No third-party requests at all; two CDN fetches removed |
| Persistence | `cookieconsent_status` cookie | `localStorage` + cookie fallback for private windows; the legacy cookie is read once and migrated so returning visitors are not re-asked |
| Link | Absolute `https://paintomics.uv.es/conditions.html` | Relative `conditions.html`, correct on every deployment |

Nothing in the product ever read the old library's status beyond a `console.log`, so the replacement keeps a matching API surface: `window.paCookieConsent.status() / hasConsented() / reset()`, plus a `pa:cookie-consent` event on choice.

## Commits

1. **A cookie consent card the design system can reach** — the replacement itself: `CookieConsent.js` (new), `cookie-consent.css` (new), CDN lines → the two files in `index.html`, the `window.cookieconsent.initialise` block removed from `PA_Step1Views.js`, the new script registered in the digest table.
2. **Republish the two assets whose markers had moved past the table** — pre-existing drift surfaced by the rebase onto the merged #17: `PA_AIInterpretView.js` ships at v=0.6 and `AlignmentGuides.js` at v=4.2, but the guard's table still recorded 0.4/4.1. Markers were already bumped; only the table lagged.
3. **Drop the dark rules for the banner that no longer exists** — dark.css's `.cc-revoke`/`.cc-window` block is dead once the widget is gone; `dark.css` marker bumped to 0.51.

## Verified in Chrome (rebased onto current master, localhost)

- Card renders in light and dark (`data-theme="dark"`) on the redesigned landing page, both screenshotted
- Accept → stored, card animates out, absent after reload; Decline → `declined`, `hasConsented()` false
- Cookie fallback proven: consent survived a `localStorage` clear
- Legacy migration: a `cookieconsent_status=dismiss` cookie suppresses the card and persists as `accepted`
- Alignment guides (`?guides=1`): HUD reports *all text on rail / all rows on baseline* with the card visible — it is `data-guides="ignore"` as a floating overlay
- No console errors on a fresh load; both guard tests pass (versioned assets, index revalidation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)