### PR TITLE
Dark-theme ink for canvas/HTML chart labels, Step 4 tooltip cleanup

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
@@ -1703,6 +1703,20 @@ function PA_Step3PathwayClassificationView(db = "KEGG") {
 }
 PA_Step3PathwayClassificationView.prototype = new View();
 
+/**
+* The ink sigma paints node labels with. Sigma renders to canvas, so dark.css
+* cannot reach the labels the way it reaches the rest of the page: the colour
+* has to be resolved here and handed over as a settings value. --pa-chart-ink
+* is defined only under [data-theme="dark"], so in the light theme the lookup
+* comes back empty and the historical black stands.
+*
+* @returns {String}
+*/
+function paNetworkLabelInk() {
+	var ink = window.getComputedStyle(document.documentElement).getPropertyValue("--pa-chart-ink").trim();
+	return (ink !== "") ? ink : "#000";
+}
+
 function PA_Step3PathwayNetworkView(db = "KEGG") {
 	/**
 	* About this view: this view (PA_Step3PathwayNetworkView) is used to visualize
@@ -1716,6 +1730,7 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 	***********************************************************************/
 	this.name = "PA_Step3PathwayNetworkView";
 	this.network = null;
+	this.themeObserver = null;
 	this.tooltips = null;
 	this.filters = null;
 	this.select = null;
@@ -2016,9 +2031,26 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 				// min/maxNodeSize:
 				minNodeSize: visualOptions.minNodeSize,
 				maxNodeSize: visualOptions.maxNodeSize,
-				defaultLabelSize: visualOptions.fontSize
+				defaultLabelSize: visualOptions.fontSize,
+				defaultLabelColor: paNetworkLabelInk()
 			}
 		});
+
+		/* The label ink is baked into canvas pixels at render time, so a theme
+		   flip after this point would strand black labels on the dark ground
+		   (or pale ones on white). One observer per view, registered on the
+		   first render only: updateObserver re-runs on every Apply and kills
+		   the old sigma instance, so the callback reads me.network at fire
+		   time instead of closing over an instance that may be dead. */
+		if (me.themeObserver === null && window.MutationObserver !== undefined) {
+			me.themeObserver = new MutationObserver(function () {
+				if (me.network !== null) {
+					me.network.settings({defaultLabelColor: paNetworkLabelInk()});
+					me.network.renderers[0].render();
+				}
+			});
+			me.themeObserver.observe(document.documentElement, {attributes: true, attributeFilter: ["data-theme"]});
+		}
 
 		/********************************************************/
 		/* STEP 4. GENERATE THE GLYPS                           */

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4Views.js
@@ -1573,9 +1573,8 @@ function PA_Step4KeggDiagramFeatureSetTooltip() {
 		this.featureView.setClosable(true);
 
 		this.component = Ext.create('Ext.window.Window', {
-			target: "", 
+			target: "",
 			layout: "auto",
-			style: "background: #fff; border: solid 2px #B7C7CF; border-radius : 2px; margin:0; padding:0;",
 			resizable: false, bodyPadding:0,
 			autoHeight: true, width: 280, minHeight:240,
 			closable: false,
@@ -1630,7 +1629,7 @@ function PA_Step4KeggDiagramFeatureSetTooltip() {
 				{
 					xtype: "box", html:
 					'<div style="text-align: center;margin: 10px 0px;">'+
-					'  <a href="javascript:void(0)" class="step4TooltipMoreButton" class="button btn-primary btn-no-float"><i class="fa fa-search-plus"></i> Show details</a>'+
+					'  <a href="javascript:void(0)" class="step4TooltipMoreButton button btn-primary btn-no-float"><i class="fa fa-search-plus"></i> Show details</a>'+
 					'</div>'
 				}
 			],
@@ -1644,7 +1643,13 @@ function PA_Step4KeggDiagramFeatureSetTooltip() {
 				boxready: function() {
 					//SOME EVENT HANDLERS
 					var domEl = me.getComponent().el.dom;
-					
+
+					// This window is anchored to wherever the user clicked on the
+					// diagram (showBy above), never to a fixed page position, so it
+					// can never land on the page's column rails - same case as
+					// #messageDialogPanel in AlignmentGuides.js's ignore list.
+					domEl.setAttribute("data-guides", "ignore");
+
 					$(domEl).find(".step4TooltipMoreButton").click(function() {
 						me.getComponent().hide();
 						me.showFeatureSetDetails(me.targetID, me.getModel());
@@ -2129,8 +2134,12 @@ function PA_Step4KeggDiagramFeatureView(showButtons) {
 			series: series,
 			plotOptions: {
 				heatmap: {
-					borderColor: "#000000",
-					borderWidth: 0.5,
+					// A light gap instead of a black grid: it reads as separation
+					// between saturated cells on both the light and dark surface this
+					// chart sits on, without a hairline that goes muddy against the
+					// diverging blue/red fills.
+					borderColor: "rgba(255,255,255,0.55)",
+					borderWidth: 1.5,
 					dataLabels: {
 						enabled: true,
 						useHTML: true,

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,13 +39,13 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.05" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.06" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=0.7" />
 	<!-- Shared chrome for both of Step 3's graph surfaces. Before more-network.css,
 	     which layers this view's own legend and layout on top of it. -->
 	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=0.6" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
-	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.51" />
+	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.52" />
 
 	<!-- Theme, resolved before the first paint.
 	     Deliberately inline and here rather than in Util.js: the stylesheets

--- a/PaintomicsClient/public_html/resources/css/dark.css
+++ b/PaintomicsClient/public_html/resources/css/dark.css
@@ -1119,6 +1119,14 @@
 }
 [data-theme="dark"] #dbs_message dt { color: var(--pa-ink-title); }
 
+/* The compound disambiguation cards. main.css inks every bare h4 #27272A and
+   this file answers that card by card rather than with a blanket (the
+   .paExploreCard note in section 2 says why); the "N compounds found" and
+   "N alternative compounds found" counters on these cards were not among the
+   answers, so they sat at 1.4:1 on the dark card. Label ink, not body ink:
+   they are secondary counts over the checkbox lists that carry the content. */
+[data-theme="dark"] .metaboliteBox h4 { color: var(--pa-ink-label); }
+
 /* ---------------------------------------------------------------------------
    10. Highcharts
 
@@ -1160,6 +1168,21 @@
 	background: var(--pa-surface-quiet) !important;
 	color: var(--pa-ink-body) !important;
 	border-color: var(--pa-border) !important;
+}
+/* The classification pie's percentage labels are HTML (useHTML), not SVG text,
+   so the fill rules above never touched them. Highcharts writes its drilldown
+   default inline on the span - navy #003399, underlined - which was 1.9:1 on
+   the dark card and needs !important to beat. Drillable labels take the link
+   colour because clicking them is the pie's whole interaction; a drilled-down
+   level has nothing further to open and reads as plain chart ink. The
+   category badge inside each label keeps its own inline ink and fill (it is
+   type-coding, same as the slices), and neither rule reaches it: they colour
+   the wrapper span only, and the badge's inline value beats inheritance. */
+[data-theme="dark"] div[id^="pathwayDistributionsContainer_"] .highcharts-data-label > span {
+	color: var(--pa-chart-ink) !important;
+}
+[data-theme="dark"] div[id^="pathwayDistributionsContainer_"] .highcharts-drilldown-data-label > span {
+	color: var(--pa-link) !important;
 }
 
 /* ---------------------------------------------------------------------------
@@ -1326,13 +1349,9 @@
 [data-theme="dark"] div.lateralOptionsPanel div.updateMessageContainer h3 { color: var(--pa-ink-title); }
 [data-theme="dark"] .step4PathwayThumbnailHover { background-color: rgba(23, 24, 27, 0.67); }
 [data-theme="dark"] td.whiteBackground { background: var(--pa-surface); }
-/* The Heatmap / Line chart pair. The unselected half is a light grey that reads
-   brighter than the panel it sits on; the selected half keeps its accent. */
-[data-theme="dark"] a.button.twoOptionsButton {
-	background: var(--pa-btn-default-bg);
-	color: var(--pa-btn-default-ink);
-	border-color: var(--pa-border-control);
-}
+/* The Heatmap/Line-chart and Genes/Metagenes segmented control (twoOptionsButton,
+   main.css) is built entirely from surface and ink tokens now, so it themes
+   itself - no dark override needed here any more. */
 
 /* ---------------------------------------------------------------------------
    13. Controls and widgets that appear on more than one step

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -2043,39 +2043,41 @@ div.more-net-side p,
 	padding-right: 0;
 }
 
+/* A flat segmented control: a sunken track holding two borderless options,
+   the active one raised on its own chip. Replaces the old beveled grey/blue
+   pill (still visible in git blame) with the same token set every other
+   control in the app already draws from, so it themes for free instead of
+   needing its own dark.css entry. Shared by this tooltip's Genes/Metagenes
+   and Heatmap/Line-chart pickers, and by the Step 3 pathway-info rail panel's
+   identical toggle. */
+div.twoOptionsButtonWrapper {
+	display: inline-flex;
+	gap: 2px;
+	padding: 3px;
+	margin: 10px 0;
+	background-color: var(--pa-surface-sunken);
+	border-radius: var(--pa-radius-sm);
+}
 a.button.twoOptionsButton {
 	float: none;
-	font-size: 9px;
-	margin: -1px;
-	padding: 5px;
-	background-color: #BDBDBD;
-	/* Outer edge. The #BDBDBD half is 1.88:1 against the white panel it sits on,
-	   so the control's extent was hard to see even though the split between its
-	   two halves was obvious. #767676 is 4.54:1 on white. The fills are left
-	   exactly as they are - they encode which option is active, which is the
-	   decision recorded below - and because the two halves overlap by the -1px
-	   margin above, their borders collapse into a single outline rather than
-	   drawing a seam down the middle. */
-	border-color: #767676;
-	/* This is a segmented control (Heatmap / Line chart), not a disabled
-	   button - both halves are clickable, `.selected` just marks the active
-	   one - so both states have to meet AA. It inherited .button's #E2E2E2
-	   label, which gave 1.45:1 on the grey half and 2.51:1 on the blue.
-	   The two fills encode which option is active, so they stay as they are
-	   and the ink goes dark instead: 9.26:1 and 5.35:1. */
-	color: #1A1A1A;
-	border-radius: 0px;
+	font-size: 11px;
+	font-weight: 600;
+	margin: 0;
+	padding: 5px 12px;
+	background-color: transparent;
+	border: none;
+	border-radius: var(--pa-radius-sm);
+	color: var(--pa-ink-label);
+	transition: background-color var(--pa-transition), color var(--pa-transition), box-shadow var(--pa-transition);
 }
-a.button.twoOptionsButton:first-child {
-	border-radius: 5px 0px 0px 5px;
-}
-a.button.twoOptionsButton:last-child {
-	border-radius: 0px 5px 5px 0px;
+a.button.twoOptionsButton:hover:not(.selected) {
+	color: var(--pa-ink);
 }
 a.button.twoOptionsButton.selected {
-	background-color: #6992BE;
+	background-color: var(--pa-surface);
+	color: var(--pa-ink);
+	box-shadow: var(--pa-shadow-inset);
 }
-div.twoOptionsButtonWrapper{text-align: center;margin: 10px 0px;}
 
 /*****************************************************************************
 **** FORMULARY STYLES ********************************************************
@@ -2291,12 +2293,20 @@ body > .x-mask {
    element so it cannot carry the ::before/::after that would redraw the ✕.
    A muted grey keeps the knocked-out glyph legible and stops the control from
    being the brightest thing in a header whose whole point is now to be quiet. */
-.x-window .x-tool-img.x-tool-close {
+.x-window .x-tool-img.x-tool-close,
+.x-window .x-tool-img.x-tool-pin,
+.x-window .x-tool-img.x-tool-unpin,
+.x-window .x-tool-img.x-tool-plus,
+.x-window .x-tool-img.x-tool-minus {
 	background-color: #8A8B92;
 	border-radius: 3px;
 	transition: background-color var(--pa-transition);
 }
-.x-window .x-tool-img.x-tool-close:hover {
+.x-window .x-tool-img.x-tool-close:hover,
+.x-window .x-tool-img.x-tool-pin:hover,
+.x-window .x-tool-img.x-tool-unpin:hover,
+.x-window .x-tool-img.x-tool-plus:hover,
+.x-window .x-tool-img.x-tool-minus:hover {
 	background-color: #5A5B62;
 }
 
@@ -4241,7 +4251,8 @@ i.masterRegulator:before {
 .boxTitleLabel {
 	font-weight: bold;
 	padding-top: 5px;
-	border-bottom: 1px solid #3892d3;
+	padding-bottom: 8px;
+	border-bottom: 1px solid var(--pa-border);
 }
 
 /*PATHWAYS THUMBNAILS FOR HISTORY PANEL*/
@@ -5110,7 +5121,7 @@ div.omicSelection div.omicPosition + div {
 /***********************************************************/
 
 .tooltipDetailsSpan {
-	color: #317AB6;
+	color: var(--pa-link);
 	cursor: pointer
 }
 .tooltipDetailsSpan a {

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -94,7 +94,7 @@ PUBLISHED = {
     "app/view/common/AlignmentGuides.js": (
         "4.2", "ce2ba85063e8059eb2cc4c8e1992744854a14ad0db6f866213b8df1136650a59"),
     "app/view/PathwayAcquisitionViews/PA_AIInterpretView.js": (
-        "0.6", "220aaea6269eafd08b10f8e6f9f0fefca952b7412cfc7c76c53617e383f65572"),
+        "0.7", "b009d48e1d6d5d027b80cb59ccdc8e26c2f73f6d9d96443ca8fb62e43530f1e2"),
     "app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js": (
         "0.7", "b135712a9564f8ae0eac94daf9c567ef275c4c748dbc270fdbdeb7d25fc79e34"),
     "resources/ServerConfiguration.js": (


### PR DESCRIPTION
Resolves dark-theme ink for the two chart surfaces CSS cannot reach — the sigma canvas network (re-renders on a data-theme MutationObserver) and Highcharts' inline-styled HTML pie labels — plus metabolite disambiguation counters, the Step 4 feature tooltip (duplicate class attribute, lost data-guides exemption), and a translucent-white heatmap grid. Also republishes the PA_AIInterpretView digest-table entry whose marker had already moved to v=0.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)