### PR TITLE
Explain cluster ids where the reader meets them (cluster-first AI report readability)

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_AIInterpretView.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_AIInterpretView.js
@@ -100,6 +100,13 @@ function PA_AIInterpretView() {
             me.openPathway($(this).attr("data-pathway-id"),
                            $(this).attr("data-pathway-name"));
         });
+        // A cluster id in the prose jumps to that cluster's row in the
+        // Pathway Clusters table (the id's definition); the hover title
+        // already names the cluster and its members.
+        this.$root.find(".ai-widget-messages").on("click", ".ai-cluster-link", function(e) {
+            e.preventDefault();
+            me.revealCluster($(this).attr("data-cluster"));
+        });
     };
 
     this.show = function() {
@@ -576,6 +583,84 @@ function PA_AIInterpretView() {
         return linked;
     };
 
+    /**
+     * Cluster ids ("C01") in the report prose become hover-explained links.
+     *
+     * The report groups pathways into clusters and refers to them by id, which
+     * a reader meets before the table that defines them. Each id in the body
+     * gets a title carrying the cluster's label and member pathways, and a
+     * click scrolls to its row in the Pathway Clusters table. Only ids of real
+     * clusters are touched; text inside links, code and the table itself is
+     * left alone (the table row is the destination, not a link).
+     */
+    this._linkifyClusters = function(rootEl, clusters, pathways) {
+        var list = clusters && clusters.clusters;
+        if (!list || !list.length) return;
+        var nameOf = {};
+        (pathways || []).forEach(function(p) { if (p && p.id) nameOf[p.id] = p.name; });
+        var byId = {};
+        list.forEach(function(c) {
+            if (!c || !c.id) return;
+            var members = (c.members || []).concat(c.satellites || [])
+                .map(function(id) { return nameOf[id] || id; });
+            var shown = members.slice(0, 6).join("; ") + (members.length > 6 ? "; +" + (members.length - 6) + " more" : "");
+            byId[c.id] = c.id + " — " + (c.label || "") + "\n" + shown +
+                (c.hub_driven ? "\n(held together by hub genes shared across the network)" : "") +
+                "\nClick to see the cluster in the table.";
+        });
+        var SKIP = { A: 1, CODE: 1, PRE: 1, SCRIPT: 1, STYLE: 1, TABLE: 1, H1: 1 };
+        var pattern = /\bC\d{2}\b/g;
+        var walk = function(node) {
+            var child = node.firstChild;
+            while (child) {
+                var next = child.nextSibling;
+                if (child.nodeType === 1) {
+                    if (!SKIP[child.tagName.toUpperCase()]) walk(child);
+                } else if (child.nodeType === 3 && child.nodeValue && /C\d\d/.test(child.nodeValue)) {
+                    var text = child.nodeValue;
+                    var frag = document.createDocumentFragment();
+                    var cursor = 0, match;
+                    pattern.lastIndex = 0;
+                    while ((match = pattern.exec(text)) !== null) {
+                        var title = byId[match[0]];
+                        if (!title) continue;
+                        if (match.index > cursor) {
+                            frag.appendChild(document.createTextNode(text.slice(cursor, match.index)));
+                        }
+                        var a = document.createElement("a");
+                        a.className = "ai-cluster-link";
+                        a.setAttribute("href", "#");
+                        a.setAttribute("data-cluster", match[0]);
+                        a.setAttribute("title", title);
+                        a.appendChild(document.createTextNode(match[0]));
+                        frag.appendChild(a);
+                        cursor = match.index + match[0].length;
+                    }
+                    if (cursor > 0) {
+                        if (cursor < text.length) frag.appendChild(document.createTextNode(text.slice(cursor)));
+                        node.replaceChild(frag, child);
+                    }
+                }
+                child = next;
+            }
+        };
+        walk(rootEl);
+    };
+
+    /** Scroll the Pathway Clusters table row for a cluster id into view and flash it. */
+    this.revealCluster = function(clusterID) {
+        if (!this.$root || !clusterID) return;
+        var cells = this.$root.find(".ai-widget-messages table td").filter(function() {
+            return $(this).text().trim().indexOf(clusterID + " ") === 0 ||
+                   $(this).text().trim() === clusterID;
+        });
+        var row = cells.first().closest("tr");
+        if (!row.length) return;
+        row[0].scrollIntoView({ behavior: "smooth", block: "center" });
+        row.addClass("ai-cluster-row-flash");
+        setTimeout(function() { row.removeClass("ai-cluster-row-flash"); }, 2200);
+    };
+
     this.displayReport = function(reportText, papers, pathways) {
         var html = "";
         try {
@@ -610,6 +695,7 @@ function PA_AIInterpretView() {
         var holder = document.createElement("div");
         holder.innerHTML = html;
         this._linkifyPathways(holder, pathways);
+        this._linkifyClusters(holder, this.clusters, pathways);
 
         /* Who wrote this. The report is model output that gets read, quoted and
            pasted into drafts, so the attribution rides inside the bubble rather

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -40,7 +40,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
 	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.07" />
-	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=0.7" />
+	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=0.8" />
 	<!-- Shared chrome for both of Step 3's graph surfaces. Before more-network.css,
 	     which layers this view's own legend and layout on top of it. -->
 	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=0.6" />
@@ -133,7 +133,7 @@
 	<!--MARKDOWN RENDERING LIBRARY -->
 	<script type="text/javascript" src="js/libs/marked/marked.min.js"></script>
 	<!--AI INTERPRETATION VIEW -->
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_AIInterpretView.js?v=0.9"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_AIInterpretView.js?v=1.0"></script>
 	<!--MORE REGULATOR–TARGET NETWORK VIEW -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js?v=0.7"></script>
 

--- a/PaintomicsClient/public_html/resources/css/ai-interpret.css
+++ b/PaintomicsClient/public_html/resources/css/ai-interpret.css
@@ -570,6 +570,28 @@
     opacity: 0.7;
 }
 
+/* ── Cluster ids ── */
+/* "C01" in the prose is shorthand for a group of pathways. The dotted mark
+   says "there is more here"; the browser title on hover names the cluster
+   and its members, and a click scrolls to the row that defines it. */
+.ai-cluster-link {
+    color: inherit;
+    text-decoration: none;
+    font-weight: var(--pa-ai-bold);
+    cursor: help;
+    border-bottom: 1px dotted currentColor;
+    padding: 0 1px;
+    border-radius: 2px;
+}
+.ai-cluster-link:hover {
+    background-color: rgba(46, 139, 87, 0.12);
+    border-bottom-style: solid;
+}
+tr.ai-cluster-row-flash > td {
+    background-color: rgba(46, 139, 87, 0.18);
+    transition: background-color 0.6s;
+}
+
 /* ── Input Area ── */
 .ai-widget-input-area {
     padding: 10px;

--- a/PaintomicsServer/src/classes/AIInterpret/agent.py
+++ b/PaintomicsServer/src/classes/AIInterpret/agent.py
@@ -1380,6 +1380,15 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
         try:
             cluster_table = clusters_mod.render_partition_table(partition, ctx_by_id)
             report = report.rstrip() + "\n\n" + cluster_table + "\n"
+            # The reading note goes under the report's title (or at the very
+            # top): the ids must be explained before the reader meets them.
+            note = clusters_mod.render_reading_note(partition)
+            if note and note not in report:
+                lines = report.split("\n", 1)
+                if lines[0].lstrip().startswith("# ") and len(lines) > 1:
+                    report = lines[0] + "\n\n" + note + "\n" + lines[1]
+                else:
+                    report = note + "\n\n" + report
         except Exception as e:
             logger.warning("[%s][sdk] cluster table failed: %s", job_id, e)
     stats["synth_s"] = time.time() - t0
@@ -1555,6 +1564,9 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
             ("## Enriched Pathway Summary", table),
             ("## Pathway Clusters", cluster_table),
         ])
+        note = clusters_mod.render_reading_note(partition)
+        if note and note not in report:
+            report = note + "\n\n" + report
     stats["verify_iterations"] = verify_iters
 
     # -- Phase 6: the programmatic safety net ---------------------------------

--- a/PaintomicsServer/src/classes/AIInterpret/clusters.py
+++ b/PaintomicsServer/src/classes/AIInterpret/clusters.py
@@ -717,16 +717,39 @@ def render_synthesis_block(partition, pathway_ctx_by_id):
         "Writing rules for the clusters:",
         "- Key Findings lead with the highest-RANKED pathways and their clusters; rank, "
         "not cluster size, decides emphasis.",
+        "- The ids C01, C02 ... are shorthand the reader does not know yet. NEVER refer to a "
+        "cluster by its bare id. The first time a cluster appears anywhere (Key Findings, a "
+        "theme, a bullet) name it by what it is and show two or three member pathways, e.g. "
+        "'the G-protein / second-messenger signalling cluster (C02: Cholinergic synapse, "
+        "Chemokine signaling, Apelin signaling ...)'; afterwards write 'the G-protein "
+        "signalling cluster (C02)'. A sentence like 'Clusters C02, C03, C04 are rewired' "
+        "with no names is not acceptable.",
         "- Use the clusters as the themes of 'Cross-Pathway Themes' and group 'Detailed "
-        "Pathway Analysis' by cluster, in the order given (best-ranked member first), "
-        "heading each as '### Cxx -- <label>' and naming every member (a member with little "
-        "to add gets one clause, not silence).",
+        "Pathway Analysis' by cluster, in the order given (best-ranked member first). Head "
+        "each section '### Cxx -- <your short biological name for the cluster> "
+        "(<best-ranked member> +N related)' -- the short name is yours, the member name is "
+        "the database's -- and name every member (a member with little to add gets one "
+        "clause, not silence).",
         "- Add a 'Standalone pathways' subsection for the standalone ones and a one-line "
         "reading for each further pathway; nothing significant is dropped.",
         "- A HUB-DRIVEN cluster is shared-gene overlap: say so; do not narrate it as one "
         "coordinated module.",
     ]
     return "\n".join(lines)
+
+
+def render_reading_note(partition):
+    """One italic line for the top of a cluster-mode report, so a reader meets
+    'C01' knowing what it stands for and where the full list is."""
+    n = len(partition.get("clusters") or [])
+    if not n:
+        return ""
+    return ("*How to read this report: the %d significant pathways were grouped into %d "
+            "clusters of pathways that share matched genes and compounds (C01 to C%02d, "
+            "numbered by their most significant member). A cluster is named where it is "
+            "first discussed; the full membership of every cluster is in the Pathway "
+            "Clusters table at the end, and in the app each cluster id can be hovered "
+            "for its members.*" % (len(partition.get("nodes") or []), n, n))
 
 
 def render_partition_table(partition, pathway_ctx_by_id):

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -94,7 +94,7 @@ PUBLISHED = {
     "app/view/common/AlignmentGuides.js": (
         "4.2", "ce2ba85063e8059eb2cc4c8e1992744854a14ad0db6f866213b8df1136650a59"),
     "app/view/PathwayAcquisitionViews/PA_AIInterpretView.js": (
-        "0.9", "527874a0bd9354177a1e5d29b951c88a1bbdd528c1a83baa88ce4d46966672a8"),
+        "1.0", "1250cdec9f81a78bc2e4c2a7229c4628f7a4c6105a261dbf03987da8b3950290"),
     "app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js": (
         "0.7", "b135712a9564f8ae0eac94daf9c567ef275c4c748dbc270fdbdeb7d25fc79e34"),
     "resources/ServerConfiguration.js": (


### PR DESCRIPTION
Follow-up to #26 after reading a live report: the first bullets referred to "Clusters C02, C03, C04" before a reader could know what those were (the table defining them sits at the end).

- Synthesis rules (`clusters.render_synthesis_block`): never a bare cluster id — the first mention names the cluster by what it is with two or three member pathways ("the G-protein signalling cluster (C02: Cholinergic synapse, Chemokine signaling, …)"), then the short name with the id; each Detailed Analysis section is headed with the model's own biological name for the cluster.
- A one-line reading note under the report title (deterministic, cluster mode only) explains what the ids are and where the full membership lives; re-attached after correction rewrites.
- Client: every cluster id in the prose gets a hover title (label + members) and a click scrolls to its row in the Pathway Clusters table (`_linkifyClusters`, `revealCluster`); table cells and links are left alone. Markers: PA_AIInterpretView.js 0.9→1.0, ai-interpret.css 0.7→0.8.

Sanity: one replay on the stategra-v4 fold with the new wording scored train 0.726 / held claim 0.365 (round-6 variant band 0.613–0.789 / 0.31–0.42); the report opens with named clusters. Flag-off path untouched. Verified in Chrome on a stored cluster-mode report (74 ids linked, none inside the table, click flashes the C02 row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)