### PR TITLE
Hide the tooltip's placeholder title when the box has none

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4Views.js
@@ -1509,6 +1509,11 @@ function PA_Step4KeggDiagramFeatureSetTooltip() {
 				$(domEl).find(".boxTitleLabel span").html(htmlTitle).show();
 
 				showBoxTitle = true;
+			} else {
+				// The title span shares .boxTitleLabel with the Genes/Metagenes
+				// toggle: when metagenes reveal the container without a box
+				// title, the template placeholder must not ride along.
+				$(domEl).find(".boxTitleLabel span").hide();
 			}
 
 			var buttonWrapper = $(domEl).find(".twoOptionsButtonWrapper");


### PR DESCRIPTION
## Problem

Hovering a metagene on a Step 4 pathway diagram opened a tooltip headed **"Unnamed event"** above the Genes/Metagenes toggle.

The tooltip template hard-codes `<span>Unnamed event</span>` inside `.boxTitleLabel`, expecting `updateObserver` to overwrite it with "Feature: X" when the hovered box has a title. Metagene pseudo-features have no box title, but the presence of metagenes un-hides the shared `.boxTitleLabel` container to show the Genes/Metagenes toggle — dragging the untouched placeholder into view.

## Fix

In `updateObserver`, hide the title span whenever the feature has no box title, so revealing the container for the toggle no longer exposes the placeholder. The titled path is untouched (it already calls `.show()` on the span).

## Verification (Chrome, this branch on :8001)

- Hovered `Metagene 1` on mmu01200 (job with metagenes): tooltip shows only the Genes/Metagenes toggle; span is `display:none` in the DOM.
- Clicked the Genes/Metagenes toggle: `updateObserver` re-runs on the same DOM, features cycle ("135 more Genes at this position"), placeholder stays hidden.
- No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)