### PR TITLE
Cluster-first AI interpretation: interpret every significant pathway inside its shared-feature cluster (AI_CLUSTER_MODE)

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_AIInterpretView.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_AIInterpretView.js
@@ -192,8 +192,11 @@ function PA_AIInterpretView() {
             $progress.hide();
             $fab.removeClass("is-processing");
             $badge.css("background", "#66bb6a").html("&#10003;").show();
-            // Auto-load if expanded
-            if (this.isExpanded && !this.reportLoaded) {
+            // Load as soon as it is ready, expanded or not: the Step 3
+            // network's "AI pathway clusters" colouring reads the partition
+            // the report carries, so waiting for the panel to be opened would
+            // hide that option until then.
+            if (!this.reportLoaded) {
                 this.loadReport();
             }
         } else if (status === "error") {

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_AIInterpretView.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_AIInterpretView.js
@@ -22,6 +22,12 @@ function PA_AIInterpretView() {
     // id/name/source of the pathways the report was written from, used to turn
     // pathway mentions into links.
     this.pathwayIndex = [];
+    // The shared-feature pathway partition the report was written from
+    // (cluster mode only): {clusters:[{id,label,members,satellites,core}],
+    // standalone:[ids], further:[ids]}. Handed to the Step 3 view through
+    // onClustersLoaded so the pathway network can colour nodes by cluster.
+    this.clusters = null;
+    this.onClustersLoaded = null;
     this._pathwayRequestInFlight = null;
 
     this.init = function(jobID) {
@@ -230,9 +236,13 @@ function PA_AIInterpretView() {
             success: function(response) {
                 if (response.success && response.report) {
                     me.pathwayIndex = response.pathways || [];
+                    me.clusters = response.clusters || null;
                     me.displayReport(response.report, response.papers || [], me.pathwayIndex);
                     me.displayCitations(response.papers || []);
                     me.reportLoaded = true;
+                    if (me.onClustersLoaded) {
+                        try { me.onClustersLoaded(me.clusters); } catch (e) { console.warn(e); }
+                    }
                 } else if (response.status === "error") {
                     me.addMessage("assistant",
                         "The AI interpretation failed: **" + (response.message || "Unknown error") + "**");

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
@@ -71,6 +71,8 @@ function PA_Step3JobView() {
 	this.hubAnalysisView = null;
 	this.aiWidget = null;
 	this.aiJobID = null;
+	// Shared-feature pathway partition from the AI report (cluster mode), or null.
+	this.aiClusters = null;
 	this.pollTimerID = null;
 
 	/**
@@ -794,6 +796,7 @@ function PA_Step3JobView() {
 			this.aiWidget.destroy();
 			this.aiWidget = null;
 		}
+		this.aiClusters = null;
 		this.aiJobID = null;
 		$("#aiInterpretButton").hide();
 	};
@@ -820,6 +823,16 @@ function PA_Step3JobView() {
 		$("#aiInterpretButton").show();
 		me.aiWidget = new PA_AIInterpretView();
 		me.aiWidget.init(jobID);
+		// Cluster mode: the report carries the shared-feature partition it was
+		// written from. Keep it on the Step 3 view and let each pathway network
+		// offer "AI pathway clusters" as a colouring; the network itself is
+		// only redrawn when the user applies the option.
+		me.aiWidget.onClustersLoaded = function(clusters) {
+			me.aiClusters = (clusters && clusters.clusters && clusters.clusters.length) ? clusters : null;
+			$.each(me.pathwayNetworkViews, function(db, view) {
+				try { view.updateObserver(); } catch (e) { console.warn(e); }
+			});
+		};
 		me.aiWidget.onRetry = function() {
 			$.ajax({
 				type: "POST", url: SERVER_URL_AI_INTERPRET_INITIATE,
@@ -1824,7 +1837,7 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 				var selectedCombinedPvalueMethod = me.getParent().visualOptions.selectedCombinedMethod;
 				var selectedAdjustingMethod = visualOptions.networkPvalMethod;
 				var useCombinedPvalue = visualOptions.useCombinedPvalCheckbox;
-				var methodSelected =  (visualOptions.colorBy === "classification" || useCombinedPvalue) ? selectedCombinedPvalueMethod : visualOptions.colorBy;
+				var methodSelected =  (visualOptions.colorBy === "classification" || visualOptions.colorBy === "aiclusters" || useCombinedPvalue) ? selectedCombinedPvalueMethod : visualOptions.colorBy;
 
 				/*
 					The adjusted p-values are different in the job has been category filtered (number of tests decreases).
@@ -1894,6 +1907,15 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 				elem.data.clusters =  [];
 				if(visualOptions.colorBy === "classification"){ //Color by classification
 					elem.data.colors.push(this.getParent().getClassificationColor(elem.data.parent[0]));
+				}else if(visualOptions.colorBy === "aiclusters"){ //Color by the AI report's shared-feature clusters
+					var aiCluster = me.getAIClusterOf(elem.data.id);
+					if(aiCluster){
+						CLUSTERS[aiCluster.id] = me.getAIClusterColor(aiCluster.id);
+						elem.data.colors.push(CLUSTERS[aiCluster.id]);
+						elem.data.clusters.push(aiCluster.id);
+					}else{
+						elem.data.colors.push("#dfdfdf"); // standalone / further: not in any cluster
+					}
 				}else{ //Color by metagenes clusters
 					var metagenes = matchedPathway.metagenes[visualOptions.colorBy];
 					if(metagenes){
@@ -2172,7 +2194,7 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 		this.network.bind('hovers', function(e) {
 			if(e.data.current.nodes.length > 0 && me.showTooltips){
 				PA_Step3PathwayNetworkTooltipView().timeoutID = setTimeout(function(){
-					PA_Step3PathwayNetworkTooltipView().show(e.data.captor.clientX, e.data.captor.clientY, me.getModel().getPathway(e.data.current.nodes[0].id), [visualOptions.colorBy], me.getModel().getDataDistributionSummaries(), visualOptions);
+					PA_Step3PathwayNetworkTooltipView().show(e.data.captor.clientX, e.data.captor.clientY, me.getModel().getPathway(e.data.current.nodes[0].id), (visualOptions.colorBy === "aiclusters" ? [] : [visualOptions.colorBy]), me.getModel().getDataDistributionSummaries(), visualOptions);
 				}, 600);
 			}else{
 				clearTimeout(PA_Step3PathwayNetworkTooltipView().timeoutID);
@@ -2200,6 +2222,35 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 			}
 			$("#networkClustersContainer_" + me.dbid + " div").html(htmlCode);
 			$("#sliderClusterNumberContainer_" + me.dbid).hide();
+		}else if(visualOptions.colorBy === "aiclusters"){
+			// One legend entry per AI cluster with a node in this network:
+			// colour, label, member count; grey = not in any cluster.
+			var ai = me.getParent().aiClusters || {clusters: []};
+			var drawnIds = Object.keys(CLUSTERS);
+			$("#networkClustersContainer_" + me.dbid + " h4").text("Coloring by AI pathway clusters");
+			$("#networkClustersContainer_" + me.dbid + " h5").text(drawnIds.length + " of " + ai.clusters.length + " clusters have nodes in this network. Grey nodes belong to no cluster.");
+			$.each(ai.clusters, function(i, c){
+				if(!CLUSTERS[c.id]){ return; }
+				var members = (c.members || []).length + (c.satellites || []).length;
+				htmlCode += '<span class="networkClusterImage networkAICluster" name="' + c.id + '" title="' + Ext.String.htmlEncode((c.core || []).slice(0, 8).join(", ")) + '">' +
+					'<i class="fa fa-eye-slash fa-2x"></i>' +
+					'<p><i class="fa fa-square" style="color:' + CLUSTERS[c.id] + '"></i> ' + c.id + ' &middot; ' + Ext.String.htmlEncode(c.label || "") + ' (' + members + ')</p></span>';
+			});
+			$("#networkClustersContainer_" + me.dbid + " div").html(htmlCode);
+			$("#sliderClusterNumberContainer_" + me.dbid).hide();
+			// Same click-to-hide behaviour as the metagene clusters.
+			$("#networkClustersContainer_" + me.dbid + " .networkClusterImage").click(function(){
+				var cluster = $(this).attr("name");
+				if($(this).hasClass("disabled")){
+					$(this).removeClass("disabled");
+					me.filters.undo('cluster-filter-' + cluster).apply();
+				}else{
+					$(this).addClass("disabled");
+					me.filters.nodesBy(function(node, params) {
+						return node.clusters.indexOf(params.cluster) === -1;
+					}, {cluster: cluster}, 'cluster-filter-' + cluster).apply();
+				}
+			});
 		}else{
 			var clusterNumber = Object.keys(CLUSTERS).length;
 			var totalClusters = TOTAL_CLUSTERS[visualOptions.colorBy].size;
@@ -2679,6 +2730,30 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 	this.getClusterColor= function(cluster){
 		return getClusterColor(cluster);
 	};
+	/**
+	 * The AI report's shared-feature cluster containing a pathway, or null.
+	 * Read from the partition the Step 3 view keeps (aiClusters).
+	 */
+	this.getAIClusterOf = function(pathwayID){
+		var ai = this.getParent().aiClusters;
+		if(!ai || !ai.clusters){ return null; }
+		for(var i = 0; i < ai.clusters.length; i++){
+			var c = ai.clusters[i];
+			if((c.members || []).indexOf(pathwayID) !== -1 || (c.satellites || []).indexOf(pathwayID) !== -1){
+				return c;
+			}
+		}
+		return null;
+	};
+	/**
+	 * A stable colour per AI cluster id ("C01" -> palette slot 1), so the same
+	 * cluster is drawn in the same colour in the KEGG and the Reactome network.
+	 */
+	this.getAIClusterColor = function(clusterID){
+		var n = parseInt(String(clusterID).replace(/[^0-9]/g, ""), 10);
+		if(isNaN(n)){ n = 0; }
+		return getClusterColor(n % 20);
+	};
 
 	this.updateNodePositions = function(updateCache, preserveExisting=false){
 		var visualOptions = this.getParent().getVisualOptions(this.database);
@@ -3062,6 +3137,13 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 			'<div class="radio">' +
 			'  <input type="radio" ' + ((visualOptions.colorBy === inputOmics[i].omicName)? "checked": "")+ ' id="' + inputOmics[i].omicName.replace(/ /g, "_").toLowerCase() + '-check_' + this.dbid + '" name="colorByCheckbox_' + this.dbid + '" value="' + inputOmics[i].omicName + '">' +
 			'  <label for="' + inputOmics[i].omicName.replace(/ /g, "_").toLowerCase() + '-check_' + this.dbid + '">' + inputOmics[i].omicName + '</label>' +
+			'</div>';
+		}
+		if(this.getParent().aiClusters){
+			htmlContent +=
+			'<div class="radio">' +
+			'  <input type="radio" ' + ((visualOptions.colorBy === "aiclusters")? "checked": "")+ ' id="aiclusters-check_' + this.dbid + '" name="colorByCheckbox_' + this.dbid + '" value="aiclusters">' +
+			'  <label for="aiclusters-check_' + this.dbid + '">AI pathway clusters</label>' +
 			'</div>';
 		}
 		$("#colorByContainer_" + this.dbid).html(htmlContent);

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
@@ -1776,6 +1776,13 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 	this.generateNetwork = function(data, forceStop=false) {
 		var me = this;
 		var visualOptions = this.getParent().getVisualOptions(this.database);
+		// A colouring saved from an earlier visit may name the AI clusters
+		// before this visit's report has loaded (or for a job with no cluster
+		// report at all); without a partition every node would draw grey with
+		// an empty legend, so fall back to the classification colouring.
+		if (visualOptions.colorBy === "aiclusters" && !this.getParent().aiClusters) {
+			visualOptions.colorBy = "classification";
+		}
 		var indexedPathways = this.getParent().getIndexedPathways(this.database);
 		var CLUSTERS = {};
 		var TOTAL_CLUSTERS = this.getModel().getClusterNumber()[this.database];

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,13 +39,13 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.06" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.07" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=0.7" />
 	<!-- Shared chrome for both of Step 3's graph surfaces. Before more-network.css,
 	     which layers this view's own legend and layout on top of it. -->
 	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=0.6" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
-	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.52" />
+	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.53" />
 
 	<!-- Theme, resolved before the first paint.
 	     Deliberately inline and here rather than in Util.js: the stylesheets
@@ -133,7 +133,7 @@
 	<!--MARKDOWN RENDERING LIBRARY -->
 	<script type="text/javascript" src="js/libs/marked/marked.min.js"></script>
 	<!--AI INTERPRETATION VIEW -->
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_AIInterpretView.js?v=0.8"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_AIInterpretView.js?v=0.9"></script>
 	<!--MORE REGULATOR–TARGET NETWORK VIEW -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js?v=0.7"></script>
 

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -133,7 +133,7 @@
 	<!--MARKDOWN RENDERING LIBRARY -->
 	<script type="text/javascript" src="js/libs/marked/marked.min.js"></script>
 	<!--AI INTERPRETATION VIEW -->
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_AIInterpretView.js?v=0.7"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_AIInterpretView.js?v=0.8"></script>
 	<!--MORE REGULATOR–TARGET NETWORK VIEW -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js?v=0.7"></script>
 

--- a/PaintomicsClient/public_html/resources/css/dark.css
+++ b/PaintomicsClient/public_html/resources/css/dark.css
@@ -1274,6 +1274,7 @@
 [data-theme="dark"] div[id ^= "pathwayNetworkBox_"].fullscreen { background-color: var(--pa-surface-page); }
 [data-theme="dark"] div[id ^= "pathwayNetworkWaitBox_"] { background-color: rgba(23, 24, 27, 0.76); }
 [data-theme="dark"] span.networkClusterImage > i { background-color: rgba(30, 31, 35, 0.54); }
+[data-theme="dark"] span.networkClusterImage.networkAICluster:hover { background-color: rgba(255, 255, 255, 0.06); }
 /* The network toolbar, its status line and its two popovers used to need three
    translucent literals here because main.css painted them with
    `rgba(255,255,255,.91)`. They are stated in tokens now - see

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -3325,6 +3325,15 @@ span.networkClusterImage > i {
 	line-height: 75px;
 }
 span.networkClusterImage.disabled > i {display:block;}
+/* AI pathway clusters (network colouring from the AI report): one legend
+   row per cluster instead of the metagene thumbnail grid. A hidden cluster
+   dims and strikes through rather than showing the eye overlay, which sized
+   itself for a 97px image. */
+span.networkClusterImage.networkAICluster {display: block; width: auto; margin: 2px 0; padding: 2px 4px; border-radius: 3px;}
+span.networkClusterImage.networkAICluster > i {display: none !important;}
+span.networkClusterImage.networkAICluster p {text-align: left; font-size: 11px; line-height: 1.35;}
+span.networkClusterImage.networkAICluster.disabled p {opacity: 0.45; text-decoration: line-through;}
+span.networkClusterImage.networkAICluster:hover {background-color: rgba(0, 0, 0, 0.05);}
 .mainInfoPanel {font-size: 12px;}
 .pathwayPlotwrappers h4{color: #B14C2D;/* was #D16949 - 3.60:1 */font-size: 13px;margin: 0;margin-top: 5px;}
 /* Vertical margin only. The horizontal 10px put the "Pathways network" card

--- a/PaintomicsServer/src/classes/AIInterpret/agent.py
+++ b/PaintomicsServer/src/classes/AIInterpret/agent.py
@@ -1146,7 +1146,22 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
             logger.info("[%s][sdk] cluster batch %s: %d pathways, %s",
                         job_id, "/".join(u["id"] for u in unit_batch), len(batch),
                         "full tool loop" if heavy else "single-shot")
-        res = await Runner.run(agents[agent_key], prompt, context=ctx, max_turns=turns)
+        try:
+            res = await Runner.run(agents[agent_key], prompt, context=ctx, max_turns=turns)
+        except Exception as e:
+            if not (unit_batch and agent_key == "interpret"):
+                raise
+            # A tool loop that runs out of turns (an 11-pathway cluster can
+            # ask for a timecourse per member) or dies on the gateway must not
+            # take its whole cluster out of the report: answer it in one call
+            # from the same brief instead. Measured: 4 of 14 batches were lost
+            # this way in one servlet run before this fallback existed.
+            logger.warning("[%s][sdk] cluster batch %s: tool loop failed (%s: %s); "
+                           "retrying single-shot", job_id,
+                           "/".join(u["id"] for u in unit_batch), type(e).__name__,
+                           str(e)[:120])
+            res = await Runner.run(agents["interpret_light"], prompt, context=ctx,
+                                   max_turns=2)
         return _remap_citation_indices(str(res.final_output), local_to_global)
 
     if partition is not None:
@@ -1171,7 +1186,14 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
                    for i in range(0, len(pathways), AI_PATHWAYS_PER_BATCH)]
         batch_reports = await asyncio.gather(*[_one_batch(b) for b in batches],
                                              return_exceptions=True)
-    failed_batches = sum(1 for b in batch_reports if isinstance(b, Exception))
+    failed_batches = 0
+    for i, b in enumerate(batch_reports):
+        if isinstance(b, Exception):
+            failed_batches += 1
+            label = ("/".join(u["id"] for u in batches[i]) if partition is not None
+                     else "batch %d" % (i + 1))
+            logger.warning("[%s][sdk] interpretation batch %s failed: %s: %s", job_id,
+                           label, type(b).__name__, str(b)[:160])
     if failed_batches:
         logger.warning("[%s][sdk] %d of %d interpretation batches failed", job_id,
                        failed_batches, len(batch_reports))

--- a/PaintomicsServer/src/classes/AIInterpret/agent.py
+++ b/PaintomicsServer/src/classes/AIInterpret/agent.py
@@ -62,8 +62,19 @@ from src.classes.AIInterpret.shared import (
     _build_local_paper_index, _remap_citation_indices, _shared_gene_core,
 )
 from src.classes.AIInterpret.llm_client import LLMClient
+# Cluster-first interpretation (AI_CLUSTER_MODE=1): the shared-feature
+# pathway network is partitioned and every significant pathway is interpreted
+# inside its cluster. Off by default so the base arm stays reproducible.
+from src.classes.AIInterpret import clusters as clusters_mod
 
 logger = logging.getLogger(__name__)
+
+# How many pathways one cluster-mode interpretation batch may hold (units are
+# never split; a bigger cluster travels alone) and how many batches run at
+# once. Cluster mode has ~5x the batches of the top-15 path, so it needs a
+# bound the three-batch path never did.
+CLUSTER_BATCH_MAX = int(os.getenv("AI_CLUSTER_BATCH_MAX", "8"))
+CLUSTER_CONCURRENCY = int(os.getenv("AI_CLUSTER_CONCURRENCY", "6"))
 
 # Tuning knobs for the SDK arm. Separate from the shared AI_* settings so
 # sweeping this workflow keeps its behaviour stable mid-comparison.
@@ -374,6 +385,20 @@ def _completeness_gaps(report, pathways):
     return missing_pw, gaps
 
 
+def _reattach_blocks(report, blocks):
+    """Put deterministic blocks (the pathway and cluster tables) back if a
+    correction rewrite dropped them, keeping them ahead of the References
+    section. Blocks already present are left where they are."""
+    from src.classes.AIInterpret.verification import _REFERENCES_HEADING_RE
+    m = _REFERENCES_HEADING_RE.search(report)
+    body = report[:m.start()].rstrip() if m else report.rstrip()
+    refs = report[m.start():] if m else ""
+    for heading, text in blocks:
+        if text and heading not in body:
+            body += "\n\n" + text.rstrip()
+    return body + ("\n\n" + refs if refs else "\n")
+
+
 def _pick_best_draft(drafts, pathways, papers):
     """Choose among synthesis drafts on evidence the DATA provides.
 
@@ -644,13 +669,50 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
     organism = job_instance.getOrganism()
     organism_name = get_organism_name(organism)
     pathways = build_pathway_context(job_instance, max_pathways=budgets["max_pathways"])
+    # Cluster mode widens the pathway set from the top-N by p-value to every
+    # significant pathway the network draws, grouped by shared matched
+    # features. The list stays in global rank order -- clustering decides what
+    # is discussed together, never the order of emphasis (evolve round 1 vs 2).
+    partition = None
+    if clusters_mod.CLUSTER_MODE:
+        try:
+            candidate = clusters_mod.build_partition(job_instance)
+            member_ids = clusters_mod.partition_member_ids(candidate)
+            if candidate.get("clusters") and member_ids:
+                partition = candidate
+                pathways = build_pathway_context(job_instance, pathway_ids=member_ids)
+                logger.info("[%s][sdk] cluster mode: %s", job_id,
+                            clusters_mod.partition_summary(partition))
+            else:
+                logger.info("[%s][sdk] cluster mode found no clusters (%s); using the "
+                            "rank-ordered top-%d", job_id,
+                            clusters_mod.partition_summary(candidate), len(pathways))
+        except Exception as e:
+            logger.warning("[%s][sdk] cluster mode failed (%s); using the rank-ordered "
+                           "top-%d", job_id, e, len(pathways))
+            partition = None
+    ctx_by_id = {p["id"]: p for p in pathways}
     if hooks and hooks.get("pathways"):
         try:
             hooks["pathways"](pathways)
         except Exception:
             logger.debug("pathway-index hook failed", exc_info=True)
+    if partition is not None and hooks and hooks.get("partition"):
+        try:
+            hooks["partition"](partition)
+        except Exception:
+            logger.debug("partition hook failed", exc_info=True)
+    if partition is not None:
+        stats["clusters"] = len(partition["clusters"])
+        stats["cluster_pathways"] = len(pathways)
+        stats["cluster_standalone"] = len(partition["standalone"])
+        stats["cluster_further"] = len(partition["further"])
     gene_whitelist = build_gene_symbol_whitelist(job_instance)
-    major, minor = triage_pathways(pathways)
+    # The planner and the cross-omic matrix keep the top-N view even in
+    # cluster mode: the wider set reaches literature through per-cluster
+    # queries below, and a 100-pathway planner prompt is not a better planner.
+    plan_pathways = pathways[:budgets["max_pathways"]] if partition is not None else pathways
+    major, minor = triage_pathways(plan_pathways)
     matrix = build_cross_omic_matrix(major)
 
     ctx = AgentContext(job_instance=job_instance, job_id=job_id,
@@ -680,20 +742,26 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
     # Keys must match build_pathway_context's current record shape: the old
     # p.get("pvalue")/p.get("omics") read fields that no longer exist, so
     # every triage line said "p=None, omics=0" and the agent picked on names.
-    pathway_lines = "\n".join(
-        "- %s (combined p=%.3g, significant omics=%s)"
-        % (p.get("name"), p.get("combined_pvalue") or 1.0,
-           p.get("significant_omic_count", "?"))
-        for p in pathways)
-    triage_res = await Runner.run(
-        agents["triage"],
-        "Experiment: %s\nOrganism: %s\n\nEnriched pathways:\n%s\n\n"
-        "Select up to %d to investigate." % (experiment_design, organism_name,
-                                             pathway_lines, budgets["max_pathways"]),
-        context=ctx, max_turns=3)
-    picks = triage_res.final_output.picks
+    if partition is None:
+        pathway_lines = "\n".join(
+            "- %s (combined p=%.3g, significant omics=%s)"
+            % (p.get("name"), p.get("combined_pvalue") or 1.0,
+               p.get("significant_omic_count", "?"))
+            for p in pathways)
+        triage_res = await Runner.run(
+            agents["triage"],
+            "Experiment: %s\nOrganism: %s\n\nEnriched pathways:\n%s\n\n"
+            "Select up to %d to investigate." % (experiment_design, organism_name,
+                                                 pathway_lines, budgets["max_pathways"]),
+            context=ctx, max_turns=3)
+        picks = triage_res.final_output.picks
+        logger.info("[%s][sdk] triage picked %d pathways", job_id, len(picks))
+    else:
+        # The partition already decided what is investigated (every
+        # significant pathway, in its cluster); the triage pick is not
+        # consumed downstream, so cluster mode skips the call.
+        picks = []
     stats["triage_s"] = time.time() - t0
-    logger.info("[%s][sdk] triage picked %d pathways", job_id, len(picks))
 
     # -- Phase 2: search planning -------------------------------------------
     _hb("searching_pubmed", 15, "Planning literature searches...")
@@ -717,6 +785,19 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
     # batching the fetches costs N+1. That is what makes a wider search budget
     # affordable inside 300s: 88 tasks previously blew past 600s.
     _fetched = {}   # pmid -> paper, filled by the batched fetch below
+    # task.pathway is the attribution key. The planner and the per-pathway
+    # backfill use a pathway name; cluster-mode queries use the cluster id so
+    # one search feeds every member's drill-down. This maps a key back to the
+    # pathway names a paper should be attributed to.
+    attribution = {}
+
+    def _attributed(task):
+        return list(attribution.get(task.pathway) or [task.pathway])
+
+    def _task_display(task):
+        names = attribution.get(task.pathway)
+        return ", ".join(names[:4]) + (" ..." if names and len(names) > 4 else "") \
+            if names else task.pathway
 
     async def _search_only(task):
         try:
@@ -758,7 +839,7 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
             "Precision beats volume: a kept paper with no quotable finding costs "
             "a citation, since the claim it was attached to is then removed. An "
             "empty list is correct when nothing fits."
-            % (experiment_design, organism_name, task.pathway, task.query, listing),
+            % (experiment_design, organism_name, _task_display(task), task.query, listing),
             context=ctx, max_turns=3)
         answered = {str(x).strip() for x in (res.final_output.pmids or [])}
         candidates = {str(p.get("pmid")) for p in papers}
@@ -783,7 +864,7 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
                 # erase every other pathway it was found for. The dedup below
                 # merges these lists back together.
                 paper = dict(p)
-                paper["pathways"] = [task.pathway]
+                paper["pathways"] = _attributed(task)
                 out.append(paper)
         # Which stage is actually starving the citation count: PubMed returning
         # little, or the filter rejecting most of what it returns? Without this
@@ -821,7 +902,29 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
                                              for t in system_terms)
                         if system_terms else "")
         budget = SDK_BACKFILL_MAX_TASKS
-        for pw in pathways:
+        if partition is not None:
+            # One or two gene-anchored queries per cluster from its shared
+            # core (one per standalone / further pathway), in cluster rank
+            # order so the budget goes to the strongest clusters first.
+            # Attributed to every member, so a paper found for a cluster is
+            # available to each member's interpretation and drill-down.
+            seen_queries = {t.query for t in tasks}
+            n_before = len(tasks)
+            for query, key, names, why in clusters_mod.cluster_search_queries(
+                    partition, ctx_by_id, organism_name, system_angle):
+                if len(tasks) >= budget:
+                    logger.info("[%s][sdk] backfill budget of %d tasks reached; "
+                                "remaining clusters get no extra search", job_id, budget)
+                    break
+                if query in seen_queries:
+                    continue
+                seen_queries.add(query)
+                attribution[key] = names
+                tasks.append(SearchTask(query=query, pathway=key, rationale=why))
+            logger.info("[%s][sdk] %d cluster search tasks added (%d total, system "
+                        "angle: %s)", job_id, len(tasks) - n_before, len(tasks),
+                        system_angle or "none")
+        for pw in (pathways if partition is None else []):
             if pw["name"] in covered:
                 continue
             if len(tasks) >= budget:
@@ -907,7 +1010,7 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
                            "the top %d hits", job_id, task.query[:60], r, len(fallback))
             for p in fallback:
                 paper = dict(p)
-                paper["pathways"] = [task.pathway]
+                paper["pathways"] = _attributed(task)
                 all_papers.append(paper)
             continue
         all_papers.extend(r)
@@ -959,7 +1062,7 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
     _hb("interpreting", 45, "Generating interpretation with evidence extraction...")
     t0 = time.time()
 
-    async def _one_batch(batch):
+    async def _one_batch(batch, unit_batch=None):
         names = {p["name"] for p in batch}
         batch_papers = [p for p in unique_papers
                         if names & set(p.get("pathways", []))]
@@ -985,6 +1088,10 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
         prompt = prompts_mod.build_batch_interpretation_prompt(
             batch, local_papers, experiment_design, organism_name)
         prompt += _shared_gene_core(batch, ctx.job_instance)
+        if unit_batch:
+            # Cluster context: what the members share, their global ranks,
+            # and the instruction to interpret each cluster as one unit.
+            prompt += "\n\n" + clusters_mod.render_units_block(unit_batch, partition)
         # Features corroborated across independent assays. The pathway context
         # reaches genes only through the top enriched pathways, so a gene with
         # signal in two or three layers that sits outside those pathways is
@@ -1002,10 +1109,33 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
                                max_turns=SDK_INTERPRET_TURNS)
         return _remap_citation_indices(str(res.final_output), local_to_global)
 
-    batches = [pathways[i:i + AI_PATHWAYS_PER_BATCH]
-               for i in range(0, len(pathways), AI_PATHWAYS_PER_BATCH)]
-    batch_reports = await asyncio.gather(*[_one_batch(b) for b in batches],
-                                         return_exceptions=True)
+    if partition is not None:
+        # One unit per cluster (never split), small units packed together,
+        # standalone pathways alone, the 'further' pool in chunks; the
+        # fan-out is bounded because there are ~5x more batches than the
+        # top-15 path ever ran.
+        units = clusters_mod.build_units(partition, ctx_by_id)
+        unit_batches = clusters_mod.pack_units(units, CLUSTER_BATCH_MAX)
+        bsem = asyncio.Semaphore(CLUSTER_CONCURRENCY)
+
+        async def _bounded_batch(ub):
+            async with bsem:
+                return await _one_batch(clusters_mod.batch_pathways(ub), ub)
+
+        stats["cluster_units"] = len(units)
+        batches = unit_batches
+        batch_reports = await asyncio.gather(*[_bounded_batch(ub) for ub in unit_batches],
+                                             return_exceptions=True)
+    else:
+        batches = [pathways[i:i + AI_PATHWAYS_PER_BATCH]
+                   for i in range(0, len(pathways), AI_PATHWAYS_PER_BATCH)]
+        batch_reports = await asyncio.gather(*[_one_batch(b) for b in batches],
+                                             return_exceptions=True)
+    failed_batches = sum(1 for b in batch_reports if isinstance(b, Exception))
+    if failed_batches:
+        logger.warning("[%s][sdk] %d of %d interpretation batches failed", job_id,
+                       failed_batches, len(batch_reports))
+    stats["batches_failed"] = failed_batches
     batch_reports = [b for b in batch_reports if not isinstance(b, Exception)]
     stats["interpret_s"] = time.time() - t0
     # Some runs finish with zero citations while others on identical settings
@@ -1035,6 +1165,14 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
                          + render_pathway_table(pathways))
     except Exception:
         pass
+    if partition is not None:
+        # The cluster map: which pathways belong together and why, with
+        # every member's global rank, plus the rules that keep the report's
+        # emphasis on rank while its themes follow the clusters.
+        try:
+            synth_prompt += "\n\n" + clusters_mod.render_synthesis_block(partition, ctx_by_id)
+        except Exception as e:
+            logger.warning("[%s][sdk] cluster synthesis block failed: %s", job_id, e)
     # Pin the citable range. Measured: the synthesis emitted 82 distinct markers
     # against 47 real papers -- it numbers citations past the end of the list it
     # was given. render_references_section drops the invalid ones, so nothing
@@ -1175,6 +1313,13 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
     table = render_pathway_table(pathways)
     if table:
         report = report.rstrip() + "\n\n" + table + "\n"
+    cluster_table = ""
+    if partition is not None:
+        try:
+            cluster_table = clusters_mod.render_partition_table(partition, ctx_by_id)
+            report = report.rstrip() + "\n\n" + cluster_table + "\n"
+        except Exception as e:
+            logger.warning("[%s][sdk] cluster table failed: %s", job_id, e)
     stats["synth_s"] = time.time() - t0
     stats["synth_citations"] = len(set(re.findall(r'\[(\d+)\]', str(report))))
 
@@ -1341,6 +1486,13 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
                                             job_id, known=quotes))
         report, _ = render_references_section(report, ctx.paper_index, quotes)
     stats["verify_loop_s"] = time.time() - t0
+    if partition is not None:
+        # A correction rewrite re-authors the whole report and can drop the
+        # appended data tables; they are data, not prose, so put them back.
+        report = _reattach_blocks(report, [
+            ("## Enriched Pathway Summary", table),
+            ("## Pathway Clusters", cluster_table),
+        ])
     stats["verify_iterations"] = verify_iters
 
     # -- Phase 6: the programmatic safety net ---------------------------------
@@ -1462,6 +1614,7 @@ def run_ai_agent(job_id, experiment_design, RESPONSE):
                 job_id, {"status": s, "percent": p, "detail": d}),
             "cancelled": lambda: bool(_cancel_flags.get(job_id)),
             "pathways": lambda pw: dao.save_pathway_index(job_id, pw),
+            "partition": lambda part: dao.save_clusters(job_id, part),
         }
         out = run_agent_workflow(job_instance, job_id, experiment_design,
                                hooks=hooks)

--- a/PaintomicsServer/src/classes/AIInterpret/agent.py
+++ b/PaintomicsServer/src/classes/AIInterpret/agent.py
@@ -75,6 +75,17 @@ logger = logging.getLogger(__name__)
 # bound the three-batch path never did.
 CLUSTER_BATCH_MAX = int(os.getenv("AI_CLUSTER_BATCH_MAX", "8"))
 CLUSTER_CONCURRENCY = int(os.getenv("AI_CLUSTER_CONCURRENCY", "6"))
+# Two tiers of interpretation in cluster mode. A unit that carries a top-N
+# (by p-value) pathway gets the full tool-loop interpreter, capped at
+# CLUSTER_INTERPRET_TURNS; every other unit gets one single-shot
+# call from the same instructions without tools. Measured: a full-protocol
+# cluster run at 8 turns x 14 batches blew a 600 s cap on the gateway, where
+# parallel tool loops serialise; single-shot calls parallelise.
+CLUSTER_INTERPRET_TURNS = int(os.getenv("AI_CLUSTER_INTERPRET_TURNS", "5"))
+# AI_CLUSTER_TOOLS=0 makes every cluster batch single-shot (no data tools) --
+# the cheap mode for gateways whose tool loops crawl, and the mode a
+# qualitative smoke can run on a backend that never finishes a tool loop.
+CLUSTER_TOOLS = os.getenv("AI_CLUSTER_TOOLS", "1") == "1"
 
 # Tuning knobs for the SDK arm. Separate from the shared AI_* settings so
 # sweeping this workflow keeps its behaviour stable mid-comparison.
@@ -615,6 +626,17 @@ def _build_agents():
         tools=DATA_TOOLS,           # SDK drives the tool loop
     )
 
+    # Cluster mode's second tier: the same brief, no tools, one call. Used for
+    # units without a top-N or multi-omic pathway, where the data block in the
+    # prompt already carries what the tools would fetch.
+    interpreter_light = Agent[AgentContext](
+        name="Pathway Interpreter (single-shot)",
+        model=_model(),
+        instructions=prompts_mod.SYSTEM_PROMPT_INTERPRET,
+        model_settings=ms,
+        tools=[],
+    )
+
     synthesizer = Agent[AgentContext](
         name="Report Writer",
         model=_model(),
@@ -644,7 +666,8 @@ def _build_agents():
         tools=VERIFY_TOOLS,
     )
     return dict(triage=triage_agent, planner=search_planner, filter=paper_filter,
-                interpret=interpreter, synth=synthesizer, verify=verifier)
+                interpret=interpreter, interpret_light=interpreter_light,
+                synth=synthesizer, verify=verifier)
 
 
 # ---------------------------------------------------------------------------
@@ -1105,8 +1128,21 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
         # times, and the rushed retries pulled off-lineage claims into the report
         # (GATA3 presented as a B-cell regulator) and dropped the score to 5.00.
         # Speed bought that way is not speed.
-        res = await Runner.run(agents["interpret"], prompt, context=ctx,
-                               max_turns=SDK_INTERPRET_TURNS)
+        agent_key, turns = "interpret", SDK_INTERPRET_TURNS
+        if unit_batch:
+            # Heavy = the unit holds one of the top-N pathways by p-value, the
+            # set the top-N path interpreted with tools. "Or any multi-omic
+            # pathway" was tried first: on the STATegra fold that made every
+            # one of the 14 batches heavy (36 of 101 nodes are multi-omic), so
+            # it saved nothing.
+            core_ids = {p["id"] for p in pathways[:budgets["max_pathways"]]}
+            heavy = CLUSTER_TOOLS and any(p["id"] in core_ids for p in batch)
+            agent_key = "interpret" if heavy else "interpret_light"
+            turns = CLUSTER_INTERPRET_TURNS if heavy else 2
+            logger.info("[%s][sdk] cluster batch %s: %d pathways, %s",
+                        job_id, "/".join(u["id"] for u in unit_batch), len(batch),
+                        "full tool loop" if heavy else "single-shot")
+        res = await Runner.run(agents[agent_key], prompt, context=ctx, max_turns=turns)
         return _remap_citation_indices(str(res.final_output), local_to_global)
 
     if partition is not None:

--- a/PaintomicsServer/src/classes/AIInterpret/agent.py
+++ b/PaintomicsServer/src/classes/AIInterpret/agent.py
@@ -699,7 +699,11 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
     partition = None
     if clusters_mod.CLUSTER_MODE:
         try:
-            candidate = clusters_mod.build_partition(job_instance)
+            # The top-N by p-value the plain path would have shown are pinned
+            # into the universe: a change that widens the context must never
+            # drop a pathway the narrower one presented.
+            candidate = clusters_mod.build_partition(
+                job_instance, always_include=[p["id"] for p in pathways])
             member_ids = clusters_mod.partition_member_ids(candidate)
             if candidate.get("clusters") and member_ids:
                 partition = candidate

--- a/PaintomicsServer/src/classes/AIInterpret/clusters.py
+++ b/PaintomicsServer/src/classes/AIInterpret/clusters.py
@@ -78,6 +78,9 @@ DEFAULT_PARAMS = {
     "standalone_top": int(os.getenv("AI_CLUSTER_STANDALONE_TOP", "10")),
     "hub_fraction": float(os.getenv("AI_CLUSTER_HUB_FRACTION", "0.25")),
     "core_limit": 12,
+    # PubMed queries per cluster (1 = core genes + experimental system; 2 adds
+    # a second core-gene set). Each query costs a search and a screener call.
+    "queries_per_cluster": int(os.getenv("AI_CLUSTER_QUERIES", "1")),
 }
 METHOD = "hier-average-dice"
 VERSION = 1
@@ -767,14 +770,17 @@ def cluster_search_queries(partition, pathway_ctx_by_id, organism_name, system_a
         genes = genes[:6]
         if not genes:
             continue
-        yield ("(%s) AND (%s)" % (" OR ".join(genes[:3]), organism_name), c["id"], names,
-               "cluster core genes")
-        if system_angle:
-            yield ("(%s) AND %s" % (" OR ".join(genes[:3]), system_angle), c["id"], names,
-                   "cluster core genes, experimental system")
-        elif len(genes) > 3:
-            yield ("(%s) AND (%s)" % (" OR ".join(genes[3:6]), organism_name), c["id"], names,
-                   "cluster core genes (second set)")
+        n_q = int((partition.get("params") or {}).get("queries_per_cluster", 1) or 1)
+        first = ("(%s) AND %s" % (" OR ".join(genes[:3]), system_angle) if system_angle
+                 else "(%s) AND (%s)" % (" OR ".join(genes[:3]), organism_name))
+        yield (first, c["id"], names, "cluster core genes")
+        if n_q >= 2:
+            if system_angle:
+                yield ("(%s) AND (%s)" % (" OR ".join(genes[:3]), organism_name), c["id"], names,
+                       "cluster core genes, organism")
+            elif len(genes) > 3:
+                yield ("(%s) AND (%s)" % (" OR ".join(genes[3:6]), organism_name), c["id"], names,
+                       "cluster core genes (second set)")
     for kind in ("standalone", "further"):
         for pid in partition.get(kind) or []:
             pw = pathway_ctx_by_id.get(pid)

--- a/PaintomicsServer/src/classes/AIInterpret/clusters.py
+++ b/PaintomicsServer/src/classes/AIInterpret/clusters.py
@@ -1,0 +1,788 @@
+"""Pathway clusters over the shared-feature network, for the AI interpreter.
+
+The Step 3 pathway network draws one node per significant pathway and, in
+"shared biological features" mode, an edge wherever two pathways have matched
+genes or compounds in common (Sorensen-Dice similarity, PA_Step3Views.js). This
+module recovers that structure server-side and partitions it so the AI can
+interpret biologically related pathways together instead of in arbitrary
+p-value chunks, and so every significant pathway -- not only the top 15 --
+reaches the report.
+
+Everything here is pure computation over the four job methods the evolve
+harness's frozen context also exposes (getMatchedPathways, getInputGenesData,
+getGeneBasedInputOmics, getOrganism): no LLM, no MongoDB. Same input -> same
+partition, byte for byte, in any process; there is no random seed anywhere.
+
+Two rules the partition must respect, both measured:
+
+* A cluster has at least two members. A size-1 group is not a cluster; it is
+  an isolate and goes through the isolate rule below.
+* Clustering decides CONTEXT (which pathways are discussed together, which
+  shared genes glue them), never ORDER. Round 1 of the stategra-v4 evolve loop
+  reordered the interpretation batches by theme and the rank score collapsed
+  (-0.108 train); round 2 kept the rank presentation and only annotated shared
+  genes and was KEPT. Members are therefore always listed in global rank order
+  with their rank shown, and the caller keeps the rank-ordered pathway table.
+
+Isolate rule (a significant pathway no cluster claims):
+  1. satellite -- mean Dice to a cluster's members >= ``attach`` (default 0.10):
+     joins that cluster flagged as loosely connected, at most ``satellites_per``
+     per cluster;
+  2. standalone -- major (>= 2 significant omic layers) or in the global top
+     ``standalone_top`` by combined p: its own interpretation unit;
+  3. further -- everything else: rendered deterministically and interpreted in
+     one pooled batch, so nothing significant is silently dropped.
+
+Cross-database identity: KEGG stores matchedGenes as Entrez ids and Reactome as
+gene symbols / entity names, so the raw sets never overlap. Both are clones of
+the same input feature carrying the same ``omicsValues[*].inputName``; joining
+clones through their input names gives one key per input feature (compounds
+already share the KEGG C-id in both databases). Reactome modified-entity
+variants (``PHOSPHO-P-S259-RAF1``, ``RAF1``) collapse onto one key, which is a
+correction: they are one input gene.
+"""
+import json
+import logging
+import math
+import os
+
+import numpy as np
+from scipy.cluster.hierarchy import fcluster, linkage
+from scipy.spatial.distance import squareform
+
+from .context_builder import (
+    _best_pval, _conditionPvaluesOf, _count_significant_omics, _numericValues,
+)
+
+logger = logging.getLogger(__name__)
+
+# All knobs are environment-overridable, like the AI_SDK_* settings in agent.py,
+# so the base arm stays reproducible for A/B: the whole feature is off unless
+# AI_CLUSTER_MODE=1.
+CLUSTER_MODE = os.getenv("AI_CLUSTER_MODE", "0") == "1"
+
+DEFAULT_PARAMS = {
+    # Node universe: what the Step 3 network draws under its default filters.
+    "min_pvalue": float(os.getenv("AI_CLUSTER_MIN_PVALUE", "0.05")),
+    "min_features": float(os.getenv("AI_CLUSTER_MIN_FEATURES", "0.5")),
+    "max_nodes": int(os.getenv("AI_CLUSTER_MAX_NODES", "150")),
+    # Partition. Dice 0.25 rather than the slider's 0.10: at 0.10 the top raw
+    # group on the STATegra example is 47 pathways of hub-gene overlap and any
+    # split of it is arbitrary; at 0.25 the raw groups are <= 23 and 21 of 22
+    # clusters carry a strict-majority core of >= 5 shared features.
+    "cut": float(os.getenv("AI_CLUSTER_CUT", "0.25")),
+    "cap": int(os.getenv("AI_CLUSTER_CAP", "10")),
+    "min_size": 2,
+    "attach": float(os.getenv("AI_CLUSTER_ATTACH", "0.10")),
+    "satellites_per": int(os.getenv("AI_CLUSTER_SATELLITES", "2")),
+    "standalone_top": int(os.getenv("AI_CLUSTER_STANDALONE_TOP", "10")),
+    "hub_fraction": float(os.getenv("AI_CLUSTER_HUB_FRACTION", "0.25")),
+    "core_limit": 12,
+}
+METHOD = "hier-average-dice"
+VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Feature identity
+# ---------------------------------------------------------------------------
+
+def _ugly(symbol):
+    s = str(symbol or "")
+    return (not s) or s.isdigit() or s.upper().startswith(("ENSMUSG", "ENSG",
+                                                            "ENSRNOG", "ENSDARG"))
+
+
+class _UnionFind:
+    def __init__(self):
+        self.parent = {}
+
+    def find(self, x):
+        self.parent.setdefault(x, x)
+        root = x
+        while self.parent[root] != root:
+            root = self.parent[root]
+        while self.parent[x] != root:
+            self.parent[x], x = root, self.parent[x]
+        return root
+
+    def union(self, a, b):
+        ra, rb = self.find(a), self.find(b)
+        if ra == rb:
+            return
+        # Deterministic representative: the lexically smaller root.
+        if rb < ra:
+            ra, rb = rb, ra
+        self.parent[rb] = ra
+
+
+def canonical_feature_map(job_instance):
+    """gene clone id -> (canonical key, display symbol).
+
+    Clones (one per database that resolved the input row) are joined through
+    the input names they carry; the canonical key is the smallest clone id of
+    the joined group prefixed ``F:``. The display symbol prefers a real gene
+    symbol from any clone in the group (KEGG clones carry it as ``name``;
+    Reactome clones carry the raw input id there and the symbol as ``ID``).
+    Features with no omics values (should not happen) map to themselves.
+    """
+    genes = job_instance.getInputGenesData() or {}
+    uf = _UnionFind()
+    by_input = {}
+    for gid, gene in genes.items():
+        gid = str(gid)
+        uf.find(gid)
+        try:
+            ovs = gene.getOmicsValues() or []
+        except Exception:
+            ovs = []
+        for ov in ovs:
+            try:
+                name = ov.getInputName()
+            except Exception:
+                name = getattr(ov, "inputName", None)
+            if not name:
+                continue
+            name = str(name)
+            first = by_input.get(name)
+            if first is None:
+                by_input[name] = gid
+            else:
+                uf.union(first, gid)
+
+    # Symbol per group: best candidate across the group's clones.
+    groups = {}
+    for gid in genes:
+        groups.setdefault(uf.find(str(gid)), []).append(str(gid))
+    symbol_of_group = {}
+    for root, members in groups.items():
+        best = None
+        for gid in sorted(members):
+            gene = genes.get(gid)
+            candidates = []
+            try:
+                candidates.append(gene.getName())
+            except Exception:
+                pass
+            candidates.append(gid)
+            for c in candidates:
+                if c and not _ugly(c):
+                    # Prefer a mixed-case symbol (KEGG's "Csf2rb") over an
+                    # all-caps Reactome entity id when both exist.
+                    if best is None or (best.isupper() and not str(c).isupper()):
+                        best = str(c)
+        symbol_of_group[root] = best or sorted(members)[0]
+
+    out = {}
+    for gid in genes:
+        root = uf.find(str(gid))
+        out[str(gid)] = ("F:" + root, symbol_of_group[root])
+    return out
+
+
+def pathway_feature_sets(job_instance, pathway_ids, feature_map=None):
+    """pathway id -> frozenset of canonical feature keys (genes + compounds)."""
+    matched = job_instance.getMatchedPathways()
+    feature_map = feature_map if feature_map is not None else canonical_feature_map(job_instance)
+    sets = {}
+    for pid in pathway_ids:
+        pw = matched.get(pid)
+        if pw is None:
+            sets[pid] = frozenset()
+            continue
+        keys = set()
+        for g in (getattr(pw, "matchedGenes", None) or []):
+            entry = feature_map.get(str(g))
+            keys.add(entry[0] if entry else "G:" + str(g))
+        for c in (getattr(pw, "matchedCompounds", None) or []):
+            keys.add("C:" + str(c))
+        sets[pid] = frozenset(keys)
+    return sets
+
+
+# ---------------------------------------------------------------------------
+# Node universe
+# ---------------------------------------------------------------------------
+
+def _fisher_min_pvalue(pw):
+    """The p-value the network view filters on: combined Fisher, min over
+    conditions. Falls back to the strongest combined value of any method."""
+    cp = getattr(pw, "combinedSignificancePvalues", None) or {}
+    vals = _numericValues(cp.get("Fisher")) if isinstance(cp, dict) else []
+    if vals:
+        return min(vals)
+    return _best_pval(pw)
+
+
+def _load_total_features(organism):
+    """pathway id -> total feature count from the installed network file.
+
+    Mirrors the client's "min features in pathway" filter. Missing file or
+    unexpected shape -> {} and the filter is simply not applied.
+    """
+    try:
+        from src.conf.serverconf import KEGG_DATA_DIR
+    except Exception:
+        return {}
+    totals = {}
+    base = os.path.join(KEGG_DATA_DIR, "current", str(organism))
+    for fn in ("pathways_network.json", "pathways_network_Reactome.json"):
+        path = os.path.join(base, fn)
+        if not os.path.exists(path):
+            continue
+        try:
+            with open(path) as fh:
+                data = json.load(fh)
+        except Exception:
+            continue
+        blocks = []
+        if isinstance(data, dict) and "nodes" in data:
+            blocks.append(data)
+        elif isinstance(data, dict):
+            blocks.extend(v for v in data.values() if isinstance(v, dict) and "nodes" in v)
+        for block in blocks:
+            for node in block.get("nodes") or []:
+                d = node.get("data") or {}
+                if d.get("is_classification") is not None:
+                    continue
+                pid, total = d.get("id"), d.get("total_features")
+                if pid and isinstance(total, (int, float)):
+                    totals.setdefault(pid, int(total))
+    return totals
+
+
+def select_network_nodes(job_instance, params=None):
+    """The significant pathways the network draws, ranked by combined p.
+
+    Returns a list of (pathway_id, pathway) in rank order (best p first, ties
+    by id). Applies the network view's defaults: combined Fisher p <= min_pvalue
+    (min over conditions), matched features >= min_features x pathway total
+    when the pathway total is known, and drops the organism-wide map
+    (<org>01100). Capped at max_nodes by rank.
+    """
+    p = dict(DEFAULT_PARAMS, **(params or {}))
+    matched = job_instance.getMatchedPathways() or {}
+    organism = str(job_instance.getOrganism() or "")
+    totals = _load_total_features(organism) if p["min_features"] > 0 else {}
+    rows = []
+    for pid, pw in matched.items():
+        pid = str(pid)
+        if pid == organism + "01100":
+            continue
+        pval = _fisher_min_pvalue(pw)
+        if pval is None or pval > p["min_pvalue"]:
+            continue
+        n_matched = len(getattr(pw, "matchedGenes", None) or []) + \
+            len(getattr(pw, "matchedCompounds", None) or [])
+        total = totals.get(pid)
+        if total and total * p["min_features"] > n_matched:
+            continue
+        rows.append((pval, pid, pw))
+    rows.sort(key=lambda r: (r[0], r[1]))
+    return [(pid, pw) for _p, pid, pw in rows[:p["max_nodes"]]]
+
+
+# ---------------------------------------------------------------------------
+# Partition
+# ---------------------------------------------------------------------------
+
+def _dice(a, b):
+    if not a or not b:
+        return 0.0
+    return 2.0 * len(a & b) / (len(a) + len(b))
+
+
+def dice_matrix(ids, sets):
+    n = len(ids)
+    m = np.zeros((n, n), dtype=np.float64)
+    for i in range(n):
+        m[i, i] = 1.0
+        for j in range(i + 1, n):
+            m[i, j] = m[j, i] = _dice(sets[ids[i]], sets[ids[j]])
+    return m
+
+
+def _cut_groups(index_list, dist, cut_distance):
+    """Average-linkage cut of the sub-matrix over index_list -> list of lists."""
+    if len(index_list) < 2:
+        return [list(index_list)]
+    sub = dist[np.ix_(index_list, index_list)]
+    labels = fcluster(linkage(squareform(sub, checks=False), method="average"),
+                      t=cut_distance, criterion="distance")
+    groups = {}
+    for idx, lab in zip(index_list, labels):
+        groups.setdefault(int(lab), []).append(idx)
+    return [groups[k] for k in sorted(groups)]
+
+
+def _split_to_cap(index_list, dist, cap):
+    """Re-cut an over-cap group on its own sub-matrix until every part <= cap.
+
+    Splits with maxclust=2 at each level (the top merge of the sub-dendrogram)
+    and recurses into any part still over the cap. Deterministic; terminates
+    because every level strictly reduces the part size or ends in singletons.
+    """
+    if len(index_list) <= cap:
+        return [list(index_list)]
+    sub = dist[np.ix_(index_list, index_list)]
+    labels = fcluster(linkage(squareform(sub, checks=False), method="average"),
+                      t=2, criterion="maxclust")
+    parts = {}
+    for idx, lab in zip(index_list, labels):
+        parts.setdefault(int(lab), []).append(idx)
+    parts = [parts[k] for k in sorted(parts)]
+    if len(parts) < 2:
+        # Degenerate (all distances equal): cut by rank into cap-sized chunks.
+        return [list(index_list[i:i + cap]) for i in range(0, len(index_list), cap)]
+    out = []
+    for part in parts:
+        out.extend(_split_to_cap(part, dist, cap))
+    return out
+
+
+def build_partition(job_instance, params=None, feature_map=None):
+    """Compute the deterministic partition. Returns a plain dict:
+
+    {
+      "method", "version", "params",
+      "nodes": [ids in rank order], "ranks": {id: 1-based rank},
+      "pvalues": {id: combined Fisher p}, "major": {id: n significant omics},
+      "clusters": [ {id, label, members:[ids rank-ordered], satellites:[ids],
+                     core:[{symbol, key, count}], hub_core:[...], hub_driven,
+                     sources:[...], best_pvalue, size} ],
+      "standalone": [ids], "further": [ids],
+      "unit_of": {id: cluster id | "standalone" | "further"},
+    }
+    An empty universe returns clusters=[] with the other fields empty.
+    """
+    p = dict(DEFAULT_PARAMS, **(params or {}))
+    ranked = select_network_nodes(job_instance, p)
+    ids = [pid for pid, _pw in ranked]
+    pw_by_id = dict(ranked)
+    ranks = {pid: i + 1 for i, pid in enumerate(ids)}
+    pvalues = {pid: _fisher_min_pvalue(pw) for pid, pw in ranked}
+    major = {}
+    for pid, pw in ranked:
+        try:
+            major[pid] = _count_significant_omics(pw)
+        except Exception:
+            major[pid] = 0
+
+    result = {"method": METHOD, "version": VERSION, "params": p,
+              "nodes": ids, "ranks": ranks, "pvalues": pvalues, "major": major,
+              "clusters": [], "standalone": [], "further": [], "unit_of": {}}
+    if not ids:
+        return result
+
+    feature_map = feature_map if feature_map is not None else canonical_feature_map(job_instance)
+    sets = pathway_feature_sets(job_instance, ids, feature_map)
+    symbol_of_key = {}
+    for _gid, (key, symbol) in feature_map.items():
+        symbol_of_key.setdefault(key, symbol)
+
+    # Cluster over the ids in a fixed (sorted) order so the linkage input is
+    # independent of dict iteration; ranks are re-applied afterwards.
+    order = sorted(ids)
+    if len(order) >= 2:
+        sim = dice_matrix(order, sets)
+        dist = 1.0 - sim
+        np.fill_diagonal(dist, 0.0)
+        raw_groups = _cut_groups(list(range(len(order))), dist, 1.0 - p["cut"])
+    else:
+        sim = np.ones((1, 1))
+        raw_groups = [[0]]
+
+    groups, isolates = [], []
+    for g in raw_groups:
+        for part in _split_to_cap(g, dist, p["cap"]) if len(g) > p["cap"] else [g]:
+            if len(part) >= p["min_size"]:
+                groups.append(part)
+            else:
+                isolates.extend(part)
+
+    # Satellite attachment: single pass against the pre-attach clusters, so
+    # the outcome does not depend on the order isolates are visited.
+    satellites = {gi: [] for gi in range(len(groups))}
+    still_isolated = []
+    for idx in sorted(isolates, key=lambda i: ranks[order[i]]):
+        best_gi, best_mean = None, 0.0
+        for gi, g in enumerate(groups):
+            mean = float(np.mean([sim[idx, j] for j in g]))
+            if mean >= p["attach"] and mean > best_mean and \
+                    len(satellites[gi]) < p["satellites_per"]:
+                best_gi, best_mean = gi, mean
+        if best_gi is None:
+            still_isolated.append(idx)
+        else:
+            satellites[best_gi].append(idx)
+
+    # Hub features: present in >= hub_fraction of all nodes; a core made only
+    # of these is overlap the whole network shares, not this cluster's biology.
+    n_nodes = len(ids)
+    key_counts = {}
+    for pid in ids:
+        for k in sets[pid]:
+            key_counts[k] = key_counts.get(k, 0) + 1
+    hub_keys = {k for k, c in key_counts.items()
+                if n_nodes >= 4 and c >= math.ceil(p["hub_fraction"] * n_nodes)}
+
+    def _label_for(key):
+        if key.startswith("C:"):
+            return key[2:]
+        return symbol_of_key.get(key, key.split(":", 1)[-1])
+
+    clusters = []
+    for gi, g in enumerate(groups):
+        members = sorted((order[i] for i in g), key=lambda pid: ranks[pid])
+        sats = sorted((order[i] for i in satellites[gi]), key=lambda pid: ranks[pid])
+        # Strict-majority core over the core members (pairs -> intersection).
+        need = len(members) // 2 + 1
+        counts = {}
+        for pid in members:
+            for k in sets[pid]:
+                counts[k] = counts.get(k, 0) + 1
+        core_all = sorted(((k, c) for k, c in counts.items() if c >= need),
+                          key=lambda kc: (-kc[1], _label_for(kc[0]).lower(), kc[0]))
+        specific = [{"symbol": _label_for(k), "key": k, "count": c}
+                    for k, c in core_all if k not in hub_keys]
+        hub_core = [{"symbol": _label_for(k), "key": k, "count": c}
+                    for k, c in core_all if k in hub_keys]
+        clusters.append({
+            "members": members, "satellites": sats,
+            "core": specific[:p["core_limit"]], "core_size": len(specific),
+            "hub_core": hub_core[:p["core_limit"]], "hub_core_size": len(hub_core),
+            "hub_driven": bool(core_all) and not specific,
+            "sources": sorted({getattr(pw_by_id[pid], "source", "?") for pid in members + sats}),
+            "best_pvalue": pvalues[members[0]],
+            "size": len(members) + len(sats),
+        })
+    # Cluster order = rank of the best member; ids follow that order.
+    clusters.sort(key=lambda c: (ranks[c["members"][0]], c["members"][0]))
+    for i, c in enumerate(clusters, 1):
+        c["id"] = "C%02d" % i
+        best = pw_by_id[c["members"][0]]
+        if len(c["members"]) == 2 and not c["satellites"]:
+            c["label"] = "%s & %s" % (best.name, pw_by_id[c["members"][1]].name)
+        else:
+            c["label"] = "%s (+%d related)" % (best.name, c["size"] - 1)
+        for pid in c["members"] + c["satellites"]:
+            result["unit_of"][pid] = c["id"]
+
+    standalone, further = [], []
+    for idx in sorted(still_isolated, key=lambda i: ranks[order[i]]):
+        pid = order[idx]
+        if major.get(pid, 0) >= 2 or ranks[pid] <= p["standalone_top"]:
+            standalone.append(pid)
+            result["unit_of"][pid] = "standalone"
+        else:
+            further.append(pid)
+            result["unit_of"][pid] = "further"
+
+    result["clusters"] = clusters
+    result["standalone"] = standalone
+    result["further"] = further
+    return result
+
+
+def partition_member_ids(partition):
+    """Every pathway the partition covers, in global rank order."""
+    ranks = partition.get("ranks") or {}
+    ids = set(partition.get("unit_of") or {})
+    return sorted(ids, key=lambda pid: (ranks.get(pid, 10 ** 9), pid))
+
+
+def partition_summary(partition):
+    """One human line, for logs and the report header."""
+    n = len(partition.get("nodes") or [])
+    return ("%d significant pathways -> %d clusters (%d pathways), %d standalone, "
+            "%d further" % (
+                n, len(partition.get("clusters") or []),
+                sum(c["size"] for c in partition.get("clusters") or []),
+                len(partition.get("standalone") or []),
+                len(partition.get("further") or [])))
+
+
+# ---------------------------------------------------------------------------
+# Units and batches for the interpreter
+# ---------------------------------------------------------------------------
+
+def build_units(partition, pathway_ctx_by_id):
+    """Interpretation units in rank order of their best member.
+
+    Each unit: {"kind": "cluster"|"standalone"|"further", "id", "label",
+    "pathways": [context dicts, rank order], "cluster": cluster dict or None}.
+    Pathways missing from the context (should not happen) are skipped; a
+    cluster left with < 2 pathways is demoted to standalone units.
+    """
+    units = []
+    for c in partition.get("clusters") or []:
+        pws = [pathway_ctx_by_id[pid] for pid in c["members"] + c["satellites"]
+               if pid in pathway_ctx_by_id]
+        if len(pws) >= 2:
+            units.append({"kind": "cluster", "id": c["id"], "label": c["label"],
+                          "pathways": pws, "cluster": c})
+        else:
+            for pw in pws:
+                units.append({"kind": "standalone", "id": pw["id"],
+                              "label": pw["name"], "pathways": [pw], "cluster": None})
+    for pid in partition.get("standalone") or []:
+        pw = pathway_ctx_by_id.get(pid)
+        if pw:
+            units.append({"kind": "standalone", "id": pid, "label": pw["name"],
+                          "pathways": [pw], "cluster": None})
+    further = [pathway_ctx_by_id[pid] for pid in partition.get("further") or []
+               if pid in pathway_ctx_by_id]
+    if further:
+        units.append({"kind": "further", "id": "further",
+                      "label": "Further significant pathways",
+                      "pathways": further, "cluster": None})
+    ranks = partition.get("ranks") or {}
+    units.sort(key=lambda u: (u["kind"] == "further",
+                              min(ranks.get(pw["id"], 10 ** 9) for pw in u["pathways"])))
+    return units
+
+
+def pack_units(units, max_pathways=8):
+    """Group units into interpretation batches without ever splitting a unit.
+
+    Greedy in unit order (rank of best member): a batch takes the next unit
+    while its pathway total stays within ``max_pathways``; a unit larger than
+    the limit travels alone. The "further" pool is chunked on its own.
+    """
+    batches, current, count = [], [], 0
+    for u in units:
+        if u["kind"] == "further":
+            if current:
+                batches.append(current)
+                current, count = [], 0
+            pws = u["pathways"]
+            for i in range(0, len(pws), max_pathways):
+                batches.append([dict(u, pathways=pws[i:i + max_pathways])])
+            continue
+        n = len(u["pathways"])
+        if current and count + n > max_pathways:
+            batches.append(current)
+            current, count = [], 0
+        current.append(u)
+        count += n
+    if current:
+        batches.append(current)
+    return batches
+
+
+def batch_pathways(batch):
+    """All pathway context dicts of a batch, in global rank order (by
+    combined p, the order build_pathway_context returns)."""
+    seen, out = set(), []
+    for u in batch:
+        for pw in u["pathways"]:
+            if pw["id"] not in seen:
+                seen.add(pw["id"])
+                out.append(pw)
+    out.sort(key=lambda pw: (pw.get("combined_pvalue") or 1.0, pw.get("id")))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Prompt and report rendering (deterministic text; the model never
+# recomputes any of it)
+# ---------------------------------------------------------------------------
+
+def _fmt_p(p):
+    try:
+        return "%.2e" % float(p)
+    except Exception:
+        return "n/a"
+
+
+def _member_line(pw, partition, mark=""):
+    ranks = partition.get("ranks") or {}
+    major = partition.get("major") or {}
+    return "- #%s %s (%s, %s; combined p=%s; significant omic layers: %s)%s" % (
+        ranks.get(pw["id"], "?"), pw["name"], pw["id"], pw.get("source", "?"),
+        _fmt_p(pw.get("combined_pvalue")), major.get(pw["id"], pw.get("significant_omic_count", "?")),
+        mark)
+
+
+def render_units_block(batch, partition, total_nodes=None):
+    """The cluster context prepended to an interpretation batch prompt.
+
+    Names each unit, its members with GLOBAL rank (#k of N), the shared core
+    (with member counts), hub-shared features separately, satellites, and how
+    to treat the unit. Ranks are the reader's anchor: the report's emphasis
+    must follow them, the clusters only say what belongs together.
+    """
+    n = total_nodes or len(partition.get("nodes") or [])
+    lines = ["## Pathway clusters in this batch (computed from shared matched features)",
+             "Rank #k is the pathway's position among the %d significant pathways of this "
+             "analysis by combined p-value (1 = most significant). Give the most attention "
+             "to the highest-ranked pathways wherever they sit." % n]
+    for u in batch:
+        if u["kind"] == "cluster":
+            c = u["cluster"]
+            lines.append("")
+            lines.append("### %s: %s -- %d pathways, %s" % (
+                c["id"], c["label"], c["size"], "/".join(c["sources"])))
+            sat_ids = set(c.get("satellites") or [])
+            for pw in u["pathways"]:
+                lines.append(_member_line(pw, partition,
+                                          "  [loosely connected]" if pw["id"] in sat_ids else ""))
+            core = c.get("core") or []
+            if core:
+                lines.append("Shared core (features matched in a majority of the members; "
+                             "count = members carrying it): " +
+                             ", ".join("%s(%d)" % (f["symbol"], f["count"]) for f in core) +
+                             (" ... +%d more" % (c["core_size"] - len(core))
+                              if c.get("core_size", 0) > len(core) else ""))
+            hub = c.get("hub_core") or []
+            if hub:
+                lines.append("Also shared, but common across the whole network (hub features, "
+                             "not specific to this cluster): " +
+                             ", ".join(f["symbol"] for f in hub[:8]))
+            if c.get("hub_driven"):
+                lines.append("NOTE: this cluster is held together only by hub features shared "
+                             "across the network -- treat it as overlap, not as one biological "
+                             "module, and say so.")
+            lines.append("Interpret this cluster as one unit: first what unites the members "
+                         "(shared core = coordinated biology, or hub-gene overlap = annotation "
+                         "artefact -- judge from the data), then each member briefly, "
+                         "highest-ranked first, naming every member.")
+        elif u["kind"] == "standalone":
+            pw = u["pathways"][0]
+            lines.append("")
+            lines.append("### Standalone pathway (no shared-feature cluster)")
+            lines.append(_member_line(pw, partition))
+            lines.append("Interpret it on its own; do not invent links to other pathways.")
+        else:
+            lines.append("")
+            lines.append("### Further significant pathways (no shared-feature cluster, "
+                         "single-layer evidence)")
+            for pw in u["pathways"]:
+                lines.append(_member_line(pw, partition))
+            lines.append("Give each one or two sentences on what its enrichment means for "
+                         "this experiment, naming the layer that carries it; do not group them.")
+    return "\n".join(lines)
+
+
+def render_synthesis_block(partition, pathway_ctx_by_id):
+    """Cluster map for the synthesis prompt: every cluster with rank-ordered
+    members, standalone and further pathways, and the writing rules that keep
+    the rank presentation intact."""
+    ranks = partition.get("ranks") or {}
+    n = len(partition.get("nodes") or [])
+    lines = ["## Pathway clusters (from the data)",
+             "The %d significant pathways were clustered by shared matched features "
+             "(Sorensen-Dice on genes and compounds). %s. Members are listed by global "
+             "rank (#k = k-th most significant)." % (n, partition_summary(partition))]
+    for c in partition.get("clusters") or []:
+        names = []
+        for pid in c["members"] + c["satellites"]:
+            pw = pathway_ctx_by_id.get(pid)
+            nm = pw["name"] if pw else pid
+            names.append("#%s %s%s" % (ranks.get(pid, "?"), nm,
+                                       " (loose)" if pid in c["satellites"] else ""))
+        core = ", ".join(f["symbol"] for f in (c.get("core") or [])[:8])
+        lines.append("- %s %s: %s%s%s" % (
+            c["id"], c["label"], "; ".join(names),
+            (" | shared core: " + core) if core else "",
+            " | HUB-DRIVEN (overlap, not a module)" if c.get("hub_driven") else ""))
+    if partition.get("standalone"):
+        lines.append("- Standalone: " + "; ".join(
+            "#%s %s" % (ranks.get(pid, "?"), (pathway_ctx_by_id.get(pid) or {}).get("name", pid))
+            for pid in partition["standalone"]))
+    if partition.get("further"):
+        lines.append("- Further significant pathways (single-layer, unclustered): " + "; ".join(
+            "#%s %s" % (ranks.get(pid, "?"), (pathway_ctx_by_id.get(pid) or {}).get("name", pid))
+            for pid in partition["further"]))
+    lines += [
+        "",
+        "Writing rules for the clusters:",
+        "- Key Findings lead with the highest-RANKED pathways and their clusters; rank, "
+        "not cluster size, decides emphasis.",
+        "- Use the clusters as the themes of 'Cross-Pathway Themes' and group 'Detailed "
+        "Pathway Analysis' by cluster, in the order given (best-ranked member first), "
+        "heading each as '### Cxx -- <label>' and naming every member (a member with little "
+        "to add gets one clause, not silence).",
+        "- Add a 'Standalone pathways' subsection for the standalone ones and a one-line "
+        "reading for each further pathway; nothing significant is dropped.",
+        "- A HUB-DRIVEN cluster is shared-gene overlap: say so; do not narrate it as one "
+        "coordinated module.",
+    ]
+    return "\n".join(lines)
+
+
+def render_partition_table(partition, pathway_ctx_by_id):
+    """Appended to the report after the pathway table: the partition as data."""
+    ranks = partition.get("ranks") or {}
+    lines = ["## Pathway Clusters (shared matched features)",
+             "*%s. Clusters: average-linkage on Sorensen-Dice similarity of matched "
+             "features, cut at Dice >= %.2f, at most %d core members; loosely connected "
+             "= attached at mean Dice >= %.2f.*" % (
+                 partition_summary(partition), partition["params"]["cut"],
+                 partition["params"]["cap"], partition["params"]["attach"]),
+             "", "| Cluster | Pathways (global rank) | Shared core |", "|---|---|---|"]
+    for c in partition.get("clusters") or []:
+        names = []
+        for pid in c["members"] + c["satellites"]:
+            pw = pathway_ctx_by_id.get(pid)
+            names.append("%s (#%s%s)" % (pw["name"] if pw else pid, ranks.get(pid, "?"),
+                                          ", loose" if pid in c["satellites"] else ""))
+        core = ", ".join(f["symbol"] for f in (c.get("core") or [])[:10])
+        if c.get("hub_driven"):
+            core = (core + "; " if core else "") + "hub features only"
+        lines.append("| %s %s | %s | %s |" % (c["id"], c["label"].replace("|", "/"),
+                                            "; ".join(names).replace("|", "/"),
+                                            core.replace("|", "/") or "-"))
+    for kind, title in (("standalone", "Standalone"), ("further", "Further")):
+        for pid in partition.get(kind) or []:
+            pw = pathway_ctx_by_id.get(pid)
+            lines.append("| %s | %s (#%s) | - |" % (
+                title, (pw["name"] if pw else pid).replace("|", "/"), ranks.get(pid, "?")))
+    return "\n".join(lines)
+
+
+def cluster_search_queries(partition, pathway_ctx_by_id, organism_name, system_angle=""):
+    """Gene-anchored PubMed queries per unit, replacing the per-pathway backfill.
+
+    Yields (query, attribution_key, member_names, rationale). One or two
+    queries per cluster from its specific core (or its best member's top genes
+    when the core is thin), one per standalone pathway, one per further
+    pathway. Attribution key is the cluster id (mapped to member names by the
+    caller) so retrieved papers reach every member's drill-down.
+    """
+    def _genes_of(pw):
+        return [g["symbol"] for g in (pw.get("top_genes") or []) if g.get("relevant")
+                and not _ugly(g.get("symbol"))]
+
+    for c in partition.get("clusters") or []:
+        members = [pathway_ctx_by_id[pid] for pid in c["members"] if pid in pathway_ctx_by_id]
+        if not members:
+            continue
+        names = [pw["name"] for pw in members] + [
+            pathway_ctx_by_id[pid]["name"] for pid in c["satellites"] if pid in pathway_ctx_by_id]
+        genes = [f["symbol"] for f in (c.get("core") or []) if not _ugly(f["symbol"])
+                 and not f["key"].startswith("C:")]
+        if len(genes) < 2:
+            genes = genes + [g for g in _genes_of(members[0]) if g not in genes]
+        genes = genes[:6]
+        if not genes:
+            continue
+        yield ("(%s) AND (%s)" % (" OR ".join(genes[:3]), organism_name), c["id"], names,
+               "cluster core genes")
+        if system_angle:
+            yield ("(%s) AND %s" % (" OR ".join(genes[:3]), system_angle), c["id"], names,
+                   "cluster core genes, experimental system")
+        elif len(genes) > 3:
+            yield ("(%s) AND (%s)" % (" OR ".join(genes[3:6]), organism_name), c["id"], names,
+                   "cluster core genes (second set)")
+    for kind in ("standalone", "further"):
+        for pid in partition.get(kind) or []:
+            pw = pathway_ctx_by_id.get(pid)
+            if not pw:
+                continue
+            genes = _genes_of(pw)[:3]
+            if genes:
+                q = "(%s) AND (%s)" % (" OR ".join(genes), system_angle or organism_name)
+            else:
+                q = '"%s"[Title/Abstract]' % pw["name"]
+            yield (q, pw["name"], [pw["name"]], "%s pathway" % kind)

--- a/PaintomicsServer/src/classes/AIInterpret/clusters.py
+++ b/PaintomicsServer/src/classes/AIInterpret/clusters.py
@@ -64,7 +64,12 @@ CLUSTER_MODE = os.getenv("AI_CLUSTER_MODE", "0") == "1"
 DEFAULT_PARAMS = {
     # Node universe: what the Step 3 network draws under its default filters.
     "min_pvalue": float(os.getenv("AI_CLUSTER_MIN_PVALUE", "0.05")),
-    "min_features": float(os.getenv("AI_CLUSTER_MIN_FEATURES", "0.5")),
+    # The network view also hides pathways with < 50% of their features
+    # matched; that is visual de-clutter, not a significance rule, and applying
+    # it here dropped a top-8 pathway from the AI's universe entirely (round 6
+    # B1: 'Ribosome biogenesis in eukaryotes' absent from the report). Off by
+    # default; the caller also pins its top-N via always_include.
+    "min_features": float(os.getenv("AI_CLUSTER_MIN_FEATURES", "0")),
     "max_nodes": int(os.getenv("AI_CLUSTER_MAX_NODES", "150")),
     # Partition. Dice 0.25 rather than the slider's 0.10: at 0.10 the top raw
     # group on the STATegra example is 47 pathways of hub-gene overlap and any
@@ -254,35 +259,45 @@ def _load_total_features(organism):
     return totals
 
 
-def select_network_nodes(job_instance, params=None):
+def select_network_nodes(job_instance, params=None, always_include=None):
     """The significant pathways the network draws, ranked by combined p.
 
     Returns a list of (pathway_id, pathway) in rank order (best p first, ties
     by id). Applies the network view's defaults: combined Fisher p <= min_pvalue
     (min over conditions), matched features >= min_features x pathway total
-    when the pathway total is known, and drops the organism-wide map
-    (<org>01100). Capped at max_nodes by rank.
+    when the pathway total is known and min_features > 0, and drops the
+    organism-wide map (<org>01100). ``always_include`` ids are kept regardless
+    of the filters (the caller's top-N by p-value must never fall out of the
+    universe). Capped at max_nodes by rank, forced ids first.
     """
     p = dict(DEFAULT_PARAMS, **(params or {}))
     matched = job_instance.getMatchedPathways() or {}
     organism = str(job_instance.getOrganism() or "")
     totals = _load_total_features(organism) if p["min_features"] > 0 else {}
+    forced = {str(i) for i in (always_include or [])}
     rows = []
     for pid, pw in matched.items():
         pid = str(pid)
         if pid == organism + "01100":
             continue
         pval = _fisher_min_pvalue(pw)
-        if pval is None or pval > p["min_pvalue"]:
-            continue
-        n_matched = len(getattr(pw, "matchedGenes", None) or []) + \
-            len(getattr(pw, "matchedCompounds", None) or [])
-        total = totals.get(pid)
-        if total and total * p["min_features"] > n_matched:
-            continue
-        rows.append((pval, pid, pw))
-    rows.sort(key=lambda r: (r[0], r[1]))
-    return [(pid, pw) for _p, pid, pw in rows[:p["max_nodes"]]]
+        if pval is None:
+            pval = 1.0
+        keep = pid in forced
+        if not keep:
+            if pval > p["min_pvalue"]:
+                continue
+            n_matched = len(getattr(pw, "matchedGenes", None) or []) + \
+                len(getattr(pw, "matchedCompounds", None) or [])
+            total = totals.get(pid)
+            if total and total * p["min_features"] > n_matched:
+                continue
+        rows.append((pid not in forced, pval, pid, pw))
+    rows.sort(key=lambda r: (r[0], r[1], r[2]))
+    kept = rows[:p["max_nodes"]]
+    # Rank order is by p-value alone; forcing only decides membership.
+    kept.sort(key=lambda r: (r[1], r[2]))
+    return [(pid, pw) for _f, _p, pid, pw in kept]
 
 
 # ---------------------------------------------------------------------------
@@ -343,7 +358,7 @@ def _split_to_cap(index_list, dist, cap):
     return out
 
 
-def build_partition(job_instance, params=None, feature_map=None):
+def build_partition(job_instance, params=None, feature_map=None, always_include=None):
     """Compute the deterministic partition. Returns a plain dict:
 
     {
@@ -359,7 +374,7 @@ def build_partition(job_instance, params=None, feature_map=None):
     An empty universe returns clusters=[] with the other fields empty.
     """
     p = dict(DEFAULT_PARAMS, **(params or {}))
-    ranked = select_network_nodes(job_instance, p)
+    ranked = select_network_nodes(job_instance, p, always_include)
     ids = [pid for pid, _pw in ranked]
     pw_by_id = dict(ranked)
     ranks = {pid: i + 1 for i, pid in enumerate(ids)}

--- a/PaintomicsServer/src/classes/AIInterpret/context_builder.py
+++ b/PaintomicsServer/src/classes/AIInterpret/context_builder.py
@@ -6,14 +6,24 @@ import re
 import os
 
 
-def build_pathway_context(job_instance, max_pathways=15):
-    """Extract curated data for LLM. Target: <5,000 tokens for pathway section."""
+def build_pathway_context(job_instance, max_pathways=15, pathway_ids=None):
+    """Extract curated data for LLM. Target: <5,000 tokens for pathway section.
+
+    ``pathway_ids`` selects an explicit set (any size, unknown ids ignored)
+    instead of the top ``max_pathways`` by combined p; the result is still in
+    rank order, so callers that present pathways keep the global ranking.
+    """
     matched = job_instance.getMatchedPathways()
     input_genes = job_instance.getInputGenesData()
     header_map = _build_omic_header_map(job_instance)
 
     # Sort by best combined p-value
-    sorted_pws = sorted(matched.values(), key=lambda pw: _best_pval(pw))[:max_pathways]
+    if pathway_ids is not None:
+        wanted = {str(pid) for pid in pathway_ids}
+        sorted_pws = sorted((pw for pid, pw in matched.items() if str(pid) in wanted),
+                            key=lambda pw: (_best_pval(pw), str(pw.ID)))
+    else:
+        sorted_pws = sorted(matched.values(), key=lambda pw: _best_pval(pw))[:max_pathways]
 
     pathways = []
     for pw in sorted_pws:

--- a/PaintomicsServer/src/common/DAO/AIInterpretDAO.py
+++ b/PaintomicsServer/src/common/DAO/AIInterpretDAO.py
@@ -84,6 +84,39 @@ class AIInterpretDAO(DAO):
         doc = collection.find_one({"jobID": job_id}, {"pathwayIndex": 1})
         return (doc or {}).get("pathwayIndex", []) or []
 
+    def save_clusters(self, job_id, partition):
+        """Store the shared-feature pathway partition the report was written
+        from (cluster mode only): clusters with member ids, shared-core
+        symbols and hub flag, plus the standalone / further pathway ids and
+        the parameters. Compact by design -- ranks and p-values are already
+        in pathwayIndex, and feature keys stay out of the document."""
+        clusters = [
+            {"id": c.get("id"), "label": c.get("label"),
+             "members": list(c.get("members") or []),
+             "satellites": list(c.get("satellites") or []),
+             "core": [f.get("symbol") for f in (c.get("core") or [])],
+             "hub_driven": bool(c.get("hub_driven")),
+             "sources": list(c.get("sources") or [])}
+            for c in (partition.get("clusters") or [])
+        ]
+        doc = {"method": partition.get("method"), "version": partition.get("version"),
+               "params": {k: v for k, v in (partition.get("params") or {}).items()},
+               "nodes": len(partition.get("nodes") or []),
+               "clusters": clusters,
+               "standalone": list(partition.get("standalone") or []),
+               "further": list(partition.get("further") or [])}
+        collection = self.dbManager.getCollection(self.collectionName)
+        collection.update_one(
+            {"jobID": job_id},
+            {"$set": {"clusters": doc, "updatedAt": datetime.utcnow()}},
+            upsert=True
+        )
+
+    def get_clusters(self, job_id):
+        collection = self.dbManager.getCollection(self.collectionName)
+        doc = collection.find_one({"jobID": job_id}, {"clusters": 1})
+        return (doc or {}).get("clusters") or None
+
     def get_pathway_report(self, job_id, pathway_id):
         """Return a cached per-pathway interpretation, or None.
 

--- a/PaintomicsServer/src/servlets/AIInterpretServlet.py
+++ b/PaintomicsServer/src/servlets/AIInterpretServlet.py
@@ -318,6 +318,10 @@ def aiInterpretReport(REQUEST, RESPONSE):
                 # Lets the client turn pathway names in the report prose into
                 # links that open the pathway. Sent as id/name/source only.
                 "pathways": record.get("pathwayIndex", []),
+                # Cluster mode only: the shared-feature partition the report
+                # was written from (cluster ids, labels, member ids, core
+                # symbols), so the network view can colour by cluster.
+                "clusters": record.get("clusters"),
             })
     except Exception as ex:
         handleException(RESPONSE, ex, __file__, "aiInterpretReport", userID=userID)
@@ -641,6 +645,46 @@ def aiGenerateExpDesign(REQUEST, RESPONSE, EXAMPLE_FILES_DIR=None):
         return RESPONSE
 
 
+def _clusterContextBlock(clusters, pathwayID, pathwayIndex):
+    """Prompt text describing the stored cluster a pathway belongs to, or "".
+
+    Reads the compact partition AIInterpretDAO.save_clusters stores; names come
+    from the pathway index. Never raises -- a malformed record just yields no
+    block, and the drill-down proceeds as it did before cluster mode.
+    """
+    try:
+        if not clusters:
+            return ""
+        names = {p.get("id"): p.get("name") for p in (pathwayIndex or [])}
+        for c in clusters.get("clusters") or []:
+            members = list(c.get("members") or [])
+            satellites = list(c.get("satellites") or [])
+            if pathwayID not in members and pathwayID not in satellites:
+                continue
+            others = [names.get(pid, pid) for pid in members + satellites if pid != pathwayID]
+            lines = ["## Cluster context (from the analysis)",
+                     "This pathway belongs to %s (%s), a group of %d pathways that share "
+                     "matched features%s." % (
+                         c.get("id"), c.get("label"), len(members) + len(satellites),
+                         " (loosely connected)" if pathwayID in satellites else "")]
+            if others:
+                lines.append("Other members: " + "; ".join(others))
+            core = [s for s in (c.get("core") or []) if s]
+            if core:
+                lines.append("Shared core: " + ", ".join(core[:12]))
+            if c.get("hub_driven"):
+                lines.append("The cluster is held together only by hub features common to "
+                             "the whole network; do not present it as one module.")
+            lines.append("Say what THIS pathway adds beyond what the cluster shares.")
+            return "\n".join(lines)
+        if pathwayID in (clusters.get("standalone") or []):
+            return ("## Cluster context (from the analysis)\nThis pathway shares no cluster "
+                    "with any other significant pathway (standalone).")
+        return ""
+    except Exception:
+        return ""
+
+
 def aiInterpretPathway(REQUEST, RESPONSE):
     """Return a focused AI interpretation of one pathway.
 
@@ -709,7 +753,10 @@ def aiInterpretPathway(REQUEST, RESPONSE):
         # Rebuild the full context and pick this pathway out of it. The stored
         # index deliberately holds only display fields; the gene-level detail
         # the prompt needs has to be recomputed.
-        allPathways = build_pathway_context(jobInstance, max_pathways=AI_MAX_PATHWAYS)
+        # Selected by id rather than "top AI_MAX_PATHWAYS by p-value": in
+        # cluster mode the index covers every significant pathway, most of
+        # which sit far below the top 15.
+        allPathways = build_pathway_context(jobInstance, pathway_ids=[pathwayID])
         pathway = next((p for p in allPathways if p.get("id") == pathwayID), None)
         if pathway is None:
             raise UserWarning("Pathway " + pathwayID + " is no longer present in this job's results.")
@@ -725,6 +772,12 @@ def aiInterpretPathway(REQUEST, RESPONSE):
         organismName = get_organism_name(jobInstance.getOrganism())
         llm = LLMClient(AI_PROVIDERS[AI_LLM_PROVIDER], AI_LLM_PROVIDER)
         prompt = build_pathway_focus_prompt(pathway, papers, experimentDesign, organismName)
+        # Cluster mode: tell the focus prompt which cluster this pathway sits
+        # in and what its members share, so the drill-down can say what this
+        # pathway adds beyond its cluster rather than re-describing the core.
+        clusterBlock = _clusterContextBlock(record.get("clusters"), pathwayID, pathwayIndex)
+        if clusterBlock:
+            prompt += "\n\n" + clusterBlock
 
         report = llm.complete(
             messages=[

--- a/PaintomicsServer/src/tests/test_module_imports.py
+++ b/PaintomicsServer/src/tests/test_module_imports.py
@@ -46,6 +46,7 @@ CRITICAL = (
     "src.paintomicsserver",
     "src.classes.AIInterpret.agent",
     "src.classes.AIInterpret.shared",
+    "src.classes.AIInterpret.clusters",
     "src.classes.AIInterpret.llm_client",
     "src.classes.AIInterpret.verification",
     "src.classes.AIInterpret.context_builder",

--- a/PaintomicsServer/src/tests/test_pathway_clusters.py
+++ b/PaintomicsServer/src/tests/test_pathway_clusters.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""The shared-feature pathway partition behind cluster-first interpretation.
+
+Pure computation, so this needs no LLM, no MongoDB and no network. It pins
+the contracts agent.py relies on:
+
+* a cluster has at least two members -- a size-1 group is an isolate;
+* KEGG (Entrez) and Reactome (symbol) clones of the same input feature join,
+  so a pathway pair spanning both databases can share a cluster;
+* the isolate rule: satellite attach, then standalone (major or top-ranked),
+  else "further" -- nothing significant is dropped;
+* determinism: same job -> identical partition;
+* packing never splits a unit and keeps global rank order inside a batch;
+* every rendered block carries global ranks (cluster for context, never for
+  order -- the evolve-loop lesson).
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_pathway_clusters
+"""
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from src.classes.AIInterpret import clusters as C  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fakes with exactly the surface clusters.py touches
+# ---------------------------------------------------------------------------
+
+class _OV:
+    def __init__(self, omic, input_name, values, relevant=True):
+        self.omicName, self.inputName, self.values, self.relevant = omic, input_name, values, relevant
+
+    def getOmicName(self):
+        return self.omicName
+
+    def getInputName(self):
+        return self.inputName
+
+    def getValues(self):
+        return self.values
+
+    def isRelevant(self):
+        return self.relevant
+
+
+class _Feature:
+    def __init__(self, fid, name, omics):
+        self.ID, self.name, self.omicsValues = fid, name, omics
+
+    def getName(self):
+        return self.name
+
+    def getOmicsValues(self):
+        return self.omicsValues
+
+
+class _Pathway:
+    def __init__(self, pid, name, source, genes, compounds=(), fisher=1e-3, sig_omics=None):
+        self.ID, self.name, self.source = pid, name, source
+        self.matchedGenes = list(genes)
+        self.matchedCompounds = list(compounds)
+        self.combinedSignificancePvalues = {"Fisher": [fisher], "Stouffer": [fisher * 2]}
+        # significanceValues[omic] = [[matched, relevant, p]] per condition
+        sig = sig_omics or {"Gene expression": 0.01}
+        self.significanceValues = {o: [[5, 3, p]] for o, p in sig.items()}
+        self.globalOmicPvalues = {o: p for o, p in sig.items()}
+
+
+class _Job:
+    def __init__(self, pathways, genes, organism="mmu"):
+        self._p = {p.ID: p for p in pathways}
+        self._g = genes
+        self._o = organism
+
+    def getMatchedPathways(self):
+        return self._p
+
+    def getInputGenesData(self):
+        return self._g
+
+    def getGeneBasedInputOmics(self):
+        return [{"omicName": "Gene expression", "omicHeader": ["id", "0h", "2h", "6h"]}]
+
+    def getOrganism(self):
+        return self._o
+
+
+def _genes(n_entrez=40):
+    """KEGG clones 1..n keyed by Entrez id, plus Reactome clones for the first
+    ten keyed by an upper-case symbol, both carrying the same input name."""
+    genes = {}
+    for i in range(1, n_entrez + 1):
+        ent = str(1000 + i)
+        sym = "Gene%d" % i
+        ens = "ENSMUSG%011d" % i
+        genes[ent] = _Feature(ent, sym, [_OV("Gene expression", ens, [0.1 * i, 0.5, 1.0])])
+        if i <= 10:
+            genes[sym.upper()] = _Feature(sym.upper(), ens,
+                                          [_OV("Gene expression", ens, [0.1 * i, 0.5, 1.0])])
+    return genes
+
+
+def _job():
+    E = lambda *ids: [str(1000 + i) for i in ids]  # noqa: E731
+    R = lambda *ids: ["GENE%d" % i for i in ids]  # noqa: E731
+    pathways = [
+        # A/B/C: a real cluster (share genes 1-8), best p first.
+        _Pathway("mmu00001", "Alpha signaling", "KEGG", E(1, 2, 3, 4, 5, 6, 7, 8, 21), fisher=1e-6,
+                 sig_omics={"Gene expression": 0.001, "Proteomics": 0.01}),
+        _Pathway("mmu00002", "Beta signaling", "KEGG", E(1, 2, 3, 4, 5, 6, 7, 8, 22, 23), fisher=1e-5),
+        _Pathway("mmu00003", "Gamma signaling", "KEGG", E(1, 2, 3, 4, 5, 6, 9, 24), fisher=1e-4),
+        # A's Reactome twin: symbols only -- joins A only through the input names.
+        _Pathway("R-MMU-1", "Alpha signalling (Reactome)", "Reactome", R(1, 2, 3, 4, 5, 6, 7, 8),
+                 fisher=2e-6),
+        # D/E: a pair sharing compounds and a few genes.
+        _Pathway("mmu00004", "Delta metabolism", "KEGG", E(30, 31, 32), ("C00001", "C00002", "C00003"),
+                 fisher=1e-3),
+        _Pathway("mmu00005", "Epsilon metabolism", "KEGG", E(30, 31, 33), ("C00001", "C00002", "C00004"),
+                 fisher=2e-3),
+        # F: isolate, major (2 significant omics) -> standalone.
+        _Pathway("mmu00006", "Zeta process", "KEGG", E(35, 36, 37, 38), fisher=3e-3,
+                 sig_omics={"Gene expression": 0.01, "miRNA-seq": 0.02}),
+        # G: isolate, minor, ranks last -> further.
+        _Pathway("mmu00007", "Eta process", "KEGG", E(39, 40), fisher=4e-2),
+        # H: loosely related to the A cluster (1 of 8 core genes, mean Dice
+        # ~0.13: below the 0.25 cut, above the 0.10 attach) -> satellite.
+        _Pathway("mmu00008", "Theta signaling", "KEGG", E(1, 25, 26, 27, 28, 29), fisher=5e-3),
+        # Not significant: must not be a node at all.
+        _Pathway("mmu00009", "Iota nothing", "KEGG", E(1, 2, 3), fisher=0.5),
+    ]
+    return _Job(pathways, _genes())
+
+
+class PartitionTest(unittest.TestCase):
+    def setUp(self):
+        self.job = _job()
+        # standalone_top small so rank alone does not promote the minor isolate.
+        self.params = {"min_features": 0.0, "standalone_top": 3, "hub_fraction": 0.9}
+        self.part = C.build_partition(self.job, self.params)
+
+    def test_universe_is_significant_only_and_ranked(self):
+        self.assertNotIn("mmu00009", self.part["nodes"])
+        self.assertEqual(self.part["nodes"][0], "mmu00001")  # best p
+        self.assertEqual(self.part["ranks"]["mmu00001"], 1)
+        self.assertEqual(len(self.part["nodes"]), 9)
+
+    def test_clusters_have_at_least_two_members(self):
+        self.assertTrue(self.part["clusters"])
+        for c in self.part["clusters"]:
+            self.assertGreaterEqual(len(c["members"]), 2, c)
+
+    def test_cross_database_clones_join(self):
+        # The Reactome twin lands in the same cluster as its KEGG original.
+        unit = self.part["unit_of"]
+        self.assertEqual(unit["R-MMU-1"], unit["mmu00001"])
+        c = next(c for c in self.part["clusters"] if c["id"] == unit["mmu00001"])
+        self.assertEqual(sorted(c["sources"]), ["KEGG", "Reactome"])
+        # And the core is rendered with symbols, not Entrez ids or ENSMUSG.
+        syms = [f["symbol"] for f in c["core"]]
+        self.assertTrue(syms and all(s.startswith("Gene") for s in syms), syms)
+
+    def test_isolate_rule(self):
+        unit = self.part["unit_of"]
+        # Theta shares 2/8 core genes with the A cluster: satellite, not core.
+        self.assertTrue(unit["mmu00008"].startswith("C"))
+        c = next(c for c in self.part["clusters"] if c["id"] == unit["mmu00008"])
+        self.assertIn("mmu00008", c["satellites"])
+        self.assertNotIn("mmu00008", c["members"])
+        # Zeta: major isolate -> standalone. Eta: minor, low rank -> further.
+        self.assertIn("mmu00006", self.part["standalone"])
+        self.assertIn("mmu00007", self.part["further"])
+        # Every significant pathway is accounted for exactly once.
+        self.assertEqual(sorted(unit), sorted(self.part["nodes"]))
+
+    def test_deterministic(self):
+        again = C.build_partition(_job(), self.params)
+        self.assertEqual(json.dumps(self.part, sort_keys=True, default=str),
+                         json.dumps(again, sort_keys=True, default=str))
+
+    def test_cap_split_never_emits_singletons_as_clusters(self):
+        # Force a tiny cap so the A cluster must be split.
+        part = C.build_partition(self.job, dict(self.params, cap=2, attach=0.99))
+        for c in part["clusters"]:
+            self.assertGreaterEqual(len(c["members"]), 2)
+            self.assertLessEqual(len(c["members"]), 2)
+        self.assertEqual(sorted(part["unit_of"]), sorted(part["nodes"]))
+
+
+class UnitsAndRenderingTest(unittest.TestCase):
+    def setUp(self):
+        self.job = _job()
+        self.part = C.build_partition(self.job, {"min_features": 0.0, "standalone_top": 3,
+                                                 "hub_fraction": 0.9})
+        # Minimal pathway-context dicts, as build_pathway_context returns them.
+        self.ctx = {}
+        for pid, pw in self.job.getMatchedPathways().items():
+            if pid in self.part["ranks"]:
+                self.ctx[pid] = {"id": pid, "name": pw.name, "source": pw.source,
+                                 "combined_pvalue": pw.combinedSignificancePvalues["Fisher"][0],
+                                 "significant_omic_count": 1,
+                                 "top_genes": [{"symbol": "Gene1", "relevant": True}]}
+
+    def test_units_and_packing_never_split_a_cluster(self):
+        units = C.build_units(self.part, self.ctx)
+        kinds = [u["kind"] for u in units]
+        self.assertIn("cluster", kinds)
+        self.assertIn("standalone", kinds)
+        self.assertEqual(kinds[-1], "further")
+        batches = C.pack_units(units, max_pathways=3)
+        for b in batches:
+            for u in b:
+                if u["kind"] == "cluster":
+                    # the whole cluster is present in that batch
+                    self.assertEqual(len(u["pathways"]), u["cluster"]["size"])
+            pws = C.batch_pathways(b)
+            ps = [pw["combined_pvalue"] for pw in pws]
+            self.assertEqual(ps, sorted(ps))  # rank order inside the batch
+        covered = sorted(pw["id"] for b in batches for pw in C.batch_pathways(b))
+        self.assertEqual(covered, sorted(self.part["nodes"]))
+
+    def test_rendered_blocks_carry_ranks_and_labels(self):
+        units = C.build_units(self.part, self.ctx)
+        batch = C.pack_units(units, max_pathways=8)[0]
+        block = C.render_units_block(batch, self.part)
+        self.assertIn("#1 Alpha signaling", block)
+        self.assertIn("Shared core", block)
+        synth = C.render_synthesis_block(self.part, self.ctx)
+        self.assertIn("Key Findings lead with the highest-RANKED", synth)
+        self.assertIn("Standalone", synth)
+        table = C.render_partition_table(self.part, self.ctx)
+        self.assertIn("| Cluster |", table)
+        self.assertIn("Zeta process", table)
+
+    def test_search_queries_cover_units(self):
+        qs = list(C.cluster_search_queries(self.part, self.ctx, "Mus musculus", ""))
+        keys = {k for _q, k, _n, _w in qs}
+        self.assertTrue(any(k.startswith("C0") for k in keys))
+        self.assertIn("Zeta process", keys)   # standalone by name
+        for q, _k, names, _w in qs:
+            self.assertIn("AND", q)
+            self.assertTrue(names)
+
+
+class FrozenContextTest(unittest.TestCase):
+    """Optional: the real STATegra frozen fold, when the evolve repo is present."""
+
+    FROZEN = os.path.expanduser(
+        "~/Desktop/github_dev/agentevolve/evaluators/stategra-v4/context.pkl.gz")
+
+    def test_frozen_partition_shape(self):
+        if not os.path.exists(self.FROZEN):
+            self.skipTest("frozen fold not present")
+        sys.path.insert(0, os.path.expanduser("~/Desktop/github_dev/agentevolve"))
+        try:
+            from wrap.freeze import FrozenJobInstance
+        except Exception as e:  # pragma: no cover
+            self.skipTest("evolve harness not importable: %s" % e)
+        job = FrozenJobInstance.load(self.FROZEN)
+        part = C.build_partition(job)
+        self.assertGreater(len(part["clusters"]), 5)
+        for c in part["clusters"]:
+            self.assertGreaterEqual(len(c["members"]), 2)
+        self.assertTrue(any(len(c["sources"]) == 2 for c in part["clusters"]),
+                        "expected at least one KEGG+Reactome cluster")
+        self.assertEqual(sorted(part["unit_of"]), sorted(part["nodes"]))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_pathway_clusters.py
+++ b/PaintomicsServer/src/tests/test_pathway_clusters.py
@@ -183,6 +183,15 @@ class PartitionTest(unittest.TestCase):
         self.assertEqual(json.dumps(self.part, sort_keys=True, default=str),
                          json.dumps(again, sort_keys=True, default=str))
 
+    def test_always_include_pins_the_callers_top_n(self):
+        # The plain path's top-N must never fall out of the cluster universe,
+        # whatever the network filters say (round 6 B1 lost a rank-8 pathway).
+        part = C.build_partition(self.job, self.params, always_include=["mmu00009"])
+        self.assertIn("mmu00009", part["nodes"])
+        self.assertIn("mmu00009", part["unit_of"])
+        # Rank order is still by p-value: the forced (p=0.5) pathway ranks last.
+        self.assertEqual(part["nodes"][-1], "mmu00009")
+
     def test_cap_split_never_emits_singletons_as_clusters(self):
         # Force a tiny cap so the A cluster must be split.
         part = C.build_partition(self.job, dict(self.params, cap=2, attach=0.99))

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -94,7 +94,7 @@ PUBLISHED = {
     "app/view/common/AlignmentGuides.js": (
         "4.2", "ce2ba85063e8059eb2cc4c8e1992744854a14ad0db6f866213b8df1136650a59"),
     "app/view/PathwayAcquisitionViews/PA_AIInterpretView.js": (
-        "0.7", "b009d48e1d6d5d027b80cb59ccdc8e26c2f73f6d9d96443ca8fb62e43530f1e2"),
+        "0.8", "0f1a91d47f5f62a4e03bd28a169e8ce9a08e22bc260b0181be492eb9e5608609"),
     "app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js": (
         "0.7", "b135712a9564f8ae0eac94daf9c567ef275c4c748dbc270fdbdeb7d25fc79e34"),
     "resources/ServerConfiguration.js": (

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -94,7 +94,7 @@ PUBLISHED = {
     "app/view/common/AlignmentGuides.js": (
         "4.2", "ce2ba85063e8059eb2cc4c8e1992744854a14ad0db6f866213b8df1136650a59"),
     "app/view/PathwayAcquisitionViews/PA_AIInterpretView.js": (
-        "0.8", "0f1a91d47f5f62a4e03bd28a169e8ce9a08e22bc260b0181be492eb9e5608609"),
+        "0.9", "527874a0bd9354177a1e5d29b951c88a1bbdd528c1a83baa88ce4d46966672a8"),
     "app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js": (
         "0.7", "b135712a9564f8ae0eac94daf9c567ef275c4c748dbc270fdbdeb7d25fc79e34"),
     "resources/ServerConfiguration.js": (


### PR DESCRIPTION
## What

The Step 3 pathway network already says which significant pathways share matched features. The AI interpreter used to see only the top 15 pathways by p-value, in arbitrary chunks of five, and never the other ~85. This PR partitions the network server-side and, behind `AI_CLUSTER_MODE=1` (default **off** — the flag-off path is byte-for-byte the workflow that PR #25 gated), interprets **every** significant pathway inside its cluster.

- `AIInterpret/clusters.py` (new, pure, scipy only, works on the harness's frozen 4-method job): average-linkage on 1−Dice over canonical cross-database feature keys (KEGG Entrez ↔ Reactome symbol clones joined through their input names), cut at Dice 0.25, cap 10 with a deterministic re-cut, **minimum cluster size 2**; isolates → satellite attach (mean Dice ≥ 0.10, ≤ 2 per cluster) → standalone unit if major (≥ 2 significant omic layers) or top-10 → pooled "further" unit. The plain path's top-N is pinned into the universe (a widening change must never present less than the narrower one did). Deterministic: same job → identical partition, no seed anywhere.
- `agent.py` seam: partition → all members enter the context (`build_pathway_context(pathway_ids=…)`), triage skipped (its picks were unused), one core-gene PubMed query per cluster attributed to every member, interpretation batches are units that are never split (bounded fan-out; tool loop only for batches holding a top-N pathway, single-shot for the rest, single-shot fallback if a tool loop fails), cluster map + rank rules in the synthesis prompt, a *Pathway Clusters* table appended and re-attached after correction rewrites. **Global rank order is preserved everywhere** (evolve round 1 measured that reordering by theme collapses the rank score; round 2 measured that annotating shared genes helps).
- Persistence/API: `AIInterpretDAO.save_clusters`, `/ai_interpret_report` returns `clusters`; drill-down builds its context by id (so all members are drillable) and gets a cluster-context block.
- Client: the AI view hands the partition to the Step 3 view; each pathway network offers **AI pathway clusters** as a colouring (one stable colour per cluster across KEGG/Reactome, grey = no cluster, legend rows with core genes, click-to-hide); the report is fetched on completion so the option appears without opening the panel; stale `colorBy` falls back to classification.

## Measured (stategra-v4 evolve fold, journal round 6, results.tsv 6a/6b)

BABABA, n=3/arm, same bytes flag-only, 55 rpm, DeepSeek:

| | train | held-out | full | rank | penalty | secs |
|---|---|---|---|---|---|---|
| base | 0.487 (sd 0.042) | 0.321 | 0.393 | 0.450 | 0.000 | 144–306 |
| cluster | 0.698 (sd 0.072) | 0.432 | 0.547 | 0.479 | 0.000 | 284–376 |
| Δ | **+0.210** | **+0.111** | +0.154 | +0.029 | 0 | |

KEEP by the pre-registered rules (train and held-out up, rank not down, penalty flat, cost under the line). Mechanism is coverage: 101/102 significant pathways named with per-pathway data statements. Qualitative gate: omic-layer claims match the stored p-values (DNase-seq is the dominant layer in this dataset: significant in 73/102 significant pathways), no invented pathway headings, no hub-driven cluster narrated as a module. One abort is journaled: the first attempt mirrored the network's "≥ 50 % features matched" filter into the universe and lost a rank-8 pathway; fixed (filter off by default + top-N pinned).

## Verified

- Battery on the merged tree: module imports (clusters is CRITICAL), versioned assets, `test_pathway_clusters` (11), semaphore/heartbeat, dao cleanup, consent, servlet handlers, citation remapping, logging, quote source — green; stub-gateway e2e green with the flag off and on; clean `git archive` import.
- Chrome on the merged tree (port 8002, real DeepSeek run on the STATegra example): report renders with clusters as themes and `Cxx —` sections, 102 pathway links, Pathway Clusters table; network coloured by cluster with legend; drill-down works for pathways outside the top 15.

## Deploy note

Flag stays off in code. Enabling on a host = `AI_CLUSTER_MODE=1` in the service environment (systemd unit), restart; rollback = unset + restart. Reports in cluster mode are ~7–9k words (vs ~3k) — the client renders them; length is a product question the score does not see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)