### PR TITLE
Give a 429 its own retry policy in the SDK transport

### DIFF
--- a/PaintomicsServer/src/classes/AIInterpret/agent.py
+++ b/PaintomicsServer/src/classes/AIInterpret/agent.py
@@ -395,6 +395,23 @@ def configure_sdk():
                 and getattr(e, "status_code", None) in _RETRY_STATUSES)
 
     _ATTEMPTS = 4  # one call plus three retries
+    # 429 has a policy of its own. A throttled request answers instantly and
+    # costs nothing to retry, where a 408 already cost minutes on the wire; and
+    # with the client's own retries off (max_retries=0) this shim is all that
+    # stands between a 60 rpm key and a verification phase that fans out 28
+    # citations at once. Four quick tries there redacted citations the gateway
+    # had merely throttled (live run 11n0VMC305). Retry-After is honoured when
+    # the gateway sends it; otherwise the wait grows to a 30 s cap.
+    _RATE_ATTEMPTS = 8
+
+    def _retry_after(e):
+        response = getattr(e, "response", None)
+        headers = getattr(response, "headers", None)
+        value = headers.get("retry-after") if headers else None
+        try:
+            return float(value) if value else None
+        except (TypeError, ValueError):
+            return None
 
     async def _issue(*args, **kwargs):
         # A caller that streams for itself (Runner.run_streamed) gets the raw
@@ -410,33 +427,39 @@ def configure_sdk():
         return await _stream_to_completion(stream)
 
     async def _paced_create(*args, **kwargs):
-        last = None
-        for attempt in range(_ATTEMPTS):
+        attempt = 0
+        while True:
             await pacer.wait()
             try:
                 return await _issue(*args, **kwargs)
             except (_oai.APIError, httpx.HTTPError, _EmptyStream) as e:
                 if not _transient(e):
                     raise
-                last = e
+                attempt += 1
+                throttled = isinstance(e, _oai.RateLimitError)
+                limit = _RATE_ATTEMPTS if throttled else _ATTEMPTS
                 status = getattr(e, "status_code", None)
-                if attempt + 1 < _ATTEMPTS:
-                    logger.warning("SDK transport retry %d/%d after %s%s",
-                                   attempt + 1, _ATTEMPTS - 1, type(e).__name__,
-                                   " %s" % status if status else "")
-                    await asyncio.sleep(min(2 ** attempt * 2, 15))
-                else:
+                if attempt >= limit:
                     logger.warning("SDK transport giving up after %d attempts (%s%s)",
-                                   _ATTEMPTS, type(e).__name__,
+                                   attempt, type(e).__name__,
                                    " %s" % status if status else "")
-        raise last
+                    raise
+                if throttled:
+                    delay = _retry_after(e) or min(3.0 * 2 ** (attempt - 1), 30.0)
+                else:
+                    delay = min(2 ** (attempt - 1) * 2, 15)
+                logger.warning("SDK transport retry %d/%d after %s%s (waiting %.0fs)",
+                               attempt, limit - 1, type(e).__name__,
+                               " %s" % status if status else "", delay)
+                await asyncio.sleep(delay)
 
     # The original stays reachable as _pa_orig_create: tests substitute it,
     # and a provider that cannot stream is pointed back at it by AI_SDK_STREAM=0.
     completions.create = _paced_create
     logger.info("Agents SDK transport armed: pacing %s rpm, streaming %s, "
-                "retry x3 on 5xx/timeouts, read timeout %ss",
-                rpm or "off", "on" if SDK_STREAM else "off", SDK_HTTP_READ_TIMEOUT)
+                "retry x%d on 5xx/timeouts and x%d on 429, read timeout %ss",
+                rpm or "off", "on" if SDK_STREAM else "off",
+                _ATTEMPTS - 1, _RATE_ATTEMPTS - 1, SDK_HTTP_READ_TIMEOUT)
     # chat_completions, not the Responses API: the CSIC gateway is vLLM, which
     # speaks /chat/completions only.
     set_default_openai_api("chat_completions")

--- a/PaintomicsServer/src/tests/test_ai_sdk_transport.py
+++ b/PaintomicsServer/src/tests/test_ai_sdk_transport.py
@@ -199,6 +199,82 @@ class ClientConfigurationTest(unittest.TestCase):
         self.assertEqual(raw, "raw-stream")
 
 
+class RateLimitRetryTest(unittest.TestCase):
+    """429 gets a patient policy of its own.
+
+    With the client's own retries switched off (see above), the shim is the
+    only thing standing between a 60 rpm key and a verification phase that
+    fans out 28 citations at once. A 429 answers instantly and costs nothing
+    to retry -- unlike a 408 that took eight minutes to arrive -- so it gets
+    more attempts and honours Retry-After, instead of the four quick tries
+    that made the first live run redact citations the gateway had merely
+    throttled.
+    """
+
+    def setUp(self):
+        import src.classes.AIInterpret.agent as agent
+        self.agent = agent
+        self._saved = (agent._sdk_configured, agent._MODEL_OBJ)
+        agent._sdk_configured = False
+        agent._MODEL_OBJ = None
+        agent.configure_sdk()
+        self.client = agent._MODEL_OBJ._client
+        self.sleeps = []
+        self._real_sleep = asyncio.sleep
+
+        async def fake_sleep(d):
+            self.sleeps.append(d)
+        agent.asyncio.sleep = fake_sleep
+
+    def tearDown(self):
+        self.agent.asyncio.sleep = self._real_sleep
+        self.agent._sdk_configured, self.agent._MODEL_OBJ = self._saved
+
+    def _rate_limited(self, times, retry_after=None):
+        import openai, httpx
+        state = {"n": 0}
+
+        async def fake_orig(*args, **kwargs):
+            if state["n"] < times:
+                state["n"] += 1
+                headers = {"retry-after": str(retry_after)} if retry_after else {}
+                resp = httpx.Response(429, headers=headers,
+                                      request=httpx.Request("POST", "http://x"))
+                raise openai.RateLimitError("slow down", response=resp, body=None)
+            return _FakeStream([_chunk(delta={"content": "ok"}, finish_reason="stop")])
+        self.client.chat.completions._pa_orig_create = fake_orig
+        return state
+
+    def test_six_throttles_in_a_row_still_succeed(self):
+        state = self._rate_limited(6)
+        done = asyncio.run(self.client.chat.completions.create(model="m", messages=[]))
+        self.assertEqual(done.choices[0].message.content, "ok")
+        self.assertEqual(state["n"], 6)
+        self.assertEqual(len(self.sleeps), 6)
+        # Backoff grows and is capped, never a fixed 2 s.
+        self.assertGreater(self.sleeps[-1], self.sleeps[0])
+        self.assertLessEqual(max(self.sleeps), 30.0)
+
+    def test_retry_after_header_is_honoured(self):
+        self._rate_limited(1, retry_after=7)
+        asyncio.run(self.client.chat.completions.create(model="m", messages=[]))
+        self.assertEqual(self.sleeps, [7.0])
+
+    def test_a_408_keeps_the_short_policy(self):
+        # Each 408 already cost minutes on the wire; four attempts is plenty.
+        import openai, httpx
+        state = {"n": 0}
+
+        async def fake_orig(*args, **kwargs):
+            state["n"] += 1
+            resp = httpx.Response(408, request=httpx.Request("POST", "http://x"))
+            raise openai.APIStatusError("timeout", response=resp, body=None)
+        self.client.chat.completions._pa_orig_create = fake_orig
+        with self.assertRaises(openai.APIStatusError):
+            asyncio.run(self.client.chat.completions.create(model="m", messages=[]))
+        self.assertEqual(state["n"], 4)
+
+
 class BoundedAwaitTest(unittest.TestCase):
 
     def test_bounded_cancels_at_the_deadline(self):


### PR DESCRIPTION
## Summary
Follow-up to #30. `max_retries=0` left the shim's 4-attempt / 2–15 s policy as the only one, which is right for a 408 (minutes per attempt) and wrong for a 429 (instant, cheap). On the first live run after deploying #30 (`11n0VMC305`, done, 27/27 cited) the shim gave up on throttled verifier calls after four quick tries; the citations were then redacted as unverifiable although the gateway had merely throttled them (the CSIC key is 60 rpm; 429s pre-date #30 — 1,338 in yesterday's log).

- `RateLimitError`: 8 attempts, honours `Retry-After`, else 3 s doubling to a 30 s cap.
- Everything else transient keeps 4 attempts, 2–15 s.

## Test plan
- [x] `test_ai_sdk_transport` 11/11 (six 429s in a row succeed; Retry-After honoured; a 408 still stops at four)
- [x] stub e2e `test_ai_agent_endtoend` 8/8, `test_agent_semaphore_release`
- [ ] deploy the file to UV and watch one live STATegra run's verification phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)