### PR TITLE
Stream every SDK call, bound the long ones, refuse a second Step 1 submit

### DIFF
--- a/PaintomicsClient/public_html/app/controller/JobController.js
+++ b/PaintomicsClient/public_html/app/controller/JobController.js
@@ -89,7 +89,12 @@ function JobController() {
 						// heading has no heading, and the one line that matters ("Running job
 						// X") was indistinguishable from the two lines of housekeeping under
 						// it. The body slot has existed on this dialog all along.
-						var title = "Running job " + jobID;
+						// A conversion job (regions/miRNA/MORE to genes) is named for
+						// what it prepares, so the analysis job that follows -- with
+						// its own id -- does not read as the same job renumbered.
+						var title = other.jobLabel
+							? other.jobLabel + " (conversion job " + jobID + ")..."
+							: "Running job " + jobID;
 						var body = "";
 						var progress = null;
 
@@ -127,6 +132,61 @@ function JobController() {
 	};
 
 	/**
+	* One submission at a time per Step 1 form.
+	*
+	* On 2026-08-17 the live server received the same STATegra example form
+	* twice, three seconds apart, from one browser (jobs Ov57R61V4y and
+	* yL0zFsu5xt). Nothing here refused the second POST: both jobs ran through
+	* the whole of step 1, the client polled both, and whichever callback landed
+	* last owned the view -- so the job id the dialog had been announcing was
+	* not the one step 2 continued with. Seen from the user's side, "the job id
+	* changed between step 1 and step 2".
+	*
+	* The lock is a flag on the job view. It is taken when a submission starts
+	* (either entry point below), released when that submission's own callback
+	* or error path runs, and a submit that arrives while it is held is refused
+	* with a note naming the job already under way. `step1ActiveJobID` records
+	* which job the view is following, so a callback for any other job -- a
+	* stale poll from a submission the lock did not exist for -- cannot take
+	* the view over.
+	*
+	* @param {JobView} jobView
+	* @returns {Boolean} true when the caller may proceed
+	*/
+	this.beginStep1Submission = function (jobView) {
+		if (jobView.step1SubmitInFlight === true) {
+			var active = jobView.step1ActiveJobID;
+			console.warn("Step 1 submit ignored: " + (active ? "job " + active + " is" : "a submission is") + " already in progress for this form.");
+			showInfoMessage(active ? "Job " + active + " is already running" : "Your files are already being submitted", {
+				message: "This form has already been submitted. Please wait for the current job to finish before submitting again.",
+				logMessage: "Duplicate step 1 submission refused.",
+				showSpin: true
+			});
+			return false;
+		}
+		jobView.step1SubmitInFlight = true;
+		jobView.step1ActiveJobID = null;
+		return true;
+	};
+
+	this.endStep1Submission = function (jobView) {
+		jobView.step1SubmitInFlight = false;
+	};
+
+	/**
+	* Reset abandons whatever the Step 1 form was following: the lock is
+	* released and the active id cleared, so a late poll for the abandoned job
+	* is dropped rather than resurrecting it, and a fresh submission is allowed.
+	*/
+	this.abandonStep1Submission = function () {
+		var step1View = application.getMainView().getSubView("PA_Step1JobView");
+		if (step1View !== undefined) {
+			step1View.step1SubmitInFlight = false;
+			step1View.step1ActiveJobID = null;
+		}
+	};
+
+	/**
 	* This function gets a list of of RegionBasedOmicViews/miRNABasedOmicView and send each item to
 	* server for processing.
 	*
@@ -144,6 +204,9 @@ function JobController() {
 
 		//CHECK FORM VALIDITY
 		if (jobView.checkForm() === true) {
+			if (!me.beginStep1Submission(jobView)) {
+				return false;
+			}
 
 			var regionURL = SERVER_URL_DM_FROMBED2GENES;
 			var miRNAURL = SERVER_URL_DM_FROMMIRNA2GENES;
@@ -239,7 +302,13 @@ function JobController() {
 					success: function (form, action) {
 						var response = JSON.parse(action.response.responseText);
 
-						showInfoMessage("Job " + response.jobID + " is waiting at job queue...", {logMessage: "Now Job is in the queue...", showSpin: true, append: true, itemId: response.jobID, icon: "clock-o"});
+						// These are conversion jobs (regions/miRNA/MORE to genes), each
+						// with its own id, and the pathway analysis that follows gets
+						// another. Said so in the dialog, because a line reading
+						// "Job X is waiting" followed by "Running job Y" reads as the
+						// job having changed id.
+						var omicLabel = (itemsContainer.queryById("omicNameField") && itemsContainer.queryById("omicNameField").getValue()) || "input";
+						showInfoMessage("Preparing " + omicLabel + " (conversion job " + response.jobID + ") is waiting at job queue...", {logMessage: "Now Job is in the queue...", showSpin: true, append: true, itemId: response.jobID, icon: "clock-o"});
 
 						/* Restore elements used to create the temporal form */
 						_restoreElements();			
@@ -252,7 +321,7 @@ function JobController() {
 						* @returns {undefined}
 						*/
 						var callback = function (response, jobID, jobView, other) {
-							showInfoMessage("Job " + jobID + " finished successfully.", {logMessage: "Job " + jobID + " finished.", showSpin: true, append: true, itemId: jobID, icon: "check-circle-o"});
+							showInfoMessage("Preparing " + omicLabel + " (conversion job " + jobID + ") finished successfully.", {logMessage: "Job " + jobID + " finished.", showSpin: true, append: true, itemId: jobID, icon: "check-circle-o"});
 
 							jobView.pendingRequests--;
 
@@ -269,15 +338,18 @@ function JobController() {
 
 							if (jobView.pendingRequests === 0) {
 								if (jobView.failedRequests === 0) {
-									me.step1OnFormSubmitHandler(jobView);
+									// The lock taken above carries over into the pathway
+									// submission; `chained` tells it not to take a second one.
+									me.step1OnFormSubmitHandler(jobView, {chained: true});
 								} else {
+									me.endStep1Submission(jobView);
 									showErrorMessage("Ops!... Something went wrong during the request files processing.", {message: "One or more files were not succesfully processed.</br>Please check the form for more info."});
 								}
 							}
 						};
 
 						var errorHandler = function (response, jobID, jobView, other) {
-							showInfoMessage("Job " + jobID + " finished with errors.", {logMessage: "Job " + jobID + " finished.", showSpin: true, append: other.multipleJobs, itemId: jobID, icon: "times-circle-o"});
+							showInfoMessage("Preparing " + omicLabel + " (conversion job " + jobID + ") finished with errors.", {logMessage: "Job " + jobID + " finished.", showSpin: true, append: other.multipleJobs, itemId: jobID, icon: "times-circle-o"});
 
 							//WHAT TO DO IN CASE OF ERROR
 							jobView.failedRequests++;
@@ -291,13 +363,14 @@ function JobController() {
 							}
 
 							if (jobView.pendingRequests === 0) {
+								me.endStep1Submission(jobView);
 								showErrorMessage("Ops!... Something went wrong during the request files processing.", {
 									message: "One or more files were not succesfully processed.</br>Please check the form for more information."
 								});
 							}
 						};
 
-						me.checkJobStatus(response.jobID, jobView, callback, {subview: subview, errorHandler: errorHandler, multipleJobs: true});
+						me.checkJobStatus(response.jobID, jobView, callback, {subview: subview, errorHandler: errorHandler, multipleJobs: true, jobLabel: "Preparing " + omicLabel});
 
 						if (genericBasedOmic.length > 0) {
 							sendRequest(jobView, genericBasedOmic);
@@ -307,6 +380,7 @@ function JobController() {
 						/* Restore elements used to create the temporal form */
 						_restoreElements();
 
+						me.endStep1Submission(jobView);
 						extJSErrorHandler(form, responseObj);
 					}
 				});
@@ -327,7 +401,8 @@ function JobController() {
 	* @param {type} jobView
 	* @returns {undefined}
 	************************************************************/
-	this.step1OnFormSubmitHandler = function (jobView) {
+	this.step1OnFormSubmitHandler = function (jobView, options) {
+		options = (options || {});
 		var URL = SERVER_URL_PA_STEP1;
 		// Only a pathway-acquisition example submits step 1 as an example. The
 		// pre-processing pipelines (regions2genes, mirna2genes, more) have
@@ -341,6 +416,12 @@ function JobController() {
 
 		if (jobView.checkForm() === true) {
 			var me = this;
+			// A chained call arrives from the pre-processing pipeline already
+			// holding the lock (see beginStep1Submission); every other call
+			// takes it here, and is refused if it is held.
+			if (options.chained !== true && !me.beginStep1Submission(jobView)) {
+				return false;
+			}
 			var form = jobView.getComponent().down("form").getForm();
 
 			showInfoMessage("Uploading files...", {logMessage: "New Job created, submitting files...", showSpin: true});
@@ -349,6 +430,9 @@ function JobController() {
 				success: function (form, action) {
 					var response = JSON.parse(action.response.responseText);
 					console.log("JOB " + response.jobID + " is queued ");
+					// The job this view now follows. A poll callback for any
+					// other id is stale and is dropped in `callback` below.
+					jobView.step1ActiveJobID = response.jobID;
 
 					showInfoMessage("Waiting at job queue...", {logMessage: "Now Job is in the queue...", showSpin: true, icon: "clock-o"});
 					/**
@@ -359,6 +443,11 @@ function JobController() {
 					* @returns {undefined}
 					*/
 					var callback = function (response, jobID, jobView) {
+						if (jobView.step1ActiveJobID !== jobID) {
+							console.warn("Ignoring step 1 result for job " + jobID + ": this form is following job " + jobView.step1ActiveJobID + ".");
+							return;
+						}
+						me.endStep1Submission(jobView);
 						showSuccessMessage("Done", {logMessage: "FILES PROCESSED SUCCESSFULLY"});
 						//Wait 0.5 sec and update the page content with the STEP2 content
 						showInfoMessage("Generating Metabolites list...", {showTimeout: 0.5, showSpin: true});
@@ -456,11 +545,28 @@ function JobController() {
 						showSuccessMessage("Done", {logMessage: "Generating Metabolites list...DONE", showTimeout: 1, closeTimeout: 0.5});
 					};
 
-					me.checkJobStatus(response.jobID, jobView, callback, {}, true);
+					// A job that fails on the queue (a validation error in the
+					// files, say) must hand the form back too, or the lock would
+					// refuse the corrected resubmission.
+					var errorHandler = function (errorResponse, jobID, jobView) {
+						if (jobView.step1ActiveJobID === jobID) {
+							me.endStep1Submission(jobView);
+						}
+						ajaxErrorHandler(errorResponse);
+					};
+					me.checkJobStatus(response.jobID, jobView, callback, {errorHandler: errorHandler}, true);
 				},
-				failure: extJSErrorHandler
+				failure: function (form, responseObj) {
+					me.endStep1Submission(jobView);
+					extJSErrorHandler(form, responseObj);
+				}
 			});
 		} else {
+			if (options.chained === true) {
+				// The pipeline took the lock before its conversion jobs ran;
+				// a form that fails validation here must not keep it.
+				this.endStep1Submission(jobView);
+			}
 			showErrorMessage("Invalid form. <br/> Please provide at least: <span style='color: auto;text-decoration: underline;'>Gene expression /Metabolomics /Proteomics data.</span> Also, please make sure to <span style='color: auto;text-decoration: underline;'>select an organism.</span>", {height: 150, width: 400, showReportButton:false});
 			return false;
 		}
@@ -1179,6 +1285,7 @@ function JobController() {
 		var me = this;
 		if (force === true) {
 			me.cleanStoredApplicationData();
+			me.abandonStep1Submission();
 			me.showJobInstance(new JobInstance(null));
 			if (callback !== undefined) {
 				callback();
@@ -1189,6 +1296,7 @@ function JobController() {
 		Ext.MessageBox.confirm('Confirm', 'Are you sure you want to exit the current job?', function (opcion) {
 			if (opcion === "yes") {
 				me.cleanStoredApplicationData();
+				me.abandonStep1Submission();
 				me.showJobInstance(new JobInstance(null));
 				if (callback !== undefined) {
 					callback();

--- a/PaintomicsServer/src/classes/AIInterpret/agent.py
+++ b/PaintomicsServer/src/classes/AIInterpret/agent.py
@@ -33,7 +33,9 @@ from agents import (
     function_tool, set_default_openai_api, set_default_openai_client,
     set_tracing_disabled,
 )
+import httpx
 from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletion
 from pydantic import BaseModel, Field
 
 from src.conf.serverconf import (
@@ -53,7 +55,7 @@ from src.classes.AIInterpret.pubmed_client import PubMedClient
 from src.classes.AIInterpret.verification import (
     verify_report_v2, redact_unverified_v2, renumber_citations,
     parse_references_section, render_references_section,
-    normalize_citation_markers,
+    normalize_citation_markers, resolve_pmid_mentions, count_body_citations,
 )
 # The shared verdict parser: the verifier agent keeps its tools (see the
 # DANGER note in _build_agents), so its verdict arrives as free text.
@@ -129,6 +131,29 @@ SDK_SYNTH_DRAFTS = int(os.getenv("AI_SDK_SYNTH_DRAFTS", "1"))
 # Deterministic completeness pass. Off by default -- see the note at its call
 # site: it works, and it costs ~190s for a quality change that measured negative.
 SDK_GAP_FILL = os.getenv("AI_SDK_GAP_FILL", "0") == "1"
+# Every chat completion is issued as a stream and folded back into a
+# ChatCompletion for the SDK (see _stream_to_completion). Measured on the CSIC
+# gateway 2026-08-17: a non-streamed generation has ~120 s per attempt before
+# the gateway abandons it (14k tokens: HTTP 200 after 477 s = four attempts;
+# the citation top-up of a 105-pathway report: HTTP 408 after 489 s, three
+# times over), while a streamed 25k-token generation completed in 203 s --
+# the budget is per read, not per response. Set AI_SDK_STREAM=0 only for a
+# provider that cannot stream chat completions.
+SDK_STREAM = os.getenv("AI_SDK_STREAM", "1") != "0"
+# httpx read timeout, per read: with streaming that is "no token for this
+# long", not "the whole answer in this long". Generous, because a large prompt
+# queues behind other work before its first token; a stalled stream still
+# surfaces as APITimeoutError and gets the shim's retry.
+SDK_HTTP_READ_TIMEOUT = float(os.getenv("AI_SDK_HTTP_READ_TIMEOUT", "180"))
+# Wall-clock cap on one long-form call (synthesis draft, gap-fill, top-up,
+# correction rewrite). These echo or write a whole report, so they cannot use
+# run_hedged's 45 s straggler cutoff -- but nor may they run unbounded: two
+# live runs sat 90+ minutes inside one top-up before this existed.
+SDK_LONG_CALL_TIMEOUT = float(os.getenv("AI_SDK_LONG_CALL_TIMEOUT", "600"))
+# The whole interpretation, end to end. A run that is still going after this
+# has stalled somewhere the phase caps did not reach; better an error the user
+# can retry than a job that reads as running for the rest of the day.
+AI_MAX_RUN_SECONDS = float(os.getenv("AI_MAX_RUN_SECONDS", "2700"))
 
 _SYSTEM_STOPWORDS = frozenset("""
 a an the and or of in on at to for from with without by as is are was were be
@@ -206,20 +231,145 @@ class _AsyncPacer:
             await asyncio.sleep(delay)
 
 
+class _EmptyStream(Exception):
+    """The gateway closed a completion stream without a single choice."""
+
+
+async def _stream_to_completion(stream):
+    """Fold a chat-completion chunk stream into one ChatCompletion.
+
+    The SDK's non-streaming path calls ``create(stream=False)`` and reads a
+    ``ChatCompletion``. We issue the request as a stream instead (see
+    SDK_STREAM for why) and rebuild the object it expects: content deltas
+    concatenate, tool-call deltas join by ``index`` (name and id arrive in the
+    first fragment, arguments trickle in over the rest), the last non-null
+    ``finish_reason`` wins, and ``usage`` is whatever the final chunk carried
+    (vLLM sends it only when ``stream_options.include_usage`` is set).
+
+    Provider-specific delta fields the SDK does not read (DeepSeek's
+    ``reasoning_content``, for one) are dropped here on purpose.
+    """
+    content = []
+    role = None
+    refusal = []
+    tool_calls = {}          # index -> {"id", "type", "name", "arguments"}
+    finish_reason = None
+    usage = None
+    meta = {}
+    saw_choice = False
+    try:
+        async for chunk in stream:
+            if not meta:
+                meta = {"id": chunk.id, "created": chunk.created,
+                        "model": chunk.model,
+                        "system_fingerprint": getattr(chunk, "system_fingerprint", None)}
+            if getattr(chunk, "usage", None) is not None:
+                usage = chunk.usage
+            for choice in (chunk.choices or []):
+                saw_choice = True
+                delta = choice.delta
+                if delta is None:
+                    continue
+                if delta.role:
+                    role = delta.role
+                if delta.content:
+                    content.append(delta.content)
+                if getattr(delta, "refusal", None):
+                    refusal.append(delta.refusal)
+                for tc in (delta.tool_calls or []):
+                    slot = tool_calls.setdefault(tc.index, {
+                        "id": None, "type": "function", "name": "", "arguments": ""})
+                    if tc.id:
+                        slot["id"] = tc.id
+                    if tc.type:
+                        slot["type"] = tc.type
+                    fn = tc.function
+                    if fn is not None:
+                        if fn.name:
+                            slot["name"] += fn.name
+                        if fn.arguments:
+                            slot["arguments"] += fn.arguments
+                if choice.finish_reason:
+                    finish_reason = choice.finish_reason
+    finally:
+        close = getattr(stream, "close", None)
+        if close is not None:
+            try:
+                await close()
+            except Exception:
+                pass
+    if not saw_choice:
+        raise _EmptyStream("completion stream ended without any choice")
+
+    message = {"role": role or "assistant",
+               "content": "".join(content) if content else None,
+               "refusal": "".join(refusal) if refusal else None}
+    if tool_calls:
+        message["tool_calls"] = [
+            {"id": slot["id"] or "call_%d" % idx, "type": slot["type"] or "function",
+             "function": {"name": slot["name"], "arguments": slot["arguments"]}}
+            for idx, slot in sorted(tool_calls.items())]
+    if finish_reason is None:
+        # vLLM always closes with one; a provider that does not has still
+        # answered, so record the answer rather than discard it.
+        finish_reason = "tool_calls" if tool_calls else "stop"
+        logger.warning("completion stream ended without finish_reason; assuming %s",
+                       finish_reason)
+    payload = {
+        "id": meta.get("id") or "chatcmpl-stream",
+        "object": "chat.completion",
+        "created": meta.get("created") or int(time.time()),
+        "model": meta.get("model") or "",
+        "system_fingerprint": meta.get("system_fingerprint"),
+        "choices": [{"index": 0, "finish_reason": finish_reason,
+                     "message": message, "logprobs": None}],
+        "usage": usage.model_dump() if usage is not None else None,
+    }
+    return ChatCompletion.model_validate(payload)
+
+
+async def bounded(awaitable, timeout, label=""):
+    """``asyncio.wait_for`` with the reason on the record.
+
+    Every long-form model call goes through here so a stall has a ceiling: the
+    task is cancelled at ``timeout`` and asyncio.TimeoutError propagates to a
+    caller that decides whether the phase was optional (skip it) or not (fail
+    the run). Logged at WARNING because a timeout here is always news.
+    """
+    try:
+        return await asyncio.wait_for(awaitable, timeout=timeout)
+    except asyncio.TimeoutError:
+        logger.warning("[bounded] %s exceeded %ss and was cancelled",
+                       label or "call", timeout)
+        raise
+
+
 def configure_sdk():
     """Point the SDK at our OpenAI-compatible gateway. Idempotent."""
     global _sdk_configured, _MODEL_OBJ
     if _sdk_configured:
         return
     provider = AI_PROVIDERS[AI_LLM_PROVIDER]
-    client = AsyncOpenAI(base_url=provider["api_base"], api_key=provider["api_key"])
+    # max_retries=0: the shim below is the ONE retry policy. The client's own
+    # default (2) stacked under the shim's 4 attempts turned a single 408 --
+    # eight minutes each on this gateway -- into twelve of them, and that is
+    # how two live runs spent 90+ minutes inside one citation top-up.
+    # The read timeout is per read: with streaming (SDK_STREAM) it bounds the
+    # silence between tokens, and a stalled request surfaces as
+    # APITimeoutError instead of holding the phase open.
+    client = AsyncOpenAI(
+        base_url=provider["api_base"], api_key=provider["api_key"],
+        max_retries=0,
+        timeout=httpx.Timeout(connect=30.0, read=SDK_HTTP_READ_TIMEOUT,
+                              write=60.0, pool=30.0))
 
     # Honour the same pacing knob as LLMClient. Applied at the transport
     # method the SDK actually calls, so every agent turn and tool round-trip
     # is spaced -- not just the calls this module makes directly.
     rpm = int(os.getenv("AI_LLM_MAX_RPM", "0") or 0)
     pacer = _AsyncPacer(rpm)
-    _orig_create = client.chat.completions.create
+    completions = client.chat.completions
+    completions._pa_orig_create = completions.create
 
     # One shim for pacing AND resilience: the CSIC gateway answers with bare
     # 500s ("connection reset by peer" from the vLLM behind litellm) during
@@ -236,18 +386,36 @@ def configure_sdk():
         if isinstance(e, (_oai.InternalServerError, _oai.APIConnectionError,
                           _oai.APITimeoutError, _oai.RateLimitError)):
             return True
+        if isinstance(e, (httpx.HTTPError, _EmptyStream)):
+            # Raised while *iterating* a stream (openai wraps only the initial
+            # request): a dropped connection, a read timeout between tokens,
+            # or a stream that closed empty. All as transient as a 5xx.
+            return True
         return (isinstance(e, _oai.APIStatusError)
                 and getattr(e, "status_code", None) in _RETRY_STATUSES)
 
     _ATTEMPTS = 4  # one call plus three retries
+
+    async def _issue(*args, **kwargs):
+        # A caller that streams for itself (Runner.run_streamed) gets the raw
+        # stream; every other call is issued as a stream and folded, because
+        # on this gateway a non-streamed answer has ~120 s per attempt and a
+        # streamed one has that per token.
+        orig = completions._pa_orig_create
+        if kwargs.get("stream") is True or not SDK_STREAM:
+            return await orig(*args, **kwargs)
+        kwargs = dict(kwargs, stream=True,
+                      stream_options={"include_usage": True})
+        stream = await orig(*args, **kwargs)
+        return await _stream_to_completion(stream)
 
     async def _paced_create(*args, **kwargs):
         last = None
         for attempt in range(_ATTEMPTS):
             await pacer.wait()
             try:
-                return await _orig_create(*args, **kwargs)
-            except _oai.APIError as e:
+                return await _issue(*args, **kwargs)
+            except (_oai.APIError, httpx.HTTPError, _EmptyStream) as e:
                 if not _transient(e):
                     raise
                 last = e
@@ -263,9 +431,12 @@ def configure_sdk():
                                    " %s" % status if status else "")
         raise last
 
-    client.chat.completions.create = _paced_create
-    logger.info("Agents SDK transport armed: pacing %s rpm, retry x3 on 5xx/timeouts",
-                rpm or "off")
+    # The original stays reachable as _pa_orig_create: tests substitute it,
+    # and a provider that cannot stream is pointed back at it by AI_SDK_STREAM=0.
+    completions.create = _paced_create
+    logger.info("Agents SDK transport armed: pacing %s rpm, streaming %s, "
+                "retry x3 on 5xx/timeouts, read timeout %ss",
+                rpm or "off", "on" if SDK_STREAM else "off", SDK_HTTP_READ_TIMEOUT)
     # chat_completions, not the Responses API: the CSIC gateway is vLLM, which
     # speaks /chat/completions only.
     set_default_openai_api("chat_completions")
@@ -1308,16 +1479,32 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
     # was no longer interpreting each pathway in the context of the analysis it
     # had just written. The coupling was doing real work, and buying 100s by
     # discarding it was a bad trade.
+    # Each draft is bounded (SDK_LONG_CALL_TIMEOUT); a draft that never comes
+    # back is an exception here like any other, and only a run with no draft
+    # at all fails.
     drafts = await asyncio.gather(
-        *[Runner.run(agents["synth"], synth_prompt, context=ctx, max_turns=3)
-          for _ in range(SDK_SYNTH_DRAFTS)],
+        *[bounded(Runner.run(agents["synth"], synth_prompt, context=ctx, max_turns=3),
+                  SDK_LONG_CALL_TIMEOUT, label="synthesis draft %d" % i)
+          for i in range(SDK_SYNTH_DRAFTS)],
         return_exceptions=True)
-    drafts = [str(d.final_output) for d in drafts if not isinstance(d, Exception)]
+    failures = [d for d in drafts if isinstance(d, BaseException)]
+    for f in failures:
+        logger.warning("[%s][sdk] synthesis draft failed: %s: %s",
+                       job_id, type(f).__name__, f)
+    drafts = [str(d.final_output) for d in drafts if not isinstance(d, BaseException)]
     if not drafts:
-        raise RuntimeError("all synthesis drafts failed")
+        raise RuntimeError("all synthesis drafts failed (%s)" % (
+            "; ".join("%s: %s" % (type(f).__name__, f) for f in failures) or "no drafts"))
     report, draft_scores = _pick_best_draft(drafts, pathways, unique_papers)
     stats["synth_drafts"] = len(drafts)
     stats["draft_scores"] = draft_scores
+    # The model sometimes cites by identifier -- "(PMID 42565800)", 90 times
+    # in one live draft -- and keeps "[N]" for a bibliography of its own.
+    # Every downstream reader matches "[N]" in the body, so those citations
+    # are converted here, deterministically, from the exact PMID -> index
+    # map; done before the top-up gate so a draft that cited well by PMID is
+    # not sent for a rewrite it does not need.
+    report = resolve_pmid_mentions(report, {p["ref_index"]: p for p in unique_papers})
     # Close the gaps the draft left, before anything else touches the report.
     # One targeted revision naming exactly what is missing, rather than another
     # sample of the same distribution.
@@ -1350,9 +1537,9 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
             request.append("MISSING CAVEATS -- each is warranted by this "
                            "dataset:\n%s\n" % "\n".join("  - %s" % g for g in gaps))
         try:
-            revised = await Runner.run(
+            revised = await bounded(Runner.run(
                 agents["synth"], "\n".join(request) + "\n\n## Report\n\n" + report,
-                context=ctx, max_turns=3)
+                context=ctx, max_turns=3), SDK_LONG_CALL_TIMEOUT, label="gap-fill")
             candidate = str(revised.final_output)
             # Only accept a revision that grew the report; a "revision" that
             # summarises it away would trade real content for checklist items.
@@ -1362,8 +1549,9 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
             else:
                 logger.warning("[%s][sdk] gap-fill discarded (%d -> %d chars)",
                                job_id, len(report), len(candidate))
-        except Exception as e:
-            logger.warning("[%s][sdk] gap-fill failed: %s", job_id, e)
+        except (Exception, asyncio.TimeoutError) as e:
+            logger.warning("[%s][sdk] gap-fill failed: %s: %s",
+                           job_id, type(e).__name__, e)
         stats["gap_fill_s"] = time.time() - t_gap
         logger.info("[%s][sdk] gap-fill: %d pathways, %d caveats requested",
                     job_id, len(missing_pw), len(gaps))
@@ -1419,11 +1607,10 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
     # References section of its own but never cites them in the text (seen
     # live: 25 entries, 0 in-text markers, 0 rendered) must trigger the
     # top-up, and counting the bibliography's [N] hid exactly that case.
-    from src.classes.AIInterpret.verification import _REFERENCES_HEADING_RE as _REFS_RE
-    _ref_m = _REFS_RE.search(str(report))
-    _body_for_count = str(report)[:_ref_m.start()] if _ref_m else str(report)
-    cited_now = ({int(n) for n in re.findall(r'\[(\d+)\]', _body_for_count)}
-                 & valid_indices)
+    # The acceptance test below uses the same helper, so the two cannot
+    # disagree -- they did once, and a rewrite whose whole contribution was
+    # a bibliography was accepted as "56 citations added".
+    cited_now = count_body_citations(str(report), valid_indices)
     uncited = [p for p in unique_papers if p["ref_index"] not in cited_now]
     if uncited and len(cited_now) < SDK_MIN_CITATIONS:
         listing = "\n".join(
@@ -1431,8 +1618,13 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
                               (p.get("abstract") or "")[:220])
             for p in uncited[:30])
         t_top = time.time()
+        # Optional pass, bounded: the report is already complete without it,
+        # so a top-up that outlives SDK_LONG_CALL_TIMEOUT is skipped, not
+        # waited on. (Two live runs sat 90+ min here before this bound existed:
+        # this call echoes the whole report, and on the CSIC gateway that
+        # answer outran the per-attempt budget until streaming was added.)
         try:
-            topped = await Runner.run(
+            topped = await bounded(Runner.run(
                 agents["synth"],
                 "Here is your report:\n\n%s\n\n"
                 "These retrieved papers are not cited anywhere in it:\n\n%s\n\n"
@@ -1444,12 +1636,12 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
                 "removed later along with the claim it sits on, so forcing one "
                 "in costs you the finding. Leaving a paper uncited is a fine "
                 "outcome." % (report, listing),
-                context=ctx, max_turns=3)
-            candidate = str(topped.final_output)
+                context=ctx, max_turns=3), SDK_LONG_CALL_TIMEOUT, label="citation top-up")
+            candidate = resolve_pmid_mentions(
+                str(topped.final_output), {p["ref_index"]: p for p in unique_papers})
             # Guard against the "rewrite" degenerating into a summary: keep the
-            # top-up only if it preserved the report and added citations.
-            added = len({int(n) for n in re.findall(r'\[(\d+)\]', candidate)}
-                        & valid_indices)
+            # top-up only if it preserved the report and added BODY citations.
+            added = len(count_body_citations(candidate, valid_indices))
             if len(candidate) > 0.6 * len(str(report)) and added > len(cited_now):
                 report = candidate
                 stats["topup_added"] = added - len(cited_now)
@@ -1458,8 +1650,10 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
                 logger.warning("[%s][sdk] citation top-up discarded (len %d->%d, "
                                "citations %d->%d)", job_id, len(str(report)),
                                len(candidate), len(cited_now), added)
-        except Exception as e:
-            logger.warning("[%s][sdk] citation top-up failed: %s", job_id, e)
+        except (Exception, asyncio.TimeoutError) as e:
+            stats["topup_failed"] = "%s: %s" % (type(e).__name__, e)
+            logger.warning("[%s][sdk] citation top-up failed: %s: %s",
+                           job_id, type(e).__name__, e)
         stats["topup_s"] = time.time() - t_top
     if stats.get("batch_citations") and not stats["synth_citations"]:
         logger.warning("[%s][sdk] synthesis dropped ALL citations: batches "
@@ -1555,12 +1749,25 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
                         "(%d citations will be redacted instead)", job_id, len(failed))
             break
 
-        corr = await Runner.run(
-            agents["synth"],
-            "Here is your report:\n\n%s\n\n%s"
-            % (report, prompts_mod.build_correction_prompt(report, failed)),
-            context=ctx, max_turns=3)
-        report = str(corr.final_output)
+        # The rewrite is a full-report echo like the top-up, and it is
+        # optional in the same way: the programmatic net (phase 6) redacts
+        # whatever still fails. So a rewrite that times out or raises ends the
+        # loop with the report as it stands, rather than ending the run.
+        try:
+            corr = await bounded(Runner.run(
+                agents["synth"],
+                "Here is your report:\n\n%s\n\n%s"
+                % (report, prompts_mod.build_correction_prompt(report, failed)),
+                context=ctx, max_turns=3), SDK_LONG_CALL_TIMEOUT,
+                label="correction rewrite %d" % (_iteration + 1))
+        except (Exception, asyncio.TimeoutError) as e:
+            logger.warning("[%s][sdk] correction rewrite failed: %s: %s; keeping "
+                           "the report and leaving %d citation(s) to the "
+                           "programmatic net", job_id, type(e).__name__, e,
+                           len(failed))
+            stats["correction_failed"] = "%s: %s" % (type(e).__name__, e)
+            break
+        report = resolve_pmid_mentions(str(corr.final_output), ctx.paper_index)
         # The rewrite re-authors the references, so re-render them from the
         # paper index; without this the loop verifies on iteration 1 and then
         # finishes with an unparseable section again. A rewrite also
@@ -1617,9 +1824,24 @@ def run_agent_workflow(job_instance, job_id, experiment_design, budgets=None,
                           "max_search_tasks": AI_MAX_SEARCH_TASKS}
     stats = {}
     t0 = time.time()
-    report, papers, ctx = asyncio.run(
-        _run_async(job_instance, job_id, experiment_design, budgets, stats,
-                   hooks=hooks))
+
+    async def _with_deadline():
+        # The last line of defence against "still running" as a permanent
+        # state. Every phase has its own cap; this one catches whatever they
+        # miss, and turns it into an error the UI can show and the user can
+        # retry, instead of a heartbeat that keeps a dead run looking alive.
+        try:
+            return await asyncio.wait_for(
+                _run_async(job_instance, job_id, experiment_design, budgets,
+                           stats, hooks=hooks),
+                timeout=AI_MAX_RUN_SECONDS)
+        except asyncio.TimeoutError:
+            raise RuntimeError(
+                "The interpretation exceeded its %d-minute limit and was "
+                "stopped. The literature gateway was slow to answer; please "
+                "try again later." % int(AI_MAX_RUN_SECONDS // 60))
+
+    report, papers, ctx = asyncio.run(_with_deadline())
     stats["total_s"] = time.time() - t0
     return {"report": report, "papers": papers, "stats": stats}
 

--- a/PaintomicsServer/src/classes/AIInterpret/verification.py
+++ b/PaintomicsServer/src/classes/AIInterpret/verification.py
@@ -127,6 +127,88 @@ def normalize_citation_markers(text):
     text = _RANGE_CITATION_RE.sub(_split_range, text)
     return _MULTI_CITATION_RE.sub(_split_list, text)
 
+# An inline PMID mention, in the forms the model actually writes when it
+# cites by identifier instead of by marker: "(PMID 42565800)", "PMID: 42565800",
+# "PMIDs 42505068 and 42371798", "(PMID: 1; PMID: 2)". One match covers a whole
+# group so the connective words go with the numbers it joins.
+# The parentheses are consumed only as a pair, so "(see PMID 1)" keeps its
+# closing bracket while "(PMID 1)" loses both.
+_PMID_LIST = r'\d{5,9}(?:\s*(?:,|;|/|&|and)\s*(?:PMIDs?\s*:?\s*#?\s*)?\d{5,9})*'
+_PMID_MENTION_RE = re.compile(
+    r'\(\s*PMIDs?\s*:?\s*#?\s*(?P<a>' + _PMID_LIST + r')\s*\)'   # "(PMID 1)", "(PMIDs 1 and 2)"
+    r'|\bPMIDs?\s*:?\s*#?\s*(?P<b>' + _PMID_LIST + r')',            # bare "PMID 1", "PMIDs 1, 2"
+    re.IGNORECASE)
+
+
+def resolve_pmid_mentions(text, paper_index):
+    """Rewrite inline PMID mentions of retrieved papers as [N] markers.
+
+    Every reader of citations here matches "[N]" in the body of the report:
+    quote collection, rendering, verification, renumbering. When the model
+    cites a paper by its PMID instead -- which it did 90 times in one live
+    synthesis, keeping "[N]" for a bibliography of its own -- all of that
+    support is invisible and the report ships with no references. The mapping
+    PMID -> ref_index is exact and known, so the mention is rewritten rather
+    than the model re-asked.
+
+    Only PMIDs that were retrieved are converted; an unknown PMID stays as
+    text, where verification will treat the sentence as uncited rather than
+    manufacture a reference to a paper nobody fetched. The model's own
+    References section (if any) is left as written: render_references_section
+    replaces it wholesale, and rewriting it would only create body-looking
+    markers below the heading. Idempotent, and a no-op without a paper index.
+    """
+    if not text or not paper_index:
+        return text
+    by_pmid = {}
+    for idx, paper in paper_index.items():
+        pmid = str((paper or {}).get("pmid") or "").strip()
+        if pmid:
+            by_pmid[pmid] = idx
+    if not by_pmid:
+        return text
+
+    ref_match = _REFERENCES_HEADING_RE.search(text)
+    body, tail = ((text[:ref_match.start()], text[ref_match.start():])
+                  if ref_match else (text, ""))
+
+    def _swap(match):
+        numbers = re.findall(r'\d{5,9}', match.group("a") or match.group("b") or "")
+        known = [by_pmid[n] for n in numbers if n in by_pmid]
+        if not known:
+            return match.group(0)
+        if len(known) == len(numbers):
+            return ", ".join("[%d]" % i for i in known)
+        # A mixed group: convert what we have, keep the rest as text.
+        parts = ["[%d]" % by_pmid[n] if n in by_pmid else "PMID %s" % n
+                 for n in numbers]
+        return ", ".join(parts)
+
+    body = _PMID_MENTION_RE.sub(_swap, body)
+    # "axis (PMID 1) provides" became "axis [3] provides" -- the surrounding
+    # spacing was the parenthesis's; the marker wants a single space each side.
+    body = re.sub(r'[ \t]+(\[\d+\])', r' \1', body)
+    body = re.sub(r'(\[\d+\])[ \t]+([.,;:)])', r'\1\2', body)
+    return body + tail
+
+
+def count_body_citations(report_text, valid_indices):
+    """The set of retrieved-paper markers cited in the BODY of the report.
+
+    A model that lists its papers under a References heading and never cites
+    them in the text has cited nothing: the section is discarded by
+    render_references_section, and only body markers survive to be verified.
+    Both the citation top-up's gate and its acceptance test read this, so
+    they cannot disagree with each other -- they did once (PR #28 fixed the
+    gate alone), and a top-up whose whole contribution was a bibliography was
+    accepted as having "added 56 citations".
+    """
+    text = normalize_citation_markers(report_text or "")
+    ref_match = _REFERENCES_HEADING_RE.search(text)
+    body = text[:ref_match.start()] if ref_match else text
+    return {int(n) for n in re.findall(r'\[(\d+)\]', body)} & set(valid_indices)
+
+
 def verify_report_v2(report_text, gene_whitelist, unique_papers, job_instance):
     """Verify a report using [N] citation format.
 

--- a/PaintomicsServer/src/tests/test_ai_agent_endtoend.py
+++ b/PaintomicsServer/src/tests/test_ai_agent_endtoend.py
@@ -119,6 +119,7 @@ SYNTHESIS = ("## Summary\n\nCoordinated regulation is visible across the "
 
 class _Handler(BaseHTTPRequestHandler):
     served = []
+    streamed = 0
 
     def log_message(self, *args):
         pass
@@ -134,6 +135,38 @@ class _Handler(BaseHTTPRequestHandler):
         schema = ((payload.get("response_format") or {})
                   .get("json_schema") or {}).get("schema")
         content = json.dumps(_instanceFor(schema)) if schema else SYNTHESIS
+
+        if payload.get("stream"):
+            # The SDK transport streams every call and folds the chunks back
+            # (agent._stream_to_completion), so the stand-in must speak SSE
+            # the way vLLM does: role first, content in pieces, a closing
+            # finish_reason, usage last, then [DONE].
+            _Handler.streamed += 1
+            half = max(1, len(content) // 2)
+            chunks = [
+                {"delta": {"role": "assistant", "content": ""}},
+                {"delta": {"content": content[:half]}},
+                {"delta": {"content": content[half:]}},
+                {"delta": {}, "finish_reason": "stop"},
+            ]
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Cache-Control", "no-cache")
+            self.end_headers()
+            for i, c in enumerate(chunks):
+                event = {"id": "chatcmpl-stub", "object": "chat.completion.chunk",
+                         "created": 1, "model": "stub-model",
+                         "choices": [dict({"index": 0, "finish_reason": None}, **c)]}
+                self.wfile.write(("data: " + json.dumps(event) + "\n\n").encode())
+            if (payload.get("stream_options") or {}).get("include_usage"):
+                usage = {"id": "chatcmpl-stub", "object": "chat.completion.chunk",
+                         "created": 1, "model": "stub-model", "choices": [],
+                         "usage": {"prompt_tokens": 1, "completion_tokens": 1,
+                                   "total_tokens": 2}}
+                self.wfile.write(("data: " + json.dumps(usage) + "\n\n").encode())
+            self.wfile.write(b"data: [DONE]\n\n")
+            self.wfile.flush()
+            return
 
         body = json.dumps({
             "choices": [{"index": 0, "finish_reason": "stop",
@@ -182,6 +215,7 @@ class AiPipelineEndToEndTest(unittest.TestCase):
 
         cls.server, baseUrl = _startGateway()
         _Handler.served = []
+        _Handler.streamed = 0
 
         from src.conf import serverconf
         cls._saved = dict(serverconf.AI_PROVIDERS[serverconf.AI_LLM_PROVIDER])
@@ -277,6 +311,13 @@ class AiPipelineEndToEndTest(unittest.TestCase):
     def test_the_pipeline_called_the_gateway(self):
         self.assertTrue(_Handler.served,
                         "the pipeline made no LLM request at all")
+
+    def test_the_sdk_calls_were_streamed(self):
+        # The transport issues every completion as a stream (see
+        # test_ai_sdk_transport for why); a run that reached the gateway
+        # without one streamed request would mean the shim is not on the path.
+        self.assertGreater(_Handler.streamed, 0,
+                           "no SDK call arrived at the gateway as a stream")
 
     def test_the_run_is_recorded_as_done(self):
         self.assertEqual((self.stored or {}).get("status"), "done")

--- a/PaintomicsServer/src/tests/test_ai_sdk_transport.py
+++ b/PaintomicsServer/src/tests/test_ai_sdk_transport.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""The Agents SDK transport must stream, must own its retries, and must be bounded.
+
+Why this exists
+---------------
+On 2026-08-17 two live interpretations on paintomics.uv.es sat at "Synthesizing
+report... 78%" for over an hour and a half (jobs 4101fcI63x, Wj2Nc70376). The
+citation top-up asks the model to return the whole report again; for the
+105-pathway STATegra example that answer is ~17k tokens, and the CSIC gateway
+gives each *non-streamed* attempt about 120 s before it gives up (measured:
+14k tokens took 477 s = four internal attempts; the top-up got HTTP 408 after
+489 s, three times in a row). Streaming does not have that ceiling -- a 25k
+token generation streamed through in 203 s -- because the budget is per read,
+not per response.
+
+Three transport defects turned "one slow call" into "never finishes":
+
+  1. Nothing streamed. Every SDK call went through ``create(stream=False)``.
+  2. Retries multiplied. ``AsyncOpenAI`` retries 408 twice on its own, and
+     ``_paced_create`` retried the whole thing four times: 12 attempts, each
+     eight minutes long.
+  3. Nothing bounded the call. ``run_hedged`` caps the short calls at 45 s, but
+     synthesis, gap-fill, top-up and the correction rewrite were bare
+     ``Runner.run`` awaits, and the heartbeat kept the job "alive" throughout.
+
+The tests below pin the fixed contract:
+
+  * ``_stream_to_completion`` folds a chunk stream (content, tool calls, usage)
+    into a ``ChatCompletion`` the SDK can consume unchanged.
+  * ``configure_sdk`` hands the SDK a client with ``max_retries=0`` and a
+    finite timeout, and its ``create`` shim streams by default and passes a
+    caller's ``stream=True`` straight through.
+  * ``bounded`` cancels an awaitable at its deadline instead of waiting on it.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_ai_sdk_transport
+"""
+import asyncio
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+os.environ.setdefault("AI_CSIC_API_KEY", "test-key")
+
+
+def _chunk(**kw):
+    """A ChatCompletionChunk with one choice, built from delta fields."""
+    from openai.types.chat import ChatCompletionChunk
+    delta = kw.pop("delta", {})
+    finish = kw.pop("finish_reason", None)
+    usage = kw.pop("usage", None)
+    return ChatCompletionChunk.model_validate({
+        "id": "chatcmpl-test", "object": "chat.completion.chunk",
+        "created": 1, "model": "stub-model",
+        "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+        "usage": usage,
+    })
+
+
+class _FakeStream:
+    """Stands in for openai's AsyncStream: async-iterable, closable."""
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+        self.closed = False
+
+    def __aiter__(self):
+        async def _gen():
+            for c in self._chunks:
+                yield c
+        return _gen()
+
+    async def close(self):
+        self.closed = True
+
+
+class StreamReassemblyTest(unittest.TestCase):
+
+    def test_content_and_usage_fold_into_a_chat_completion(self):
+        from src.classes.AIInterpret.agent import _stream_to_completion
+        from openai.types.chat import ChatCompletion
+        stream = _FakeStream([
+            _chunk(delta={"role": "assistant", "content": "Hel"}),
+            _chunk(delta={"content": "lo"}),
+            _chunk(delta={"content": " [1]"}, finish_reason="stop"),
+            _chunk(usage={"prompt_tokens": 10, "completion_tokens": 3,
+                          "total_tokens": 13}),
+        ])
+        done = asyncio.run(_stream_to_completion(stream))
+        self.assertIsInstance(done, ChatCompletion)
+        self.assertEqual(done.choices[0].message.content, "Hello [1]")
+        self.assertEqual(done.choices[0].message.role, "assistant")
+        self.assertEqual(done.choices[0].finish_reason, "stop")
+        self.assertEqual(done.usage.completion_tokens, 3)
+        self.assertEqual(done.usage.total_tokens, 13)
+        self.assertEqual(done.id, "chatcmpl-test")
+        self.assertEqual(done.object, "chat.completion")
+        self.assertTrue(stream.closed, "the stream must be closed once folded")
+
+    def test_tool_call_deltas_are_joined_by_index(self):
+        from src.classes.AIInterpret.agent import _stream_to_completion
+        stream = _FakeStream([
+            _chunk(delta={"role": "assistant", "content": None,
+                          "tool_calls": [{"index": 0, "id": "call_a",
+                                          "type": "function",
+                                          "function": {"name": "get_gene_timecourse",
+                                                       "arguments": ""}}]}),
+            _chunk(delta={"tool_calls": [{"index": 0,
+                                          "function": {"arguments": "{\"gene_sym"}}]}),
+            _chunk(delta={"tool_calls": [{"index": 0,
+                                          "function": {"arguments": "bol\": \"Ccl2\"}"}}]}),
+            _chunk(delta={"tool_calls": [{"index": 1, "id": "call_b",
+                                          "type": "function",
+                                          "function": {"name": "compare_genes",
+                                                       "arguments": "{}"}}]}),
+            _chunk(delta={}, finish_reason="tool_calls"),
+        ])
+        done = asyncio.run(_stream_to_completion(stream))
+        calls = done.choices[0].message.tool_calls
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0].id, "call_a")
+        self.assertEqual(calls[0].function.name, "get_gene_timecourse")
+        self.assertEqual(calls[0].function.arguments, '{"gene_symbol": "Ccl2"}')
+        self.assertEqual(calls[1].id, "call_b")
+        self.assertEqual(calls[1].function.name, "compare_genes")
+        self.assertEqual(done.choices[0].finish_reason, "tool_calls")
+        self.assertIsNone(done.choices[0].message.content)
+
+    def test_no_usage_chunk_yields_no_usage(self):
+        # vLLM only sends usage when stream_options asks for it; the SDK treats a
+        # missing usage as zero rather than crashing, so None must survive.
+        from src.classes.AIInterpret.agent import _stream_to_completion
+        stream = _FakeStream([_chunk(delta={"content": "x"}, finish_reason="stop")])
+        done = asyncio.run(_stream_to_completion(stream))
+        self.assertIsNone(done.usage)
+        self.assertEqual(done.choices[0].message.content, "x")
+
+    def test_an_empty_stream_is_an_error_not_an_empty_answer(self):
+        # A gateway that closes the stream without a single choice has not
+        # answered; surfacing that as a retryable error beats handing the SDK
+        # a blank message it would score as "the model said nothing".
+        from src.classes.AIInterpret.agent import _stream_to_completion, _EmptyStream
+        with self.assertRaises(_EmptyStream):
+            asyncio.run(_stream_to_completion(_FakeStream([])))
+
+
+class ClientConfigurationTest(unittest.TestCase):
+
+    def setUp(self):
+        import src.classes.AIInterpret.agent as agent
+        self.agent = agent
+        self._saved = (agent._sdk_configured, agent._MODEL_OBJ)
+        agent._sdk_configured = False
+        agent._MODEL_OBJ = None
+
+    def tearDown(self):
+        self.agent._sdk_configured, self.agent._MODEL_OBJ = self._saved
+
+    def test_client_owns_no_retries_and_has_a_finite_timeout(self):
+        self.agent.configure_sdk()
+        client = self.agent._MODEL_OBJ._client
+        self.assertEqual(client.max_retries, 0,
+                         "the shim is the only retry policy; stacked retries "
+                         "made one 408 cost twelve eight-minute attempts")
+        timeout = client.timeout
+        # httpx.Timeout or a float -- either way every phase must be finite.
+        read = getattr(timeout, "read", timeout)
+        self.assertIsNotNone(read)
+        self.assertLess(float(read), 600.0)
+
+    def test_create_streams_by_default_and_passes_stream_true_through(self):
+        self.agent.configure_sdk()
+        client = self.agent._MODEL_OBJ._client
+        calls = []
+
+        async def fake_orig(*args, **kwargs):
+            calls.append(kwargs)
+            if kwargs.get("stream") is True and kwargs.get("_passthrough_test"):
+                return "raw-stream"
+            return _FakeStream([_chunk(delta={"content": "ok"}, finish_reason="stop")])
+
+        # The shim keeps the original under a known name so tests (and a
+        # future provider that cannot stream) can reach it.
+        client.chat.completions._pa_orig_create = fake_orig
+        from openai.types.chat import ChatCompletion
+
+        done = asyncio.run(client.chat.completions.create(model="m", messages=[]))
+        self.assertIsInstance(done, ChatCompletion)
+        self.assertEqual(done.choices[0].message.content, "ok")
+        self.assertIs(calls[-1].get("stream"), True,
+                      "a non-streaming call must be issued as a stream")
+        self.assertEqual(calls[-1].get("stream_options"), {"include_usage": True})
+
+        raw = asyncio.run(client.chat.completions.create(
+            model="m", messages=[], stream=True, _passthrough_test=True))
+        self.assertEqual(raw, "raw-stream")
+
+
+class BoundedAwaitTest(unittest.TestCase):
+
+    def test_bounded_cancels_at_the_deadline(self):
+        from src.classes.AIInterpret.agent import bounded
+        state = {"cancelled": False}
+
+        async def hang():
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                state["cancelled"] = True
+                raise
+
+        async def go():
+            with self.assertRaises(asyncio.TimeoutError):
+                await bounded(hang(), 0.05, label="hang")
+        asyncio.run(go())
+        self.assertTrue(state["cancelled"])
+
+    def test_bounded_returns_the_value_in_time(self):
+        from src.classes.AIInterpret.agent import bounded
+
+        async def quick():
+            return 42
+        self.assertEqual(asyncio.run(bounded(quick(), 1.0, label="quick")), 42)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_pmid_mentions_resolve_to_markers.py
+++ b/PaintomicsServer/src/tests/test_pmid_mentions_resolve_to_markers.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Inline PMID mentions become [N] markers; a bibliography alone is not citing.
+
+Why this exists
+---------------
+The first STATegra 5-omics run after the streaming transport landed (local
+job n6e03200f1, 2026-08-17) finished in 8 minutes and reported
+"0 of 56 retrieved papers cited". The synthesis draft had in fact cited 90
+times -- as ``(PMID 42565800)``, ``PMIDs 42505068 and 42371798``,
+``PMID 39112517 links CCL2 to ...`` -- and put its ``[N]`` markers only in a
+References list it wrote itself. Every reader of citations in the pipeline
+(quote collection, rendering, verification, renumbering) matches ``[N]`` in
+the body, so all of that support was dropped and the final report carried no
+references at all. Two things let it happen:
+
+  * nothing turned a PMID the model *did* name into the marker the pipeline
+    reads, although the mapping PMID -> ref_index is known exactly;
+  * the citation top-up accepted its own rewrite because the count of "added"
+    markers included the model's bibliography -- the gate before it had been
+    fixed to count body markers only (PR #28), the acceptance after it had not.
+
+The tests pin both: ``resolve_pmid_mentions`` rewrites the mention forms seen
+live into markers (only for PMIDs that were retrieved), and
+``count_body_citations`` ignores anything under a References heading.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_pmid_mentions_resolve_to_markers
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+PAPERS = {
+    3: {"ref_index": 3, "pmid": "42565800"},
+    7: {"ref_index": 7, "pmid": "42505068"},
+    9: {"ref_index": 9, "pmid": "42371798"},
+    12: {"ref_index": 12, "pmid": "39112517"},
+}
+
+
+class ResolvePmidMentionsTest(unittest.TestCase):
+
+    def setUp(self):
+        from src.classes.AIInterpret.verification import resolve_pmid_mentions
+        self.resolve = resolve_pmid_mentions
+
+    def test_parenthesised_pmid_becomes_a_marker(self):
+        out = self.resolve("The STAT5A axis (PMID 42565800) provides a link.", PAPERS)
+        self.assertEqual(out, "The STAT5A axis [3] provides a link.")
+
+    def test_colon_form_and_pmid_list_forms(self):
+        out = self.resolve("As shown (PMID: 42565800; PMID: 42505068).", PAPERS)
+        self.assertEqual(out, "As shown [3], [7].")
+        out = self.resolve("connecting to PMIDs 42505068 and 42371798.", PAPERS)
+        self.assertEqual(out, "connecting to [7], [9].")
+
+    def test_a_bracket_that_is_not_the_mentions_own_survives(self):
+        out = self.resolve("Reported before (see PMID 42565800).", PAPERS)
+        self.assertEqual(out, "Reported before (see [3]).")
+
+    def test_sentence_initial_mention_keeps_the_sentence(self):
+        out = self.resolve("PMID 39112517 links CCL2 to IKZF1 expression.", PAPERS)
+        self.assertEqual(out, "[12] links CCL2 to IKZF1 expression.")
+
+    def test_unretrieved_pmids_are_left_alone(self):
+        text = "Elsewhere (PMID 11111111) this was disputed."
+        self.assertEqual(self.resolve(text, PAPERS), text)
+        # A mixed group keeps the unknown one as text and converts the known.
+        out = self.resolve("(PMIDs 42565800 and 11111111)", PAPERS)
+        self.assertIn("[3]", out)
+        self.assertIn("11111111", out)
+
+    def test_existing_markers_and_prose_are_untouched(self):
+        text = "Ccl2 falls to -5.24 [3]; see Table 2 and p=1.7e-08 in 2024."
+        self.assertEqual(self.resolve(text, PAPERS), text)
+
+    def test_the_models_own_references_section_is_not_rewritten(self):
+        # It is discarded by render_references_section anyway; rewriting it
+        # would only manufacture body-looking markers below the heading.
+        text = ("Body cites (PMID 42565800).\n\n### References\n\n"
+                "[3] Some title. PMID 42565800\n")
+        out = self.resolve(text, PAPERS)
+        self.assertTrue(out.startswith("Body cites [3]."))
+        self.assertIn("[3] Some title. PMID 42565800", out)
+
+    def test_idempotent(self):
+        once = self.resolve("(PMID 42565800) and (PMID 42505068)", PAPERS)
+        self.assertEqual(self.resolve(once, PAPERS), once)
+
+
+class BodyCitationCountTest(unittest.TestCase):
+
+    def test_bibliography_only_counts_as_zero(self):
+        from src.classes.AIInterpret.verification import count_body_citations
+        report = ("## Findings\n\nNo markers here.\n\n### References\n\n"
+                  "[3] A. [7] B. [9] C.\n")
+        self.assertEqual(count_body_citations(report, set(PAPERS)), set())
+
+    def test_body_markers_are_counted_and_unknown_ones_are_not(self):
+        from src.classes.AIInterpret.verification import count_body_citations
+        report = "Claim [3], claim [7], invented [99].\n\n### References\n\n[9] C."
+        self.assertEqual(count_body_citations(report, set(PAPERS)), {3, 7})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -119,6 +119,11 @@ chardet==5.2.0
 # --- AI interpretation pipeline (src/classes/AIInterpret/) ---
 openai==2.25.0
 openai-agents==0.8.4
+# Imported directly by AIInterpret/agent.py (httpx.Timeout for the SDK client,
+# httpx.HTTPError while iterating a completion stream). openai pulls it in
+# anyway; pinned here so the direct import is declared, at the version openai
+# 2.25.0 resolves to.
+httpx==0.28.1
 # No longer strictly required, and kept deliberately. openai-agents' models use
 # PEP 604 annotations ("float | None"), which pydantic cannot evaluate before
 # 3.10 without this backport -- on 3.9, `import agents` raised TypeError at


### PR DESCRIPTION
## Summary

Diagnosis of two things seen on paintomics.uv.es on 2026-08-17 (job `4101fcI63x`):

**1. "The job id changes between step 1 and step 2."** The server log shows the same Step 1 form POSTed twice, 3 s apart, from one browser (`Ov57R61V4y` at 05:28:27, `yL0zFsu5xt` at 05:28:30). Both jobs ran through all of step 1, the client polled both, and whichever callback landed last owned the view. Nothing refused the second submit and nothing rejected a stale poll result. (Separately, the regions/miRNA/MORE examples run a *conversion* job before the pathway job — two ids by design — and both were titled "Job X".)

- `JobController.beginStep1Submission` / `endStep1Submission` / `abandonStep1Submission`: a per-view lock taken at both submit entry points, released by that submission's own callback/error paths and on Reset; a second submit is refused naming the running job; `step1ActiveJobID` drops results for any other job.
- Conversion jobs are titled "Preparing <omic> (conversion job X)…".

**2. "The AI interpretation never finishes."** `4101fcI63x` and `Wj2Nc70376` sat at "Synthesizing report… 78%" for 1.5 h+. The citation top-up echoes the whole report (~17k tokens for the 105-pathway STATegra example). Measured on the CSIC gateway: a **non-streamed** completion gets ~120 s per attempt (14k tokens → HTTP 200 after 477 s = 4 internal attempts; the top-up → **HTTP 408 after 489 s, three times**), while a **streamed** 25k-token generation completes in 203 s. openai's own 2 retries under the shim's 4 attempts made one call cost ~98 minutes; the top-up/gap-fill/correction/synthesis calls had no wall clock; the heartbeat kept the job "alive".

- `configure_sdk`: `AsyncOpenAI(max_retries=0, timeout=httpx.Timeout(read=180))`; the `create` shim issues every call as a stream and folds chunks back into a `ChatCompletion` (`_stream_to_completion`; `AI_SDK_STREAM=0` opts out; original kept as `_pa_orig_create`).
- `bounded()` caps synthesis drafts, gap-fill, top-up and the correction rewrite (`AI_SDK_LONG_CALL_TIMEOUT`, 600 s; optional passes are skipped, the correction loop breaks); the whole run is capped by `AI_MAX_RUN_SECONDS` (2700 s) → a clear error instead of a permanent "running".
- Surfaced by the first full run after that (finished in 8 min, "0 of 56 papers cited"): the model cites as `(PMID 42565800)` inline and keeps `[N]` for a bibliography of its own, and the top-up accepted its own bibliography-only rewrite because it counted markers anywhere while the gate counted body markers only. `resolve_pmid_mentions` converts retrieved-paper PMID mentions into `[N]` deterministically; `count_body_citations` is shared by the gate and the acceptance test.

## Test plan
- [x] `test_ai_sdk_transport` (stream folding incl. tool-call deltas, `max_retries=0` + finite timeout, streams by default / passes `stream=True` through, `bounded` cancels) — 8/8
- [x] `test_pmid_mentions_resolve_to_markers` — 10/10
- [x] `test_ai_agent_endtoend` (stub gateway now speaks SSE, asserts a streamed call arrived) — 8/8
- [x] Full suite: 142 modules, only the two pre-existing failures on master (`test_dependencies_declared`, `test_relevance_file_shape_and_conditions`)
- [x] Live gateway through `Runner.run`: tool-call round trip (2 calls, correct answer); 21,640-token generation streamed in 171 s (the case that used to 408)
- [x] STATegra 5-omics example locally, twice, through the UI: run 1 (before the PMID fix) done in 496 s; run 2 done in **535 s, 22 of 22 papers cited (11 with full text)**, report + references render in the AI widget, no console errors
- [x] Playwright: forced second Step 1 submit → 1 POST, "Job X is already running", job continues, lock released after completion; regions example dialog reads "Preparing DNase unmapped (conversion job …)…" then "Running job …"
- [x] Clean `git archive` import gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)