### PR TITLE
Cluster-mode report: no enrichment table, top-up sees bibliography-only syntheses

### DIFF
--- a/PaintomicsServer/src/classes/AIInterpret/agent.py
+++ b/PaintomicsServer/src/classes/AIInterpret/agent.py
@@ -47,7 +47,7 @@ from src.classes.AIInterpret import prompts as prompts_mod
 from src.classes.AIInterpret.context_builder import (
     build_pathway_context, build_gene_symbol_whitelist, get_organism_name,
     triage_pathways, build_cross_omic_matrix, build_key_regulators_block,
-    render_pathway_table, render_pathway_table_compact,
+    render_pathway_table,
 )
 from src.classes.AIInterpret.pubmed_client import PubMedClient
 from src.classes.AIInterpret.verification import (
@@ -1372,15 +1372,13 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
     # before the references rebuild, so citation extraction sees the prose the
     # model wrote rather than table rows -- a quote lookup pointed at a table
     # cell has nothing to find.
-    # In cluster mode the report gets the compact table (rank, p, layers,
-    # cluster) -- the full one with gene lists stays in the synthesis prompt,
-    # where the grounding was measured, but a 100-row wall of gene values is
-    # not what a reader or a paper wants at the end of a report.
-    if partition is not None:
-        table = render_pathway_table_compact(
-            pathways, cluster_of=partition.get("unit_of") or {})
-    else:
-        table = render_pathway_table(pathways)
+    # In cluster mode the report carries NO enrichment table: the full table
+    # stays in the synthesis prompt, where its grounding effect was measured,
+    # but at the end of a report a 100-row table is noise for a reader and
+    # nothing a paper would include -- the Pathway Clusters table below is the
+    # one deterministic block that earns its place there (it defines the
+    # cluster ids the prose uses). The plain path keeps its table as before.
+    table = "" if partition is not None else render_pathway_table(pathways)
     if table:
         report = report.rstrip() + "\n\n" + table + "\n"
     cluster_table = ""

--- a/PaintomicsServer/src/classes/AIInterpret/agent.py
+++ b/PaintomicsServer/src/classes/AIInterpret/agent.py
@@ -47,7 +47,7 @@ from src.classes.AIInterpret import prompts as prompts_mod
 from src.classes.AIInterpret.context_builder import (
     build_pathway_context, build_gene_symbol_whitelist, get_organism_name,
     triage_pathways, build_cross_omic_matrix, build_key_regulators_block,
-    render_pathway_table,
+    render_pathway_table, render_pathway_table_compact,
 )
 from src.classes.AIInterpret.pubmed_client import PubMedClient
 from src.classes.AIInterpret.verification import (
@@ -1372,7 +1372,15 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
     # before the references rebuild, so citation extraction sees the prose the
     # model wrote rather than table rows -- a quote lookup pointed at a table
     # cell has nothing to find.
-    table = render_pathway_table(pathways)
+    # In cluster mode the report gets the compact table (rank, p, layers,
+    # cluster) -- the full one with gene lists stays in the synthesis prompt,
+    # where the grounding was measured, but a 100-row wall of gene values is
+    # not what a reader or a paper wants at the end of a report.
+    if partition is not None:
+        table = render_pathway_table_compact(
+            pathways, cluster_of=partition.get("unit_of") or {})
+    else:
+        table = render_pathway_table(pathways)
     if table:
         report = report.rstrip() + "\n\n" + table + "\n"
     cluster_table = ""
@@ -1409,7 +1417,14 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
     # against 11 real papers), so the threshold was always satisfied and the
     # top-up never once fired on runs that badly needed it.
     valid_indices = {p["ref_index"] for p in unique_papers}
-    cited_now = ({int(n) for n in re.findall(r'\[(\d+)\]', str(report))}
+    # Count markers in the BODY only. A synthesis that lists its papers in a
+    # References section of its own but never cites them in the text (seen
+    # live: 25 entries, 0 in-text markers, 0 rendered) must trigger the
+    # top-up, and counting the bibliography's [N] hid exactly that case.
+    from src.classes.AIInterpret.verification import _REFERENCES_HEADING_RE as _REFS_RE
+    _ref_m = _REFS_RE.search(str(report))
+    _body_for_count = str(report)[:_ref_m.start()] if _ref_m else str(report)
+    cited_now = ({int(n) for n in re.findall(r'\[(\d+)\]', _body_for_count)}
                  & valid_indices)
     uncited = [p for p in unique_papers if p["ref_index"] not in cited_now]
     if uncited and len(cited_now) < SDK_MIN_CITATIONS:

--- a/PaintomicsServer/src/classes/AIInterpret/context_builder.py
+++ b/PaintomicsServer/src/classes/AIInterpret/context_builder.py
@@ -434,6 +434,44 @@ def build_gene_symbol_whitelist(job_instance):
     return whitelist
 
 
+def render_pathway_table_compact(pathways, cluster_of=None):
+    """The enrichment result as a reader (or a paper) wants it: rank, pathway,
+    source, combined p, which omic layers were significant, and -- when the
+    report is organised by clusters -- the cluster. No gene lists and no raw
+    values: those belong in the prompt, where they ground the writing, not
+    in a 100-row table at the end of the report.
+    """
+    if not pathways:
+        return ""
+    cluster_of = cluster_of or {}
+    lines = ["## Enriched Pathway Summary", "",
+             "*Every significant pathway of the analysis, in rank order (combined "
+             "p-value). 'Significant layers' are the omic layers with p <= 0.05 for "
+             "that pathway.*", "",
+             "| # | Pathway | Source | Combined p | Significant layers | Cluster |",
+             "|---|---|---|---|---|---|"]
+    for i, pw in enumerate(pathways, 1):
+        pvalue = pw.get("combined_pvalue")
+        try:
+            pvalue = "%.2e" % float(pvalue)
+        except (TypeError, ValueError):
+            pvalue = str(pvalue)
+        sig = []
+        for part in str(pw.get("per_omic") or "").split(";"):
+            m = re.match(r"\s*(.+?):\s*p=([0-9.eE+-]+)", part)
+            if m:
+                try:
+                    if float(m.group(2)) <= AI_MAJOR_PATHWAY_MAX_PVAL:
+                        sig.append(m.group(1).strip())
+                except ValueError:
+                    pass
+        lines.append("| %d | %s | %s | %s | %s | %s |" % (
+            i, str(pw.get("name", "")).replace("|", "/"), pw.get("source", ""),
+            pvalue, ", ".join(sig) or "-",
+            str(cluster_of.get(pw.get("id"), "-")).replace("|", "/")))
+    return "\n".join(lines)
+
+
 def render_pathway_table(pathways, max_genes=6):
     """Render the enrichment result as a markdown table, from the data.
 

--- a/PaintomicsServer/src/classes/AIInterpret/context_builder.py
+++ b/PaintomicsServer/src/classes/AIInterpret/context_builder.py
@@ -434,44 +434,6 @@ def build_gene_symbol_whitelist(job_instance):
     return whitelist
 
 
-def render_pathway_table_compact(pathways, cluster_of=None):
-    """The enrichment result as a reader (or a paper) wants it: rank, pathway,
-    source, combined p, which omic layers were significant, and -- when the
-    report is organised by clusters -- the cluster. No gene lists and no raw
-    values: those belong in the prompt, where they ground the writing, not
-    in a 100-row table at the end of the report.
-    """
-    if not pathways:
-        return ""
-    cluster_of = cluster_of or {}
-    lines = ["## Enriched Pathway Summary", "",
-             "*Every significant pathway of the analysis, in rank order (combined "
-             "p-value). 'Significant layers' are the omic layers with p <= 0.05 for "
-             "that pathway.*", "",
-             "| # | Pathway | Source | Combined p | Significant layers | Cluster |",
-             "|---|---|---|---|---|---|"]
-    for i, pw in enumerate(pathways, 1):
-        pvalue = pw.get("combined_pvalue")
-        try:
-            pvalue = "%.2e" % float(pvalue)
-        except (TypeError, ValueError):
-            pvalue = str(pvalue)
-        sig = []
-        for part in str(pw.get("per_omic") or "").split(";"):
-            m = re.match(r"\s*(.+?):\s*p=([0-9.eE+-]+)", part)
-            if m:
-                try:
-                    if float(m.group(2)) <= AI_MAJOR_PATHWAY_MAX_PVAL:
-                        sig.append(m.group(1).strip())
-                except ValueError:
-                    pass
-        lines.append("| %d | %s | %s | %s | %s | %s |" % (
-            i, str(pw.get("name", "")).replace("|", "/"), pw.get("source", ""),
-            pvalue, ", ".join(sig) or "-",
-            str(cluster_of.get(pw.get("id"), "-")).replace("|", "/")))
-    return "\n".join(lines)
-
-
 def render_pathway_table(pathways, max_genes=6):
     """Render the enrichment result as a markdown table, from the data.
 


### PR DESCRIPTION
Two follow-ups from reading live cluster-mode reports on paintomics.uv.es:

- **No Enriched Pathway Summary in cluster-mode reports.** The 100-row table with per-omic p strings and gene lists is what grounds the synthesis prompt (round-3 KEEP), not what a reader or a paper wants at the end of a report; the prose already covers every significant pathway inside its cluster and the Pathway Clusters table defines the ids. The full table stays in the synthesis prompt; the flag-off path keeps its table unchanged.
- **Citation top-up counts body markers only.** A live run had the synthesis list all 25 papers in a References section of its own with zero in-text citations; the References rebuild (which trusts body markers) rendered nothing and the report shipped citation-less, while the top-up never fired because it counted the bibliography's [N]. Counting the body only makes that case trigger the "add citations where papers support your statements" pass.

Sanity replay on the stategra-v4 fold (variant, before the table removal): train 0.630 / held claim 0.423, in the round-6 band; stub e2e green with the flag on; `test_pathway_clusters`, module imports green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)