### PR TITLE
A metabolite file of dashes can no longer take down the server

### DIFF
--- a/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
+++ b/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
@@ -1,6 +1,7 @@
 from pymongo import MongoClient
 import logging, itertools
-import os, sys, signal
+import os, sys, signal, time
+import re
 from multiprocessing import Process, cpu_count, Manager, RawArray
 from math import ceil
 from re import compile as compile_re, IGNORECASE as IGNORECASE_re
@@ -18,6 +19,11 @@ from src.conf.organismDB import dicDatabases
 from src.conf.serverconf import MONGODB_HOST, MONGODB_PORT, MAX_THREADS, MAX_WAIT_THREADS #MULTITHREADING
 
 
+# The parent's stream objects, kept alive in the fork child on purpose: see
+# _refreshStandardStreamsInForkChild. Never read; never emptied.
+_inheritedStreams = []
+
+
 def _refreshStandardStreamsInForkChild():
     """
     The mapping workers below are forked from a server process that keeps
@@ -32,7 +38,24 @@ def _refreshStandardStreamsInForkChild():
     MAX_WAIT_THREADS timeout killed the job -- and terminate() could not
     reap it, because the child also inherits uWSGI's SIGTERM handler, so
     the default disposition is restored here as well.
+
+    Two rules keep this hook from re-creating the very deadlock it exists
+    to prevent (both were violated by its first version, and a Manager
+    server child sat frozen for 32 minutes on paintomics.uv.es on
+    2026-08-17, its parent's ``Manager()`` blocked forever waiting for the
+    child's address, one queue worker gone until the service restarted):
+
+      * never FLUSH an inherited stream in the child. That is what
+        ``StreamHandler.setStream`` does before swapping, so handlers get
+        their ``stream`` attribute assigned directly instead;
+      * never DROP the last reference to an inherited stream in the child.
+        A TextIOWrapper's finaliser closes it, and closing flushes -- the
+        same lock again, this time from inside garbage collection. The old
+        objects are parked in ``_inheritedStreams`` for the life of the
+        child; whatever they buffered belongs to the parent, which still
+        holds them and will write it out itself.
     """
+    _inheritedStreams.extend((sys.stdout, sys.stderr))
     sys.stdout = open(1, "w", buffering=1, closefd=False)
     sys.stderr = open(2, "w", buffering=1, closefd=False)
     loggers = [logging.getLogger()] + [
@@ -41,12 +64,27 @@ def _refreshStandardStreamsInForkChild():
     for handler in {h for logger in loggers for h in logger.handlers}:
         try:
             if isinstance(handler, logging.FileHandler):
+                _inheritedStreams.append(handler.stream)
                 handler.stream = handler._open()
             elif isinstance(handler, logging.StreamHandler):
-                handler.setStream(sys.stderr)
+                _inheritedStreams.append(handler.stream)
+                handler.stream = sys.stderr
         except Exception:
             pass
     signal.signal(signal.SIGTERM, signal.SIG_DFL)
+
+
+def _joinAllWithinDeadline(processes, seconds):
+    """
+    Wait for every process in ``processes`` but never longer than ``seconds``
+    IN TOTAL. ``for p in processes: p.join(seconds)`` -- the previous form --
+    gives every process its own budget, so with six workers the "took too
+    long" kill only fired after up to six times MAX_WAIT_THREADS (90 minutes
+    at the configured 900 s), while the client kept polling.
+    """
+    deadline = time.monotonic() + seconds
+    for process in processes:
+        process.join(max(0.0, deadline - time.monotonic()))
 
 
 if hasattr(os, "register_at_fork"):
@@ -478,9 +516,8 @@ def mapFeatureNamesToKeggIDs(jobID, organism, databases, featureList, enrichment
             thread.start()
             i+=1
 
-        #WAIT UNTIL ALL THREADS FINISHED
-        for thread in threadsList:
-            thread.join(MAX_WAIT_THREADS)
+        #WAIT UNTIL ALL THREADS FINISHED (one shared budget, not one per thread)
+        _joinAllWithinDeadline(threadsList, MAX_WAIT_THREADS)
 
         isFinished = True
         for thread in threadsList:
@@ -495,6 +532,7 @@ def mapFeatureNamesToKeggIDs(jobID, organism, databases, featureList, enrichment
 
 
     except Exception as ex:
+        manager.shutdown()
         raise ex
 
     #***********************************************************************************
@@ -506,6 +544,7 @@ def mapFeatureNamesToKeggIDs(jobID, organism, databases, featureList, enrichment
     # input, and _matched.txt is written short — wrong results reported as success.
     # Every child appends exactly once, so a short list means a child was lost.
     if len(foundFeatures) != len(threadsList):
+        manager.shutdown()
         raise Exception(
             "Identifier mapping lost %d of %d worker processes. This is usually "
             "memory pressure on the server; please try again, and upload smaller "
@@ -529,7 +568,11 @@ def mapFeatureNamesToKeggIDs(jobID, organism, databases, featureList, enrichment
     # IPC round trip per element — measured at 92us x 39,527 elements = 6.9s of an
     # 83s job. A slice is a single __getitem__ call carrying the whole list, 10x
     # faster in-container. `list(proxy)` does NOT help: it iterates the same way.
-    return sumFoundFeatures, matchedFeatures[:], notMatchedFeatures[:]
+    matchedFeatures, notMatchedFeatures = matchedFeatures[:], notMatchedFeatures[:]
+    # The Manager server is a forked process holding a copy of everything the
+    # workers sent it; release it now rather than when the GC gets round to it.
+    manager.shutdown()
+    return sumFoundFeatures, matchedFeatures, notMatchedFeatures
 
 # *****************************************************************
 #    _____ ____  __  __ _____   ____  _    _ _   _ _____   _____
@@ -540,9 +583,38 @@ def mapFeatureNamesToKeggIDs(jobID, organism, databases, featureList, enrichment
 #   \_____\____/|_|  |_|_|     \____/ \____/|_| \_|_____/|_____/
 #
 # *****************************************************************
+# Upper bound on the compound-name candidates one input name may produce.
+# The lookup is a case-insensitive SUBSTRING match, so a generic name matches a
+# lot: on the 99k-name kegg_compounds collection "glucose" hits 198, "acid"
+# 2,648, "a" 26,711 and "-" 19,778. Every hit is a cloned Feature pushed
+# through a Manager pipe, so an unbounded match is a memory bill paid per
+# input row. A name over the cap is treated as too generic to be a substring
+# query and only its exact-name hits are kept.
+MAX_COMPOUND_MATCHES = int(os.getenv("PAINTOMICS_MAX_COMPOUND_MATCHES", "500"))
+
+
+def isPlaceholderCompoundName(featureName):
+    """
+    True when ``featureName`` cannot identify anything: empty, or made only of
+    punctuation such as ``-``, ``.``, ``?`` or ``N/A``-style dashes that
+    spreadsheets and pipelines leave in place of a missing identifier.
+
+    Why this matters: on 2026-08-17 a metabolomics upload on paintomics.uv.es
+    carried 1,172 rows whose identifier column was ``-``. Each became the
+    regex ``.*-.*``, matched the 19,778 KEGG compound names containing a
+    hyphen, and cloned the input feature once per hit -- 23 million Feature
+    objects into a Manager process that reached 3.8 GB, filled the 8 GB
+    machine plus its 4 GB of swap, and left every other job on the server
+    (including unrelated gene-expression mappings) crawling in swap for
+    26 minutes until the processes were killed by hand.
+    """
+    return not any(ch.isalnum() for ch in (featureName or ""))
+
+
 def findCompoundIDByFeatureName(jobID, featureName, db):
     """
-    This function queries the MongoDB looking for the associated gene ID for the given gene name
+    This function queries the MongoDB looking for the KEGG compounds whose name
+    contains the given feature name (case-insensitive).
 
     @param {String} jobID, the identifier for the running job, necessary to for the temporal caches
     @param {String} featureName, the name for the feature that we want to map
@@ -557,12 +629,27 @@ def findCompoundIDByFeatureName(jobID, featureName, db):
     #     return featureIDs, True
 
     matchedFeatures=[]
+    name = (featureName or "").strip()
+    if isPlaceholderCompoundName(name):
+        return matchedFeatures, False
     try:
-        cursor = db.kegg_compounds.find({"name": {"$regex" : compile_re(".*" + featureName +".*", IGNORECASE_re) }})
+        # The name is data, not a pattern: escape it. Unescaped, "NAD+" read as
+        # "NA" then one or more "D", "(R)-lactate" as a group that never
+        # matches its own parentheses, and a lone "." as any compound at all.
+        # $regex is a substring search already, so no ".*" padding is needed.
+        pattern = compile_re(re.escape(name), IGNORECASE_re)
+        cursor = db.kegg_compounds.find({"name": {"$regex": pattern}}).limit(MAX_COMPOUND_MATCHES + 1)
         # See findIDsByFeatureName: Cursor.count() is gone in pymongo 4 and the
         # surrounding except would have hidden the failure entirely.
         for item in cursor:
             matchedFeatures.append(item)
+
+        if len(matchedFeatures) > MAX_COMPOUND_MATCHES:
+            # Too generic for a substring query; keep exact-name hits only.
+            exact = compile_re("^" + re.escape(name) + "$", IGNORECASE_re)
+            matchedFeatures = list(db.kegg_compounds.find({"name": {"$regex": exact}}).limit(MAX_COMPOUND_MATCHES))
+            logging.warning("COMPOUND NAME %r MATCHES MORE THAN %d KEGG NAMES; KEEPING %d EXACT MATCH(ES) ONLY (JOB %s)",
+                            name, MAX_COMPOUND_MATCHES, len(matchedFeatures), jobID)
 
         return matchedFeatures, len(matchedFeatures) > 0
     except Exception as ex:
@@ -732,9 +819,8 @@ def mapFeatureNamesToCompoundsIDs(jobID, featureList):
             thread.start()
             i+=1
 
-        #WAIT UNTIL ALL THREADS FINISHED
-        for thread in threadsList:
-            thread.join(MAX_WAIT_THREADS)
+        #WAIT UNTIL ALL THREADS FINISHED (one shared budget, not one per thread)
+        _joinAllWithinDeadline(threadsList, MAX_WAIT_THREADS)
 
         isFinished = True
         for thread in threadsList:
@@ -747,6 +833,7 @@ def mapFeatureNamesToCompoundsIDs(jobID, featureList):
             raise Exception('Your data took too long to process and it was killed. Try it again later or upload smaller files if it persists.')
 
     except Exception as ex:
+        manager.shutdown()
         raise ex
 
     #***********************************************************************************
@@ -766,4 +853,6 @@ def mapFeatureNamesToCompoundsIDs(jobID, featureList):
     # One round trip each instead of one per element — see the note on the same
     # return in mapFeatureNamesToKeggIDs. Compound lists are short today (58 in the
     # bundled example), so this is correctness-by-consistency rather than a win.
-    return foundFeatures, matchedFeatures[:], notMatchedFeatures[:]
+    matchedFeatures, notMatchedFeatures = matchedFeatures[:], notMatchedFeatures[:]
+    manager.shutdown()
+    return foundFeatures, matchedFeatures, notMatchedFeatures

--- a/PaintomicsServer/src/tests/test_compound_name_lookup_is_bounded.py
+++ b/PaintomicsServer/src/tests/test_compound_name_lookup_is_bounded.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""A metabolite name cannot fan out into an unbounded number of KEGG candidates,
+and the identifier-mapping machinery cannot wedge the server.
+
+Why this exists
+---------------
+2026-08-17, paintomics.uv.es (8 GB RAM, 4 GB swap). A metabolomics upload had
+1,172 rows whose identifier column was ``-``. `findCompoundIDByFeatureName`
+turned each into the case-insensitive regex ``.*-.*``, which matches the
+19,778 KEGG compound names that contain a hyphen; `mapCompoundsIdentifiers`
+clones the input feature once per hit and appends the bundle to a
+`multiprocessing.Manager` list -- 23 million Feature objects, a 3.8 GB Manager
+process, six 800 MB workers, the whole box in swap (0 % user CPU, 32 % iowait,
+51 MB available). Every other job on the server, including an unrelated
+gene-expression mapping of 12,762 features that normally takes 4 seconds, sat
+"mapping" for 26 minutes; the fix at the time was ``kill -9``.
+
+Three separate defects let a bad file take the server down, and each is
+pinned here:
+
+  * a name that is only punctuation was queried at all (placeholders such as
+    ``-``, ``.``, ``?`` are the file's way of saying "no identifier");
+  * the name was spliced into a regex unescaped ("NAD+" is "NA" then one or
+    more "D"; a lone "." is every compound), and the number of hits was
+    unbounded (a generic name is a memory bill per input row);
+  * the "took too long" kill waited MAX_WAIT_THREADS *per worker process*
+    (6 x 900 s = 90 minutes) instead of in total.
+
+And a fourth, found in the same incident: the fork-child hook that PR #24
+added to *prevent* stdio-lock deadlocks called ``StreamHandler.setStream``,
+which flushes the inherited stream before swapping it -- the very lock the
+hook exists to avoid. A Manager server child froze in that flush at 09:14:25;
+its parent's ``Manager()`` blocked forever on the child's address, and one of
+the four queue workers was gone until the service restarted.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_compound_name_lookup_is_bounded
+"""
+import logging
+import os
+import re
+import signal
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from src.common import FeatureNamesToKeggIDsMapper as mapper
+
+
+class _FakeCursor:
+    def __init__(self, docs, calls, query):
+        self._docs = docs
+        self._calls = calls
+        self._query = query
+        self._limit = None
+
+    def limit(self, n):
+        self._limit = n
+        self._calls.append((self._query, n))
+        return self
+
+    def __iter__(self):
+        docs = self._docs if self._limit is None else self._docs[:self._limit]
+        return iter(docs)
+
+
+class _FakeCollection:
+    """kegg_compounds stand-in: `find({"name": {"$regex": pattern}})` evaluated in Python."""
+
+    def __init__(self, names):
+        self.docs = [{"id": "C%05d" % i, "name": n} for i, n in enumerate(names)]
+        self.calls = []
+
+    def find(self, query):
+        pattern = query["name"]["$regex"]
+        hits = [d for d in self.docs if pattern.search(d["name"])]
+        return _FakeCursor(hits, self.calls, pattern.pattern)
+
+
+class _FakeDB:
+    def __init__(self, names):
+        self.kegg_compounds = _FakeCollection(names)
+
+
+NAMES = ["Adenosine 5'-triphosphate", "NAD+", "NADH", "NADP+", "L-Leucine",
+         "D-Glucose", "Glucose", "Glucose 6-phosphate", "(R)-Lactate", "Acid"]
+
+
+class PlaceholderNamesTest(unittest.TestCase):
+
+    def test_punctuation_only_names_are_placeholders(self):
+        for name in ["-", "", "   ", ".", "?", "--", "/", None]:
+            self.assertTrue(mapper.isPlaceholderCompoundName(name), repr(name))
+
+    def test_names_with_a_letter_or_digit_are_not(self):
+        for name in ["-a", "1", "NAD+", "N/A", "Fe"]:
+            self.assertFalse(mapper.isPlaceholderCompoundName(name), repr(name))
+
+    def test_a_placeholder_never_reaches_the_database(self):
+        db = _FakeDB(NAMES)
+        matches, found = mapper.findCompoundIDByFeatureName("job", "-", db)
+        self.assertEqual((matches, found), ([], False))
+        self.assertEqual(db.kegg_compounds.calls, [])
+
+
+class EscapedSubstringLookupTest(unittest.TestCase):
+
+    def test_metacharacters_in_the_name_are_literal(self):
+        db = _FakeDB(NAMES)
+        matches, found = mapper.findCompoundIDByFeatureName("job", "NAD+", db)
+        self.assertTrue(found)
+        self.assertEqual(sorted(m["name"] for m in matches), ["NAD+"])
+        # Unescaped, "NAD+" would also have hit NADH and NADP+ ("NA" + "D"+).
+        pattern, limit = db.kegg_compounds.calls[0]
+        self.assertEqual(pattern, re.escape("NAD+"))
+        self.assertEqual(limit, mapper.MAX_COMPOUND_MATCHES + 1)
+
+    def test_parentheses_match_themselves(self):
+        db = _FakeDB(NAMES)
+        matches, found = mapper.findCompoundIDByFeatureName("job", "(R)-Lactate", db)
+        self.assertEqual([m["name"] for m in matches], ["(R)-Lactate"])
+
+    def test_still_a_case_insensitive_substring_search(self):
+        db = _FakeDB(NAMES)
+        matches, found = mapper.findCompoundIDByFeatureName("job", "glucose", db)
+        self.assertEqual(sorted(m["name"] for m in matches),
+                         ["D-Glucose", "Glucose", "Glucose 6-phosphate"])
+
+
+class BoundedMatchesTest(unittest.TestCase):
+
+    def setUp(self):
+        self._cap = mapper.MAX_COMPOUND_MATCHES
+        mapper.MAX_COMPOUND_MATCHES = 5
+
+    def tearDown(self):
+        mapper.MAX_COMPOUND_MATCHES = self._cap
+
+    def test_a_generic_name_keeps_only_its_exact_hits(self):
+        names = ["acid"] + ["%d-oxo acid" % i for i in range(20)]
+        db = _FakeDB(names)
+        with self.assertLogs(level="WARNING") as logs:
+            matches, found = mapper.findCompoundIDByFeatureName("job", "acid", db)
+        self.assertTrue(found)
+        self.assertEqual([m["name"] for m in matches], ["acid"])
+        self.assertIn("MORE THAN 5", logs.output[0])
+        # Two queries: the bounded substring probe, then the anchored exact one.
+        self.assertEqual([c[0] for c in db.kegg_compounds.calls],
+                         [re.escape("acid"), "^" + re.escape("acid") + "$"])
+
+    def test_a_generic_name_with_no_exact_hit_is_unmatched(self):
+        db = _FakeDB(["%d-hydroxy-acid" % i for i in range(20)])
+        with self.assertLogs(level="WARNING"):
+            matches, found = mapper.findCompoundIDByFeatureName("job", "hydroxy", db)
+        self.assertEqual((matches, found), ([], False))
+
+    def test_under_the_cap_every_hit_is_returned(self):
+        db = _FakeDB(["%d-oxo acid" % i for i in range(5)])
+        matches, found = mapper.findCompoundIDByFeatureName("job", "acid", db)
+        self.assertEqual(len(matches), 5)
+        self.assertEqual(len(db.kegg_compounds.calls), 1)
+
+
+class _FakeProcess:
+    def __init__(self, log):
+        self.log = log
+
+    def join(self, timeout=None):
+        self.log.append(timeout)
+
+
+class SharedDeadlineJoinTest(unittest.TestCase):
+
+    def test_the_budget_is_shared_not_per_process(self):
+        log = []
+        procs = [_FakeProcess(log) for _ in range(6)]
+        clock = iter([100.0, 100.0, 400.0, 900.0, 1500.0, 1500.0, 1500.0])
+        original = mapper.time.monotonic
+        mapper.time.monotonic = lambda: next(clock)
+        try:
+            mapper._joinAllWithinDeadline(procs, 900)
+        finally:
+            mapper.time.monotonic = original
+        # First waits the full budget, later ones only what is left, never < 0.
+        self.assertEqual(log, [900.0, 600.0, 100.0, 0.0, 0.0, 0.0])
+
+
+class _NeverFlushStream:
+    def __init__(self):
+        self.flushed = False
+        self.closed = False
+
+    def write(self, s):
+        pass
+
+    def flush(self):
+        self.flushed = True
+
+    def close(self):
+        self.closed = True
+
+
+class ForkChildStreamHookTest(unittest.TestCase):
+
+    def setUp(self):
+        self._stdout, self._stderr = sys.stdout, sys.stderr
+        self._sigterm = signal.getsignal(signal.SIGTERM)
+        self._logger = logging.getLogger("paintomics.test.forkhook")
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".log", delete=False)
+        self._tmp.close()
+
+    def tearDown(self):
+        for h in list(self._logger.handlers):
+            self._logger.removeHandler(h)
+            try:
+                h.close()
+            except Exception:
+                pass
+        sys.stdout, sys.stderr = self._stdout, self._stderr
+        signal.signal(signal.SIGTERM, self._sigterm)
+        os.unlink(self._tmp.name)
+
+    def test_inherited_streams_are_replaced_without_being_flushed(self):
+        inherited = _NeverFlushStream()
+        stream_handler = logging.StreamHandler(inherited)
+        file_handler = logging.FileHandler(self._tmp.name)
+        old_file_stream = file_handler.stream
+        self._logger.addHandler(stream_handler)
+        self._logger.addHandler(file_handler)
+        before = len(mapper._inheritedStreams)
+
+        mapper._refreshStandardStreamsInForkChild()
+
+        # New stream objects on both handlers...
+        self.assertIs(stream_handler.stream, sys.stderr)
+        self.assertIsNot(file_handler.stream, old_file_stream)
+        self.assertIsNot(sys.stdout, self._stdout)
+        # ...and the parent's were neither flushed nor closed (both would take
+        # the buffer lock a vanished thread may hold), and are kept alive so
+        # no finaliser does it later.
+        self.assertFalse(inherited.flushed)
+        self.assertFalse(inherited.closed)
+        self.assertFalse(old_file_stream.closed)
+        kept = mapper._inheritedStreams[before:]
+        self.assertIn(inherited, kept)
+        self.assertIn(old_file_stream, kept)
+        self.assertEqual(signal.getsignal(signal.SIGTERM), signal.SIG_DFL)
+        # The refreshed handlers work.
+        self._logger.warning("child says hi")
+        file_handler.flush()
+        with open(self._tmp.name) as fh:
+            self.assertIn("child says hi", fh.read())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What happened

paintomics.uv.es, 2026-08-17 ~09:16 UTC. A metabolomics upload whose identifier column was `-` on 1,172 of 2,339 rows put the whole 8 GB machine into swap for 26 minutes. Every `-` became the case-insensitive substring regex `.*-.*`, matched the **19,778** KEGG compound names containing a hyphen, and `mapCompoundsIdentifiers` cloned the input feature once per hit into a `multiprocessing.Manager` list — ~23M Feature objects, a 3.8 GB Manager process, six 800 MB workers, 0% user CPU / 32% iowait / 51 MB available. Unrelated jobs (a 12,762-feature gene mapping that normally takes 4 s) sat "mapping" the whole time, which is what the user reported. Diagnosed with py-spy on the live processes, not guessed.

A second, independent deadlock surfaced in the same incident: the PR #24 fork-child stream hook calls `StreamHandler.setStream`, which **flushes** the inherited stream before swapping it — taking the very buffer lock the hook exists to avoid. A Manager server child froze in that flush; its parent's `Manager()` blocked forever reading the child's address, and one of the four queue workers was gone until restart (py-spy stack in the commit message).

## Fixes (each pinned by a test in `test_compound_name_lookup_is_bounded.py`, 11 tests)

- **Placeholder names never reach the database.** `-`, `.`, `?`, empty — anything without a single alphanumeric — is the file saying "no identifier".
- **The name is `re.escape()`d and the fan-out is bounded.** Unescaped, `NAD+` read as `NA`+`D+` (hits NADH/NADP+), a lone `.` matched every compound. Past `MAX_COMPOUND_MATCHES` (500, env-overridable) only exact-name hits are kept, with a warning naming the culprit.
- **One shared kill budget.** `for p in ps: p.join(MAX_WAIT_THREADS)` gave each of 6 workers its own 900 s — 90 minutes before the axe. Now one deadline for all. `Manager()` servers are shut down explicitly on every path.
- **The fork hook no longer flushes.** `handler.stream` is assigned directly, and the inherited stream objects are parked in a module list so no GC finaliser closes (= flushes) them later.

## Verification

- Full standalone suite: green except the two failures already on master (`test_dependencies_declared`, `test_relevance_file_shape_and_conditions`).
- The exact two files from the incident, driven through the real Step 1 form in Chrome (Playwright): **step 2 in 25 s**, gene expression 2720 (99%) matched, metabolomics honestly 0/2,339 (HMDB IDs are not KEGG compound names), parent maxrss 38 MB, no leftover children.
- Clean `git archive` import gate + tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)