### PR TITLE
Pipeline speed-up: identifier mapping, step 2, R scripts, DAO layer, converters — results identical

### DIFF
--- a/PaintomicsServer/src/AdminTools/scripts/clean_databases.py
+++ b/PaintomicsServer/src/AdminTools/scripts/clean_databases.py
@@ -20,6 +20,34 @@ from conf.serverconf import (
 
 from src.common.Util import sendEmail
 
+# Directories directly under CLIENT_TMP that are NOT user directories.
+#
+# Everything else there is read as a "<userID>" directory, and STEP 7 rmtree's
+# any of them that no user in the database claims. "nologin" was always
+# excluded; "gtfcache" is the shared GTF cache Bed2GeneJob points at
+# (Bed2GeneJob.getOptions -> "cache_dir": CLIENT_TMP + "gtfcache"), and no user
+# will ever own it, so every cleanup run would have deleted the whole cache and
+# made the next regions-to-genes job re-parse its annotation from scratch.
+NON_USER_CLIENT_TMP_DIRS = ("nologin", "gtfcache")
+
+# Every index the running server depends on, as (collection, create_index keys).
+# Shared with paintomicsserver so startup and the nightly cron cannot drift:
+# rebuildIndexes is on a 24h timer, so without the startup pass a fresh
+# deployment answers every jobID query with a collection scan until it fires.
+#
+# aiInterpretationCollection was missing entirely. Its documents average 125KB
+# and ai_interpret_status polls {"jobID": ...} every few seconds for the whole
+# length of a multi-minute report, so it was the collection that most needed
+# the index and the only one that never had it.
+JOBID_INDEXES = [
+    ('jobInstanceCollection', "jobID"),
+    ('featuresCollection', "jobID"),
+    ('featuresCollection', [("jobID", 1), ("featureType", 1)]),
+    ('pathwaysCollection', "jobID"),
+    ('foundFeaturesCollection', "jobID"),
+    ('aiInterpretationCollection', "jobID"),
+]
+
 def cleanDatabases(force=False):
     log("Starting Clean Databases routine")
 
@@ -31,8 +59,9 @@ def cleanDatabases(force=False):
     # STEP 1. GET ALL USERS BY DIRECTORY
     user_dirs = os.listdir(CLIENT_TMP_DIR)
 
-    if "nologin" in user_dirs:
-        user_dirs.remove("nologin")
+    for reservedDir in NON_USER_CLIENT_TMP_DIRS:
+        if reservedDir in user_dirs:
+            user_dirs.remove(reservedDir)
 
     # STEP 2. GET ALL USERS IN DB
     users_list = connection[MONGODB_DATABASE]['userCollection'].find()
@@ -265,25 +294,32 @@ def fixUserDataByUserID(connection, user_id):
         os.makedirs(path, exist_ok=True)
 
 def rebuildIndexes(connection):
-    dbs = ['userCollection', 'jobInstanceCollection', 'foundFeaturesCollection', 'featuresCollection', 'pathwaysCollection', 'visualOptionsCollection', 'fileCollection', 'messageCollection']
-    existing_collections = set(connection[MONGODB_DATABASE].list_collection_names())
-    for db in dbs:
-        if db not in existing_collections:
-            log("Skipping index rebuild for database " + db + " (collection missing)")
-            continue
-        log("Rebuilding indexes for database " + db)
-        try:
-            connection[MONGODB_DATABASE][db].reindex()
-        except OperationFailure as err:
-            log("Failed to rebuild indexes for database " + db + ": " + str(err))
-
-    # Create indexes on jobID for collections that are queried by jobID
+    # The daily reindex() loop that used to stand here is gone.
+    #
+    # It rebuilt every index of all eight job collections from scratch, inside
+    # the single serving process, once every 24h -- including featuresCollection
+    # (2.85M documents / 2.1GB on this machine), which takes a strong collection
+    # lock for the duration. It produced no observable output: the indexes it
+    # rebuilt were the indexes it started with.
+    #
+    # It was also a live crash. reindex() is deprecated in pymongo 3.11 and
+    # REMOVED in pymongo 4, which requirements.txt now pins: under pymongo 4
+    # `collection.reindex` resolves to a *sub-collection* named "reindex"
+    # instead of a method, and calling it raises TypeError, which the
+    # `except OperationFailure` did not catch. The cron would have died before
+    # reaching the create_index calls below -- and this function is the only
+    # place job indexes are ever created, so a fresh deployment would have run
+    # every jobID query as a collection scan.
+    #
+    # The create_index calls stay: they are idempotent, cheap when the index
+    # exists, and they are the point of the whole function.
     log("Creating jobID indexes...")
-    connection[MONGODB_DATABASE]['jobInstanceCollection'].create_index("jobID")
-    connection[MONGODB_DATABASE]['featuresCollection'].create_index("jobID")
-    connection[MONGODB_DATABASE]['featuresCollection'].create_index([("jobID", 1), ("featureType", 1)])
-    connection[MONGODB_DATABASE]['pathwaysCollection'].create_index("jobID")
-    connection[MONGODB_DATABASE]['foundFeaturesCollection'].create_index("jobID")
+    for collectionName, keys in JOBID_INDEXES:
+        try:
+            connection[MONGODB_DATABASE][collectionName].create_index(keys)
+        except OperationFailure as err:
+            # One unindexable collection must not cost the others their index.
+            log("Failed to create index " + str(keys) + " on " + collectionName + ": " + str(err))
     log("jobID indexes created.")
 
 def log(msg):

--- a/PaintomicsServer/src/benchmarks/EXPERIMENTS.md
+++ b/PaintomicsServer/src/benchmarks/EXPERIMENTS.md
@@ -1,0 +1,84 @@
+# PaintOmics 4 pipeline speed experiments
+
+Goal: make the pipeline faster with **provably unchanged results**. Every
+experiment below is gated by the benchmark harness in this directory: a change
+is kept only if (a) `bench_compare` reports IDENTICAL or EQUIVALENT
+(float rel ≤ 1e-12) on **all 11 example scenarios**, or any difference is
+proven to be a pre-existing bug — and (b) the phase it targets is measurably
+faster.
+
+Cost anchors (production-measured, from in-code instrumentation):
+- Step 1 p50 **43.1 s**, 98.9% = `processFilesContent` (identifier mapping;
+  ~98% of that is Mongo round trips inside the forked mapper workers).
+- Step 2 p50 **76.5 s** with metabolites (classify 40.2%, metagenes 49.9%),
+  ~**30 s** without (pathways 57%, metagenes 38%).
+- Bed2Genes: full GTF re-parse per job (566 MB mouse GTF, est. 60–180 s).
+- MiRNA2Genes: one scipy call per (miRNA, target) pair (~98k pairs shipped).
+
+## Wave 1 — low risk, measured first
+
+| ID  | Target | Change | Expected |
+|-----|--------|--------|----------|
+| E01 | mapper | Carry the per-job translation cache across omics (workers return their tables; parent merges before next omic forks) | 2–4× step 1 on multi-omic jobs |
+| E04 | mapper | One Manager append per worker instead of per matched clone | 1–7 s per gene omic |
+| E05 | mapper | In-memory kegg_compounds name scan replacing per-name Mongo regex COLLSCANs (reproduces PR #32 escape/cap/placeholder semantics exactly, natural order preserved) | compound mapping to ms |
+| E06 | mapper | In-place translation-cache merge; hoist per-worker dbname find_ones | hygiene, frees O(cache²) |
+| E07 | step 2 | Vectorize `hypergeom.sf` (and chi2.sf grouped by df) across the worker's pathway chunk; keep `combine_pvalues` per pathway | 2–6 s |
+| E08 | step 2 | Per-worker SimpleQueue bulk result transfer replacing `Manager().dict()` per-pathway writes | 1–2 s |
+| E09 | step 2 | mtime-keyed module cache for parsed `kegg_interaction.json`; delete `print(temp)` | 2–5 s on metabolite jobs |
+| E10 | step 2 | `PathwayDAO.insertAll` → single `insert_many` (mirrors FeatureDAO) | 0.3–2 s per store |
+| E11 | step 2 | Precompute lowercased pathway ID sets once per organism in the parent | 0.1–0.5 s |
+| E12 | step 2 | Hoist per-worker preamble (max_conditions, input dicts) into the parent | 0.2–1 s |
+| E15 | metagenes R | `PCA2GO.2.R`: pre-split annotation (`split()` once) instead of O(P·A) per-pathway scans; list-accumulate instead of `cbind` growth | 10–40 s per Reactome call |
+| E19 | metagenes | Demote per-metagene-row logging; slider-path full-JSON logs → debug | s + log hygiene |
+| E20 | metagenes | Extract only the needed zip members; os-level PNG moves | s |
+| E21 | hub R | Hoist `dir()`; env/`fastmatch`-style membership sets instead of re-hashed `intersect`; hoist loop-invariant subsets | 10–25 s on metabolite jobs |
+| E23 | classify | Module-level br08001 index + reverse compound→category map; delete `print(temp)` | sub-second + hygiene |
+| E24 | DAO | Process-wide pid-keyed shared MongoClient; closeConnection no-op | ms per DAO op, removes leaks |
+| E25 | DAO | `adaptBSON` str fast-path (verifier proves identity on real collections first) | 1–3 s per cold job load |
+| E26 | DAO | Single features query on job load, partitioned client-side | round trip |
+| E28 | step 3 | `getValueIdTable` via chain (no merged-dict copy) | 10–100 ms per response |
+| E29 | step 3 | PNG-size cache; dedup member serialization in `generateSelectedPathwaysInformation` | ms–s per paint |
+| E30 | ops | `create_index` on aiInterpretationCollection.jobID; retire daily `reindex()` | unblocks writes; latent pymongo-4 crash |
+| E31 | bed2genes | Pickle-cache the parsed GTF keyed by (path, mtime, size, tags) | 60–180 s → s on repeat jobs |
+| E33a | mirna | Hoist per-pair float conversions to load time (arrays once) | 20–40 % of scoring loop |
+| E34 | step 1 misc | ensure_utf8/detect_delimiter memoize; closure hoist; numpy outlier mask for compounds; per-omic OmicValue index for replicate apply | 0.5–2 s |
+
+## Wave 2 — medium risk, gated individually
+
+| ID  | Target | Change | Risk to control |
+|-----|--------|--------|-----------------|
+| E02 | mapper | `$lookup` pipeline form filtering `dbname_id` inside (index-driven) | duplicate-mate multiset semantics; Mongo version |
+| E03 | mapper | Fetch IDs+symbols in one aggregation per batch | symbol-path mates equivalence |
+| E16 | metagenes R | One R process per job (manifest of omic×db datasets, re-seeded per dataset) | RNG stream position |
+| E27 | responses | NaN-aware single-pass JSON encoding replacing `_sanitizeForJSON` deep copy | NaN token, tuples, key order |
+| E32 | bed2genes | GTF parse: `str.find` prefix extraction + `__slots__` (pure python) | regex quirk reproduction |
+| E33b | mirna | Vectorized kendall/spearman kernel (n≤6) matching scipy tie handling bit-for-bit | last-ulp float text |
+
+## Wave 3 — evaluate only if Waves 1–2 leave the phase dominant
+
+| ID  | Target | Change | Notes |
+|-----|--------|--------|-------|
+| E13 | step 2 | Rust (PyO3) enrichment counting kernel over interned feature/pathway arrays | only if counting still dominates after E07/E08; must reproduce OR-combine + padding rules exactly |
+| E22 | hub | Full Python port of hub scoring with install-time artifact | supersedes E21 if landed |
+| E32b | bed2genes | Rust GTF parser | deploy complexity vs E31 cache win |
+
+## Explicitly rejected (recorded so effort is not re-spent)
+
+- **Rust rewrite of the identifier mapper** — measured ~98% Mongo I/O; no CPU
+  to accelerate. Wins are query count and cache hits (E01/E02/E05).
+- **Larger aggregation batches** — 250 vs 2000 measured within ~2% on Drago.
+- **NumPy port of metagene k-means** — R's Hartigan–Wong + Mersenne-Twister
+  stream cannot be reproduced bit-for-bit; cluster labels are user-visible.
+
+## Equivalence protocol
+
+1. `bench_all` on master (baseline), 2 runs: run1 vs run2 establishes the
+   noise floor (A/A must be IDENTICAL/EQUIVALENT; PYTHONHASHSEED pinned,
+   mapper-worker line order pre-sorted at capture).
+2. `bench_all` on the candidate branch, same Mongo + KEGG_DATA + machine.
+3. `bench_compare --a baseline --b candidate` must pass all scenarios.
+4. Timings compared per phase (median of ≥3 runs for the phases a change
+   targets); a kept change must not regress any other phase beyond noise.
+5. Pre-existing-bug differences require a standalone reproduction on
+   unmodified master before the change is accepted.

--- a/PaintomicsServer/src/benchmarks/REPORT.md
+++ b/PaintomicsServer/src/benchmarks/REPORT.md
@@ -1,0 +1,251 @@
+# PaintOmics 4 pipeline speed-up — benchmark report
+
+Branch `perf/pipeline-speed` (base: master `b0641ce4`, 2026-08-17). Every
+scenario in `src/examplefiles/datasets/` (11 datasets, all four pipelines:
+pathway acquisition, regions→genes, miRNA→genes, MORE) was run through the
+harness in this directory on the same machine, MongoDB and KEGG snapshot,
+before and after the changes.
+
+**Acceptance rule applied to every commit:** results identical to master
+(or the difference proven to be a pre-existing master defect) **and**
+faster. Nothing that failed either half was kept.
+
+## 1. Headline (local, interleaved A/B, 6 mapper/enrichment workers, medians)
+
+Machine: Apple M4 Pro, 12 cores, MongoDB 8.2 local, KEGG snapshot 20260813.
+Both sides run back to back per scenario and repeat (`bench_ab`), so drift
+hits both alike. "Strict" = the same job run with one worker on both sides,
+where master itself is deterministic.
+
+| Scenario | Baseline median (s) | Candidate median (s) | Speed-up | Runs (A/B) | Equivalence (timing runs) | Equivalence (strict, 1 worker) |
+|---|---:|---:|---:|:-:|:-:|:-:|
+| gene-multi-condition | 7.79 | 4.46 | 1.75x | 2/2 | WITHIN-NOISE | IDENTICAL |
+| gene-multi-condition-relevance | 8.29 | 4.54 | 1.83x | 2/2 | WITHIN-NOISE | IDENTICAL |
+| gene-single-condition | 6.99 | 3.47 | 2.01x | 2/2 | WITHIN-NOISE | IDENTICAL |
+| multiomics-integration | 73.36 | 12.10 | 6.06x | 2/2 | WITHIN-NOISE | IDENTICAL |
+| region-based | 1.47 | 1.39 | 1.05x | 2/2 | IDENTICAL | IDENTICAL |
+| regulatory-mirna | 0.29 | 0.10 | 2.99x | 2/2 | IDENTICAL | IDENTICAL |
+| regulatory-more | 68.37 | 66.51 | 1.03x | 2/2 | IDENTICAL | IDENTICAL |
+| stategra-mirna | 14.97 | 4.09 | 3.66x | 2/2 | IDENTICAL | IDENTICAL |
+| stategra-more | 236.5 | 246.9 | 0.96x | 3/3 | IDENTICAL | IDENTICAL |
+| stategra-multiomics | 51.07 | 15.57 | 3.28x | 2/2 | WITHIN-NOISE | IDENTICAL |
+| stategra-regions | 8.10 | 6.32 | 1.28x | 2/2 | IDENTICAL | IDENTICAL |
+
+
+Verdict columns:
+
+* **Equivalence (strict, 1 worker)** — bit-for-bit comparison of every
+  client-visible result (step-1 mapping summary and matched metabolites, the
+  whole step-2 payload: pathways with all p-values, adjusted p-values,
+  combined p-values, matched members, metagenes; hub and metabolite-class
+  results; step-3 graphical data and feature values; every converter output
+  file; every MORE output file) — **IDENTICAL for all 11 scenarios**
+  (`bench_compare`, floats compared exactly, NaN==NaN).
+* **Equivalence (timing runs)** — same comparison against master's 6-worker
+  output. `WITHIN-NOISE` means the only differences fall in the classes where
+  master's *own* output already depends on how many workers it uses (see
+  §3): which of two aliases fills a symbol-keyed display slot, the order of a
+  feature's omics values, and how many values a merged duplicate compound
+  carries. **No p-value, matched-pathway set, significance or converter
+  byte differs in any comparison.**
+
+The MORE scenarios are unchanged code paths (R/Rust MORE engine); their
+±4 % is machine noise (one candidate run of `stategra-more` stalled to
+706 s wall / 288 s in-process for reasons outside the pipeline — a third
+run on each side was added: 242 s vs 247 s).
+
+`step2.compoundsClassification` reads slower in `multiomics-integration`
+(0.16 → 0.54 s): the harness starts a fresh process per run, so it always
+pays the one-time build of the per-process compound-neighbour cache; on the
+server every job after the first costs milliseconds there and no longer
+allocates ~1 GB of transient objects to look up 50–100 compounds.
+
+## 2. Per-phase medians
+
+
+### gene-multi-condition
+
+| Phase | Baseline (s) | Candidate (s) | Speed-up |
+|---|---:|---:|---:|
+| step1.processFilesContent | 3.57 | 1.02 | 3.49x |
+| step1.store | 0.24 | 0.24 | 1.01x |
+| step2.generatePathwaysList | 0.47 | 0.38 | 1.23x |
+| step2.metagenes | 3.03 | 2.44 | 1.24x |
+| step2.store | 0.14 | 0.05 | 2.55x |
+| step3.generateSelectedPathwaysInformation | 0.18 | 0.18 | 1.02x |
+
+### gene-multi-condition-relevance
+
+| Phase | Baseline (s) | Candidate (s) | Speed-up |
+|---|---:|---:|---:|
+| step1.processFilesContent | 3.67 | 1.05 | 3.49x |
+| step1.store | 0.25 | 0.26 | 0.96x |
+| step2.generatePathwaysList | 0.72 | 0.39 | 1.86x |
+| step2.metagenes | 3.03 | 2.45 | 1.24x |
+| step2.store | 0.16 | 0.07 | 2.36x |
+| step3.generateSelectedPathwaysInformation | 0.31 | 0.19 | 1.61x |
+
+### gene-single-condition
+
+| Phase | Baseline (s) | Candidate (s) | Speed-up |
+|---|---:|---:|---:|
+| step1.processFilesContent | 3.55 | 0.96 | 3.71x |
+| step1.store | 0.22 | 0.22 | 1.02x |
+| step2.generatePathwaysList | 0.45 | 0.31 | 1.46x |
+| step2.metagenes | 2.22 | 1.61 | 1.38x |
+| step2.store | 0.13 | 0.06 | 2.22x |
+| step3.generateSelectedPathwaysInformation | 0.26 | 0.18 | 1.46x |
+
+### multiomics-integration
+
+| Phase | Baseline (s) | Candidate (s) | Speed-up |
+|---|---:|---:|---:|
+| step1.processFilesContent | 43.43 | 2.49 | 17.45x |
+| step1.store | 0.46 | 0.50 | 0.92x |
+| step2.compoundsClassification | 0.16 | 0.54 | 0.30x |
+| step2.generatePathwaysList | 1.08 | 0.42 | 2.58x |
+| step2.hubAnalysis | 14.73 | 3.05 | 4.83x |
+| step2.metagenes | 11.99 | 4.38 | 2.74x |
+| step2.store | 0.72 | 0.20 | 3.52x |
+| step2.updateCompounds | 0.07 | 0.06 | 1.03x |
+| step3.generateSelectedPathwaysInformation | 0.50 | 0.26 | 1.95x |
+
+### region-based
+
+| Phase | Baseline (s) | Candidate (s) | Speed-up |
+|---|---:|---:|---:|
+| bed.fromBED2Genes | 1.46 | 1.38 | 1.05x |
+
+### regulatory-mirna
+
+| Phase | Baseline (s) | Candidate (s) | Speed-up |
+|---|---:|---:|---:|
+| mirna.fromMiRNA2Genes | 0.28 | 0.09 | 3.21x |
+
+### regulatory-more
+
+| Phase | Baseline (s) | Candidate (s) | Speed-up |
+|---|---:|---:|---:|
+| more.step2 | 68.37 | 66.51 | 1.03x |
+
+### stategra-mirna
+
+| Phase | Baseline (s) | Candidate (s) | Speed-up |
+|---|---:|---:|---:|
+| mirna.fromMiRNA2Genes | 14.84 | 3.96 | 3.74x |
+
+### stategra-more
+
+| Phase | Baseline (s) | Candidate (s) | Speed-up |
+|---|---:|---:|---:|
+| more.step2 | 236.5 | 246.9 | 0.96x |
+
+### stategra-multiomics
+
+| Phase | Baseline (s) | Candidate (s) | Speed-up |
+|---|---:|---:|---:|
+| step1.processFilesContent | 22.54 | 5.32 | 4.24x |
+| step1.store | 0.88 | 0.69 | 1.27x |
+| step2.compoundsClassification | 0.37 | 0.30 | 1.25x |
+| step2.generatePathwaysList | 1.17 | 0.61 | 1.91x |
+| step2.globalExpressionData | 0.03 | 0.22 | 0.11x |
+| step2.hubAnalysis | 13.10 | 2.66 | 4.92x |
+| step2.metagenes | 12.22 | 5.14 | 2.38x |
+| step2.store | 0.18 | 0.10 | 1.84x |
+| step3.generateSelectedPathwaysInformation | 0.29 | 0.26 | 1.11x |
+
+### stategra-regions
+
+| Phase | Baseline (s) | Candidate (s) | Speed-up |
+|---|---:|---:|---:|
+| bed.fromBED2Genes | 8.06 | 6.27 | 1.28x |
+
+## 3. What changed, and how each change was proven equivalent
+
+| Area | Change | Proof of equivalence | Local effect |
+|---|---|---|---|
+| Identifier mapping | Translation cache carried across omics (workers hand tables back; misses cached too) | function-level dump of 12,762 genes / 2,385 proteins / 4,700 compounds identical to master | repeat mapping of the same names 5.1 s → 0.38 s |
+| Identifier mapping | `$lookup` filtered on `dbname_id` inside the join instead of unwinding every mate | identical per-name id lists **including order** on gene, protein and symbol lookups | 12,762-gene cold mapping 5.7 s → 1.1 s |
+| Identifier mapping | `kegg_compounds` (93k names) held in memory as a lower-cased haystack; same escaped-literal / anchored / 500-cap semantics as PR #32 | table vs live Mongo identical for every name in the example files + probes; 11 PR #32 contract tests | 4,667 compound names 40.5 s → 0.9 s |
+| Identifier mapping | one hand-over per worker instead of one Manager round trip per clone; results concatenated in worker (= input) order | 6-worker output now equals the sequential output bit for bit | removes ~92 µs × up to 40k IPC calls per omic; deterministic results |
+| Step 2 | metagene R scripts run per omic in parallel (databases of one omic sequential; `PAINTOMICS_METAGENES_PARALLEL`, default 3) | independent processes with their own seeds and output names; consumed in original order | metagenes 12–14 s → 4–5 s |
+| Step 2 | Stouffer / Fisher combination via the special functions scipy reduces to | bit-identical to `combine_pvalues` / `chi2.sf` over 80,000 random cases each (test) | enrichment single-worker pass 0.9 → 0.6 s |
+| Step 2 | enrichment workers hand back one dict; feature lookups computed once; shared join deadline; Manager shut down | dict equality of matched pathways | ~900 IPC round trips removed |
+| Step 2 | `kegg_interaction.json` parsed once per process into compact per-compound strings | same filtered dict (JSON round trip) | 34–79 MB parse and ~370 MB–1 GB transient per job removed |
+| R: metagenes | `PCA2GO.2.R` pre-splits the annotation (levels pinned, positional lookup) and accumulates instead of growing | `identical()` on every returned element, 26 scenarios; 24 end-to-end runs, 74 `.tab`/PNG files byte-identical | Reactome PCA call 0.94 → 0.40 s |
+| R: hub analysis | `hubAnalysis.R` lists the directory once, integer-codes membership per block, hoists loop invariants | `hub_result.csv` byte-identical on real mmu hubData (3 input shapes) + synthetic edge cases | 13.7 s → 2.0 s per metabolomics job |
+| DAO | one shared, pid-keyed MongoClient; `insert_many` for pathways; `adaptBSON` fast path (its `None→"None"` and ObjectId→str behaviour kept); one features query on load; jobID index on the AI collection; daily `reindex()` retired; indexes ensured off the boot path | 332,869 real documents `adaptBSON` bit-identical; 500-pathway old/new dump identical; 5 real jobs deep-compared old vs new load; 100 loads: +0 threads (was +300) | store phase 2–3×; every DAO op loses a client construction |
+| Regions→genes | parsed GTF cached (pickle, keyed on path/mtime/size/tags/format); regex attribute extraction replaced by an equivalent scanner; `__slots__` records | RGMatch/B2G outputs byte-identical on the synthetic and the real 566 MB GTF, cold and warm; 42 tests | real-GTF job 8.4 → 5.4 s warm |
+| miRNA→genes | exact Kendall τ-b kernel (scipy's own arithmetic on the same counts) instead of the full test with its unused p-value | bit-identical to `kendalltau` over 120,000 random rows; both miRNA scenarios byte-identical | 97,983 pairs 14.9 → 4.1 s |
+
+### Pre-existing master behaviour surfaced by the harness (not changed here)
+
+* Master's mapping results depend on worker scheduling: which alias fills a
+  symbol-keyed slot (`globalExpressionData.inputGene[SYMBOL]`, a feature's
+  displayed `name`), the order of a feature's `omicsValues`, and how many
+  values a merged duplicate compound carries all vary between a 1-worker
+  and a 6-worker run of the same job (and run to run under `spawn`). The
+  branch makes this deterministic (input order); p-values and pathway
+  membership were never affected.
+* `paintomics.uv.es` (original code) killed one of two `multiomics-
+  integration` runs at step 1 after a mapper worker hung for the full 900 s
+  budget on a 1,200-feature omic (see §4).
+* The gzipped-BED reader drops the last character of every output row
+  (`reportOutput`'s `[:-1]`); the gz paths were deliberately left untouched
+  because fixing them changes bytes. Filed for a separate fix.
+* `PathwayAcquisitionJob.toBSON(recursive=True)` raises on any DB-loaded
+  job (`FoundFeatureDAO` returns `Feature`, the recursive branch expects
+  `FoundFeature`); nothing on the hot path calls it.
+
+### Rejected experiments (measured, not kept)
+
+* Rust rewrite of the identifier mapper — ~98 % of its time is MongoDB round
+  trips; the wins were query count and cache hits.
+* Larger aggregation batches — 250 vs 2000 within ~2 % (measured on Drago).
+* NumPy port of the metagene k-means — R's Hartigan–Wong + Mersenne-Twister
+  stream cannot be reproduced bit for bit; cluster labels are user-visible.
+* Hoisting the per-pair float conversion in the miRNA scorer alone (E33a) —
+  correct but worth ~1 %; the Kendall kernel above is what moved that phase.
+
+## 4. paintomics.uv.es (production, 6 cores, 7 GB): original code
+
+Driven over HTTPS the way the browser does (`bench_http`), before any
+deploy; wall time per step includes queueing and payload transfer.
+
+| Scenario | run | total (s) | step 1 | step 2 | step 3 |
+|---|---|---:|---:|---:|---:|
+| gene-single-condition | 1 | 44.9 | 20.8 | 10.9 | 13.2 |
+| gene-single-condition | 2 | 37.0 | 17.7 | 11.4 | 7.9 |
+| gene-multi-condition | 1 | 41.9 | 18.9 | 14.1 | 9.0 |
+| gene-multi-condition | 2 | 36.0 | 18.6 | 12.9 | 4.4 |
+| gene-multi-condition-relevance | 1 | 40.9 | 18.6 | 12.7 | 9.6 |
+| gene-multi-condition-relevance | 2 | 40.2 | 17.6 | 13.4 | 9.1 |
+| multiomics-integration | 1 | FAILED (job l5ABJ0uHZT failed at step1: Exception: AT PathwayAcquisitionServlet.py: pathwayAcquisi) | | | |
+| multiomics-integration | 2 | 188.8 | 69.9 | 99.0 | 19.7 |
+| stategra-multiomics | 1 | 213.0 | 98.5 | 81.7 | 32.7 |
+| stategra-multiomics | 2 | 183.2 | 95.3 | 75.2 | 12.7 |
+
+The failed run is the original code: a mapper worker on the third omic
+(1,200 features) hung for the whole shared 900 s budget and the job was
+killed ("Your data took too long to process"); the second run of the same
+dataset completed in 189 s.
+
+## 5. paintomics.uv.es after the deploy
+
+_Filled in below after deployment (same driver, same scenarios, compared
+with the runs above using `bench_compare --noise-runs`)._
+
+## 6. Method
+
+* `bench_runner.py` — one scenario per fresh process, calls the same job
+  methods the servlets call in the same order, records per-phase timings and
+  every client-visible result. Fork start method is forced (production
+  forks; macOS `spawn` distorts both timing and cache inheritance).
+* `bench_all.py` / `bench_ab.py` — sweeps; `bench_compare.py` — verdicts
+  (`IDENTICAL` / `EQUIVALENT` (floats within 1e-12) / `WITHIN-NOISE` /
+  `DIFFERENT`), with the client contract encoded (ordered lists where the
+  client renders order, keyed dicts elsewhere, `omicsValuesID` tokens and a
+  feature's `omicsValues` list compared as sets because their order follows
+  the process hash seed / worker scheduling on master).
+* `bench_http.py` — the same measurement against a live server;
+  `bench_report.py` — this document's tables.

--- a/PaintomicsServer/src/benchmarks/bench_ab.py
+++ b/PaintomicsServer/src/benchmarks/bench_ab.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Interleaved A/B timing sweep: for every scenario and repeat, run the
+baseline checkout and the candidate checkout back to back under the same
+machine conditions, so drift (thermal, background load) hits both sides
+alike. Output trees are bench_all-compatible.
+
+    PAINTOMICS_KEGG_DATA=... PAINTOMICS_CLIENT_TMP=... \
+    python -m src.benchmarks.bench_ab \
+        --a /path/to/baseline/PaintomicsServer --b /path/to/candidate/PaintomicsServer \
+        --out /tmp/bench/ab --repeat 3
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+from src.benchmarks.bench_all import DEFAULT_SCENARIOS
+
+
+def runOne(root, scenario, runDir, python, env, timeout):
+    os.makedirs(runDir, exist_ok=True)
+    started = time.time()
+    proc = subprocess.run(
+        [python, "-m", "src.benchmarks.bench_runner", "--scenario", scenario, "--out", runDir],
+        cwd=root, env=env, capture_output=True, text=True, timeout=timeout)
+    record = {"scenario": scenario, "wall": round(time.time() - started, 2),
+              "returncode": proc.returncode, "root": root}
+    if proc.returncode == 0:
+        try:
+            record.update(json.loads(proc.stdout.strip().splitlines()[-1]))
+        except (ValueError, IndexError):
+            pass
+    else:
+        record["stderr_tail"] = proc.stderr[-3000:]
+    return record
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--a", required=True, help="baseline PaintomicsServer dir")
+    parser.add_argument("--b", required=True, help="candidate PaintomicsServer dir")
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--repeat", type=int, default=3)
+    parser.add_argument("--scenarios", nargs="*", default=DEFAULT_SCENARIOS)
+    parser.add_argument("--timeout", type=int, default=3600)
+    parser.add_argument("--python", default=sys.executable)
+    args = parser.parse_args()
+
+    env = dict(os.environ, PYTHONHASHSEED="0")
+    summary = []
+    for scenario in args.scenarios:
+        for run in range(1, args.repeat + 1):
+            for label, root in (("A", args.a), ("B", args.b)):
+                runDir = os.path.join(args.out, label, scenario, "run%d" % run)
+                record = runOne(root, scenario, runDir, args.python, env, args.timeout)
+                record.update({"side": label, "run": run})
+                summary.append(record)
+                print("%-32s run%d %s %8.1fs %s" % (
+                    scenario, run, label, record["wall"],
+                    "ok" if record["returncode"] == 0 else "FAIL"), flush=True)
+                with open(os.path.join(args.out, "summary.json"), "w") as handle:
+                    json.dump(summary, handle, indent=2)
+
+    failures = [r for r in summary if r["returncode"] != 0]
+    print("\n%d/%d runs ok" % (len(summary) - len(failures), len(summary)))
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/PaintomicsServer/src/benchmarks/bench_all.py
+++ b/PaintomicsServer/src/benchmarks/bench_all.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Run every (or a chosen) example scenario through bench_runner, N times each,
+in fresh subprocesses, and collect the timing summaries.
+
+    PAINTOMICS_KEGG_DATA=... PAINTOMICS_CLIENT_TMP=... \
+    python -m src.benchmarks.bench_all --out /tmp/bench/baseline --repeat 3
+
+PYTHONHASHSEED is pinned so set-iteration order cannot masquerade as a result
+difference between two builds; both sides of an A/B comparison must run
+through this driver for that pin to hold.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+DEFAULT_SCENARIOS = [
+    "gene-single-condition",
+    "gene-multi-condition",
+    "gene-multi-condition-relevance",
+    "multiomics-integration",
+    "regulatory-mirna",
+    "regulatory-more",
+    "region-based",
+    "stategra-multiomics",
+    "stategra-regions",
+    "stategra-mirna",
+    "stategra-more",
+]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--repeat", type=int, default=1)
+    parser.add_argument("--scenarios", nargs="*", default=DEFAULT_SCENARIOS)
+    parser.add_argument("--timeout", type=int, default=3600,
+                        help="per-run kill timeout in seconds")
+    parser.add_argument("--python", default=sys.executable)
+    args = parser.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+    env = dict(os.environ, PYTHONHASHSEED="0")
+
+    summary = []
+    for scenario in args.scenarios:
+        for run in range(1, args.repeat + 1):
+            runDir = os.path.join(args.out, scenario, "run%d" % run)
+            os.makedirs(runDir, exist_ok=True)
+            started = time.time()
+            proc = subprocess.run(
+                [args.python, "-m", "src.benchmarks.bench_runner",
+                 "--scenario", scenario, "--out", runDir],
+                cwd=ROOT, env=env, capture_output=True, text=True,
+                timeout=args.timeout)
+            elapsed = round(time.time() - started, 2)
+            record = {"scenario": scenario, "run": run, "wall": elapsed,
+                      "returncode": proc.returncode}
+            if proc.returncode == 0:
+                try:
+                    record.update(json.loads(proc.stdout.strip().splitlines()[-1]))
+                except (ValueError, IndexError):
+                    pass
+            else:
+                record["stderr_tail"] = proc.stderr[-3000:]
+            summary.append(record)
+            status = "ok" if proc.returncode == 0 else "FAIL"
+            print("%-32s run%d %8.1fs %s" % (scenario, run, elapsed, status),
+                  flush=True)
+            with open(os.path.join(args.out, "summary.json"), "w") as handle:
+                json.dump(summary, handle, indent=2)
+
+    failures = [r for r in summary if r["returncode"] != 0]
+    print("\n%d/%d runs ok" % (len(summary) - len(failures), len(summary)))
+    if failures:
+        for record in failures:
+            print("FAILED: %(scenario)s run%(run)d" % record)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/PaintomicsServer/src/benchmarks/bench_compare.py
+++ b/PaintomicsServer/src/benchmarks/bench_compare.py
@@ -139,6 +139,18 @@ def _canonicalise(artifacts):
             step["omicsValuesID"] = {
                 key: "|".join(sorted(value.split("|"))) if isinstance(value, str) else value
                 for key, value in table.items()}
+        # A feature's omicsValues list is assembled in the order the mapper
+        # workers delivered their clones -- racy on master, so its order is
+        # already meaningless to the client (which looks entries up by
+        # omicName). Sorted into a canonical order before comparing; the
+        # multiset is what is compared.
+        features = step.get("omicsValues")
+        if isinstance(features, dict):
+            for feature in features.values():
+                values = feature.get("omicsValues") if isinstance(feature, dict) else None
+                if isinstance(values, list):
+                    feature["omicsValues"] = sorted(
+                        values, key=lambda item: json.dumps(item, sort_keys=True, default=str))
     return artifacts
 
 
@@ -206,6 +218,9 @@ def main():
     parser.add_argument("--noise-runs", nargs=2, metavar=("RUN_X", "RUN_Y"),
                         help="two run names under --a (e.g. run1 run2) whose "
                              "mutual differences define the baseline's own noise")
+    parser.add_argument("--noise-from",
+                        help="derive the noise classes from this bench_all tree "
+                             "(with --noise-runs) instead of from --a")
     args = parser.parse_args()
 
     scenarios = sorted(
@@ -219,9 +234,10 @@ def main():
     noise = None
     if args.noise_runs:
         noise = set()
-        for scenario in scenarios:
-            noiseA = os.path.join(args.a, scenario, args.noise_runs[0])
-            noiseB = os.path.join(args.a, scenario, args.noise_runs[1])
+        noiseRoot = args.noise_from or args.a
+        for scenario in sorted(os.listdir(noiseRoot)):
+            noiseA = os.path.join(noiseRoot, scenario, args.noise_runs[0])
+            noiseB = os.path.join(noiseRoot, scenario, args.noise_runs[1])
             if os.path.isdir(noiseA) and os.path.isdir(noiseB):
                 noise |= noiseClasses(noiseA, noiseB, args.rtol)
         print("baseline noise classes (%d): %s" % (len(noise), sorted(noise)))

--- a/PaintomicsServer/src/benchmarks/bench_compare.py
+++ b/PaintomicsServer/src/benchmarks/bench_compare.py
@@ -123,10 +123,29 @@ def _short(value, limit=120):
     return text if len(text) <= limit else text[:limit] + "..."
 
 
+def _canonicalise(artifacts):
+    """Normalise fields whose byte form depends on the process, not the data.
+
+    `omicsValuesID` (Job.getValueIdTable) joins a Python *set* of names with
+    '|', so the token order follows the process's string-hash seed: two
+    server processes give different strings for the same set. The tokens are
+    sorted here; the client only ever splits the string into a search blob.
+    """
+    for step in artifacts.values():
+        if not isinstance(step, dict):
+            continue
+        table = step.get("omicsValuesID")
+        if isinstance(table, dict):
+            step["omicsValuesID"] = {
+                key: "|".join(sorted(value.split("|"))) if isinstance(value, str) else value
+                for key, value in table.items()}
+    return artifacts
+
+
 def loadArtifacts(runDir):
     path = os.path.join(runDir, "artifacts.json.gz")
     with gzip.open(path, "rt", encoding="utf-8") as handle:
-        return json.load(handle)
+        return _canonicalise(json.load(handle))
 
 
 _PATH_INDEX = re.compile(r"\[\d+\]")

--- a/PaintomicsServer/src/benchmarks/bench_compare.py
+++ b/PaintomicsServer/src/benchmarks/bench_compare.py
@@ -129,7 +129,39 @@ def loadArtifacts(runDir):
         return json.load(handle)
 
 
-def compareScenario(dirA, dirB, rtol):
+_PATH_INDEX = re.compile(r"\[\d+\]")
+
+
+def pathClass(path):
+    """A path with its data-dependent parts collapsed: list indices become
+    [*], and from the third segment on every segment that has no lower-case
+    letter (feature IDs, symbols, numeric keys -- schema keys are camelCase)
+    becomes *, so `.step3.omicsValues.GSTP1.omicsValues[2].inputName` and the
+    same field of another feature share a class."""
+    generic = _PATH_INDEX.sub("[*]", path)
+    parts = generic.split(".")
+    for index in range(3, len(parts)):
+        segment = parts[index]
+        if segment and not any(ch.islower() for ch in segment.replace("[*]", "")):
+            parts[index] = "*"
+    return ".".join(parts)
+
+
+def noiseClasses(dirA, dirB, rtol):
+    """The diff classes two runs of the SAME code produce (run-to-run
+    noise, e.g. which of two aliases wins a symbol-keyed slot after the
+    forked mapper workers race). Used to tell a candidate's differences
+    from the baseline's own nondeterminism."""
+    comparison = Comparison(rtol)
+    comparison.compare(loadArtifacts(dirA), loadArtifacts(dirB))
+    return {pathClass(path) for path, kind, _ in comparison.diffs}
+
+
+def compareScenario(dirA, dirB, rtol, noise=None):
+    """Verdicts: IDENTICAL; EQUIVALENT (floats within rtol only);
+    WITHIN-NOISE (every remaining difference falls in a class the baseline
+    produces between two runs of itself -- only when `noise` is given);
+    DIFFERENT."""
     comparison = Comparison(rtol)
     comparison.compare(loadArtifacts(dirA), loadArtifacts(dirB))
     hard = [d for d in comparison.diffs if d[1] not in ("float",)]
@@ -137,6 +169,12 @@ def compareScenario(dirA, dirB, rtol):
         return "IDENTICAL", comparison
     if not hard and comparison.maxFloatRel <= rtol:
         return "EQUIVALENT", comparison
+    if noise is not None:
+        outside = [d for d in comparison.diffs
+                   if d[1] != "float" and pathClass(d[0]) not in noise]
+        if not outside:
+            return "WITHIN-NOISE", comparison
+        comparison.outsideNoise = outside
     return "DIFFERENT", comparison
 
 
@@ -146,11 +184,28 @@ def main():
     parser.add_argument("--b", required=True, help="candidate bench_all --out dir")
     parser.add_argument("--run", default="run1")
     parser.add_argument("--rtol", type=float, default=1e-12)
+    parser.add_argument("--noise-runs", nargs=2, metavar=("RUN_X", "RUN_Y"),
+                        help="two run names under --a (e.g. run1 run2) whose "
+                             "mutual differences define the baseline's own noise")
     args = parser.parse_args()
 
     scenarios = sorted(
         name for name in os.listdir(args.a)
         if os.path.isdir(os.path.join(args.a, name, args.run)))
+
+    # The baseline's own run-to-run noise, pooled over every scenario: the
+    # mechanism (forked mapper workers racing on which alias fills a slot)
+    # is the same whatever the dataset, and one pair of runs of one dataset
+    # samples only some of the slots it can hit.
+    noise = None
+    if args.noise_runs:
+        noise = set()
+        for scenario in scenarios:
+            noiseA = os.path.join(args.a, scenario, args.noise_runs[0])
+            noiseB = os.path.join(args.a, scenario, args.noise_runs[1])
+            if os.path.isdir(noiseA) and os.path.isdir(noiseB):
+                noise |= noiseClasses(noiseA, noiseB, args.rtol)
+        print("baseline noise classes (%d): %s" % (len(noise), sorted(noise)))
 
     exitCode = 0
     for scenario in scenarios:
@@ -161,7 +216,7 @@ def main():
             exitCode = 1
             continue
         try:
-            verdict, comparison = compareScenario(dirA, dirB, args.rtol)
+            verdict, comparison = compareScenario(dirA, dirB, args.rtol, noise)
         except Exception as exc:
             print("%-32s ERROR %s" % (scenario, exc))
             exitCode = 1
@@ -173,7 +228,8 @@ def main():
         if verdict == "DIFFERENT":
             exitCode = 1
             shown = 0
-            for path, kind, detail in comparison.diffs:
+            reportable = getattr(comparison, "outsideNoise", None) or comparison.diffs
+            for path, kind, detail in reportable:
                 if kind == "float":
                     continue
                 print("    %s [%s] %s" % (path or "<root>", kind, detail))

--- a/PaintomicsServer/src/benchmarks/bench_compare.py
+++ b/PaintomicsServer/src/benchmarks/bench_compare.py
@@ -21,6 +21,7 @@ import gzip
 import json
 import math
 import os
+import re
 import sys
 
 # Dict paths whose KEY ORDER is part of the contract (client iterates and
@@ -65,6 +66,8 @@ class Comparison(object):
                            _short(a), _short(b)))
             return
         if a != b:
+            if isinstance(a, str) and _stripCheckout(a) == _stripCheckout(b):
+                return  # same file, different checkout root (A vs B worktree)
             self.record(path, "value", "%r vs %r" % (_short(a), _short(b)))
 
     def _floats(self, a, b, path):
@@ -104,6 +107,15 @@ class Comparison(object):
         for key in keysA:
             if key in b:
                 self.compare(a[key], b[key], "%s.%s" % (path, key))
+
+
+_CHECKOUT_ROOT = re.compile(r"^.*?/PaintomicsServer/")
+
+
+def _stripCheckout(text):
+    """Absolute example-file paths embed the checkout the run used; the A and
+    B sides of a comparison are different worktrees by construction."""
+    return _CHECKOUT_ROOT.sub("<checkout>/PaintomicsServer/", text)
 
 
 def _short(value, limit=120):

--- a/PaintomicsServer/src/benchmarks/bench_compare.py
+++ b/PaintomicsServer/src/benchmarks/bench_compare.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Compare two bench_all output trees (baseline vs candidate).
+
+Verdict per scenario:
+    IDENTICAL   every artifact deep-equal (bitwise floats, NaN==NaN)
+    EQUIVALENT  only float differences, all within --rtol (default 1e-12)
+    DIFFERENT   anything else -- every differing path is listed
+
+Comparison rules encode the client contract (see the reader reports):
+dict *values* are compared key-by-key regardless of key order, EXCEPT the
+paths in ORDERED_DICT_PATHS whose insertion order the client renders; lists
+are order-sensitive everywhere (list-typed artifacts are either contractually
+ordered, e.g. matchedMetabolites, or pre-sorted at capture time, e.g.
+mapping-file lines).
+
+    python -m src.benchmarks.bench_compare --a /tmp/bench/baseline \
+        --b /tmp/bench/candidate [--rtol 1e-12]
+"""
+import argparse
+import gzip
+import json
+import math
+import os
+import sys
+
+# Dict paths whose KEY ORDER is part of the contract (client iterates and
+# renders in insertion order).
+ORDERED_DICT_PATHS = (
+    "step2.classificationDict",
+)
+
+MAX_REPORTED_DIFFS = 40
+
+
+class Comparison(object):
+    def __init__(self, rtol):
+        self.rtol = rtol
+        self.diffs = []          # (path, kind, detail)
+        self.maxFloatRel = 0.0
+        self.floatOnly = True
+
+    def record(self, path, kind, detail):
+        self.diffs.append((path, kind, detail))
+        if kind != "float":
+            self.floatOnly = False
+
+    def compare(self, a, b, path=""):
+        if isinstance(a, float) or isinstance(b, float):
+            self._floats(a, b, path)
+            return
+        if isinstance(a, dict) and isinstance(b, dict):
+            self._dicts(a, b, path)
+            return
+        if isinstance(a, list) and isinstance(b, list):
+            if len(a) != len(b):
+                self.record(path, "len", "list %d vs %d" % (len(a), len(b)))
+                return
+            for index, (itemA, itemB) in enumerate(zip(a, b)):
+                self.compare(itemA, itemB, "%s[%d]" % (path, index))
+            return
+        if type(a) is not type(b):
+            # bool/int cross-type or str-vs-number: type is contract-relevant
+            self.record(path, "type", "%s vs %s (%r vs %r)"
+                        % (type(a).__name__, type(b).__name__,
+                           _short(a), _short(b)))
+            return
+        if a != b:
+            self.record(path, "value", "%r vs %r" % (_short(a), _short(b)))
+
+    def _floats(self, a, b, path):
+        okA = isinstance(a, (int, float)) and not isinstance(a, bool)
+        okB = isinstance(b, (int, float)) and not isinstance(b, bool)
+        if not (okA and okB):
+            self.record(path, "type", "%s vs %s" % (type(a).__name__,
+                                                    type(b).__name__))
+            return
+        a, b = float(a), float(b)
+        if math.isnan(a) and math.isnan(b):
+            return
+        if a == b:
+            return
+        denom = max(abs(a), abs(b), 1e-300)
+        rel = abs(a - b) / denom
+        self.maxFloatRel = max(self.maxFloatRel, rel)
+        if rel > self.rtol:
+            self.record(path, "float-out-of-tol", "%r vs %r (rel %.3g)"
+                        % (a, b, rel))
+        else:
+            self.record(path, "float", "%r vs %r (rel %.3g)" % (a, b, rel))
+
+    def _dicts(self, a, b, path):
+        keysA, keysB = list(a.keys()), list(b.keys())
+        if set(keysA) != set(keysB):
+            onlyA = sorted(set(keysA) - set(keysB))[:6]
+            onlyB = sorted(set(keysB) - set(keysA))[:6]
+            self.record(path, "keys", "only in A: %s; only in B: %s"
+                        % (onlyA, onlyB))
+        if any(path.endswith(ordered) for ordered in ORDERED_DICT_PATHS):
+            shared = [k for k in keysA if k in b]
+            sharedB = [k for k in keysB if k in a]
+            if shared != sharedB:
+                self.record(path, "key-order", "%s vs %s"
+                            % (shared[:8], sharedB[:8]))
+        for key in keysA:
+            if key in b:
+                self.compare(a[key], b[key], "%s.%s" % (path, key))
+
+
+def _short(value, limit=120):
+    text = repr(value)
+    return text if len(text) <= limit else text[:limit] + "..."
+
+
+def loadArtifacts(runDir):
+    path = os.path.join(runDir, "artifacts.json.gz")
+    with gzip.open(path, "rt", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def compareScenario(dirA, dirB, rtol):
+    comparison = Comparison(rtol)
+    comparison.compare(loadArtifacts(dirA), loadArtifacts(dirB))
+    hard = [d for d in comparison.diffs if d[1] not in ("float",)]
+    if not comparison.diffs:
+        return "IDENTICAL", comparison
+    if not hard and comparison.maxFloatRel <= rtol:
+        return "EQUIVALENT", comparison
+    return "DIFFERENT", comparison
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--a", required=True, help="baseline bench_all --out dir")
+    parser.add_argument("--b", required=True, help="candidate bench_all --out dir")
+    parser.add_argument("--run", default="run1")
+    parser.add_argument("--rtol", type=float, default=1e-12)
+    args = parser.parse_args()
+
+    scenarios = sorted(
+        name for name in os.listdir(args.a)
+        if os.path.isdir(os.path.join(args.a, name, args.run)))
+
+    exitCode = 0
+    for scenario in scenarios:
+        dirA = os.path.join(args.a, scenario, args.run)
+        dirB = os.path.join(args.b, scenario, args.run)
+        if not os.path.isdir(dirB):
+            print("%-32s MISSING in B" % scenario)
+            exitCode = 1
+            continue
+        try:
+            verdict, comparison = compareScenario(dirA, dirB, args.rtol)
+        except Exception as exc:
+            print("%-32s ERROR %s" % (scenario, exc))
+            exitCode = 1
+            continue
+        line = "%-32s %-10s" % (scenario, verdict)
+        if comparison.maxFloatRel:
+            line += " maxFloatRel=%.3g" % comparison.maxFloatRel
+        print(line)
+        if verdict == "DIFFERENT":
+            exitCode = 1
+            shown = 0
+            for path, kind, detail in comparison.diffs:
+                if kind == "float":
+                    continue
+                print("    %s [%s] %s" % (path or "<root>", kind, detail))
+                shown += 1
+                if shown >= MAX_REPORTED_DIFFS:
+                    remaining = sum(1 for d in comparison.diffs
+                                    if d[1] != "float") - shown
+                    if remaining > 0:
+                        print("    ... and %d more" % remaining)
+                    break
+    sys.exit(exitCode)
+
+
+if __name__ == "__main__":
+    main()

--- a/PaintomicsServer/src/benchmarks/bench_http.py
+++ b/PaintomicsServer/src/benchmarks/bench_http.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Drive a LIVE PaintOmics server through the pathway-acquisition example
+scenarios over HTTP -- the way the browser does -- and record wall-clock
+timings plus the step-1/2/3 responses in the same artifact layout as
+bench_runner, so two servers (or one server before and after a deploy) can
+be compared with bench_compare.
+
+    python -m src.benchmarks.bench_http --server https://paintomics.uv.es \
+        --out /tmp/uv-before --scenarios stategra-multiomics gene-single-condition
+
+Only what the client would see is captured: the final /check_job_status
+payloads of step 1 and step 2 and the /pa_step3 response for every matched
+pathway. Timings are per step, queue wait included (this is what a user
+experiences), plus the JobProgress phase breakdown reported by the server
+where available.
+"""
+import argparse
+import gzip
+import json
+import os
+import sys
+import time
+
+import requests
+
+# Response fields that are per-run and expected to differ.
+_VOLATILE = {"jobID", "timestamp", "userID"}
+
+
+def _selectedCompounds(matchedMetabolites):
+    """Replicate the client's default compound selection (JobController.js
+    dedup by similarity, then PA_Step2Views.getSelectedCompounds)."""
+    sets = json.loads(json.dumps(matchedMetabolites))
+    winners = {}
+    for compoundSet in sets:
+        for compound in compoundSet.get("mainCompounds", []):
+            compound["selected"] = False
+            kept = winners.get(compound.get("ID"))
+            if kept is None or compound.get("similarity", 0) >= kept.get("similarity", 0):
+                if kept is not None:
+                    kept["selected"] = False
+                compound["selected"] = True
+                winners[compound.get("ID")] = compound
+    selected = []
+    for compoundSet in sets:
+        for key in ("mainCompounds", "otherCompounds"):
+            for compound in compoundSet.get(key, []):
+                if compound.get("selected") is True:
+                    selected.append("%s#%s#%s" % (compound.get("ID"), compound.get("name"),
+                                                  compoundSet.get("title")))
+    return selected
+
+
+class Client(object):
+    def __init__(self, server, timeout=1800, verify=True):
+        self.server = server.rstrip("/")
+        self.session = requests.Session()
+        self.timeout = timeout
+        self.verify = verify
+        self.progress = {}
+
+    def post(self, path, data=None):
+        response = self.session.post(self.server + path, data=data, timeout=120,
+                                     verify=self.verify)
+        response.raise_for_status()
+        return response.json()
+
+    def waitForJob(self, jobID, label):
+        started = time.time()
+        lastProgress = None
+        while True:
+            response = self.session.post(self.server + "/check_job_status/" + jobID,
+                                         timeout=120, verify=self.verify)
+            try:
+                payload = response.json()
+            except ValueError:
+                raise RuntimeError("non-JSON status for %s: %s" % (jobID, response.text[:200]))
+            if payload.get("success") is True and "status" not in payload:
+                return payload
+            if response.status_code >= 400 or payload.get("status") in ("failed", "JobStatus.FAILED"):
+                raise RuntimeError("job %s failed at %s: %s" % (jobID, label, payload.get("message")))
+            if payload.get("progress"):
+                lastProgress = payload["progress"]
+                self.progress[label] = lastProgress
+            if time.time() - started > self.timeout:
+                raise RuntimeError("timeout waiting for %s (%s)" % (jobID, label))
+            time.sleep(1.0)
+
+
+def runScenario(client, scenarioId):
+    timings = {}
+    artifacts = {}
+
+    t0 = time.time()
+    step1 = client.post("/pa_step1/example/" + scenarioId)
+    jobID = step1["jobID"]
+    step1Result = client.waitForJob(jobID, "step1")
+    timings["step1"] = round(time.time() - t0, 2)
+    artifacts["step1"] = {k: v for k, v in step1Result.items() if k not in _VOLATILE}
+
+    selectedCompounds = _selectedCompounds(step1Result.get("matchedMetabolites", []))
+    form = [("jobID", jobID)] + [("selectedCompounds[]", c) for c in selectedCompounds]
+    t0 = time.time()
+    client.post("/pa_step2", data=form)
+    step2Result = client.waitForJob(jobID, "step2")
+    timings["step2"] = round(time.time() - t0, 2)
+    artifacts["step2"] = {k: v for k, v in step2Result.items() if k not in _VOLATILE}
+    artifacts["step2"]["selectedCompounds"] = selectedCompounds
+
+    pathwayIDs = sorted((step2Result.get("pathwaysInfo") or {}).keys())
+    form = [("jobID", jobID)] + [("selectedPathways", p) for p in pathwayIDs]
+    t0 = time.time()
+    step3Result = client.post("/pa_step3", data=form)
+    timings["step3"] = round(time.time() - t0, 2)
+    artifacts["step3"] = {k: v for k, v in step3Result.items() if k not in _VOLATILE}
+    artifacts["step3"]["selectedPathways"] = pathwayIDs
+
+    timings["progress"] = dict(client.progress)
+    client.progress = {}
+    return jobID, timings, artifacts
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--server", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--scenarios", nargs="+", required=True)
+    parser.add_argument("--repeat", type=int, default=1)
+    parser.add_argument("--insecure", action="store_true")
+    args = parser.parse_args()
+
+    client = Client(args.server, verify=not args.insecure)
+    summary = []
+    for scenario in args.scenarios:
+        for run in range(1, args.repeat + 1):
+            runDir = os.path.join(args.out, scenario, "run%d" % run)
+            os.makedirs(runDir, exist_ok=True)
+            started = time.time()
+            try:
+                jobID, timings, artifacts = runScenario(client, scenario)
+                total = round(time.time() - started, 2)
+                with gzip.open(os.path.join(runDir, "artifacts.json.gz"), "wt", encoding="utf-8") as h:
+                    json.dump(artifacts, h)
+                record = {"scenario": scenario, "run": run, "jobID": jobID,
+                          "total": total, "phases": timings, "server": args.server}
+                with open(os.path.join(runDir, "timings.json"), "w") as h:
+                    json.dump(record, h, indent=2)
+                print("%-32s run%d %8.1fs job=%s step1=%.1f step2=%.1f step3=%.1f" % (
+                    scenario, run, total, jobID, timings["step1"], timings["step2"], timings["step3"]),
+                    flush=True)
+            except Exception as exc:
+                record = {"scenario": scenario, "run": run, "error": str(exc)}
+                print("%-32s run%d FAILED: %s" % (scenario, run, exc), flush=True)
+            summary.append(record)
+            with open(os.path.join(args.out, "summary.json"), "w") as h:
+                json.dump(summary, h, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/PaintomicsServer/src/benchmarks/bench_report.py
+++ b/PaintomicsServer/src/benchmarks/bench_report.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Summarise an A/B tree (bench_ab or two bench_all trees) into a Markdown
+table of per-scenario, per-phase medians with speed-ups, plus the
+equivalence verdict from bench_compare for each scenario.
+
+    python -m src.benchmarks.bench_report --a /tmp/bench/ab/A --b /tmp/bench/ab/B \
+        [--strict-a /tmp/bench/baseline-mt1 --strict-b /tmp/bench/cand-mt1] \
+        --out report.md
+"""
+import argparse
+import json
+import os
+import statistics
+
+from src.benchmarks.bench_compare import compareScenario
+
+
+def loadRuns(root, scenario):
+    runs = []
+    scenarioDir = os.path.join(root, scenario)
+    if not os.path.isdir(scenarioDir):
+        return runs
+    for name in sorted(os.listdir(scenarioDir)):
+        path = os.path.join(scenarioDir, name, "timings.json")
+        if os.path.isfile(path):
+            with open(path) as handle:
+                runs.append(json.load(handle))
+    return runs
+
+
+def medians(runs):
+    phases = {}
+    keys = set()
+    for run in runs:
+        keys.update(run.get("phases", {}).keys())
+    for key in sorted(keys):
+        values = [run["phases"][key] for run in runs if key in run.get("phases", {})]
+        if values:
+            phases[key] = statistics.median(values)
+    total = statistics.median([run["total"] for run in runs]) if runs else None
+    return total, phases
+
+
+def fmt(seconds):
+    if seconds is None:
+        return "-"
+    return "%.2f" % seconds if seconds < 100 else "%.1f" % seconds
+
+
+def speedup(a, b):
+    if a is None or b is None or b <= 0:
+        return "-"
+    return "%.2fx" % (a / b)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--a", required=True)
+    parser.add_argument("--b", required=True)
+    parser.add_argument("--strict-a")
+    parser.add_argument("--strict-b")
+    parser.add_argument("--rtol", type=float, default=1e-12)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--title", default="PaintOmics pipeline benchmark: baseline vs candidate")
+    args = parser.parse_args()
+
+    scenarios = sorted(set(os.listdir(args.a)) & set(os.listdir(args.b)))
+    lines = ["# %s" % args.title, ""]
+    lines.append("| Scenario | Baseline median (s) | Candidate median (s) | Speed-up | Runs (A/B) | Equivalence (timing runs) | Equivalence (strict, 1 worker) |")
+    lines.append("|---|---:|---:|---:|:-:|:-:|:-:|")
+    details = []
+    for scenario in scenarios:
+        runsA, runsB = loadRuns(args.a, scenario), loadRuns(args.b, scenario)
+        totalA, phasesA = medians(runsA)
+        totalB, phasesB = medians(runsB)
+        try:
+            verdict, comparison = compareScenario(os.path.join(args.a, scenario, "run1"),
+                                                  os.path.join(args.b, scenario, "run1"), args.rtol)
+        except Exception as exc:
+            verdict, comparison = "ERROR: %s" % exc, None
+        strictVerdict = "-"
+        if args.strict_a and args.strict_b:
+            try:
+                strictVerdict, strictComparison = compareScenario(
+                    os.path.join(args.strict_a, scenario, "run1"),
+                    os.path.join(args.strict_b, scenario, "run1"), args.rtol)
+            except Exception as exc:
+                strictVerdict = "ERROR: %s" % exc
+        lines.append("| %s | %s | %s | %s | %d/%d | %s | %s |" % (
+            scenario, fmt(totalA), fmt(totalB), speedup(totalA, totalB),
+            len(runsA), len(runsB), verdict, strictVerdict))
+        details.append((scenario, phasesA, phasesB, verdict, comparison))
+
+    lines.append("")
+    lines.append("## Per-phase medians")
+    for scenario, phasesA, phasesB, verdict, comparison in details:
+        lines.append("")
+        lines.append("### %s" % scenario)
+        lines.append("")
+        lines.append("| Phase | Baseline (s) | Candidate (s) | Speed-up |")
+        lines.append("|---|---:|---:|---:|")
+        for key in sorted(set(phasesA) | set(phasesB)):
+            a, b = phasesA.get(key), phasesB.get(key)
+            if (a or 0) < 0.05 and (b or 0) < 0.05:
+                continue
+            lines.append("| %s | %s | %s | %s |" % (key, fmt(a), fmt(b), speedup(a, b)))
+        if comparison is not None and verdict == "DIFFERENT":
+            lines.append("")
+            lines.append("Differences (timing runs, first 15):")
+            shown = 0
+            for path, kind, detail in comparison.diffs:
+                if kind == "float":
+                    continue
+                lines.append("- `%s` [%s] %s" % (path, kind, detail[:160]))
+                shown += 1
+                if shown >= 15:
+                    break
+
+    with open(args.out, "w") as handle:
+        handle.write("\n".join(lines) + "\n")
+    print("\n".join(lines[:len(scenarios) + 4]))
+
+
+if __name__ == "__main__":
+    main()

--- a/PaintomicsServer/src/benchmarks/bench_report.py
+++ b/PaintomicsServer/src/benchmarks/bench_report.py
@@ -64,7 +64,8 @@ def main():
     parser.add_argument("--title", default="PaintOmics pipeline benchmark: baseline vs candidate")
     args = parser.parse_args()
 
-    scenarios = sorted(set(os.listdir(args.a)) & set(os.listdir(args.b)))
+    scenarios = sorted(name for name in set(os.listdir(args.a)) & set(os.listdir(args.b))
+                       if os.path.isdir(os.path.join(args.a, name)) and os.path.isdir(os.path.join(args.b, name)))
     lines = ["# %s" % args.title, ""]
     lines.append("| Scenario | Baseline median (s) | Candidate median (s) | Speed-up | Runs (A/B) | Equivalence (timing runs) | Equivalence (strict, 1 worker) |")
     lines.append("|---|---:|---:|---:|:-:|:-:|:-:|")

--- a/PaintomicsServer/src/benchmarks/bench_report.py
+++ b/PaintomicsServer/src/benchmarks/bench_report.py
@@ -12,7 +12,7 @@ import json
 import os
 import statistics
 
-from src.benchmarks.bench_compare import compareScenario
+from src.benchmarks.bench_compare import compareScenario, noiseClasses
 
 
 def loadRuns(root, scenario):
@@ -62,10 +62,27 @@ def main():
     parser.add_argument("--rtol", type=float, default=1e-12)
     parser.add_argument("--out", required=True)
     parser.add_argument("--title", default="PaintOmics pipeline benchmark: baseline vs candidate")
+    parser.add_argument("--noise-runs", nargs="+", metavar="RUN",
+                        help="derive the baseline's own noise classes from the pairwise "
+                             "differences between these runs of every scenario (under "
+                             "--noise-from, else --a); the timing-run verdict then reads "
+                             "WITHIN-NOISE when a candidate differs only in those classes")
+    parser.add_argument("--noise-from",
+                        help="tree holding the --noise-runs (e.g. master with 1 and 6 workers)")
     args = parser.parse_args()
 
     scenarios = sorted(name for name in set(os.listdir(args.a)) & set(os.listdir(args.b))
                        if os.path.isdir(os.path.join(args.a, name)) and os.path.isdir(os.path.join(args.b, name)))
+    noise = None
+    if args.noise_runs:
+        noise = set()
+        noiseRoot = args.noise_from or args.a
+        for scenario in sorted(os.listdir(noiseRoot)):
+            runs = [os.path.join(noiseRoot, scenario, run) for run in args.noise_runs]
+            runs = [run for run in runs if os.path.isdir(run)]
+            for index in range(1, len(runs)):
+                noise |= noiseClasses(runs[0], runs[index], args.rtol)
+
     lines = ["# %s" % args.title, ""]
     lines.append("| Scenario | Baseline median (s) | Candidate median (s) | Speed-up | Runs (A/B) | Equivalence (timing runs) | Equivalence (strict, 1 worker) |")
     lines.append("|---|---:|---:|---:|:-:|:-:|:-:|")
@@ -76,7 +93,8 @@ def main():
         totalB, phasesB = medians(runsB)
         try:
             verdict, comparison = compareScenario(os.path.join(args.a, scenario, "run1"),
-                                                  os.path.join(args.b, scenario, "run1"), args.rtol)
+                                                  os.path.join(args.b, scenario, "run1"), args.rtol,
+                                                  noise)
         except Exception as exc:
             verdict, comparison = "ERROR: %s" % exc, None
         strictVerdict = "-"

--- a/PaintomicsServer/src/benchmarks/bench_runner.py
+++ b/PaintomicsServer/src/benchmarks/bench_runner.py
@@ -28,6 +28,7 @@ import json
 import logging
 import multiprocessing
 import os
+import re
 import sys
 import time
 import uuid
@@ -419,9 +420,19 @@ def runMore(scenarioId, outDir, timer):
                job, None, response, {})
 
     content = response.getContent() or {}
+    # jobIDs are per-run and output filenames embed a minute-resolution
+    # timestamp; both are expected to differ between runs (A/A verified: the
+    # file CONTENTS are identical). Normalize so comparisons see the science.
+    normalized = {}
+    for key, value in content.items():
+        if key == "jobID":
+            value = "<jobID>"
+        elif isinstance(value, str):
+            value = re.sub(r"\d{12}", "<TS>", value)
+        normalized[key] = value
     artifacts = {"responseKeys": sorted(content.keys()),
                  "success": content.get("success"),
-                 "response": content,
+                 "response": normalized,
                  "outputFiles": _fileContents(job.getOutputDir(), ["*.tab", "*.csv"])}
     job.cleanDirectories()
     return {"more": artifacts}

--- a/PaintomicsServer/src/benchmarks/bench_runner.py
+++ b/PaintomicsServer/src/benchmarks/bench_runner.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+"""Run ONE example scenario through the real pipeline, headless, and dump
+timings plus every result the client would see.
+
+This is the measurement kernel for the performance work: it calls the same
+job methods, in the same order, as the servlets do (pathwayAcquisitionStep1_
+PART2 / Step2_PART2 / Step3, Bed2GenesServlet STEP2, MiRNA2GenesServlet STEP2,
+MOREServlet STEP2), so its artifacts are the equivalence contract between two
+builds. One scenario per process: a fresh interpreter defeats the job cache,
+the KEGG organism cache and the per-job translation cache, exactly like the
+first request after a deploy.
+
+Usage (from PaintomicsServer/):
+
+    PAINTOMICS_KEGG_DATA=... PAINTOMICS_CLIENT_TMP=... \
+    python -m src.benchmarks.bench_runner --scenario gene-single-condition \
+        --out /tmp/bench/baseline/run1
+
+Outputs in --out:
+    timings.json         phase -> seconds (plus scraped STEP2 TIMING line)
+    artifacts.json.gz    everything the client would see, per step
+"""
+import argparse
+import glob
+import gzip
+import io
+import json
+import logging
+import multiprocessing
+import os
+import sys
+import time
+import uuid
+import zipfile
+
+# Production (Linux) forks its mapper/enrichment workers; macOS defaults to
+# spawn, which changes both the cost profile (full re-import + re-pickle per
+# worker, cold KEGG singleton per child) and cache-inheritance semantics.
+# Benchmarks must measure the production behaviour.
+multiprocessing.set_start_method("fork", force=True)
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, ROOT)
+
+for _var in ("PAINTOMICS_KEGG_DATA", "PAINTOMICS_CLIENT_TMP"):
+    if not os.environ.get(_var):
+        sys.exit("bench_runner: %s must be set before any src import "
+                 "(serverconf reads it at import time)" % _var)
+
+from src.conf.serverconf import CLIENT_TMP_DIR, KEGG_DATA_DIR  # noqa: E402
+from src.common.KeggInformationManager import KeggInformationManager  # noqa: E402
+
+# First construction wins for the singleton; the server does exactly this
+# (paintomicsserver.py:107) and step 3's PNG reads depend on it.
+KeggInformationManager(KEGG_DATA_DIR)
+
+from src.common.JobInformationManager import JobInformationManager  # noqa: E402
+from src.common import ExampleDatasets  # noqa: E402
+from src.common import DatabaseAvailability  # noqa: E402
+
+EXAMPLE_FILES_DIR = os.path.join(ROOT, "src", "examplefiles") + os.sep
+ROOT_DIRECTORY = os.path.join(ROOT, "src") + os.sep
+
+
+class FakeResponse(object):
+    """The two methods the servlet code calls on a Response."""
+
+    def __init__(self):
+        self.content = None
+
+    def setContent(self, content):
+        self.content = content
+
+    def getContent(self):
+        return self.content
+
+    def getResponse(self):
+        return self
+
+
+class Timer(object):
+    def __init__(self):
+        self.phases = {}
+
+    def time(self, name, fn, *args, **kwargs):
+        start = time.perf_counter()
+        result = fn(*args, **kwargs)
+        self.phases[name] = round(time.perf_counter() - start, 4)
+        return result
+
+
+class LogScraper(logging.Handler):
+    """Collect the pipeline's own timing lines (e.g. STEP2 TIMING ...)."""
+
+    def __init__(self):
+        logging.Handler.__init__(self)
+        self.lines = []
+
+    def emit(self, record):
+        try:
+            message = record.getMessage()
+        except Exception:
+            return
+        if "TIMING" in message:
+            self.lines.append(message)
+
+
+def clientSelectedCompounds(matchedMetabolites):
+    """Replicate the client's default compound selection.
+
+    JobController.js:527-541 dedups across CompoundSets: for every unique
+    compound ID appearing in any mainCompounds list, exactly one occurrence
+    ends selected -- the one with the highest similarity, later entries
+    winning ties (>=). otherCompounds keep the server-side selected flags.
+    PA_Step2Views.js getSelectedCompounds then collects "ID#name#title" in
+    list order. This runs on the BSON dicts so the job objects stay untouched.
+    """
+    sets = [foundFeature.toBSON() for foundFeature in matchedMetabolites]
+
+    winners = {}
+    for compoundSet in sets:
+        for compound in compoundSet.get("mainCompounds", []):
+            compound["selected"] = False
+            kept = winners.get(compound.get("ID"))
+            if kept is None or compound.get("similarity", 0) >= kept.get("similarity", 0):
+                if kept is not None:
+                    kept["selected"] = False
+                compound["selected"] = True
+                winners[compound.get("ID")] = compound
+
+    selected = []
+    for compoundSet in sets:
+        for compound in compoundSet.get("mainCompounds", []):
+            if compound.get("selected") is True:
+                selected.append("%s#%s#%s" % (compound.get("ID"),
+                                              compound.get("name"),
+                                              compoundSet.get("title")))
+        for compound in compoundSet.get("otherCompounds", []):
+            if compound.get("selected") is True:
+                selected.append("%s#%s#%s" % (compound.get("ID"),
+                                              compound.get("name"),
+                                              compoundSet.get("title")))
+    return selected
+
+
+def jsonSafe(obj):
+    """Encode with full fidelity; unknown types become tagged markers so a
+    type drift between builds shows up as a diff instead of a crash."""
+    return {"__unserializable__": type(obj).__name__, "repr": repr(obj)}
+
+
+def dumpArtifacts(outDir, artifacts):
+    path = os.path.join(outDir, "artifacts.json.gz")
+    with gzip.open(path, "wt", encoding="utf-8") as handle:
+        json.dump(artifacts, handle, default=jsonSafe)
+
+
+def readMappingZip(job):
+    """Per-omic matched/unmatched lines from the mapping results zip.
+
+    Line order across mapper workers is nondeterministic on master, so the
+    lines are sorted here; content, not order, is the contract.
+    """
+    zipPath = os.path.join(job.getOutputDir(),
+                           "mapping_results_" + job.getJobID() + ".zip")
+    if not os.path.isfile(zipPath):
+        return {}
+    result = {}
+    with zipfile.ZipFile(zipPath) as bundle:
+        for name in sorted(bundle.namelist()):
+            with bundle.open(name) as member:
+                text = io.TextIOWrapper(member, encoding="utf-8",
+                                        errors="replace").read()
+            result[name] = sorted(text.splitlines())
+    return result
+
+
+def pathwaysBSON(job):
+    return {pathwayID: pathway.toBSON()
+            for pathwayID, pathway in (job.getMatchedPathways() or {}).items()}
+
+
+def cleanupJob(jobID):
+    """Best-effort removal of the benchmark job's Mongo footprint."""
+    try:
+        from src.common.DAO.PathwayAcquisitionJobDAO import PathwayAcquisitionJobDAO
+        from src.common.DAO.FeatureDAO import FeatureDAO
+        from src.common.DAO.FoundFeatureDAO import FoundFeatureDAO
+        from src.common.DAO.PathwayDAO import PathwayDAO
+        PathwayAcquisitionJobDAO().remove(jobID)
+        FeatureDAO().removeAll(otherParams={"jobID": jobID})
+        FoundFeatureDAO().removeAll(otherParams={"jobID": jobID})
+        PathwayDAO().removeAll(otherParams={"jobID": jobID})
+    except Exception as exc:  # pragma: no cover - cleanup only
+        logging.warning("bench cleanup failed for %s: %s", jobID, exc)
+
+
+# ---------------------------------------------------------------------------
+# Pathway acquisition (scenarios 01-04, 08)
+# ---------------------------------------------------------------------------
+
+def runPathwayAcquisition(scenarioId, outDir, timer):
+    from src.classes.JobInstances.PathwayAcquisitionJob import PathwayAcquisitionJob
+
+    jobID = "BM" + uuid.uuid4().hex[:10]
+    job = PathwayAcquisitionJob(jobID, None, CLIENT_TMP_DIR)
+    job.initializeDirectories()
+
+    scenario = ExampleDatasets.applyScenario(job, EXAMPLE_FILES_DIR, scenarioId)
+    # The servlet overrides the manifest's databases with everything installed
+    # for the organism (PathwayAcquisitionServlet.py:257-258).
+    job.setDatabases(DatabaseAvailability.resolveDatabases(job.getOrganism()))
+    job.setName(scenario.get("title", "")[:100])
+    job.setAIConsent("false")
+
+    # --- step 1 (mirrors pathwayAcquisitionStep1_PART2) ---
+    timer.time("step1.validateInput", job.validateInput)
+    matchedMetabolites = timer.time("step1.processFilesContent",
+                                    job.processFilesContent)
+    job.setLastStep(2)
+    job.getJobDescription(True, True)
+    timer.time("step1.store", JobInformationManager().storeJobInstance, job, 1)
+
+    step1Artifacts = {
+        "organism": job.getOrganism(),
+        "databases": job.getDatabases(),
+        "matchedMetabolites": [f.toBSON() for f in matchedMetabolites],
+        "geneBasedInputOmics": job.getGeneBasedInputOmics(),
+        "compoundBasedInputOmics": job.getCompoundBasedInputOmics(),
+        "mappingFiles": readMappingZip(job),
+    }
+    job.cleanDirectories()
+
+    # --- step 2 (mirrors pathwayAcquisitionStep2_PART2) ---
+    job2 = JobInformationManager().loadJobInstance(jobID)
+    job2.setDirectories(CLIENT_TMP_DIR)
+    job2.initializeDirectories()
+
+    selectedCompounds = clientSelectedCompounds(matchedMetabolites)
+    timer.time("step2.updateCompounds",
+               job2.updateSubmitedCompoundsList, selectedCompounds)
+    summary = timer.time("step2.generatePathwaysList", job2.generatePathwaysList)
+    globalExpressionData = timer.time("step2.globalExpressionData",
+                                      job2.getGlobalExpressionData)
+
+    classification = None
+    hubResult = None
+    if selectedCompounds:
+        classification = timer.time("step2.compoundsClassification",
+                                    job2.compundsClassification, {})
+        hubResult = timer.time("step2.hubAnalysis",
+                               job2.hubAnalysis, ROOT_DIRECTORY)
+    job2.parseRegulationPerCondition()
+    timer.time("step2.metagenes",
+               job2.generateMetagenesList, ROOT_DIRECTORY, {})
+    job2.setLastStep(3)
+    timer.time("step2.store", JobInformationManager().storeJobInstance, job2, 2)
+
+    step2Artifacts = {
+        "summary": summary,
+        "selectedCompounds": selectedCompounds,
+        "pathwaysInfo": pathwaysBSON(job2),
+        "classInfo": {classID: matchedClass.toBSON() for classID, matchedClass
+                      in (job2.getMatchedClass() or {}).items()},
+        "omicsValuesID": job2.getValueIdTable(),
+        "globalExpressionData": globalExpressionData,
+        "conditionNames": getattr(job2, "conditionNames", []),
+        "regulationPerConditionData": getattr(job2, "regulationPerConditionData", None),
+        "hubAnalysisResult": hubResult,
+    }
+    if classification is not None:
+        (mappingComp, pValueInDict, classificationDict, exprssionMetabolites,
+         adjustPvalue, totalRelevantFeaturesInCategory, featureSummary,
+         compoundRegulateFeatures) = classification
+        step2Artifacts.update({
+            "mappingComp": mappingComp,
+            "pValueInDict": pValueInDict,
+            "classificationDict": classificationDict,
+            "exprssionMetabolites": exprssionMetabolites,
+            "adjustPvalue": adjustPvalue,
+            "totalRelevantFeaturesInCategory": totalRelevantFeaturesInCategory,
+            "featureSummary": featureSummary,
+            "compoundRegulateFeatures": compoundRegulateFeatures,
+        })
+
+    # --- step 3 (mirrors pathwayAcquisitionStep3) over every matched pathway ---
+    selectedPathways = sorted((job2.getMatchedPathways() or {}).keys())
+    step3 = timer.time(
+        "step3.generateSelectedPathwaysInformation",
+        job2.generateSelectedPathwaysInformation, selectedPathways, [], True)
+    timer.time("step3.store", JobInformationManager().storeJobInstance, job2, 3)
+    step3Artifacts = {
+        "selectedPathways": selectedPathways,
+        "graphicalOptionsInstances": step3[1],
+        "omicsValues": step3[2],
+    }
+
+    job2.cleanDirectories()
+    cleanupJob(jobID)
+    return {"step1": step1Artifacts, "step2": step2Artifacts,
+            "step3": step3Artifacts}
+
+
+# ---------------------------------------------------------------------------
+# Conversion pipelines (scenarios 05, 07, 09, 10)
+# ---------------------------------------------------------------------------
+
+def _fileContents(directory, patterns):
+    """{pattern: [file contents]} for glob patterns under directory. Filenames
+    embed dates/random seeds, so content is stored under the pattern key."""
+    collected = {}
+    for pattern in patterns:
+        matches = sorted(glob.glob(os.path.join(directory, pattern)))
+        collected[pattern] = []
+        for path in matches:
+            with open(path, "r", encoding="utf-8", errors="replace") as handle:
+                collected[pattern].append(handle.read())
+    return collected
+
+
+def runMiRNA2Genes(scenarioId, outDir, timer):
+    from src.classes.JobInstances.MiRNA2GeneJob import MiRNA2GeneJob
+
+    jobID = "BM" + uuid.uuid4().hex[:10]
+    job = MiRNA2GeneJob(jobID, None, CLIENT_TMP_DIR)
+    job.initializeDirectories()
+    scenario = ExampleDatasets.applyScenario(job, EXAMPLE_FILES_DIR, scenarioId)
+
+    regulator = next((omic for omic in scenario.get("omics", [])
+                      if omic.get("role") == "regulator"),
+                     scenario["omics"][0])
+    # The defaults the servlet applies when the form carries no override
+    # (MiRNA2GenesServlet.py:138-149).
+    job.omicName = regulator["omicName"]
+    job.report = "all"
+    job.score_method = "kendall"
+    job.selection_method = "negative_correlation"
+    job.cutoff = 0.5
+    job.enrichment = "genes"
+
+    timer.time("mirna.validateInput", job.validateInput)
+    timer.time("mirna.fromMiRNA2Genes", job.fromMiRNA2Genes)
+    timer.time("mirna.store", JobInformationManager().storeJobInstance, job, 1)
+
+    artifacts = {
+        "temporalFiles": _fileContents(job.getTemporalDir(), [
+            "miRNAMatch_output.txt",
+        ]),
+        "outputFiles": _fileContents(job.getOutputDir(), [
+            "regulator2Gene_output_*.tab",
+            "regulator2Gene_relevant_*.tab",
+            "regulator_associations*.tab",
+            "regulator_relevant_associations*.tab",
+            "genesToMiRNA*",
+        ]),
+    }
+    job.cleanDirectories()
+    return {"conversion": artifacts}
+
+
+def runRegions2Genes(scenarioId, outDir, timer):
+    from src.classes.JobInstances.Bed2GeneJob import Bed2GeneJob
+
+    jobID = "BM" + uuid.uuid4().hex[:10]
+    job = Bed2GeneJob(jobID, None, CLIENT_TMP_DIR)
+    job.initializeDirectories()
+    scenario = ExampleDatasets.applyScenario(job, EXAMPLE_FILES_DIR, scenarioId)
+
+    regionOmic = scenario["omics"][0]
+    # Servlet defaults (Bed2GenesServlet.py:135-165).
+    job.omicName = regionOmic["omicName"]
+    job.presortedGTF = False
+    job.report = "gene"
+    job.distance = 10
+    job.tss = 200
+    job.promoter = 1300
+    job.geneAreaPercentage = 90
+    job.regionAreaPercentage = 50
+    job.ignoreMissing = False
+    job.enrichment = "genes"
+    job.geneIDtag = "gene_id"
+    job.summarizationMethod = "mean"
+    job.reportRegions = ["all"]
+
+    timer.time("bed.validateInput", job.validateInput)
+    timer.time("bed.fromBED2Genes", job.fromBED2Genes)
+    timer.time("bed.store", JobInformationManager().storeJobInstance, job, 1)
+
+    artifacts = {
+        "temporalFiles": _fileContents(job.getTemporalDir(), [
+            "RGMatch_output.txt",
+            "regionsToGene.tab",
+            "genesToRegions.tab",
+        ]),
+        "outputFiles": _fileContents(job.getOutputDir(), [
+            "B2G_output_*.tab",
+            "B2G_relevant_*.tab",
+        ]),
+    }
+    job.cleanDirectories()
+    return {"conversion": artifacts}
+
+
+# ---------------------------------------------------------------------------
+# MORE (scenarios 06, 11)
+# ---------------------------------------------------------------------------
+
+def runMore(scenarioId, outDir, timer):
+    from src.classes.JobInstances.MOREJob import MOREJob
+    from src.servlets import MOREServlet
+
+    jobID = "BM" + uuid.uuid4().hex[:10]
+    job = MOREJob(jobID, None, CLIENT_TMP_DIR)
+    job.initializeDirectories()
+    ExampleDatasets.applyMoreScenario(job, EXAMPLE_FILES_DIR, scenarioId)
+
+    response = FakeResponse()
+    timer.time("more.step2", MOREServlet.fromMOREtoGenes_STEP2,
+               job, None, response, {})
+
+    content = response.getContent() or {}
+    artifacts = {"responseKeys": sorted(content.keys()),
+                 "success": content.get("success"),
+                 "response": content,
+                 "outputFiles": _fileContents(job.getOutputDir(), ["*.tab", "*.csv"])}
+    job.cleanDirectories()
+    return {"more": artifacts}
+
+
+# ---------------------------------------------------------------------------
+
+PIPELINES = {
+    "pathway-acquisition": runPathwayAcquisition,
+    "mirna2genes": runMiRNA2Genes,
+    "regions2genes": runRegions2Genes,
+    "more": runMore,
+}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--scenario", required=True)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+    logging.basicConfig(level=logging.INFO,
+                        format="%(levelname)s %(message)s",
+                        stream=sys.stderr)
+    scraper = LogScraper()
+    root = logging.getLogger()
+    root.addHandler(scraper)
+    # logging.cfg (loaded via serverconf import) leaves the root above INFO;
+    # the pipeline's own STEP2 TIMING lines are logged at INFO.
+    root.setLevel(logging.INFO)
+
+    scenario = ExampleDatasets.getScenario(EXAMPLE_FILES_DIR, args.scenario)
+    pipeline = scenario.get("pipeline")
+    if pipeline not in PIPELINES:
+        sys.exit("bench_runner: no driver for pipeline %r" % pipeline)
+
+    timer = Timer()
+    started = time.perf_counter()
+    artifacts = PIPELINES[pipeline](args.scenario, args.out, timer)
+    total = round(time.perf_counter() - started, 4)
+
+    timings = {"scenario": args.scenario, "pipeline": pipeline,
+               "total": total, "phases": timer.phases,
+               "pipeline_timing_lines": scraper.lines}
+    with open(os.path.join(args.out, "timings.json"), "w") as handle:
+        json.dump(timings, handle, indent=2)
+    dumpArtifacts(args.out, artifacts)
+
+    print(json.dumps({"scenario": args.scenario, "total": total,
+                      "phases": timer.phases}))
+
+
+if __name__ == "__main__":
+    main()

--- a/PaintomicsServer/src/benchmarks/bench_runner.py
+++ b/PaintomicsServer/src/benchmarks/bench_runner.py
@@ -319,6 +319,37 @@ def _fileContents(directory, patterns):
     return collected
 
 
+_NAME_NOISE = re.compile(r"(_\d{8,14}(_\d+)?)(?=\.|$)|_[A-Za-z0-9]{10}(?=\.|_|$)")
+
+
+def _normalizedName(name):
+    """Strip the date/seed/jobID tokens converters embed in file names."""
+    return _NAME_NOISE.sub("", name)
+
+
+def _conversionOutputs(job, outputs):
+    """Everything a conversion job leaves behind, keyed by normalized name:
+    the members of its results zip (the temporal dir as it was before
+    cleanDirectories) and the files it copied into the input dir."""
+    collected = {"zipMembers": {}, "inputDirCopies": {}}
+    if not outputs:
+        return collected
+    zipPath = os.path.join(job.getOutputDir(), outputs[0])
+    if os.path.isfile(zipPath):
+        with zipfile.ZipFile(zipPath) as bundle:
+            for member in sorted(bundle.namelist()):
+                with bundle.open(member) as handle:
+                    text = io.TextIOWrapper(handle, encoding="utf-8",
+                                            errors="replace").read()
+                collected["zipMembers"][_normalizedName(member)] = text
+    for copied in outputs[1:]:
+        path = os.path.join(job.getInputDir(), copied)
+        if os.path.isfile(path):
+            with open(path, "r", encoding="utf-8", errors="replace") as handle:
+                collected["inputDirCopies"][_normalizedName(copied)] = handle.read()
+    return collected
+
+
 def runMiRNA2Genes(scenarioId, outDir, timer):
     from src.classes.JobInstances.MiRNA2GeneJob import MiRNA2GeneJob
 
@@ -340,22 +371,15 @@ def runMiRNA2Genes(scenarioId, outDir, timer):
     job.enrichment = "genes"
 
     timer.time("mirna.validateInput", job.validateInput)
-    timer.time("mirna.fromMiRNA2Genes", job.fromMiRNA2Genes)
+    outputs = timer.time("mirna.fromMiRNA2Genes", job.fromMiRNA2Genes)
     timer.time("mirna.store", JobInformationManager().storeJobInstance, job, 1)
 
-    artifacts = {
-        "temporalFiles": _fileContents(job.getTemporalDir(), [
-            "miRNAMatch_output.txt",
-        ]),
-        "outputFiles": _fileContents(job.getOutputDir(), [
-            "regulator2Gene_output_*.tab",
-            "regulator2Gene_relevant_*.tab",
-            "regulator_associations*.tab",
-            "regulator_relevant_associations*.tab",
-            "genesToMiRNA*",
-        ]),
-    }
-    job.cleanDirectories()
+    # fromMiRNA2Genes wipes the temporal dir on the way out; what survives is
+    # the results zip in the output dir (every intermediate and output file)
+    # and the copies written into the user's input dir, which are the files
+    # pa_step1 will consume. Names embed a date and a random seed, so
+    # contents are keyed by normalized name.
+    artifacts = _conversionOutputs(job, outputs)
     return {"conversion": artifacts}
 
 
@@ -384,21 +408,10 @@ def runRegions2Genes(scenarioId, outDir, timer):
     job.reportRegions = ["all"]
 
     timer.time("bed.validateInput", job.validateInput)
-    timer.time("bed.fromBED2Genes", job.fromBED2Genes)
+    outputs = timer.time("bed.fromBED2Genes", job.fromBED2Genes)
     timer.time("bed.store", JobInformationManager().storeJobInstance, job, 1)
 
-    artifacts = {
-        "temporalFiles": _fileContents(job.getTemporalDir(), [
-            "RGMatch_output.txt",
-            "regionsToGene.tab",
-            "genesToRegions.tab",
-        ]),
-        "outputFiles": _fileContents(job.getOutputDir(), [
-            "B2G_output_*.tab",
-            "B2G_relevant_*.tab",
-        ]),
-    }
-    job.cleanDirectories()
+    artifacts = _conversionOutputs(job, outputs)
     return {"conversion": artifacts}
 
 

--- a/PaintomicsServer/src/benchmarks/bench_runner.py
+++ b/PaintomicsServer/src/benchmarks/bench_runner.py
@@ -319,11 +319,13 @@ def _fileContents(directory, patterns):
     return collected
 
 
-_NAME_NOISE = re.compile(r"(_\d{8,14}(_\d+)?)(?=\.|$)|_[A-Za-z0-9]{10}(?=\.|_|$)")
+_NAME_NOISE = re.compile(r"_?\d{8,14}(_\d{1,5})?(?=\.|_|$)")
 
 
-def _normalizedName(name):
+def _normalizedName(name, jobID=""):
     """Strip the date/seed/jobID tokens converters embed in file names."""
+    if jobID:
+        name = name.replace(jobID + "_", "").replace(jobID, "")
     return _NAME_NOISE.sub("", name)
 
 
@@ -341,12 +343,12 @@ def _conversionOutputs(job, outputs):
                 with bundle.open(member) as handle:
                     text = io.TextIOWrapper(handle, encoding="utf-8",
                                             errors="replace").read()
-                collected["zipMembers"][_normalizedName(member)] = text
+                collected["zipMembers"][_normalizedName(member, job.getJobID())] = text
     for copied in outputs[1:]:
         path = os.path.join(job.getInputDir(), copied)
         if os.path.isfile(path):
             with open(path, "r", encoding="utf-8", errors="replace") as handle:
-                collected["inputDirCopies"][_normalizedName(copied)] = handle.read()
+                collected["inputDirCopies"][_normalizedName(copied, job.getJobID())] = handle.read()
     return collected
 
 

--- a/PaintomicsServer/src/classes/JobInstances/Bed2GeneJob.py
+++ b/PaintomicsServer/src/classes/JobInstances/Bed2GeneJob.py
@@ -26,6 +26,10 @@ from src.servlets.DataManagementServlet import copyFile
 from src.common.Util import ensure_utf8
 from src.common.bioscripts.DHS_exon_association import run as run_DHS_exon_association
 from src.conf.serverconf import MAX_WAIT_THREADS #MULTITHREADING
+# Aliased: this class's __init__ takes a parameter literally named
+# CLIENT_TMP_DIR, and a module-level name spelled the same way is a trap for
+# the next person to touch it.
+from src.conf.serverconf import CLIENT_TMP_DIR as SERVER_CLIENT_TMP_DIR
 
 from os import path as os_path, mkdir as os_mkdir
 from csv import reader as csv_reader
@@ -105,7 +109,15 @@ class Bed2GeneJob(Job):
             "perc_area": self.geneAreaPercentage,
             "perc_region": self.regionAreaPercentage,
             "gene_id_tag": self.geneIDtag,
-            "ignore_missing": self.ignoreMissing
+            "ignore_missing": self.ignoreMissing,
+            # Where run() keeps its parsed-annotation sidecars. One directory
+            # shared by every job, deliberately: the win only exists when the
+            # SECOND job against the same GTF finds what the first one parsed,
+            # and the built-in annotations (examplefiles/GTF/) are the same
+            # files for every user. Nothing job-specific may be written here --
+            # the temporal directory is wiped at the end of each job, which is
+            # exactly what a cache must survive.
+            "cache_dir": SERVER_CLIENT_TMP_DIR + "gtfcache"
         }
 
     def getJobDescription(self, generate=False, dataFile="", relevantFile="", gtfFile=""):

--- a/PaintomicsServer/src/classes/JobInstances/PathwayAcquisitionJob.py
+++ b/PaintomicsServer/src/classes/JobInstances/PathwayAcquisitionJob.py
@@ -42,6 +42,7 @@ from src.common.ReplicateDetection import detect_replicates, aggregate_replicate
 from src.common.DesignFile import parse_design, derive_groupings
 
 from src.common.KeggInformationManager import KeggInformationManager
+from src.common.FeatureNamesToKeggIDsMapper import _joinAllWithinDeadline
 from src.common import JobProgress
 
 from src.classes.Job import Job
@@ -102,23 +103,163 @@ PAINTOMICS4_LARGE_FIELDS = {
 }
 
 
-def _matchPathways(jobInstance, pathwaysList, genesInAllPathways, compoundsInAllPathways, inputGenes,
-                    inputCompounds, totalFeaturesByOmic, totalRelevantFeaturesByOmic, matchedPathways,
-                    mappedRatiosByOmic, enrichmentByOmic):
-    """Module-level wrapper so multiprocessing.Process can pickle the target."""
-    keggInformationManager = KeggInformationManager()
+import json as _json
+import threading as _threading
 
-    # OPTIMIZATION: Pre-calculate lookups once per thread instead of per pathway
+# One organism's kegg_interaction.json, parsed once per process:
+# (path, mtime, size) -> {compoundID: compact JSON text of its neighbours}.
+_compoundNeighbourCache = {"key": None, "map": None}
+_compoundNeighbourCacheLock = _threading.Lock()
+
+
+def _loadCompoundNeighbourMap(interactionJSONPath):
+    """
+    {compoundID: JSON text} for every compound in ``interactionJSONPath``,
+    or {} when the file is missing or does not hold a compound map (both
+    logged, exactly as before).
+
+    kegg_interaction.json is the whole KEGG compound -> neighbour map (34 MB
+    locally, 79 MB for production mmu) and it was read and json.loads()ed on
+    every step 2 with metabolites -- ~370 MB of transient Python objects
+    (~1 GB on the production file) to look up the 50-100 compounds of one
+    job. It is per-organism, static between installs, so it is parsed once
+    per process and kept as one compact JSON string per compound: about the
+    size of the file itself, and a lookup is json.loads of one small string
+    -- the same dict/list/str the full parse produced. One organism is kept
+    (the last used); the key includes mtime and size so a reinstall in place
+    is noticed.
+
+    The file is double-encoded: the top level is a one-element list holding
+    the JSON *text* of the map, not the map itself; a file written either
+    way loads (unwrapped until a dict falls out).
+
+    Not every installed species ships hubData (87 of ~97 on the production
+    server; a fresh install may lack it entirely). That used to be a
+    FileNotFoundError that killed the whole of step 2 for eco and every newly
+    installed bacterium -- the hub extras must degrade, not take the pathway
+    results down with them.
+    """
+    if not os_path.isfile(interactionJSONPath):
+        logging.warning("HUB ANALYSIS - %s does not exist (species installed "
+                        "without hubData); metabolite neighbours will be "
+                        "unavailable.", interactionJSONPath)
+        return {}
+
+    stat = os.stat(interactionJSONPath)
+    key = (interactionJSONPath, stat.st_mtime, stat.st_size)
+    with _compoundNeighbourCacheLock:
+        if _compoundNeighbourCache["key"] == key:
+            return _compoundNeighbourCache["map"]
+
+        with open(interactionJSONPath, 'r') as e:
+            compoundRegulateFeatures = _json.loads(e.read())
+
+        for _ in range(4):
+            if isinstance(compoundRegulateFeatures, dict):
+                break
+            if isinstance(compoundRegulateFeatures, list) and len(compoundRegulateFeatures) == 1:
+                compoundRegulateFeatures = compoundRegulateFeatures[0]
+            elif isinstance(compoundRegulateFeatures, str):
+                compoundRegulateFeatures = _json.loads(compoundRegulateFeatures)
+            else:
+                break
+
+        if not isinstance(compoundRegulateFeatures, dict):
+            logging.warning("HUB ANALYSIS - %s holds %s, not a compound map; "
+                            "metabolite neighbours will be unavailable.",
+                            interactionJSONPath, type(compoundRegulateFeatures).__name__)
+            return {}
+
+        compact = {compoundID: _json.dumps(neighbours, separators=(",", ":"))
+                   for compoundID, neighbours in compoundRegulateFeatures.items()}
+        _compoundNeighbourCache["key"] = key
+        _compoundNeighbourCache["map"] = compact
+        logging.info("HUB ANALYSIS - cached %d compound neighbour entries from %s",
+                     len(compact), interactionJSONPath)
+        return compact
+
+
+def _metagenesParallelism():
+    """How many omics' R scripts run at once. Each Rscript peaks near 260 MB
+    (cluster + mclust + factoextra/ggplot2), so this is bounded by memory
+    before cores; 3 is safe on the 8 GB production host. 1 restores the old
+    strictly sequential behaviour."""
+    try:
+        return max(1, int(os.getenv("PAINTOMICS_METAGENES_PARALLEL", "3")))
+    except ValueError:
+        return 3
+
+
+def _runMetagenesScripts(omicNames, databases, commands):
+    """
+    Run one generateMetaGenes.R per (omic, database) -- `commands[(omic, db)]`
+    is (argv, kClusters) -- with the OMICS in parallel and each omic's databases
+    one after another (see generateMetagenesList for why), and return
+    {(omic, db): (returncode, output bytes)} exactly as check_output would have
+    observed each run. A launch failure (e.g. no Rscript) is stored as
+    (None, OSError) and re-raised where the sequential loop would have met it,
+    so the caller's error handling is unchanged.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+    from subprocess import Popen, PIPE
+
+    def runOmic(omicName):
+        omicResults = {}
+        for dbname in databases:
+            argv = commands[(omicName, dbname)][0]
+            try:
+                process = Popen(argv, stdout=PIPE, stderr=STDOUT)
+                output, _ = process.communicate()
+                omicResults[(omicName, dbname)] = (process.returncode, output)
+            except OSError as ex:
+                omicResults[(omicName, dbname)] = (None, ex)
+        return omicResults
+
+    results = {}
+    workers = min(_metagenesParallelism(), max(1, len(omicNames)))
+    if workers <= 1:
+        for omicName in omicNames:
+            results.update(runOmic(omicName))
+        return results
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        for omicResults in pool.map(runOmic, omicNames):
+            results.update(omicResults)
+    return results
+
+
+def _inputFeatureLookups(inputGenes, inputCompounds):
+    """The per-job lookups every enrichment worker needs: features indexed by
+    lower-cased ID, and whether the job carries more than one condition.
+
+    Computed ONCE by the parent (they depend only on the input) and handed to
+    the workers, which used to rebuild them six times over.
+    """
     inputGenesDict = {g.getID().lower(): g for g in inputGenes}
     inputCompoundsDict = {c.getID().lower(): c for c in inputCompounds}
 
-    # OPTIMIZATION: Determine multi-condition mode once per thread
     max_conditions = 1
     for feature in chain(inputGenes, inputCompounds):
         for ov in feature.getOmicsValues():
             if isinstance(ov.relevant, list):
                 max_conditions = max(max_conditions, len(ov.relevant))
-    has_multi_cond = max_conditions > 1
+    return inputGenesDict, inputCompoundsDict, max_conditions > 1
+
+
+def _matchPathways(jobInstance, pathwaysList, genesInAllPathways, compoundsInAllPathways, inputGenes,
+                    inputCompounds, totalFeaturesByOmic, totalRelevantFeaturesByOmic, matchedPathways,
+                    mappedRatiosByOmic, enrichmentByOmic, lookups=None):
+    """Module-level wrapper so multiprocessing.Process can pickle the target."""
+    keggInformationManager = KeggInformationManager()
+
+    if lookups is None:
+        lookups = _inputFeatureLookups(inputGenes, inputCompounds)
+    inputGenesDict, inputCompoundsDict, has_multi_cond = lookups
+
+    # Collected locally and handed to the parent in ONE update at the end.
+    # `matchedPathways` is a Manager dict proxy in the forked path: every
+    # per-pathway assignment on it was a pickle of the whole Pathway plus a
+    # socket round trip to the manager process, ~900 of them per job.
+    localMatched = {}
 
     for pathwayID in pathwaysList:
         genesInPathway = genesInAllPathways.get(pathwayID)
@@ -142,7 +283,9 @@ def _matchPathways(jobInstance, pathwaysList, genesInAllPathways, compoundsInAll
             pathway.setClassification(
                 keggInformationManager.getPathwayClassificationByID(jobInstance.getOrganism(), pathwayID))
             pathway.setSource(sourceDB)
-            matchedPathways[pathwayID] = pathway
+            localMatched[pathwayID] = pathway
+
+    matchedPathways.update(localMatched)
 
 
 class PathwayAcquisitionJob(Job):
@@ -1396,12 +1539,15 @@ class PathwayAcquisitionJob(Job):
         #                 totalFeaturesByOmic, totalRelevantFeaturesByOmic, matchedPathways, mappedRatiosByOmic,
         #                 enrichmentByOmic )
 
+        # Once here, inherited by every forked worker, instead of once per worker.
+        lookups = _inputFeatureLookups(inputGenes, inputCompounds)
+
         # LAUNCH THE THREADS
         for pathwayIDsList in pathwaysListParts:
             thread = Process(target=_matchPathways, args=(
                 self, pathwayIDsList, allGenesInPathway, allCompoundsInPathway, inputGenes, inputCompounds,
                 totalFeaturesByOmic, totalRelevantFeaturesByOmic, matchedPathways, mappedRatiosByOmic,
-                enrichmentByOmic))
+                enrichmentByOmic, lookups))
             threadsList.append(thread)
             thread.start()
 
@@ -1416,13 +1562,13 @@ class PathwayAcquisitionJob(Job):
                 threadClass = Process( target=_matchPathways, args=(
                     self, classNameList, classGene, classComp, inputGenes, inputCompounds,
                     totalFeaturesByOmic, totalRelevantFeaturesByOmic, matchedClass, mappedRatiosByOmic,
-                    enrichmentByOmic) )
+                    enrichmentByOmic, lookups) )
                 threadsList.append( threadClass )
                 threadClass.start()
 
-        # WAIT UNTIL ALL THREADS FINISH
-        for thread in threadsList:
-            thread.join(MAX_WAIT_THREADS)
+        # WAIT UNTIL ALL THREADS FINISH -- one shared budget, not one per
+        # worker (the same rule the identifier mapper applies).
+        _joinAllWithinDeadline(threadsList, MAX_WAIT_THREADS)
 
         isFinished = True
         for thread in threadsList:
@@ -1432,6 +1578,7 @@ class PathwayAcquisitionJob(Job):
                 logging.info("THREAD TERMINATED IN generatePathwaysList")
 
         if not isFinished:
+            manager.shutdown()
             raise Exception(
                 'Your data took too long to process and it was killed. Try again later or upload smaller files if it persists.')
 
@@ -1444,6 +1591,10 @@ class PathwayAcquisitionJob(Job):
         if 'Reactome' in self.databases:
             self.setMatchedClass(dict(matchedClass))
             #self.setReactomeClass(reactomeClass)
+
+        # The manager server is a forked process holding a copy of every
+        # matched pathway; release it now instead of when the GC gets round to it.
+        manager.shutdown()
 
         pvalues_list = defaultdict(dict)
         combined_pvalues_list = defaultdict(dict)
@@ -2052,11 +2203,11 @@ class PathwayAcquisitionJob(Job):
         @param {type}
         @returns
         """
-        # STEP 1. EXTRACT THE COMPRESSED FILE WITH THE MAPPING FILES
-        zipFile(self.getOutputDir() + "/mapping_results_" + self.getJobID() + ".zip").extractall(
-            path=self.getTemporalDir())
-
-        # STEP 2. GENERATE THE DATA FOR EACH OMIC DATA TYPE
+        # STEP 1. EXTRACT THE MAPPING FILES THE R SCRIPT READS
+        # Only the `<omic>_matched.txt` members: they are the R script's only
+        # input, and re-inflating every omic's matched AND unmatched files (the
+        # whole zip) on every call made the single-omic slider recompute pay for
+        # the entire job.
         filtered_omics = self.geneBasedInputOmics
         filtered_databases = self.getDatabases()
 
@@ -2067,6 +2218,14 @@ class PathwayAcquisitionJob(Job):
         if database:
             filtered_databases = set(database).intersection(set(filtered_databases))
 
+        with zipFile(self.getOutputDir() + "/mapping_results_" + self.getJobID() + ".zip") as mappingZip:
+            wanted = {inputOmic.get("omicName") + "_matched.txt" for inputOmic in filtered_omics}
+            for member in mappingZip.namelist():
+                if member in wanted:
+                    mappingZip.extract(member, path=self.getTemporalDir())
+
+        # STEP 2. GENERATE THE DATA FOR EACH OMIC DATA TYPE
+
         # This loop is the whole of the metagenes phase and its size is known
         # exactly before it starts, so the bar here is a real count rather than a
         # clock-based guess. It is ~50% of step 2, and without this it showed a
@@ -2076,32 +2235,54 @@ class PathwayAcquisitionJob(Job):
         JobProgress.units(self.getJobID(), 0, total=metageneUnits,
                           detail="0 of %d" % metageneUnits)
 
+        # One Rscript per (omic, database) pair, each paying R start-up plus the
+        # cluster/mclust/factoextra library load plus the annotation read before
+        # any work -- ~1.3 s here, several seconds on the production CPU, times
+        # 10-18 pairs, run one after another. The R processes are independent
+        # (their own seeds, their own output files, named by omic and database),
+        # so the OMICS run concurrently; the databases of one omic stay
+        # sequential because the elbow plot `<omic>_elbow.png` carries no
+        # database suffix and the last database written must keep winning.
+        # Results are consumed below in the original loop order, so logging,
+        # error handling, pathway updates and progress ticks are unchanged.
+        commands = {}
+        for inputOmic in filtered_omics:
+            for dbname in filtered_databases:
+                inputFile = self.getTemporalDir() + "/" + inputOmic.get("omicName") + '_matched.txt'
+                kClusters = str(dict(clusterNumber).get(inputOmic.get("omicName"), "dynamic"))
+                commands[(inputOmic.get("omicName"), dbname)] = ([
+                    "Rscript",
+                    ROOT_DIRECTORY + "common/bioscripts/generateMetaGenes.R",
+                    '--specie=' + self.getOrganism(),
+                    '--input_file=' + inputFile,
+                    '--output_prefix=' + inputOmic.get("omicName"),
+                    '--data_dir=' + self.getTemporalDir(),
+                    '--kegg_dir=' + KEGG_DATA_DIR,
+                    '--sources_dir=' + ROOT_DIRECTORY + 'common/bioscripts/',
+                    '--kclusters=' + kClusters if kClusters.isdigit() else '',
+                    '--database=' + dbname if dbname != "KEGG" else ''], kClusters)
+
+        results = _runMetagenesScripts(
+            [inputOmic.get("omicName") for inputOmic in filtered_omics],
+            list(filtered_databases), commands)
+
         for inputOmic in filtered_omics:
             # STEP 2.1 EXECUTE THE R SCRIPT FOR EACH DATABASE
             for dbname in filtered_databases:
                 try:
                     logging.info("GENERATING METAGENES INFORMATION FOR " + str(dbname) + "...CALLING")
-                    inputFile = self.getTemporalDir() + "/" + inputOmic.get("omicName") + '_matched.txt'
-                    # Select number of clusters, default to dynamic
-
-                    kClusters = str(dict(clusterNumber).get(inputOmic.get("omicName"), "dynamic"))
+                    kClusters = commands[(inputOmic.get("omicName"), dbname)][1]
                     logging.info("kClusters=" + str(kClusters))
                     logging.info(str(ROOT_DIRECTORY))
 
                     logging.info("dbname is " + str(dbname))
 
                     try:
-                        output = check_output([
-                            "Rscript",
-                            ROOT_DIRECTORY + "common/bioscripts/generateMetaGenes.R",
-                            '--specie=' + self.getOrganism(),
-                            '--input_file=' + inputFile,
-                            '--output_prefix=' + inputOmic.get("omicName"),
-                            '--data_dir=' + self.getTemporalDir(),
-                            '--kegg_dir=' + KEGG_DATA_DIR,
-                            '--sources_dir=' + ROOT_DIRECTORY + 'common/bioscripts/',
-                            '--kclusters=' + kClusters if kClusters.isdigit() else '',
-                            '--database=' + dbname if dbname != "KEGG" else ''], stderr=STDOUT)
+                        returncode, output = results[(inputOmic.get("omicName"), dbname)]
+                        if returncode is None:
+                            raise output  # the OSError check_output would have raised here
+                        if returncode != 0:
+                            raise CalledProcessError(returncode, "Rscript", output=output)
                     except CalledProcessError as ex:
                         error_detail = ex.output.decode('utf-8') if ex.output else str(ex)
                         logging.error("STEP2 - Error while generating metagenes information for " + inputOmic.get("omicName") + " db: " + str(dbname))
@@ -2139,16 +2320,19 @@ class PathwayAcquisitionJob(Job):
                                                 ("_" + str(dbname).lower() + ".tab" if dbname != "KEGG" else ".tab")
 
                     if os_path.exists(metagenesFileName):
+                        metageneRows = 0
                         with open(metagenesFileName, 'r') as inputDataFile:
                             for line in csv_reader(inputDataFile, delimiter="\t"):
                                 if line[0] in self.matchedPathways:
                                     self.matchedPathways.get(line[0]).addMetagenes(inputOmic.get("omicName"),
                                                                                    {"metagene": line[1], "cluster": line[2],
                                                                                     "values": line[3:]})
-                                    logging.info(
-                                        "pathway:" + str(line[0]) + " metaGene:" + str(line[1]) + " cluster:" + str(
-                                            line[2]) + " values:" + str(line[3:]))
-                        inputDataFile.close()
+                                    metageneRows += 1
+                        # One line per (omic, database) rather than one per
+                        # metagene row: the per-row form was hundreds to
+                        # thousands of formatted writes per job.
+                        logging.info("METAGENES - %d rows added for omic '%s' (%s) from %s",
+                                     metageneRows, inputOmic.get("omicName"), dbname, metagenesFileName)
                     else:
                         logging.warning(f"Metagenes file {metagenesFileName} not found. This is expected if no matches were found for db {dbname}.")
 
@@ -2164,8 +2348,19 @@ class PathwayAcquisitionJob(Job):
                 JobProgress.units(self.getJobID(), metagenesDone,
                                   detail="%d of %d" % (metagenesDone, metageneUnits))
 
-        call("rm " +  self.getOutputDir()  + "*.png", shell=True)
-        call("mv " + self.getTemporalDir() + "/" + "*.png " + self.getOutputDir(), shell=True)
+        # The metagene thumbnails move from the temporal dir into the output
+        # dir, replacing last time's; os calls instead of `rm`/`mv` through a
+        # shell (two process spawns and a shell glob per call).
+        for oldPNG in glob.glob(os_path.join(self.getOutputDir(), "*.png")):
+            try:
+                os.remove(oldPNG)
+            except OSError:
+                pass
+        for newPNG in glob.glob(os_path.join(self.getTemporalDir(), "*.png")):
+            try:
+                os.replace(newPNG, os_path.join(self.getOutputDir(), os_path.basename(newPNG)))
+            except OSError as ex:
+                logging.warning("METAGENES - could not move %s: %s", newPNG, ex)
         return self
 
     # JSON <-> BSON FUNCTIONS ------------------------------------------------------------------------------------------------------
@@ -2289,61 +2484,25 @@ class PathwayAcquisitionJob(Job):
         # Load classification File
         with open(brPath, 'r') as f:
             temp = json.loads(f.read())
-            print(temp)
 
-        # kegg_interaction.json is double-encoded: the top level is a one-element
-        # list holding the JSON *text* of the neighbour map, not the map itself.
-        # decode-then-dumps-then-loads was a round trip that returned that same
-        # list, so every lookup below missed and the client received a list where
-        # it expected a dict. That is why "Metabolite regulates Features" on the
-        # hub analysis rendered as a heading with nothing under it.
-        #
-        # Unwrap until a dict falls out, so a file written either way loads.
-        #
-        # Not every installed species ships hubData (87 of ~97 on the
-        # production server; a fresh install may lack it entirely). That used
-        # to be a FileNotFoundError that killed the whole of step 2 for eco
-        # and every newly installed bacterium — the hub extras must degrade,
-        # not take the pathway results down with them.
-        if os.path.isfile(interactionJSONPath):
-            with open(interactionJSONPath, 'r') as e:
-                compoundRegulateFeatures = json.loads(e.read())
-        else:
-            logging.warning("HUB ANALYSIS - %s does not exist (species installed "
-                            "without hubData); metabolite neighbours will be "
-                            "unavailable.", interactionJSONPath)
-            compoundRegulateFeatures = {}
-
-        for _ in range(4):
-            if isinstance(compoundRegulateFeatures, dict):
-                break
-            if isinstance(compoundRegulateFeatures, list) and len(compoundRegulateFeatures) == 1:
-                compoundRegulateFeatures = compoundRegulateFeatures[0]
-            elif isinstance(compoundRegulateFeatures, str):
-                compoundRegulateFeatures = json.loads(compoundRegulateFeatures)
-            else:
-                break
-
-        if not isinstance(compoundRegulateFeatures, dict):
-            logging.warning("HUB ANALYSIS - %s holds %s, not a compound map; "
-                            "metabolite neighbours will be unavailable.",
-                            interactionJSONPath, type(compoundRegulateFeatures).__name__)
-            compoundRegulateFeatures = {}
-
+        # The whole compound -> neighbour map, served from a per-process cache
+        # of the file (see _loadCompoundNeighbourMap); {} when the species has
+        # no hubData or the file is not a compound map -- both already warned.
         # The file covers every compound KEGG knows about - 79 MB for mmu - and
         # the whole map used to be handed to the browser on every step 3. Only
         # the compounds in this analysis can ever be looked up, so the rest is
         # dropped before it reaches the response or the in-memory job cache.
+        neighbourMap = _loadCompoundNeighbourMap(interactionJSONPath)
         inputCompoundIDs = set(self.inputCompoundsData.keys())
-        matchedNeighbourIDs = inputCompoundIDs & set(compoundRegulateFeatures.keys())
+        matchedNeighbourIDs = inputCompoundIDs & set(neighbourMap.keys())
 
-        if compoundRegulateFeatures and not matchedNeighbourIDs:
+        if neighbourMap and not matchedNeighbourIDs:
             logging.warning("HUB ANALYSIS - none of the %d input compounds appear in %s; "
                             "check that both use KEGG compound IDs.",
                             len(inputCompoundIDs), interactionJSONPath)
 
         compoundRegulateFeatures = {
-            compoundID: compoundRegulateFeatures[compoundID]
+            compoundID: json.loads(neighbourMap[compoundID])
             for compoundID in matchedNeighbourIDs
         }
 

--- a/PaintomicsServer/src/common/DAO/DAO.py
+++ b/PaintomicsServer/src/common/DAO/DAO.py
@@ -39,6 +39,41 @@ class DAO(object):
         return True
 
     def adaptBSON(self, object, otherParams=None):
+        # Fast path for the types pymongo actually decodes into, checked by
+        # EXACT class rather than isinstance so it can never shadow a subclass
+        # the slow path below would treat differently (bson.Int64, SON, ...).
+        #
+        # For an exact str/int/float/bool, the slow path's str(x)/int(x)/
+        # float(x)/bool(x) returns the very object it was given, so returning
+        # it here is not "close enough", it is the same result. dicts and
+        # lists are still rebuilt (callers get a fresh container, as before)
+        # but without a function call per leaf.
+        #
+        # This is a no-op transformation only for those types. Everything else
+        # -- None -> "None", ObjectId -> its hex string, and any exotic leaf --
+        # falls through to the original code untouched, because the callers
+        # depend on it: adaptBSON(doc) != doc on EVERY document in this
+        # database (_id is an ObjectId), and foundFeaturesCollection alone
+        # holds ~193k None leaves that must keep becoming "None".
+        #
+        # Measured over the real local database (332,869 documents:
+        # jobInstance 278, pathways 112,769, visualOptions 60, foundFeatures
+        # 19,762, features 200,000 sampled of 2.85M): 0 mismatches against the
+        # old implementation under a type-strict deep compare, and no leaf type
+        # outside {str, int, float, bool, NoneType, ObjectId, dict, list} and
+        # no non-str key anywhere.
+        cls = object.__class__
+        if cls is str or cls is int or cls is float or cls is bool:
+            return object
+        if cls is dict:
+            adaptBSON = self.adaptBSON
+            return dict(
+                (key if key.__class__ is str else str(key), adaptBSON(value))
+                for (key, value) in object.items())
+        if cls is list:
+            adaptBSON = self.adaptBSON
+            return [adaptBSON(value) for value in object]
+
         if isinstance(object, dict):
             newDict = {}
             for (key, value) in object.items():

--- a/PaintomicsServer/src/common/DAO/PathwayAcquisitionJobDAO.py
+++ b/PaintomicsServer/src/common/DAO/PathwayAcquisitionJobDAO.py
@@ -35,12 +35,34 @@ class PathwayAcquisitionJobDAO(DAO):
             for feature in match:
                 jobInstance.addFoundCompound(feature)
 
+            # One pass over the job's features instead of two.
+            #
+            # This used to be findAll({jobID, featureType:"Gene"}) followed by
+            # findAll({jobID, featureType:"Compound"}): two cursors, two index
+            # walks and two full adaptBSON/parseBSON passes over the same jobID
+            # slice, which on a large job is 40k documents' worth of setup paid
+            # twice. Both scans walk the same jobID range in the same direction,
+            # so partitioning one cursor on the featureType the document itself
+            # carries yields each type in exactly the order its own query did,
+            # and genes are still added before compounds -- the insertion order
+            # of inputGenesData / inputCompoundsData is unchanged.
+            #
+            # A document with any other featureType (or none) was returned by
+            # neither query and is still added to neither dict.
             auxDAO = FeatureDAO(dbManager=self.dbManager)
-            match = auxDAO.findAll({"jobID":id, "featureType" : "Gene"})
+            match = auxDAO.findAll({"jobID": id})
+            geneFeatures = []
+            compoundFeatures = []
             for feature in match:
+                featureType = getattr(feature, "featureType", None)
+                if featureType == "Gene":
+                    geneFeatures.append(feature)
+                elif featureType == "Compound":
+                    compoundFeatures.append(feature)
+
+            for feature in geneFeatures:
                 jobInstance.addInputGeneData(feature)
-            match = auxDAO.findAll({"jobID":id, "featureType" : "Compound"})
-            for feature in match:
+            for feature in compoundFeatures:
                 jobInstance.addInputCompoundData(feature)
 
             auxDAO = PathwayDAO(dbManager=self.dbManager)

--- a/PaintomicsServer/src/common/DAO/PathwayDAO.py
+++ b/PaintomicsServer/src/common/DAO/PathwayDAO.py
@@ -61,11 +61,41 @@ class PathwayDAO(DAO):
             saveGraphicalData = True
             graphicalDataDAO = GraphicalDataDAO(dbManager=self.dbManager)
 
-        for instance in instancesList:
-            self.insert(instance, otherParams)
-            if(saveGraphicalData == True):
+        if(saveGraphicalData == True):
+            # Unchanged: the graphical-data write is interleaved per pathway and
+            # reads otherParams["pathwayID"] as it goes, so this branch keeps
+            # its original one-round-trip-per-pathway shape.
+            for instance in instancesList:
+                self.insert(instance, otherParams)
                 otherParams["pathwayID"] = instance.getID()
                 graphicalDataDAO.insert(instance.getGraphicalOptions(), otherParams)
+            return True
+
+        # One insert_many instead of one insert_one per pathway. A job stores
+        # 300-2000 pathways (plus the matched Reactome classes, which arrive
+        # through this same call), so this was 300-2000 sequential round trips
+        # inside step 2's store phase. FeatureDAO.insertAll has always batched;
+        # this mirrors it exactly.
+        #
+        # The documents are built the way insert() builds them -- toBSON() then
+        # the jobID tag -- in the order the caller passed them, and
+        # insert_many(ordered=True) writes them in that order, so the stored
+        # documents and their natural order are identical.
+        instanceBSONList = [pathwayInstance.toBSON() for pathwayInstance in instancesList]
+
+        if not instanceBSONList:
+            # An empty list touches neither otherParams nor the collection --
+            # the old loop never entered its body, so insertAll([], None) has
+            # to keep returning True rather than raising on otherParams["jobID"].
+            return True
+
+        jobID = otherParams["jobID"]
+        for instanceBSON in instanceBSONList:
+            instanceBSON["jobID"] = jobID
+
+        collection = self.dbManager.getCollection(self.collectionName)
+        collection.insert_many(instanceBSONList, ordered=True)
+
         return True
 
     def update(self, instance, otherParams=None):

--- a/PaintomicsServer/src/common/DBmanager.py
+++ b/PaintomicsServer/src/common/DBmanager.py
@@ -1,24 +1,167 @@
+import os
+import threading
+
 from pymongo import MongoClient
 
 from src.conf.serverconf import MONGODB_DATABASE, MONGODB_HOST, MONGODB_PORT
+
+# One MongoClient per (host, port, pid) for the whole process.
+#
+# Every DAO used to build its own MongoClient -- there are ~40 bare DAO()
+# sites -- and each one costs a topology-monitor thread pair plus a
+# server-selection round trip on its first operation, then is thrown away.
+# A MongoClient is already thread-safe and already pools its sockets, so one
+# per process serves every DAO with the same queries, the same filters and
+# the same results; only the lifecycle changes.
+#
+# The pid is part of the key and that is not optional. The identifier mapper
+# and the enrichment workers are fork()ed children (see
+# FeatureNamesToKeggIDsMapper._refreshStandardStreamsInForkChild, which exists
+# precisely because those children are real), and a MongoClient must never be
+# used across a fork: the child inherits sockets whose state belongs to the
+# parent's threads, none of which exist in the child. Keying on os.getpid()
+# means a child asking for a connection builds its own instead of inheriting
+# one, which is exactly what pymongo's "MongoClient opened before fork" warning
+# asks for.
+_sharedClients = {}
+_sharedClientsLock = threading.Lock()
+
+# Clients a forked child inherited from its parent, kept alive on purpose so
+# nothing in the child can finalise them. Never read; never emptied. See
+# getSharedClient.
+_inheritedClients = []
+
+
+def getSharedClient(host=None, port=None):
+    """
+    The process-wide MongoClient for (host, port), created on first use.
+
+    Never reused across a fork: the cache is keyed by pid, so a forked child
+    misses and builds its own client.
+    """
+    if host is None:
+        host = MONGODB_HOST
+    if port is None:
+        port = MONGODB_PORT
+
+    key = (host, port, os.getpid())
+    client = _sharedClients.get(key)
+    if client is not None:
+        return client
+
+    with _sharedClientsLock:
+        client = _sharedClients.get(key)
+        if client is None:
+            # A client inherited from a parent process is taken out of the
+            # cache and PARKED -- never closed, never released. Belt and
+            # braces: never let pymongo finalise an object whose state belongs
+            # to another process. Closing it would run pymongo's teardown here
+            # over a topology the parent owns, and letting the collector have
+            # it hands the same object to pymongo's finalisers (`Pool.__del__`
+            # is real on the installed version) at a moment nobody chose.
+            # Neither is known to damage the parent -- `close()` on an
+            # inherited descriptor releases only the child's copy -- but the
+            # cost of holding one dead object for the life of a short-lived
+            # worker is nil, and this is the same rule the fork hook in
+            # FeatureNamesToKeggIDsMapper applies to inherited stdout/stderr.
+            for staleKey in [k for k in _sharedClients if k[2] != key[2]]:
+                _inheritedClients.append(_sharedClients.pop(staleKey))
+            client = MongoClient(host, port)
+            _sharedClients[key] = client
+    return client
+
+
+def _resetSharedClientStateInForkChild():
+    """
+    Give a forked child an empty cache and a lock of its own.
+
+    The pid key alone already makes the child miss and build its own client.
+    What it does not cover is the LOCK: a child forked while another of the
+    parent's threads held `_sharedClientsLock` inherits it locked, held by a
+    thread that does not exist here, and the child's first getSharedClient()
+    blocks forever. That is not theoretical in this codebase --
+    `_matchPathways` (PathwayAcquisitionJob.py) runs in a forked worker and
+    reaches getSharedClient through
+    KeggInformationManager.getPathwaySourceByID -> loadOrganismData ->
+    getConnectionByOrganismCode -- and it is the same class of bug that wedged
+    a mapper worker for 32 minutes in production, which is why
+    FeatureNamesToKeggIDsMapper registers a hook of its own.
+
+    Rebinding the lock is safe because a fork child starts single-threaded:
+    there is nobody to race with, and any parent thread mid-critical-section
+    simply did not come across.
+    """
+    global _sharedClientsLock
+    _sharedClientsLock = threading.Lock()
+    for staleKey in list(_sharedClients):
+        _inheritedClients.append(_sharedClients.pop(staleKey))
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_resetSharedClientStateInForkChild)
+
+
+class SharedClientHandle(object):
+    """
+    A borrowed view of the process client for code that owns and closes what
+    it is handed.
+
+    Everything is forwarded to the real client except close(), which drops the
+    reference instead of tearing down a topology other threads are using. It
+    exists for KeggInformationManager.getConnectionByOrganismCode, whose one
+    caller closes the client it receives in a finally.
+    """
+
+    __slots__ = ("_client",)
+
+    def __init__(self, client):
+        object.__setattr__(self, "_client", client)
+
+    def close(self):
+        return None
+
+    def __getattr__(self, name):
+        return getattr(object.__getattribute__(self, "_client"), name)
+
+    def __getitem__(self, name):
+        return object.__getattribute__(self, "_client")[name]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, excType, excValue, traceback):
+        return False
+
+    def __repr__(self):
+        return "SharedClientHandle(%r)" % (object.__getattribute__(self, "_client"),)
+
 
 class DBmanager:
     def __init__(self):
         self.connection = None
 
     def openConnection(self):
-        self.connection = MongoClient(MONGODB_HOST, MONGODB_PORT)
+        self.connection = getSharedClient(MONGODB_HOST, MONGODB_PORT)
 
     def closeConnection(self):
-        if(self.connection != None):
-            self.connection.close()
-            self.connection = None
+        # A reference drop, not a teardown -- and now an inert one: the client
+        # belongs to the process, not to this manager, other DAOs (possibly on
+        # other threads) are using it right now, and getCollection looks it up
+        # again on every call. Callers keep calling closeConnection() in their
+        # finally blocks; it just costs nothing.
+        self.connection = None
 
     def getConnection(self):
         return self.connection
 
     def getCollection(self, collectionName):
-        if(self.connection == None):
-            self.openConnection()
+        # Looked up on EVERY call rather than cached on the manager. The
+        # lookup is one dict get on a (host, port, pid) key plus an
+        # os.getpid(), which is nothing beside a round trip, and it closes the
+        # one hole the pid key would otherwise leave: a DAO that is alive when
+        # the process forks used to keep serving the child out of
+        # self.connection -- the parent's client -- without the pid ever being
+        # consulted again.
+        self.openConnection()
         db = self.getConnection()[MONGODB_DATABASE]
         return db[collectionName]

--- a/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
+++ b/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
@@ -853,7 +853,12 @@ def getCompoundNameTable(db=None, revalidate=True):
         size = db.kegg_compounds.estimated_document_count()
         if _compoundNameTable is None or _compoundNameTableSize != size:
             started = time.monotonic()
-            _compoundNameTable = _CompoundNameTable(list(db.kegg_compounds.find({})))
+            # Without _id: nothing reads it (mapCompoundsIdentifiers uses id and
+            # name), and an ObjectId leaf keeps all 93k dicts on the garbage
+            # collector's radar for the life of the process -- ~0.2 s per full
+            # collection, measured -- whereas dicts of plain strings are
+            # untracked after the first pass.
+            _compoundNameTable = _CompoundNameTable(list(db.kegg_compounds.find({}, {"_id": 0})))
             _compoundNameTableSize = size
             logging.info("LOADED %d KEGG COMPOUND NAMES INTO MEMORY IN %.2fs",
                          size, time.monotonic() - started)

--- a/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
+++ b/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
@@ -306,7 +306,26 @@ def resolveDatabaseIds(organism, databases, db=None):
     return databaseConvertion_ids, databaseGeneSymbol_ids
 
 
-def mapFeatureIdentifiers(jobID, organism, databases, featureList,  matchedFeatures, notMatchedFeatures, foundFeatures, enrichment, progressArray=None, progressSlot=0, databaseIds=None, cacheTables=None):
+def _handOver(target, slot, items):
+    """
+    Give a worker's result list to the parent. With ``slot`` set the list is
+    stored at that index of a pre-sized shared list, so the parent can
+    concatenate the workers' results in WORKER ORDER -- which is the input
+    order, i.e. exactly what one sequential pass produces. Appending as the
+    workers happened to finish (the previous form) made the order of the
+    matched features depend on scheduling, and everything downstream that
+    merges duplicates by keeping the first one seen (unifyAndSort on the
+    compound sets, addInputGeneData/addInputCompoundData combining values)
+    then differed from run to run. Without a slot (the direct, in-process
+    call) the items are simply appended.
+    """
+    if slot is None:
+        target.extend(items)
+    else:
+        target[slot] = items
+
+
+def mapFeatureIdentifiers(jobID, organism, databases, featureList,  matchedFeatures, notMatchedFeatures, foundFeatures, enrichment, progressArray=None, progressSlot=0, databaseIds=None, cacheTables=None, resultSlot=None):
     """
     This function is used to query the database in different threads.
 
@@ -510,8 +529,8 @@ def mapFeatureIdentifiers(jobID, organism, databases, featureList,  matchedFeatu
         #*************************************************************************************
         # STORE THE RESULTS
         #*************************************************************************************
-        matchedFeatures.extend(localMatched)
-        notMatchedFeatures.extend(localNotMatched)
+        _handOver(matchedFeatures, resultSlot, localMatched)
+        _handOver(notMatchedFeatures, resultSlot, localNotMatched)
 
         if cacheTables is not None:
             # Everything this worker resolved, keyed exactly as
@@ -588,9 +607,10 @@ def mapFeatureNamesToKeggIDs(jobID, organism, databases, featureList, enrichment
 
 
     manager=Manager()
-    #CONCATENATE THE OUTPUT LISTS
-    matchedFeatures = manager.list()
-    notMatchedFeatures= manager.list()
+    #CONCATENATE THE OUTPUT LISTS -- one slot per worker, filled by that worker,
+    # read back in worker (= input) order: see _handOver.
+    matchedFeatures = manager.list([None] * len(genesListParts))
+    notMatchedFeatures= manager.list([None] * len(genesListParts))
     foundFeatures = manager.list()
     # One entry per worker: the translations it resolved, merged into the
     # job's cache below so the NEXT omic's workers inherit them at fork time.
@@ -616,7 +636,7 @@ def mapFeatureNamesToKeggIDs(jobID, organism, databases, featureList, enrichment
         threadsList = []
         i=0
         for genesListPart in genesListParts:
-            thread = Process(target=mapFeatureIdentifiers, args=(jobID, organism, databases, genesListPart, matchedFeatures, notMatchedFeatures, foundFeatures, enrichment, progressArray, i, databaseIds, cacheTables))
+            thread = Process(target=mapFeatureIdentifiers, args=(jobID, organism, databases, genesListPart, matchedFeatures, notMatchedFeatures, foundFeatures, enrichment, progressArray, i, databaseIds, cacheTables, i))
             threadsList.append(thread)
             thread.start()
             i+=1
@@ -674,16 +694,14 @@ def mapFeatureNamesToKeggIDs(jobID, organism, databases, featureList, enrichment
     #***********************************************************************************
     #* STEP 4. RETURN THE RESULTS
     #***********************************************************************************
+    # One round trip each (a slice carries the whole list), then the workers'
+    # lists concatenated in worker order -- the order a sequential pass over
+    # the input produces.
+    matchedFeatures = list(itertools.chain.from_iterable(part for part in matchedFeatures[:] if part is not None))
+    notMatchedFeatures = list(itertools.chain.from_iterable(part for part in notMatchedFeatures[:] if part is not None))
+
     logging.info("FINISHED. %s uniquely matched features, %d features matched. %d features not matched.",
                  next(iter(sumFoundFeatures.values()), 0), len(matchedFeatures), len(notMatchedFeatures))
-
-    # Materialise the proxies with ONE round trip each before returning them.
-    # BaseListProxy exposes __getitem__/__len__ but not __iter__, so a caller's
-    # `for x in matchedFeatures` falls back to the sequence protocol and pays an
-    # IPC round trip per element — measured at 92us x 39,527 elements = 6.9s of an
-    # 83s job. A slice is a single __getitem__ call carrying the whole list, 10x
-    # faster in-container. `list(proxy)` does NOT help: it iterates the same way.
-    matchedFeatures, notMatchedFeatures = matchedFeatures[:], notMatchedFeatures[:]
     # The Manager server is a forked process holding a copy of everything the
     # workers sent it; release it now rather than when the GC gets round to it.
     manager.shutdown()
@@ -907,7 +925,7 @@ def findCompoundIDByFeatureName(jobID, featureName, db):
     except Exception as ex:
         return matchedFeatures, False
 
-def mapCompoundsIdentifiers(jobID, featureList, matchedFeatures, notMatchedFeatures, foundFeatures):
+def mapCompoundsIdentifiers(jobID, featureList, matchedFeatures, notMatchedFeatures, foundFeatures, resultSlot=None):
     """
     This function is used to query the database in different threads.
 
@@ -1012,8 +1030,8 @@ def mapCompoundsIdentifiers(jobID, featureList, matchedFeatures, notMatchedFeatu
         #*************************************************************************************
         # STORE THE RESULTS
         #*************************************************************************************
-        matchedFeatures.extend(localMatched)
-        notMatchedFeatures.extend(localNotMatched)
+        _handOver(matchedFeatures, resultSlot, localMatched)
+        _handOver(notMatchedFeatures, resultSlot, localNotMatched)
         foundFeatures.append(matches)
         # matchedCompoundIDsTablesList.append(matchedCompoundIDsTable)
 
@@ -1057,10 +1075,10 @@ def mapFeatureNamesToCompoundsIDs(jobID, featureList):
 
     manager=Manager()
 
-    #CONCATENATE THE OUTPUT LISTS
-
-    matchedFeatures = manager.list()
-    notMatchedFeatures= manager.list()
+    #CONCATENATE THE OUTPUT LISTS -- one slot per worker, read back in worker
+    # (= input) order: see _handOver.
+    matchedFeatures = manager.list([None] * len(compoundsListParts))
+    notMatchedFeatures= manager.list([None] * len(compoundsListParts))
     foundFeatures= manager.list([0]*nThreads)
 
     #matchedFeatures = list()
@@ -1078,7 +1096,7 @@ def mapFeatureNamesToCompoundsIDs(jobID, featureList):
         threadsList = []
         i=0
         for compoundListPart in compoundsListParts:
-            thread = Process(target=mapCompoundsIdentifiers, args=(jobID, compoundListPart, matchedFeatures, notMatchedFeatures, foundFeatures))
+            thread = Process(target=mapCompoundsIdentifiers, args=(jobID, compoundListPart, matchedFeatures, notMatchedFeatures, foundFeatures, i))
             threadsList.append(thread)
             thread.start()
             i+=1
@@ -1109,14 +1127,13 @@ def mapFeatureNamesToCompoundsIDs(jobID, featureList):
 
     foundFeatures = sum(foundFeatures)
 
+    # One round trip each, concatenated in worker (= input) order.
+    matchedFeatures = list(itertools.chain.from_iterable(part for part in matchedFeatures[:] if part is not None))
+    notMatchedFeatures = list(itertools.chain.from_iterable(part for part in notMatchedFeatures[:] if part is not None))
+
     #***********************************************************************************
     #* STEP 4. RETURN THE RESULTS
     #***********************************************************************************
     logging.info("FINISHED. " + str(foundFeatures) + " uniquely matched compounds, " +  str(len(matchedFeatures)) + " compounds matched. " + str(len(notMatchedFeatures)) + " compounds not matched.")
-
-    # One round trip each instead of one per element — see the note on the same
-    # return in mapFeatureNamesToKeggIDs. Compound lists are short today (58 in the
-    # bundled example), so this is correctness-by-consistency rather than a win.
-    matchedFeatures, notMatchedFeatures = matchedFeatures[:], notMatchedFeatures[:]
     manager.shutdown()
     return foundFeatures, matchedFeatures, notMatchedFeatures

--- a/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
+++ b/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
@@ -4,6 +4,7 @@ import os, sys, signal, time
 import re
 from multiprocessing import Process, cpu_count, Manager, RawArray
 from math import ceil
+from bisect import bisect_right
 from re import compile as compile_re, IGNORECASE as IGNORECASE_re
 from collections import defaultdict
 from operator import attrgetter
@@ -208,6 +209,20 @@ def findIDsByFeaturesName(jobID, featureNames, db, databaseConvertion_id):
             for foundFeature in listResultCursor:
                 matchedFeatures[foundFeature.get("original_display_id")].append(str(foundFeature.get("display_id")))
 
+            # Record the misses too, as empty lists -- in the returned table
+            # as well as in the cache, so a forked worker hands them back to
+            # the parent with its hits. Only hits used to be cached, so a name
+            # with no translation in this database was sent to MongoDB again
+            # by every later omic (and by every symbol pass that saw the same
+            # id) although the answer cannot change within a job. An empty
+            # list reads exactly like an absent entry to every consumer:
+            # `if featureIDs:` is False, chain.from_iterable adds nothing,
+            # `cached or [fallback]` falls back. Keyed by the same (jobID,
+            # database) as the hits, so a miss in one database can never mask
+            # a hit in another.
+            for name in notCachedIds:
+                if name not in matchedFeatures:
+                    matchedFeatures[name] = []
             KeggInformationManager().updateTranslationCache(jobID, matchedFeatures, "id", databaseConvertion_id)
     except Exception as ex:
         logging.error("EXCEPTION %s", ex)
@@ -244,7 +259,31 @@ def findGeneSymbolByFeatureID(jobID, featureID, organism, db, databaseConvertion
     except Exception as ex:
         return None, False
 
-def mapFeatureIdentifiers(jobID, organism, databases, featureList,  matchedFeatures, notMatchedFeatures, foundFeatures, enrichment, progressArray=None, progressSlot=0):
+def resolveDatabaseIds(organism, databases, db=None):
+    """
+    The MongoDB `dbname` ids for the ID and gene-symbol databases of each user
+    selected database. Constant per organism, so the parent resolves them once
+    per mapping call and hands them to every worker instead of each of the six
+    workers issuing the same 2 x n_db find_one calls.
+
+    @returns ({dbname: id-database _id}, {dbname: symbol-database _id})
+    """
+    databaseConvertion = getDatabasesByOrganismCode(organism)
+    gene_databases = databaseConvertion[0]
+    symbol_databases = databaseConvertion[1]
+    client = None
+    if db is None:
+        client, db = getConnectionByOrganismCode(organism)
+    try:
+        databaseConvertion_ids = {dbname: db.dbname.find_one({"dbname": gene_databases.get(dbname)}, {"item": 1, "qty": 1}).get("_id") for dbname in databases}
+        databaseGeneSymbol_ids = {dbname: db.dbname.find_one({"dbname": symbol_databases.get(dbname)}, {"item": 1, "qty": 1}).get("_id") for dbname in databases}
+    finally:
+        if client is not None:
+            client.close()
+    return databaseConvertion_ids, databaseGeneSymbol_ids
+
+
+def mapFeatureIdentifiers(jobID, organism, databases, featureList,  matchedFeatures, notMatchedFeatures, foundFeatures, enrichment, progressArray=None, progressSlot=0, databaseIds=None, cacheTables=None):
     """
     This function is used to query the database in different threads.
 
@@ -259,6 +298,15 @@ def mapFeatureIdentifiers(jobID, organism, databases, featureList,  matchedFeatu
                      progressArray[progressSlot]. Defaults to None so the direct,
                      non-forked call in Job.parseGeneBasedFiles is unaffected.
     @param  {Integer} progressSlot, this worker's index in progressArray
+    @param  {Tuple}  databaseIds, optional (id-database ids, symbol-database ids)
+                     already resolved by the parent (see resolveDatabaseIds);
+                     resolved here when None.
+    @param  {List}   cacheTables, optional shared list; when given, this worker
+                     appends ONE dict {dbname_id: {name: [ids]}} holding every
+                     translation it looked up, so the parent can merge it into
+                     the job's translation cache. A forked worker's own cache
+                     writes die with the process, which is why, before this,
+                     every omic of a job re-queried MongoDB for the same names.
 
     @returns True
     """
@@ -280,8 +328,9 @@ def mapFeatureIdentifiers(jobID, organism, databases, featureList,  matchedFeatu
 
     client, db  = getConnectionByOrganismCode(organism)
 
-    databaseConvertion_ids = {dbname: db.dbname.find_one({"dbname": gene_databases.get(dbname)}, {"item": 1, "qty": 1}).get("_id") for dbname in databases}
-    databaseGeneSymbol_ids = {dbname: db.dbname.find_one({"dbname": symbol_databases.get(dbname)}, {"item": 1, "qty": 1}).get("_id") for dbname in databases}
+    if databaseIds is None:
+        databaseIds = resolveDatabaseIds(organism, databases, db)
+    databaseConvertion_ids, databaseGeneSymbol_ids = databaseIds
 
     # Iterate symbol-capable databases first so the per-featureID dedup below keeps
     # the clone whose name was resolved against a real gene-symbol database
@@ -367,6 +416,15 @@ def mapFeatureIdentifiers(jobID, organism, databases, featureList,  matchedFeatu
         # Use a set to track which features matched in any database (O(1) lookups)
         localMatchedFeatures = set()
 
+        # Accumulate locally and hand over ONCE at the end. `matchedFeatures`
+        # is a Manager list proxy in the forked path, and every append on it
+        # is a pickle plus a socket round trip to the manager process --
+        # measured at ~92us each, 40k clones per big omic, six workers
+        # serialising on one manager. Element order within this worker is
+        # unchanged; the interleaving between workers was never deterministic.
+        localMatched = []
+        localNotMatched = []
+
         for feature in featureList:
             originalName = feature.getName()
             featureMatchedInAnyDB = False
@@ -417,11 +475,11 @@ def mapFeatureIdentifiers(jobID, organism, databases, featureList,  matchedFeatu
                         featureName = cachedSymbols[0]
 
                         featureClone.setName(featureName)
-                        matchedFeatures.append(featureClone)
+                        localMatched.append(featureClone)
 
             # Only add to notMatchedFeatures if it didn't match in ANY database
             if not featureMatchedInAnyDB:
-                notMatchedFeatures.append(feature)
+                localNotMatched.append(feature)
             else:
                 # Track that this feature was matched (for deduplication if needed)
                 localMatchedFeatures.add(originalName)
@@ -429,11 +487,29 @@ def mapFeatureIdentifiers(jobID, organism, databases, featureList,  matchedFeatu
         #*************************************************************************************
         # STORE THE RESULTS
         #*************************************************************************************
+        matchedFeatures.extend(localMatched)
+        notMatchedFeatures.extend(localNotMatched)
+
+        if cacheTables is not None:
+            # Everything this worker resolved, keyed exactly as
+            # findIDsByFeaturesName keys the translation cache: name -> ids
+            # under the id database, id -> symbols under the symbol database
+            # (one and the same table when the two databases coincide, as for
+            # Reactome). Misses are in here as empty lists too.
+            tables = {}
+            for databaseConvertion_name in databases:
+                tables.setdefault(databaseConvertion_ids.get(databaseConvertion_name), {}).update(
+                    allCacheFeatureIDS[databaseConvertion_name])
+                tables.setdefault(databaseGeneSymbol_ids.get(databaseConvertion_name), {}).update(
+                    allCacheSymbolsIDS[databaseConvertion_name])
+            cacheTables.append(tables)
 
         # If only one database was used for the species, remove the redundant "Total" counter
         if len(databaseConvertion_ids) < 2:
             matches.pop("Total", None)
 
+        # Exactly one append per worker: the parent counts these to detect a
+        # worker that died silently (see mapFeatureNamesToKeggIDs).
         foundFeatures.append(matches)
 
         return matchedFeatures, notMatchedFeatures, foundFeatures
@@ -493,6 +569,12 @@ def mapFeatureNamesToKeggIDs(jobID, organism, databases, featureList, enrichment
     matchedFeatures = manager.list()
     notMatchedFeatures= manager.list()
     foundFeatures = manager.list()
+    # One entry per worker: the translations it resolved, merged into the
+    # job's cache below so the NEXT omic's workers inherit them at fork time.
+    cacheTables = manager.list()
+
+    # Resolved once here rather than 2 x n_db find_one calls in each worker.
+    databaseIds = resolveDatabaseIds(organism, databases)
 
     #***********************************************************************************
     #* STEP 2. START THE MAPPING USING N DIFFERENT THREADS IN PARALLEL
@@ -511,7 +593,7 @@ def mapFeatureNamesToKeggIDs(jobID, organism, databases, featureList, enrichment
         threadsList = []
         i=0
         for genesListPart in genesListParts:
-            thread = Process(target=mapFeatureIdentifiers, args=(jobID, organism, databases, genesListPart, matchedFeatures, notMatchedFeatures, foundFeatures, enrichment, progressArray, i))
+            thread = Process(target=mapFeatureIdentifiers, args=(jobID, organism, databases, genesListPart, matchedFeatures, notMatchedFeatures, foundFeatures, enrichment, progressArray, i, databaseIds, cacheTables))
             threadsList.append(thread)
             thread.start()
             i+=1
@@ -556,6 +638,16 @@ def mapFeatureNamesToKeggIDs(jobID, organism, databases, featureList, enrichment
     for dbname in sumFoundFeatures.keys():
         sumFoundFeatures[dbname] = len(set(itertools.chain.from_iterable(dbmatches[dbname] for dbmatches in foundFeatures)))
 
+    # Carry the workers' translations into the parent's cache. The children
+    # wrote them into their OWN copy of the KeggInformationManager singleton
+    # (fork is copy-on-write), so until now the parent's cache -- the one the
+    # next omic's workers are forked from -- stayed empty for the whole job
+    # and a 4-omic upload paid the full MongoDB mapping cost four times over.
+    keggInformationManager = KeggInformationManager()
+    for tables in cacheTables[:]:
+        for dbID, table in tables.items():
+            keggInformationManager.updateTranslationCache(jobID, table, "id", dbID)
+
     #***********************************************************************************
     #* STEP 4. RETURN THE RESULTS
     #***********************************************************************************
@@ -591,6 +683,143 @@ def mapFeatureNamesToKeggIDs(jobID, organism, databases, featureList, enrichment
 # input row. A name over the cap is treated as too generic to be a substring
 # query and only its exact-name hits are kept.
 MAX_COMPOUND_MATCHES = int(os.getenv("PAINTOMICS_MAX_COMPOUND_MATCHES", "500"))
+
+
+class _CompoundNameCursor(object):
+    """The slice of pymongo's Cursor that findCompoundIDByFeatureName uses."""
+
+    def __init__(self, docs):
+        self._docs = docs
+        self._limit = None
+
+    def limit(self, n):
+        self._limit = n
+        return self
+
+    def __iter__(self):
+        docs = self._docs if self._limit is None else self._docs[:self._limit]
+        return iter(docs)
+
+
+class _CompoundNameTable(object):
+    """
+    An in-memory stand-in for the ``kegg_compounds`` collection: the same
+    ``find({"name": {"$regex": pattern}}).limit(n)`` calls, answered from RAM.
+
+    kegg_compounds is a static 93k-document, 1.3 MB collection with only a
+    text index, which a case-insensitive substring regex cannot use, so every
+    metabolite name used to cost a full collection scan on mongod (20-50 ms
+    each -- 40 s for a 4,667-row file even spread over six workers). Here the
+    lower-cased names are joined into ONE haystack string and searched with
+    str.find, which walks the whole 1.3 MB in well under a millisecond, and
+    the hit positions are mapped back to documents in collection order.
+
+    Semantics reproduced from the MongoDB query exactly as
+    findCompoundIDByFeatureName issues it: an escaped literal (substring,
+    case-insensitive) or the same literal anchored ``^...$`` (whole-name,
+    case-insensitive), documents returned in natural (load) order, ``limit``
+    honoured on that order. Any other pattern falls back to evaluating the
+    compiled regex against every name, which is always correct and merely
+    slow. Candidates found by the fast path are re-checked with the compiled
+    pattern, so nothing the regex would reject can be returned.
+    """
+
+    def __init__(self, docs):
+        self.docs = docs
+        names = [str(doc.get("name", "")) for doc in docs]
+        # A name containing the separator could straddle two entries; the
+        # generic path is safe for that (never seen in KEGG, checked anyway).
+        self._fastPathOK = not any("\n" in name for name in names)
+        lowered = [name.lower() for name in names]
+        self._haystack = "\n".join(lowered)
+        self._lowered = lowered
+        starts = []
+        position = 0
+        for name in lowered:
+            starts.append(position)
+            position += len(name) + 1
+        self._starts = starts
+
+    # -- collection interface -------------------------------------------------
+    @property
+    def kegg_compounds(self):
+        return self
+
+    def find(self, query):
+        pattern = query["name"]["$regex"]
+        return _CompoundNameCursor(self._matchingDocs(pattern))
+
+    # -- matching -------------------------------------------------------------
+    @staticmethod
+    def _literalOf(pattern):
+        """The literal a re.escape()d (optionally ^...$ anchored) pattern
+        stands for, plus whether it was anchored; None if not that shape."""
+        source = pattern.pattern
+        anchored = len(source) >= 2 and source.startswith("^") and source.endswith("$")
+        core = source[1:-1] if anchored else source
+        literal = re.sub(r"\\(.)", r"\1", core, flags=re.S)
+        if re.escape(literal) != core:
+            return None, anchored
+        return literal, anchored
+
+    def _matchingDocs(self, pattern):
+        literal, anchored = self._literalOf(pattern)
+        caseInsensitive = bool(pattern.flags & re.IGNORECASE)
+        if literal is None or not caseInsensitive or not self._fastPathOK or literal == "":
+            return [doc for doc in self.docs if pattern.search(str(doc.get("name", "")))]
+        needle = literal.lower()
+        if anchored:
+            candidates = [index for index, name in enumerate(self._lowered) if name == needle]
+        else:
+            candidates = []
+            haystack, starts = self._haystack, self._starts
+            position = haystack.find(needle)
+            while position != -1:
+                index = bisect_right(starts, position) - 1
+                candidates.append(index)
+                nextDoc = index + 1
+                if nextDoc >= len(starts):
+                    break
+                position = haystack.find(needle, starts[nextDoc])
+        docs = self.docs
+        return [docs[index] for index in candidates
+                if pattern.search(str(docs[index].get("name", "")))]
+
+
+_compoundNameTable = None
+_compoundNameTableSize = None
+
+
+def getCompoundNameTable(db=None, revalidate=True):
+    """
+    The process-wide _CompoundNameTable, loaded from ``global-paintomics``
+    on first use and reused for the life of the process. kegg_compounds only
+    changes when the installer runs, which already requires a server restart
+    for every other in-memory dataset; with ``revalidate`` the document count
+    is re-checked so an in-place reload of the collection is still noticed.
+    Loaded in the PARENT before the workers fork, so all of them share one
+    copy-on-write table (a worker passes revalidate=False: it inherited the
+    table the parent just validated and must not open a connection of its own
+    just to count).
+    """
+    global _compoundNameTable, _compoundNameTableSize
+    if _compoundNameTable is not None and not revalidate:
+        return _compoundNameTable
+    client = None
+    if db is None:
+        client, db = getConnectionByOrganismCode("global")
+    try:
+        size = db.kegg_compounds.estimated_document_count()
+        if _compoundNameTable is None or _compoundNameTableSize != size:
+            started = time.monotonic()
+            _compoundNameTable = _CompoundNameTable(list(db.kegg_compounds.find({})))
+            _compoundNameTableSize = size
+            logging.info("LOADED %d KEGG COMPOUND NAMES INTO MEMORY IN %.2fs",
+                         size, time.monotonic() - started)
+        return _compoundNameTable
+    finally:
+        if client is not None:
+            client.close()
 
 
 def isPlaceholderCompoundName(featureName):
@@ -671,7 +900,15 @@ def mapCompoundsIdentifiers(jobID, featureList, matchedFeatures, notMatchedFeatu
     #***********************************************************************************
     #* STEP 2. GET THE CORRESPONDING DATABASE FOR CURRENT SPECIE
     #***********************************************************************************
-    client, db  = getConnectionByOrganismCode("global")
+    # The in-memory copy of kegg_compounds (see _CompoundNameTable), inherited
+    # from the parent that loaded it before forking. It answers exactly the
+    # find(...).limit(...) calls findCompoundIDByFeatureName makes.
+    db = getCompoundNameTable(revalidate=False)
+
+    # Local accumulation, one hand-over per list at the end: see the same
+    # note in mapFeatureIdentifiers.
+    localMatched = []
+    localNotMatched = []
 
     try:
         matches=0
@@ -745,13 +982,15 @@ def mapCompoundsIdentifiers(jobID, featureList, matchedFeatures, notMatchedFeatu
                         del matchedElement.getOtherCompounds()[i]
 
                     #Add the CompoundSet to the list
-                    matchedFeatures.append(matchedElement)
+                    localMatched.append(matchedElement)
                 else:
-                    notMatchedFeatures.append(feature)
+                    localNotMatched.append(feature)
 
         #*************************************************************************************
         # STORE THE RESULTS
         #*************************************************************************************
+        matchedFeatures.extend(localMatched)
+        notMatchedFeatures.extend(localNotMatched)
         foundFeatures.append(matches)
         # matchedCompoundIDsTablesList.append(matchedCompoundIDsTable)
 
@@ -759,8 +998,6 @@ def mapCompoundsIdentifiers(jobID, featureList, matchedFeatures, notMatchedFeatu
 
     except Exception as ex:
         raise ex
-    finally:
-        client.close()
 
 def mapFeatureNamesToCompoundsIDs(jobID, featureList):
     """
@@ -790,6 +1027,10 @@ def mapFeatureNamesToCompoundsIDs(jobID, featureList):
     nLinesPerThread = int(ceil(len(featureList)/nThreads)) + 1
     #SPLIT THE ARRAY IN n PARTS
     compoundsListParts = chunks(featureList, nLinesPerThread)
+
+    # Load (or revalidate) the in-memory kegg_compounds table BEFORE forking so
+    # every worker inherits the same copy instead of scanning MongoDB per name.
+    getCompoundNameTable()
 
     manager=Manager()
 

--- a/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
+++ b/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
@@ -186,18 +186,37 @@ def findIDsByFeaturesName(jobID, featureNames, db, databaseConvertion_id):
 
     notCachedIds = set(featureNames).difference(set(cachedFeatureIDs.keys()))
 
+    # One xref document per input name, its mates resolved by a $lookup whose
+    # sub-pipeline filters on the target dbname_id INSIDE the join, so mongod
+    # walks the (dbname_id, _id) index and never materialises the mates that
+    # belong to other databases. The previous form -- $unwind every mate, look
+    # each one up by _id in full, THEN drop the ~90% with the wrong dbname_id
+    # -- was measured 3-4.5x slower on the same batches (mmu, 12,762 names:
+    # 4.05 s -> 1.24 s per database), and these round trips are ~98% of the
+    # identifier-mapping phase.
+    #
+    # The result must be the same as the old form to the last detail: one
+    # display_id per (input name, matching mate) pair, in the order of the
+    # input's mates array, concatenated over the input's documents in scan
+    # order. The join returns hits in index order, so they are re-walked here
+    # in mates order (a duplicated mate would be emitted twice, as $unwind
+    # did). Verified identical, per-name list order included, on the bundled
+    # gene, protein and symbol lookups.
     listMongoPipeline = [
         {"$match": {"display_id": {"$in": list(notCachedIds)}}},
-        {"$unwind": "$mates"},
         {"$lookup": {
             "from": "xref",
-            "localField": "mates",
-            "foreignField": "_id",
-            "as": "unwind_mate"
+            "let": {"m": {"$ifNull": ["$mates", []]}},
+            "pipeline": [
+                {"$match": {"$expr": {"$and": [
+                    {"$eq": ["$dbname_id", databaseConvertion_id]},
+                    {"$in": ["$_id", "$$m"]}]}}},
+                {"$project": {"_id": 1, "display_id": 1}}
+            ],
+            "as": "hits"
         }},
-        {"$match": {"unwind_mate.dbname_id": databaseConvertion_id}},
-        {"$replaceRoot": {"newRoot": { "$mergeObjects": [{ "$arrayElemAt": ["$unwind_mate", 0]}, {"original_display_id": "$display_id"}]}}},
-        {"$project": {"_id": 0, "display_id": 1, "original_display_id": 1}}
+        {"$match": {"hits.0": {"$exists": True}}},
+        {"$project": {"_id": 0, "display_id": 1, "mates": 1, "hits": 1}}
     ]
 
     matchedFeatures = defaultdict(list)
@@ -207,7 +226,11 @@ def findIDsByFeaturesName(jobID, featureNames, db, databaseConvertion_id):
             listResultCursor = db.xref.aggregate(listMongoPipeline, batchSize = 2000)
 
             for foundFeature in listResultCursor:
-                matchedFeatures[foundFeature.get("original_display_id")].append(str(foundFeature.get("display_id")))
+                hitsByID = {hit.get("_id"): hit.get("display_id") for hit in foundFeature.get("hits", [])}
+                translations = matchedFeatures[foundFeature.get("display_id")]
+                for mate in foundFeature.get("mates", []):
+                    if mate in hitsByID:
+                        translations.append(str(hitsByID[mate]))
 
             # Record the misses too, as empty lists -- in the returned table
             # as well as in the cache, so a forked worker hands them back to

--- a/PaintomicsServer/src/common/JobInformationManager.py
+++ b/PaintomicsServer/src/common/JobInformationManager.py
@@ -585,12 +585,15 @@ class JobInformationManager(metaclass=Singleton):
                 elif(matchingType.lower() == "reference_file"):
                     jobInstance.addReferenceInput({"omicName": omicType, "fileType": dataType, "inputDataFile": dataFileName})
 
-    # Both of these close in a finally rather than after the call: DBmanager
-    # builds a new MongoClient per DAO, each with its own monitor threads, so a
-    # query that raises leaves those threads behind. The raising case is a
-    # database that is unreachable, which is when every request is failing at
-    # once -- leaking a client per failure makes the outage worse rather than
-    # merely noisier.
+    # Both of these close in a finally rather than after the call. That used to
+    # be about leaked threads -- DBmanager built a new MongoClient per DAO, with
+    # its own monitor threads, and a query that raised left them behind, exactly
+    # when the database was already unreachable and every request was failing at
+    # once. DBmanager now hands out one process-wide client, so the finally no
+    # longer buys back threads; it stays because it is the shape the rule in
+    # src/tests/test_dao_connection_cleanup.py enforces, it costs nothing, and a
+    # DAO that outlives its request is the one way a manager can still carry a
+    # client reference across a fork.
     def getVisualOptions(self, jobID):
         daoInstance = VisualOptionsDAO()
         try:
@@ -606,17 +609,30 @@ class JobInformationManager(metaclass=Singleton):
         finally:
             daoInstance.closeConnection()
 
+    # The three below never released their DAO at all -- not on the error path,
+    # not on the success path. touchAccessDate in particular runs on every
+    # loadJobInstance, cache hit included, and the AI routes load a job several
+    # times per report, so a single run left a handful of managers behind.
     def storeSharingOptions(self, jobInstance):
         daoInstance = PathwayAcquisitionJobDAO()
-        daoInstance.update(jobInstance, {"fieldList": ["allowSharing", "readOnly"]})
+        try:
+            daoInstance.update(jobInstance, {"fieldList": ["allowSharing", "readOnly"]})
+        finally:
+            daoInstance.closeConnection()
 
     def touchAccessDate(self, jobID):
         jobInstanceDAO = PathwayAcquisitionJobDAO()
-        jobInstanceDAO.touch(jobID)
+        try:
+            jobInstanceDAO.touch(jobID)
+        finally:
+            jobInstanceDAO.closeConnection()
 
     def storePathways(self, jobInstance):
         daoInstance = PathwayDAO()
-        logging.info("STORE PATHWAYS - REMOVING PATHWAYS TO DATABASE...")
-        daoInstance.removeAll({"jobID": jobInstance.getJobID()})
-        logging.info("STORE PATHWAYS - SAVING PATHWAYS TO DATABASE...")
-        daoInstance.insertAll(jobInstance.getMatchedPathways().values(), {"jobID": jobInstance.getJobID()})
+        try:
+            logging.info("STORE PATHWAYS - REMOVING PATHWAYS TO DATABASE...")
+            daoInstance.removeAll({"jobID": jobInstance.getJobID()})
+            logging.info("STORE PATHWAYS - SAVING PATHWAYS TO DATABASE...")
+            daoInstance.insertAll(jobInstance.getMatchedPathways().values(), {"jobID": jobInstance.getJobID()})
+        finally:
+            daoInstance.closeConnection()

--- a/PaintomicsServer/src/common/KeggInformationManager.py
+++ b/PaintomicsServer/src/common/KeggInformationManager.py
@@ -2,7 +2,6 @@ import logging.handlers
 import logging
 
 from collections import deque, defaultdict
-from pymongo import MongoClient
 from threading import RLock as threading_lock
 from src.common.Util import Singleton
 
@@ -337,10 +336,21 @@ class KeggInformationManager(metaclass=Singleton):
         @returns
         """
         from src.conf.serverconf import MONGODB_HOST, MONGODB_PORT
-        client = MongoClient(MONGODB_HOST, MONGODB_PORT)
+        from src.common.DBmanager import getSharedClient, SharedClientHandle
+
+        # The shared, pid-keyed process client instead of a fresh MongoClient
+        # per organism load. Same host, same port, same database, same queries.
+        #
+        # It is handed back wrapped because every caller of this method owns
+        # what it is given and closes it in a finally -- and the process client
+        # is not this caller's to close: other threads are serving requests on
+        # it. The wrapper forwards everything except close(), which becomes the
+        # reference drop it now means. `db` is taken from the real client, so
+        # queries never go through the wrapper at all.
+        client = getSharedClient(MONGODB_HOST, MONGODB_PORT)
         db = client[organism + "-paintomics"]
 
-        return client, db
+        return SharedClientHandle(client), db
 
     def getKeggDataDir(self):
         return self.KEGG_DATA_DIR

--- a/PaintomicsServer/src/common/KeggInformationManager.py
+++ b/PaintomicsServer/src/common/KeggInformationManager.py
@@ -98,7 +98,7 @@ class KeggInformationManager(metaclass=Singleton):
 
             selectedDict = self.translationCache.get(jobID)[dbID][type]
 
-            return {featureID: selectedDict.get(featureID) for featureID in featureIDs if featureID in selectedDict.keys()}
+            return {featureID: selectedDict.get(featureID) for featureID in featureIDs if featureID in selectedDict}
         except Exception as ex:
             raise ex
         finally:
@@ -115,8 +115,10 @@ class KeggInformationManager(metaclass=Singleton):
             self.lock.acquire() #LOCK CACHE
 
             if self.translationCache.get(jobID) != None:
-                # self.translationCache.get(jobID)[dbID][type] = dict(self.translationCache.get(jobID)[dbID][type].items() + newDataTable.items())
-                self.translationCache.get(jobID)[dbID][type] = {**self.translationCache.get(jobID)[dbID][type], **newDataTable}
+                # In place: the previous `{**old, **new}` rebuilt (and rehashed)
+                # the whole table on every 250-name batch, O(cache) per call.
+                # Same result -- the newer entry wins in both spellings.
+                self.translationCache.get(jobID)[dbID][type].update(newDataTable)
             return True
         except Exception as ex:
                 raise ex

--- a/PaintomicsServer/src/common/Statistics.py
+++ b/PaintomicsServer/src/common/Statistics.py
@@ -1,5 +1,7 @@
 import logging
 from math import log, isfinite
+import numpy as np
+from scipy import special as _special
 from scipy.stats import chi2, fisher_exact, combine_pvalues, hypergeom
 from statsmodels.sandbox.stats.multicomp import multipletests
 
@@ -178,7 +180,14 @@ def calculateCombinedFisher(significanceValuesList):
 
     accumulatedValue = accumulatedValue * -2
 
-    combined = chi2.sf(accumulatedValue, 2*len(pvalues))
+    # chi2.sf(x, df) is sc.chdtrc(df, x) after the distribution wrapper's
+    # argument checks (chi2_gen._sf), which cost ~20 us per call against
+    # ~0.5 us for the function itself; this runs once per pathway per
+    # condition. accumulatedValue is finite and >= 0 here (every p <= 1 and
+    # floored at 1e-300), so the wrapper's support handling never changes the
+    # answer -- pinned bit for bit against chi2.sf in
+    # test_combined_pvalue_kernels_match_scipy.
+    combined = _special.chdtrc(2*len(pvalues), accumulatedValue)
 
     # The same backstop calculateStoufferCombinedPvalue carries, for the same
     # reason: a non-finite result is serialised as invalid JSON and takes the
@@ -239,6 +248,33 @@ def adjustPvalues(pvaluesList):
     return adjusted_pvalues
 
 
+def _stoufferPvalue(pvalues, weights):
+    """
+    scipy.stats.combine_pvalues(pvalues, 'stouffer', weights).pvalue, computed
+    the way scipy computes it -- Zi = norm.isf(p); Z = dot(w, Zi)/||w||;
+    p = norm.sf(Z) -- but calling the special functions those distribution
+    methods reduce to (norm.isf is -ndtri, norm.sf is ndtr(-x)) instead of
+    going through combine_pvalues' axis/nan-policy wrapper and two
+    rv_continuous method calls, which cost ~145 us per call against ~3 us
+    here. This runs a few times per matched pathway. Same numpy operations,
+    same dtypes (weights stay integer when the caller passed integers, as
+    scipy's np.atleast_1d keeps them), same C functions: bit-identical to
+    combine_pvalues over 80,000 random cases including int/float/None weights
+    and the 1e-300 / 0.9999999999 clamps -- pinned in
+    test_combined_pvalue_kernels_match_scipy.
+    """
+    p = np.atleast_1d(pvalues)
+    if weights is None:
+        w = np.ones_like(p)
+    else:
+        w = np.atleast_1d(weights)
+    Zi = -_special.ndtri(p)
+    statistic = np.dot(w, Zi) / np.linalg.norm(w)
+    # A numpy float64, as combine_pvalues returned (a float subclass, so
+    # every consumer -- isfinite, JSON, BSON -- sees the same value).
+    return _special.ndtr(-statistic)
+
+
 def calculateStoufferCombinedPvalue(pvalues, weights):
     # Stouffer method cannot deal with p-values equal to 1, returning Nan
     # Prevent that by removing a small value in those cases
@@ -276,9 +312,7 @@ def calculateStoufferCombinedPvalue(pvalues, weights):
             return 1.0
 
     # P-value in third position ([nFeatures, nRelevantFeatures, pValue])
-    combinedPvalue = combine_pvalues(curatedPvalues, 'stouffer', weights)
-
-    result = combinedPvalue[1]
+    result = _stoufferPvalue(curatedPvalues, weights)
 
     # Backstop for any other degenerate input: a non-finite float would be
     # serialised as invalid JSON and break the client the same way.

--- a/PaintomicsServer/src/common/bioscripts/DHS_exon_association.py
+++ b/PaintomicsServer/src/common/bioscripts/DHS_exon_association.py
@@ -1,12 +1,31 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # Author: Pedro Furió Tarí
+"""RGmatch: associate genomic regions (BED) with genes from an annotation (GTF).
+
+Importable (`run()`, which is what the web app calls) and runnable from the
+command line (see `usage()`).
+
+One thing to know before running it anywhere: **run() writes a sidecar cache of
+the parsed annotation to disk.** Parsing a real genome dominates the job, so the
+result is pickled next to nothing in particular -- into the directory named by
+the "cache_dir" option. Callers that pass no "cache_dir" (this module's own
+main(), and the example-data generator in
+src/AdminTools/scripts/exampledata/stategrafull.py) fall back to
+`<tempfile.gettempdir()>/paintomics-gtfcache`, where a mouse-sized annotation
+leaves a ~29MB file per (GTF, mtime, size, tag) combination. The web app points
+"cache_dir" at `<CLIENT_TMP>/gtfcache` instead. Nothing prunes either directory.
+"""
 
 import getopt
 import sys
+import os
 import os.path
 import gzip
+import hashlib
+import pickle
 import re
+import tempfile
 
 # Global variables
 rules          = ["TSS","1st_EXON","PROMOTER","TTS","INTRON","GENE_BODY","UPSTREAM","DOWNSTREAM"]
@@ -35,11 +54,18 @@ check_strand   = False
 RUN_OPTION_KEYS = frozenset([
     "presortedGTF", "rules", "perc_area", "perc_region", "tss", "tts",
     "promoter", "distance", "level", "gene_id_tag", "tran_id_tag",
-    "ignore_missing", "check_strand",
+    "ignore_missing", "check_strand", "cache_dir",
 ])
 
 # Values accepted for the "level" option / -r flag.
 REPORT_LEVELS = ("exon", "transcript", "gene")
+
+# Bumped whenever the parsed annotation changes shape -- the pickled record
+# classes, what the payload holds, or what the parser does with a GTF line.
+# It is part of the cache key, so an old sidecar written by an older build is
+# never read back into a newer one.
+GTF_CACHE_FORMAT = 1
+GTF_CACHE_SUFFIX = ".rgcache"
 
 class Candidate:
     def __init__(self, start, end, strand, exon_number, area, transcript, gene, distance, pctg_region, pctg_area, tssdist, ttsdist):
@@ -93,12 +119,34 @@ class Candidate:
         return self.ttsdist
 
 
-# Objects to store the annotations from the GTF file
+# Objects to store the annotations from the GTF file.
+#
+# The three record classes below are instantiated once per GTF row -- 843k
+# exons, 143k transcripts and 55k genes for the bundled mouse annotation -- so
+# they carry `__slots__`: no per-instance __dict__ is ~100 bytes saved on every
+# one of the million objects, and nothing anywhere sets an attribute on them
+# that is not declared here (they are used only inside this module).
+#
+# `__slots__` alone would make pickling SLOWER and bigger, because the default
+# reduction for a slotted object ships a {slot: value} dict. The explicit
+# __getstate__/__setstate__ pair ships a plain tuple instead, which is what
+# makes the annotation cache (see run()) worth having: measured on the bundled
+# mouse GTF, 18.7MB and 0.43s to load the exon records versus 28.0MB / 0.68s
+# with the default slotted reduction. Every state tuple below is non-empty, so
+# pickle always calls __setstate__ back (a falsy state is skipped).
 class Myexons:
+    __slots__ = ("start", "end", "exon")
+
     def __init__(self, start, end, exon):
         self.start = start
         self.end = end
         self.exon = exon
+
+    def __getstate__(self):
+        return (self.start, self.end, self.exon)
+
+    def __setstate__(self, state):
+        self.start, self.end, self.exon = state
 
     def getStart(self):
         return self.start
@@ -114,11 +162,19 @@ class Myexons:
 
 
 class Mytranscripts:
+    __slots__ = ("myexons", "trans_id", "start", "end")
+
     def __init__(self, trans_id):
         self.myexons = []
         self.trans_id = trans_id
         self.start = sys.maxsize
         self.end = 0
+
+    def __getstate__(self):
+        return (self.myexons, self.trans_id, self.start, self.end)
+
+    def __setstate__(self, state):
+        self.myexons, self.trans_id, self.start, self.end = state
 
     def addExon(self, myexon):
         self.myexons.append(myexon)
@@ -174,12 +230,22 @@ class Mytranscripts:
 
 
 class Mygenes:
+    __slots__ = ("mytranscripts", "start", "end", "gene_id", "strand")
+
     def __init__(self, gene_id, strand):
         self.mytranscripts = []
         self.start = sys.maxsize
         self.end = 0
         self.gene_id = gene_id
         self.strand = strand
+
+    def __getstate__(self):
+        return (self.mytranscripts, self.start, self.end, self.gene_id,
+                self.strand)
+
+    def __setstate__(self, state):
+        (self.mytranscripts, self.start, self.end, self.gene_id,
+         self.strand) = state
 
     def getGeneID(self):
         return self.gene_id
@@ -214,6 +280,347 @@ class Mygenes:
 
     def getStrand(self):
         return self.strand
+
+
+##*****************************************************************************
+## GTF attribute extraction
+##*****************************************************************************
+
+def extractAttribute(attributes, tag):
+    """The value of `tag` in a GTF attributes column.
+
+    This reproduces, character for character, what
+        re.search(r'<tag> \"?(.*?)\"?;', attributes).group(1)
+    used to return for every attribute string a GTF row can carry -- it is only
+    about twice as fast, and the parser calls it twice for every one of the ~1M
+    rows of a mouse annotation.
+
+    There is exactly ONE class of string where the two disagree, and it names
+    itself: `re`'s '.' does not match a newline, while `str.find(';', ...)`
+    crosses one. So an attributes column holding a newline with a ';' somewhere
+    after it diverges -- 'gene_id a\\nb;' is AttributeError from the regex and
+    'a\\nb' here.
+
+    That shape cannot reach this function: both readers split the file on '\\n'
+    before a row's attributes column exists, so the only newline a row can
+    carry is a trailing one with nothing after it, while a divergence needs a
+    ';' *after* the newline. Fuzzing with '\\n' in the alphabet (see
+    test_gtf_cache_and_attribute_parsing.py) finds divergences only in strings
+    containing a newline, and none at all once the strings are shaped like the
+    rows the two readers actually produce.
+
+    The regex it replaces has three behaviours that are easy to lose:
+
+    * The quotes are OPTIONAL on both sides, so `gene_id ABC;` yields `ABC`
+      exactly as `gene_id "ABC";` yields `ABC`.
+    * The group is non-greedy and the closing quote is greedy, so the value
+      ends at the FIRST ';' at or after the value start, minus one preceding
+      '"' if there is one. `gene_id "A;B";` therefore yields `A`, not `A;B`.
+    * The match is leftmost: an occurrence of the tag with no ';' after it
+      anywhere is not a match, and the search continues at the next
+      occurrence.
+
+    A tag that is not present at all made `re.search(...)` return None and the
+    caller crash on `.group(1)` with AttributeError. That is deliberately kept
+    -- a GTF row without a gene_id is malformed and must not be accepted in
+    silence -- but the message now names the tag and shows the row instead of
+    saying "'NoneType' object has no attribute 'group'". The exception CLASS is
+    unchanged so that any caller distinguishing exception types still sees what
+    it saw before.
+    """
+    needle = tag + " "
+    needleLength = len(needle)
+    position = attributes.find(needle)
+    while position != -1:
+        cursor = position + needleLength
+        # Optional opening quote: '"?' is greedy, so it takes the quote when
+        # one is there and the value starts after it.
+        if attributes[cursor:cursor + 1] == '"':
+            cursor += 1
+        semicolon = attributes.find(";", cursor)
+        if semicolon != -1:
+            # Optional closing quote, also greedy: it can only sit in the one
+            # position immediately before the ';'.
+            end = semicolon
+            if end > cursor and attributes[end - 1] == '"':
+                end -= 1
+            return attributes[cursor:end]
+        # No ';' after this occurrence means the regex would have failed here
+        # and moved on to the next one.
+        position = attributes.find(needle, position + 1)
+
+    raise AttributeError(
+        "The GTF row carries no %r attribute (or none followed by ';'), so the "
+        "annotation cannot be read: %r" % (tag, attributes[:200]))
+
+
+##*****************************************************************************
+## Parsed-annotation cache
+##*****************************************************************************
+
+def gtfCacheKey(gtf, gene_id_tag, tran_id_tag, matchTable):
+    """Everything the parse depends on, or None if it cannot be determined.
+
+    The GTF is identified by absolute path + mtime + size rather than by a
+    digest of its contents: hashing 566MB on every job would cost more than the
+    parse it is meant to save. The remaining entries are the ONLY other inputs
+    to the load loop -- the two attribute tags (they are compiled into the
+    extraction) and the chromosome match table (it renames every chromosome
+    key). Everything else run() accepts (rules, distance, tss, tts, promoter,
+    the area percentages, level, ignore_missing, check_strand, presortedGTF)
+    is consumed by the region scan, long after the annotation is built, and so
+    is deliberately absent: including it would only cause needless misses.
+
+    The limitation of mtime+size, stated plainly: an annotation replaced by a
+    DIFFERENT file of the SAME byte count whose mtime is then restored -- which
+    is what `cp -p`, `tar -x` and `rsync --times` do -- is not detected, and the
+    stale sidecar is served. Demonstrated, so it is a trade-off and not an
+    oversight: hashing 566MB on every job would cost more than the parse the
+    cache exists to skip. Anyone replacing an installed GTF in place should
+    bump `GTF_CACHE_FORMAT` or clear the cache directory. The narrower race --
+    the GTF changing WHILE it is being parsed -- is handled: run() re-stats
+    after parseGTF and refuses to persist a torn parse.
+    """
+    try:
+        gtfPath = os.path.abspath(gtf)
+        gtfStat = os.stat(gtfPath)
+        matchEntry = None
+        if matchTable is not None:
+            matchPath = os.path.abspath(matchTable)
+            matchStat = os.stat(matchPath)
+            matchEntry = (matchPath, matchStat.st_mtime_ns, matchStat.st_size)
+        return (GTF_CACHE_FORMAT, gtfPath, gtfStat.st_mtime_ns,
+                gtfStat.st_size, gene_id_tag, tran_id_tag, matchEntry)
+    except Exception:
+        # An unstattable GTF is the parse's problem to report, not the cache's.
+        return None
+
+
+def gtfCachePath(key, cacheDir):
+    """Where the sidecar for `key` lives, creating the directory if needed.
+
+    One rule, deliberately: a directory that exists for this and nothing else.
+    Writing the sidecar "next to the GTF" was the other candidate and is
+    rejected -- the bundled annotations live inside the checked-out repository
+    (datasets/07-region-based/data/synthetic_mmu.gtf is a tracked file) and an
+    uploaded one lives in the user's own input directory, so both would gain a
+    surprise multi-megabyte neighbour.
+
+    `cacheDir` is what the caller passes as the "cache_dir" option -- the web
+    app points it at <CLIENT_TMP>/gtfcache. The command-line entry point passes
+    nothing, and falls back to the system temporary directory.
+    """
+    if not cacheDir:
+        cacheDir = os.path.join(tempfile.gettempdir(), "paintomics-gtfcache")
+    os.makedirs(cacheDir, exist_ok=True)
+
+    digest = hashlib.sha256(repr(key).encode("utf-8")).hexdigest()[:32]
+    # A readable prefix so a human can tell the sidecars apart; the digest is
+    # what actually distinguishes them.
+    label = "".join(character if character.isalnum() or character in "._-"
+                    else "_" for character in os.path.basename(key[1]))[:48]
+    return os.path.join(cacheDir, "%s.%s%s" % (label, digest, GTF_CACHE_SUFFIX))
+
+
+def loadGtfCache(path, key):
+    """The cached (genes, allTranscripts) for `key`, or None.
+
+    Never raises: a truncated, unpicklable, half-written or simply foreign file
+    means "no cache", and the caller parses the GTF as it always did. The key
+    is stored inside the file and compared again here, so a digest collision or
+    a stale file reused under the same name cannot feed the wrong annotation
+    into a run.
+    """
+    try:
+        with open(path, "rb") as handle:
+            stored = pickle.load(handle)
+    except Exception:
+        return None
+
+    try:
+        if (not isinstance(stored, tuple) or len(stored) != 2
+                or stored[0] != key):
+            return None
+        payload = stored[1]
+        if (not isinstance(payload, tuple) or len(payload) != 2
+                or not isinstance(payload[0], dict)
+                or not isinstance(payload[1], dict)):
+            return None
+        if not payload[0]:
+            # An annotation with no chromosomes is not a cache hit worth having:
+            # served, it means either zero associations or the "incomplete GTF"
+            # abort, which is a silent wrong answer. A GTF that really parses to
+            # nothing costs one wasted parse per job and reports itself honestly.
+            return None
+        return payload
+    except Exception:
+        return None
+
+
+def storeGtfCache(path, key, payload):
+    """Write the sidecar atomically. Never raises: a job must not fail because
+    its cache could not be written (read-only directory, full disk, a parallel
+    job writing the same key)."""
+    temporaryPath = None
+    try:
+        handle, temporaryPath = tempfile.mkstemp(
+            dir=os.path.dirname(path), suffix=".tmp")
+        with os.fdopen(handle, "wb") as sink:
+            pickle.dump((key, payload), sink, protocol=pickle.HIGHEST_PROTOCOL)
+        os.replace(temporaryPath, path)
+        return True
+    except Exception:
+        if temporaryPath is not None:
+            try:
+                os.unlink(temporaryPath)
+            except OSError:
+                pass
+        return False
+
+
+def parseGTF(gtf, gene_id_tag, tran_id_tag, match_table):
+    """Build the annotation the region scan works against.
+
+    Returns (genes, allTranscripts):
+      genes           chromosome -> [Mygenes], in first-seen order
+      allTranscripts  transcript id -> Mytranscripts
+
+    The gene objects are shared between the two structures and carry their
+    transcripts, which carry their exons, so pickling the pair in ONE call
+    preserves every shared reference. `allGenes` is deliberately not returned:
+    nothing downstream of the exon-renumbering pass below ever reads it.
+
+    Extracted verbatim out of run() so the result can be cached; the only
+    change to the loop itself is extractAttribute() in place of two re.search
+    calls per row, which returns exactly the same strings (see its docstring).
+
+    `match_table` here is the already-loaded {gtf chromosome: bed chromosome}
+    dict, not the path.
+    """
+    inputGTF = None
+    if gtf[-2:] == "gz":
+        aux = gzip.open(gtf, 'rb').read().decode(errors='replace')
+        inputGTF = aux.split("\n")
+    else:
+        inputGTF = open(gtf, 'r')
+    genes = {}
+    allTranscripts = {}
+    allGenes  = {}
+    # Flags will tell me if "transcript" and "gene" flags can be found inside the GTF file. If they are not found,
+    # the start and end positions will have to be measured based on the exons.
+    geneFlag  = False
+    transFlag = False
+
+    for line in inputGTF:
+        # Avoid comments
+        if line and line[0] != "#":
+            linea_split = line.split("\t")
+            chrom = linea_split[0]
+            start = int(linea_split[3])
+            end   = int(linea_split[4])
+            strand = linea_split[6]
+
+            popurri = linea_split[8]
+
+            # Rename chrom if match_table exists
+            if match_table is not None:
+                chrom = match_table[chrom]
+
+            if linea_split[2] == "exon":
+
+                gene_id       = extractAttribute(popurri, gene_id_tag)
+                transcript_id = extractAttribute(popurri, tran_id_tag)
+
+                # The exon number will be calculated later
+                exon_number = None
+
+                myexon = Myexons(start, end, exon_number)
+
+                flag_transcript = False
+                if transcript_id not in allTranscripts:
+                    allTranscripts[transcript_id] = Mytranscripts(transcript_id)
+                    flag_transcript = True
+                allTranscripts[transcript_id].addExon(myexon)
+
+                if chrom not in genes:
+                    genes[chrom] = []
+
+                if gene_id not in allGenes:
+                    allGenes[gene_id] = Mygenes(gene_id, strand)
+                    genes[chrom].append(allGenes[gene_id])
+                if flag_transcript is True:
+                    # Transcript not added in gene
+                    allGenes[gene_id].addTranscript(allTranscripts[transcript_id])
+
+
+            elif linea_split[2] == "transcript":
+
+                transFlag = True
+
+                gene_id = extractAttribute(popurri, gene_id_tag)
+                transcript_id = extractAttribute(popurri, tran_id_tag)
+
+                flag_transcript = False
+                if transcript_id not in allTranscripts:
+                    allTranscripts[transcript_id] = Mytranscripts(transcript_id)
+                    flag_transcript = True
+                allTranscripts[transcript_id].setLength(start, end)
+
+                if chrom not in genes:
+                    genes[chrom] = []
+
+                if gene_id not in allGenes:
+                    allGenes[gene_id] = Mygenes(gene_id, strand)
+                    genes[chrom].append(allGenes[gene_id])
+                if flag_transcript is True:
+                    # Transcript not added in gene
+                    allGenes[gene_id].addTranscript(allTranscripts[transcript_id])
+
+
+            elif linea_split[2] == "gene":
+
+                geneFlag = True
+
+                gene_id = extractAttribute(popurri, gene_id_tag)
+
+
+                if chrom not in genes:
+                    genes[chrom] = []
+
+                if gene_id not in allGenes:
+                    allGenes[gene_id] = Mygenes(gene_id, strand)
+                    genes[chrom].append(allGenes[gene_id])
+                allGenes[gene_id].setLength(start, end)
+
+    if gtf[-2:] == "gz":
+        inputGTF = None
+    else:
+        inputGTF.close()
+
+    # Check exon number in transcripts
+    for gene_id in allGenes:
+        for transcript in allGenes[gene_id].getTranscripts():
+            transcript.checkExonNumbers(allGenes[gene_id].getStrand())
+
+            if transFlag is False:
+                allTranscripts[transcript.getTranscriptID()].calculateSize()
+
+    if geneFlag is False:
+        for gene in allGenes:
+            allGenes[gene].calculateSize()
+
+    return genes, allTranscripts
+
+
+def reportCacheEvent(message):
+    """Opt-in tracing for the annotation cache.
+
+    Off by default and on purpose: the association kernel runs in a forked
+    child, and unconditional writes to the inherited stderr of a forked process
+    are exactly the shape of problem that wedged the compound mapper.
+    """
+    if os.environ.get("PAINTOMICS_GTF_CACHE_DEBUG"):
+        sys.stderr.write("GTF CACHE: " + message + "\n")
 
 
 def main():
@@ -824,135 +1231,82 @@ def run(gtf, dhs, outputfile, match_table, options=None, managed_queue=None):
                 "Unknown report level %r for the region-to-gene association. "
                 "Expected one of: %s." % (level, ", ".join(REPORT_LEVELS)))
 
-        # The gene/transcript tags are only ever consumed through these two
-        # regexes, which the getopt path recompiles but this one did not -- so
-        # a GTF annotated with, say, gene_name was parsed looking for gene_id
-        # and every lookup raised AttributeError on a None match. Recompile
-        # unconditionally, so a second run() in the same interpreter cannot
-        # inherit the previous call's tag.
+        # The gene/transcript tags are only ever consumed through the attribute
+        # extraction, which the getopt path re-derived but this one did not --
+        # so a GTF annotated with, say, gene_name was parsed looking for
+        # gene_id and every lookup raised AttributeError on a missing tag. The
+        # tags are re-read from the options on every call, so a second run() in
+        # the same interpreter cannot inherit the previous call's tag.
+        #
+        # The two patterns are still compiled, unused as they now are: the tag
+        # arrives from a web form, and compiling it is what has always rejected
+        # a tag that is not a valid pattern (an unbalanced parenthesis, say).
+        # Keeping the compile keeps that rejection. What it deliberately does
+        # NOT keep is the tag being interpreted AS a pattern -- extractAttribute
+        # matches it literally, so a tag containing '.' or '*' now means those
+        # characters instead of silently matching anything. For every tag the
+        # web app and the examples use (gene_id, transcript_id, gene_name) the
+        # two readings are the same string.
         gene_id_re = re.compile(r"{0} \"?(.*?)\"?;".format(gene_id_tag))
         tran_id_re = re.compile(r"{0} \"?(.*?)\"?;".format(tran_id_tag))
         ## END CODE ADDED BY RAFA ##
         ############################
 
-        # 1. First, we save all the genes with their positions
-        inputGTF = None
-        if gtf[-2:] == "gz":
-            aux = gzip.open(gtf, 'rb').read().decode(errors='replace')
-            inputGTF = aux.split("\n")
-        else:
-            inputGTF = open(gtf, 'r')
-        genes = {}
-        allTranscripts = {}
-        allGenes  = {}
-        # Flags will tell me if "transcript" and "gene" flags can be found inside the GTF file. If they are not found,
-        # the start and end positions will have to be measured based on the exons.
-        geneFlag  = False
-        transFlag = False
+        # 1. First, we save all the genes with their positions.
+        #
+        # Parsing the annotation is the single most expensive thing this
+        # function does on a real genome (~3.6s of an 8.4s mouse job, and it is
+        # repeated in full for every job because the kernel runs in a fresh
+        # forked child), and it depends on nothing but the GTF itself and the
+        # two attribute tags. So it is cached: gtfCacheKey() names every
+        # parse-time input, and a hit skips both the load loop and the exon
+        # renumbering pass below. Only the annotation is ever cached -- never
+        # the regions/BED side, which is per-job data.
+        # Captured before `match_table` is rebound from a path to the loaded
+        # dict a few lines down; the key needs the path, and so does the
+        # re-stat after the parse.
+        matchTablePath = match_table
+        cacheKey = gtfCacheKey(gtf, gene_id_tag, tran_id_tag, matchTablePath)
+        cachePath = None
+        cached = None
+        if cacheKey is not None:
+            try:
+                cachePath = gtfCachePath(cacheKey, options.get("cache_dir"))
+                cached = loadGtfCache(cachePath, cacheKey)
+            except Exception:
+                # A cache that cannot even be located must not stop the run.
+                cachePath = None
+                cached = None
 
         # Prepare a match table to transform the GTF chromosome/scaffolds IDs to the
-        # ones used in the BED regions file
+        # ones used in the BED regions file. Loaded on the cached path too, so
+        # that an unreadable match table still fails the same way it always did.
         if match_table is not None:
             with open(match_table, 'r') as table_file:
                 match_table = dict(match_line.strip().split('\t') for match_line in table_file)
 
-        for line in inputGTF:
-            # Avoid comments
-            if line and line[0] != "#":
-                linea_split = line.split("\t")
-                chrom = linea_split[0]
-                start = int(linea_split[3])
-                end   = int(linea_split[4])
-                strand = linea_split[6]
-
-                popurri = linea_split[8]
-
-                # Rename chrom if match_table exists
-                if match_table is not None:
-                    chrom = match_table[chrom]
-
-                if linea_split[2] == "exon":
-
-                    gene_id       = re.search(gene_id_re, popurri).group(1)
-                    transcript_id = re.search(tran_id_re, popurri).group(1)
-
-                    # The exon number will be calculated later
-                    exon_number = None
-
-                    myexon = Myexons(start, end, exon_number)
-
-                    flag_transcript = False
-                    if transcript_id not in allTranscripts:
-                        allTranscripts[transcript_id] = Mytranscripts(transcript_id)
-                        flag_transcript = True
-                    allTranscripts[transcript_id].addExon(myexon)
-
-                    if chrom not in genes:
-                        genes[chrom] = []
-
-                    if gene_id not in allGenes:
-                        allGenes[gene_id] = Mygenes(gene_id, strand)
-                        genes[chrom].append(allGenes[gene_id])
-                    if flag_transcript is True:
-                        # Transcript not added in gene
-                        allGenes[gene_id].addTranscript(allTranscripts[transcript_id])
-
-
-                elif linea_split[2] == "transcript":
-
-                    transFlag = True
-
-                    gene_id = re.search(gene_id_re, popurri).group(1)
-                    transcript_id = re.search(tran_id_re, popurri).group(1)
-
-                    flag_transcript = False
-                    if transcript_id not in allTranscripts:
-                        allTranscripts[transcript_id] = Mytranscripts(transcript_id)
-                        flag_transcript = True
-                    allTranscripts[transcript_id].setLength(start, end)
-
-                    if chrom not in genes:
-                        genes[chrom] = []
-
-                    if gene_id not in allGenes:
-                        allGenes[gene_id] = Mygenes(gene_id, strand)
-                        genes[chrom].append(allGenes[gene_id])
-                    if flag_transcript is True:
-                        # Transcript not added in gene
-                        allGenes[gene_id].addTranscript(allTranscripts[transcript_id])
-
-
-                elif linea_split[2] == "gene":
-
-                    geneFlag = True
-
-                    gene_id = re.search(gene_id_re, popurri).group(1)
-
-
-                    if chrom not in genes:
-                        genes[chrom] = []
-
-                    if gene_id not in allGenes:
-                        allGenes[gene_id] = Mygenes(gene_id, strand)
-                        genes[chrom].append(allGenes[gene_id])
-                    allGenes[gene_id].setLength(start, end)
-
-        if gtf[-2:] == "gz":
-            inputGTF = None
+        if cached is not None:
+            reportCacheEvent("hit %s" % cachePath)
+            genes, allTranscripts = cached
         else:
-            inputGTF.close()
-
-        # Check exon number in transcripts
-        for gene_id in allGenes:
-            for transcript in allGenes[gene_id].getTranscripts():
-                transcript.checkExonNumbers(allGenes[gene_id].getStrand())
-
-                if transFlag is False:
-                    allTranscripts[transcript.getTranscriptID()].calculateSize()
-
-        if geneFlag is False:
-            for gene in allGenes:
-                allGenes[gene].calculateSize()
+            reportCacheEvent("miss %s" % cachePath)
+            genes, allTranscripts = parseGTF(gtf, gene_id_tag, tran_id_tag,
+                                             match_table)
+            # Re-stat before persisting. The key was taken before the read; if
+            # the GTF moved underneath the parse, what is in memory is a torn
+            # mixture of two files. Using it for THIS job is the behaviour that
+            # has always been there, but writing it to disk would hand the same
+            # torn annotation to every later job under the pre-change key.
+            if (cachePath is not None
+                    and gtfCacheKey(gtf, gene_id_tag, tran_id_tag,
+                                    matchTablePath) == cacheKey):
+                stored = storeGtfCache(cachePath, cacheKey,
+                                       (genes, allTranscripts))
+                reportCacheEvent(("stored " if stored else "not stored ")
+                                 + str(cachePath))
+            else:
+                reportCacheEvent("not stored (annotation changed during the "
+                                 "parse) " + str(cachePath))
 
         inputDHS = None
         if dhs[-2:] == "gz":

--- a/PaintomicsServer/src/common/bioscripts/PCA2GO.2.R
+++ b/PaintomicsServer/src/common/bioscripts/PCA2GO.2.R
@@ -59,12 +59,64 @@ eigen.val <- NULL
 go.sel <- sort(unique(annotation[,2]), method = "radix")
 n.ge <- NULL
 X.loadings <- vector(mode = "list", length = 0)
+# Group the annotation by pathway ONCE. The lookup this replaces --
+# annotation[annotation[,2] == go.sel[i], 1] -- rescanned the whole table and
+# built a fresh data.frame subset for every pathway: 524 x 183,636 string
+# comparisons for mmu Reactome, and that scan, not the c x c eigen
+# decomposition, was where this function spent its time.
+#
+# The vector each iteration reads is the same one the scan produced, element for
+# element: split() groups by exact string equality -- the predicate == used --
+# and keeps each group in the table's order of appearance, which is the order a
+# logical subset returns rows in.
+#
+# The groups are addressed BY POSITION, which is why the levels are pinned to
+# go.sel: split() then returns exactly one group per go.sel entry, in go.sel
+# order, including empty ones. Addressing them by name -- ann_by_go[[go.sel[i]]]
+# -- would be wrong twice over. read.table's as.is=TRUE only suppresses the
+# factor conversion, not type.convert, so an annotation whose pathway column is
+# all digits arrives as integer; a `[[` with an integer subscript indexes by
+# POSITION, silently handing a pathway another pathway's genes (and then running
+# off the end). And `l[[""]]` is NULL, no error, so a pathway id read from an
+# empty field would silently lose its members. No installed organism has either
+# shape (KEGG path:mmu00010, Reactome R-MMU-111885, MapMan text bins), but the
+# old full-table scan was immune by construction and this must be too.
+#
+# The one input that reads differently either way is an NA in the pathway
+# column: sort() drops NA, so go.sel never carries one, and the old scan's
+# `annotation[,2] == go.sel[i]` returned NA for those rows, which a data.frame
+# logical subset turns into one extra NA element inside *every* pathway's
+# gene.sel. That NA reached only total.genes -- is.element(rownames, NA) is
+# always FALSE, so X.sel never saw it -- and total.genes has no consumer
+# (generateMetaGenes.R reads $X.sel and $X.loadings only). Dropping it changes
+# no output byte.
+ann_by_go <- split(annotation[,1], factor(annotation[,2], levels = go.sel))
+# Loop-invariant: nothing below modifies X.
+X.rownames <- rownames(X)
+# Collect each pathway's contribution and concatenate once after the loop.
+# Growing variab / tot.variab / eigen.val / n.ge / n.go with c() and X.sel with
+# cbind() reallocated and copied the whole accumulated object on every pathway
+# (O(P^2) element copies). Concatenation order is the loop order either way, so
+# every assembled object is identical -- including total.genes, because unique()
+# of the concatenation keeps first-appearance order, exactly what the
+# incremental unique() built.
+n.sel <- length(go.sel)
+genes.parts <- vector("list", n.sel)
+X.sel.parts <- vector("list", n.sel)
+variab.parts <- vector("list", n.sel)
+tot.variab.parts <- vector("list", n.sel)
+eigen.val.parts <- vector("list", n.sel)
+n.ge.parts <- vector("list", n.sel)
+n.go.parts <- vector("list", n.sel)
 # PCAs for all GOs loop
-   for (i in 1: length(go.sel)) {
-	gene.sel <- annotation[annotation[,2] == go.sel[i],1]
+# seq_along, not 1:length(): an empty annotation made the old form walk i = 1
+# and then i = 0, which the table scan absorbed silently but a by-name lookup
+# would not. With at least one pathway the two are the same sequence.
+   for (i in seq_along(go.sel)) {
+	gene.sel <- ann_by_go[[i]]
         if (length(gene.sel) > 1) {
-      total.genes <- unique(c(total.genes, gene.sel))
-      gene.sel <- is.element(rownames(X), gene.sel)
+      genes.parts[[i]] <- gene.sel
+      gene.sel <- is.element(X.rownames, gene.sel)
       if (length(which(gene.sel)) > 1) {
          # drop = FALSE: a single-column X (one condition) would collapse this
          # subset to a plain vector, nrow() would return NULL, and the guard
@@ -92,7 +144,7 @@ X.loadings <- vector(mode = "list", length = 0)
 		pca.sel <- PCA.GENES(t(gene.sel))  # pca
 		eigen <- pca.sel$eigen$values
 		tot.var <- sum(eigen)
-		eigen.val <- c(eigen.val, tot.var)
+		eigen.val.parts[[i]] <- tot.var
 		rank <- length(which(eigen > 1e-16))
 		level <- 1
 		# num fac
@@ -107,22 +159,35 @@ X.loadings <- vector(mode = "list", length = 0)
 			abs.val.bycomp <- mean(apply(pca.sel$Xoff,2,var)) * nrow(gene.sel)
 			fac <- length(which(eigen >= abs.val.bycomp * var.cutoff / sqrt(level)))
 		}
-		tot.variab <- c(tot.variab, pca.sel$var.exp[,1])
+		tot.variab.parts[[i]] <- pca.sel$var.exp[,1]
 		#variab <- c(variab, pca.sel$var.exp[1:fac,1])
 		if (fac > 0 ) { # num fac
-		
-            	variab <- c(variab, pca.sel$var.exp[1:fac,1])
-            	n.ge <- c(n.ge, nrow(gene.sel))
-      		n.go <- c(n.go, fac)
+
+            	variab.parts[[i]] <- pca.sel$var.exp[1:fac,1]
+            	n.ge.parts[[i]] <- nrow(gene.sel)
+      		n.go.parts[[i]] <- fac
       		data.h <- as.matrix(pca.sel$scores[,1:fac])
                 loads <-  as.matrix(pca.sel$loadings[, 1:fac])
 		colnames(data.h) <- paste(go.sel[i], c(1:fac), sep="_")
-      		X.sel <- cbind(X.sel,data.h) # attach to results matrix
+      		X.sel.parts[[i]] <- data.h # attach to results matrix
                 for (u in 1:fac)  { X.loadings[[length(X.loadings)+1]] <- loads[,u] }
                	}
             }
 	}
    }
+# Assemble what the loop collected. c()/unique() over the parts reproduces the
+# incremental construction exactly, and keeps the empty case in the type the
+# initialisation chose: unlist() of an all-NULL list is NULL, so c(numeric(0),
+# NULL) stays numeric(0) for variab/tot.variab and c(NULL, NULL) stays NULL for
+# the rest. cbind() likewise ignores the NULL slots, and do.call(cbind, list())
+# is NULL -- the value the "no metagenes" branch downstream tests for.
+total.genes <- unique(unlist(genes.parts, use.names = FALSE))
+eigen.val <- c(eigen.val, unlist(eigen.val.parts, use.names = FALSE))
+tot.variab <- c(tot.variab, unlist(tot.variab.parts, use.names = FALSE))
+variab <- c(variab, unlist(variab.parts, use.names = FALSE))
+n.ge <- c(n.ge, unlist(n.ge.parts, use.names = FALSE))
+n.go <- c(n.go, unlist(n.go.parts, use.names = FALSE))
+X.sel <- do.call(cbind, X.sel.parts[!vapply(X.sel.parts, is.null, TRUE)])
 # Rearrange result
 if (!is.null(X.sel)) {
     rownames(X.sel) <- colnames(X)
@@ -176,12 +241,25 @@ CENTROID2GO <- function (X, annotation, var.cutoff = 2, fac.sel = "rel.abs")
   n.go <- NULL
   total.genes <- NULL
   metagene.names <- character(0)
+  # Same two rewrites as PCA2GO.2, for the same reasons: one split() of the
+  # annotation instead of one full-table scan per pathway -- levels pinned to
+  # go.sel so the groups can be addressed by POSITION, which is exact whatever
+  # the pathway column's type or spelling (see the long note in PCA2GO.2) -- and
+  # per-pathway pieces concatenated once instead of grown in place.
+  ann_by_go <- split(annotation[, 1], factor(annotation[, 2], levels = go.sel))
+  X.rownames <- rownames(X)
+  n.sel <- length(go.sel)
+  genes.parts <- vector("list", n.sel)
+  X.sel.parts <- vector("list", n.sel)
+  name.parts <- vector("list", n.sel)
+  n.ge.parts <- vector("list", n.sel)
+  n.go.parts <- vector("list", n.sel)
 
-  for (i in 1:length(go.sel)) {
-    gene.sel <- annotation[annotation[, 2] == go.sel[i], 1]
+  for (i in seq_along(go.sel)) {
+    gene.sel <- ann_by_go[[i]]
     if (length(gene.sel) > 1) {
-      total.genes <- unique(c(total.genes, gene.sel))
-      member <- is.element(rownames(X), gene.sel)
+      genes.parts[[i]] <- gene.sel
+      member <- is.element(X.rownames, gene.sel)
       # Same floor as PCA2GO.2: a single measured gene is not a pathway
       # summary, it is that gene.
       if (length(which(member)) > 1) {
@@ -195,15 +273,24 @@ CENTROID2GO <- function (X, annotation, var.cutoff = 2, fac.sel = "rel.abs")
         if (nrow(values) < 2) next
         centroid <- apply(values, 2, median, na.rm = TRUE)
         if (!all(is.finite(centroid))) next
-        X.sel <- cbind(X.sel, centroid)
-        metagene.names <- c(metagene.names, paste(go.sel[i], 1, sep = "_"))
+        X.sel.parts[[i]] <- centroid
+        name.parts[[i]] <- paste(go.sel[i], 1, sep = "_")
         X.loadings[[length(X.loadings) + 1]] <- setNames(rep(1, nrow(values)),
                                                          rownames(values))
-        n.ge <- c(n.ge, nrow(values))
-        n.go <- c(n.go, 1)
+        n.ge.parts[[i]] <- nrow(values)
+        n.go.parts[[i]] <- 1
       }
     }
   }
+  # cbind() of the collected centroid vectors: the column names it derives are
+  # different (the incremental form deparsed the argument to "centroid" every
+  # time) but both are overwritten by metagene.names below, and the row names
+  # come from the vectors themselves either way.
+  total.genes <- unique(unlist(genes.parts, use.names = FALSE))
+  X.sel <- do.call(cbind, X.sel.parts[!vapply(X.sel.parts, is.null, TRUE)])
+  metagene.names <- c(metagene.names, unlist(name.parts, use.names = FALSE))
+  n.ge <- c(n.ge, unlist(n.ge.parts, use.names = FALSE))
+  n.go <- c(n.go, unlist(n.go.parts, use.names = FALSE))
   if (!is.null(X.sel)) {
     colnames(X.sel) <- metagene.names
     rownames(X.sel) <- colnames(X)

--- a/PaintomicsServer/src/common/bioscripts/hubAnalysis.R
+++ b/PaintomicsServer/src/common/bioscripts/hubAnalysis.R
@@ -32,29 +32,107 @@ tryCatch(
 
 
 all_met_neigh <- list()
-for (i in 1: length(dir(args$inputDir))) {
-  if(grepl(".RData", dir(args$inputDir)[i], fixed=TRUE)){
-    load(paste0(args$inputDir,dir(args$inputDir)[i]))
+# dir() was re-evaluated three times per iteration (once for the loop bound,
+# once for the grepl, once for the load path): 1,865 iterations x a readdir of
+# 1,869 entries each time. On mmu that directory listing, not the 60 MB of
+# .RData, was where this loop spent its time -- measured 4.9 s per 1,865 dir()
+# calls on the same directory, ~9.7 s of the 10.8 s loop. The listing cannot
+# change while the loop runs, so read it once.
+files <- dir(args$inputDir)
+for (i in 1: length(files)) {
+  if(grepl(".RData", files[i], fixed=TRUE)){
+    load(paste0(args$inputDir,files[i]))
     theTablesFlat <- flatten(theTables)
+    # The per-call unwrapping the scorer below used to do
+    # (`if (class(neighbours) == "list") neighbours <- neighbours[[1]]`), hoisted
+    # here so the block encoding downstream always sees plain id vectors. On
+    # installed hubData flatten() already returns them, so this is a no-op.
+    #
+    # It unwraps to the bottom rather than one level, because the block encoding
+    # measures each radius with length() while unlist() flattens recursively: a
+    # radius still wrapped after one unwrap would advance the block's read
+    # cursor by 1 instead of by its id count and so corrupt the counts of every
+    # LATER metabolite in the same block. The old per-call form could only
+    # produce garbage for the one (metabolite, radius) pair it was handed; that
+    # containment has to survive here, and unwrapping fully is what gives it.
+    theTablesFlat <- lapply(theTablesFlat, function(v) {
+      while (is.list(v)) v <- v[[1]]
+      v
+    })
     all_met_neigh[[i]] <- theTablesFlat
     names(all_met_neigh)[i] <- names(theTables)[1]
     names(all_met_neigh[[i]]) <- paste(names(theTables)[1], 1:4, sep = "_")
   }
 }
 
-PercDEinMetaboliteNeighbours <- function (neighbours, genes, DEG) {
-  # This function calculate the number of DEG among a given metabolite gene neighbours
-  if (class(neighbours) == "list") {neighbours = neighbours[[1]]}
-  measured_neighbours <- intersect(neighbours, genes)
-  DEneigbhours <- intersect(measured_neighbours, DEG) # neighbours that are DE
-  notDEneigbhours <- setdiff(measured_neighbours, DEneigbhours) # neighbours that are notDE
-  neigh <- length (neighbours)
-  measured_neigh <- length (measured_neighbours)
-  DEN <- length(DEneigbhours)
-  noDEN <- length(notDEneigbhours)
-  percDEN <- round(DEN/(noDEN+DEN),4)
-  result <- c(KEEG_neighbours = neigh, InDataset_neighbours = measured_neigh,
-              DEN = DEN, noDEN = noDEN, percDEN = percDEN)
+PercDEinMetaboliteNeighbours <- function (all_met_neigh, genes, DEG, blockIds = 200000L) {
+  # This function calculates the number of DEG among a given metabolite gene
+  # neighbours -- for every metabolite and every neighbourhood radius at once.
+  #
+  # It used to be called once per (metabolite, radius) pair, ~7,500 times, and
+  # each call ran intersect(neighbours, genes) then intersect(., DEG).
+  # intersect() is match()-based and match() builds a fresh hash table of its
+  # `table` argument on every call, so the whole measured-genes vector (6.5k on
+  # this mmu dataset, up to 40k on a large upload) and the DEG vector were
+  # re-hashed for each pair: tens to hundreds of millions of hash insertions to
+  # produce five counts per pair.
+  #
+  # Here each block of metabolites is hashed once: every id in the block is
+  # mapped to an index into the block's own id universe (one match() for the
+  # block), and that universe's membership of genes / DEG is one match() each.
+  # Everything per radius is then integer work -- unique() over codes and
+  # logical indexing -- i.e. O(neighbours), with no table rebuild. Blocks are
+  # cut by id count rather than metabolite count so the temporary integer
+  # vectors stay bounded whatever the size of an organism's hubData (mmu:
+  # 4.0M ids across 1,865 metabolites; hsa is an order of magnitude larger).
+  #
+  # Every count is the one the set operations produced, by construction:
+  #   InDataset_neighbours = |intersect(neighbours, genes)|. intersect() returns
+  #     unique matches, and only its length is ever read, so deduplicating
+  #     before the filter (unique() of the codes) gives the same number.
+  #   DEN   = |intersect(measured, DEG)|, measured being already unique.
+  #   noDEN = |setdiff(measured, DEneighbours)| = |measured| - DEN, because
+  #     DEneighbours is a subset of an already-unique measured.
+  #   KEEG_neighbours = length(neighbours) WITH duplicates -- the one count that
+  #     is not deduplicated, and it stays that way.
+  #   percDEN = round(DEN/(noDEN+DEN), 4) = round(DEN/|measured|, 4), which is
+  #     NaN for a metabolite with no measured neighbour exactly as 0/0 was.
+  statNames <- c("KEEG_neighbours", "InDataset_neighbours", "DEN", "noDEN", "percDEN")
+  nMet <- length(all_met_neigh)
+  result <- vector("list", nMet)
+  first <- 1L
+  while (first <= nMet) {
+    last <- first; held <- 0L
+    repeat {
+      held <- held + sum(lengths(all_met_neigh[[last]]))
+      if (last >= nMet || held >= blockIds) break
+      last <- last + 1L
+    }
+    block <- all_met_neigh[first:last]
+    blockIdVector <- unlist(block, use.names = FALSE)
+    universe <- unique(blockIdVector)
+    inGenes <- match(universe, genes, 0L) > 0L
+    inDEG <- match(universe, DEG, 0L) > 0L
+    codes <- match(blockIdVector, universe)
+    at <- 0L                                  # read cursor into codes
+    for (b in seq_along(block)) {
+      radii <- block[[b]]
+      counts <- vapply(seq_along(radii), function(r) {
+        neigh <- length(radii[[r]])
+        code <- unique(codes[at + seq_len(neigh)])
+        at <<- at + neigh
+        measured <- code[inGenes[code]]
+        DEN <- sum(inDEG[measured])
+        measured_neigh <- length(measured)
+        noDEN <- measured_neigh - DEN
+        c(neigh, measured_neigh, DEN, noDEN, round(DEN/(noDEN+DEN), 4))
+      }, numeric(5))
+      dimnames(counts) <- list(statNames, names(radii))
+      result[[first + b - 1L]] <- as.data.frame(counts)
+    }
+    first <- last + 1L
+  }
+  names(result) <- names(all_met_neigh)
   result
 }
 prepare_KEGG <- function (kegg_interactions, features, significant_features) {
@@ -107,12 +185,12 @@ if (length(DEm) == 0 && length(mydata$metabolites)) {
   DEm = mydata$metabolites 
 }
 
-myfunction <- function (x) {
-  as.data.frame(purrr::map(x, PercDEinMetaboliteNeighbours,
-                           genes = mydata["genes"][[1]], DEG = mydata["DEG"][[1]])) }
-
 print('STEP 3: calculating the number of DEG among a given metabolite gene neighbours...')
-all.perc <- purrr::map(all_met_neigh, myfunction)
+# One call for every metabolite x radius (the per-pair purrr::map this replaces
+# is what re-hashed genes/DEG 7,500 times); the returned list is the same list
+# of per-metabolite data.frames, one column per radius, five named rows.
+all.perc <- PercDEinMetaboliteNeighbours(all_met_neigh, genes = mydata["genes"][[1]],
+                                         DEG = mydata["DEG"][[1]])
 
 extract.per <- function (x, step) {
   value <- x[5,step]
@@ -170,22 +248,32 @@ processData = function(stepNumber) {
     return(emptyResult)
   }
   #Calculate percentile for each DEm
-  percentile <- as.vector(apply(stepNumber_DEm, 1,  function(x) ecdf(stepNumber_except_DEm$Density)(x)))
+  # The step function is built from the background densities, which do not
+  # change across DEm rows, so build it once and evaluate it on the whole
+  # column instead of rebuilding it per row inside apply().
+  backgroundEcdf <- ecdf(stepNumber_except_DEm$Density)
+  percentile <- as.vector(backgroundEcdf(stepNumber_DEm$Density))
   stepNumber_DEm$Name = rownames(stepNumber_DEm)
   stepNumber_DEm$Percentile <- percentile
   #Calculate p-value for each DEm
   stepNumber_DEm$pvalue <- NA
   stepNumber_DEm$pvalue_adjust <- NA
+  # Loop-invariant: both columns were re-subset by the full DEm row-name vector
+  # on every iteration (an O(nDEm x nMetabolites) row-name match each time) only
+  # to read element i out of the result. Same values, resolved once.
+  demRows <- rownames(stepNumber_DEm)
+  demDEN <- as.numeric(stepNumber[demRows, 2])
+  demTotal <- as.numeric(stepNumber[demRows, 3])
   for (i in 1:nrow(stepNumber_DEm)) {
-    if (as.numeric(stepNumber[rownames(stepNumber_DEm),3])[i] == 0) {
+    if (demTotal[i] == 0) {
       pvalue = 1
     } else {
-      pvalue = binom.test(as.numeric(stepNumber[rownames(stepNumber_DEm),2])[i],
-                          as.numeric(stepNumber[rownames(stepNumber_DEm),3])[i],
+      pvalue = binom.test(demDEN[i],
+                          demTotal[i],
                           p = globalSigPer,
                           alternative = 'greater')$p.value
     }
-    
+
     stepNumber_DEm$pvalue[i] <- pvalue
 
   }
@@ -217,8 +305,13 @@ final_result$DEN <- rep(NA_real_, nrow(final_result))
 final_result$noDEN <- rep(NA_real_, nrow(final_result))
 #extract DE/noDE neighbors
 if (nrow(final_result) > 0){
+  # Resolve every output row's metabolite to its position in all.perc in one
+  # match() instead of a by-name list lookup plus an as.data.frame() rebuild per
+  # row. The names come from all.perc itself (via the step data.frames' row
+  # names), so every one of them resolves.
+  percIndex <- match(final_result$Name, names(all.perc))
   for (i in seq_len(nrow(final_result))){
-    neighbors <- as.data.frame(all.perc[final_result$Name[i]])[3:4,final_result$Step[i]]
+    neighbors <- all.perc[[percIndex[i]]][3:4,final_result$Step[i]]
     DEN = neighbors[1]
     noDEN = neighbors[2]
     final_result$DEN[i] <- DEN

--- a/PaintomicsServer/src/common/bioscripts/miRNA2Target.py
+++ b/PaintomicsServer/src/common/bioscripts/miRNA2Target.py
@@ -26,6 +26,7 @@
 import getopt
 import sys
 import os.path
+import numpy as np
 import scipy.stats
 from csv import reader as csv_reader
 from collections import defaultdict
@@ -91,6 +92,38 @@ def print_usage():
     print("\nVersion 0.1 August 2016\n")
 
 
+def toFloats(values):
+    """Decimal text -> float, or the cells untouched if any of them is not a
+    number.
+
+    Called once per row while the files are read, instead of once per
+    (miRNA, target) pair inside getScore(): the same miRNA row used to be
+    re-parsed for every one of its targets (209 of them on average in the
+    STATegra example), and a gene row once for every miRNA targeting it.
+
+    The fallback is not defensive padding, it is required. The gene expression
+    file is read WITHOUT skipping its header, so `geneTable` legitimately
+    contains a row keyed '#geneID' whose cells are condition names. Converting
+    eagerly and letting that raise would abort the read before the output file
+    is even opened -- a different failure, and a different (empty) output, than
+    the one this script has always produced. Keeping the raw cells makes such a
+    row fail exactly where it failed before: inside the scoring loop, on the
+    first pair that actually uses it, under the blanket handler that keeps the
+    partial file.
+    """
+    try:
+        return [float(value) for value in values]
+    except ValueError:
+        return values
+
+
+def asFloats(values):
+    """Convert only if the caller has not already done it (see toFloats)."""
+    if values and type(values[0]) is str:
+        return [float(value) for value in values]
+    return values
+
+
 def run(referenceFile, relevantReferenceFile, dataFile, geneExpresion, corrOutputFile, method="fc"):
     miRNAtable = {}
     geneTable = {}
@@ -120,7 +153,11 @@ def run(referenceFile, relevantReferenceFile, dataFile, geneExpresion, corrOutpu
                 else:
                     dataFile_header = rawHeader[1:]      # first cell labels the ID column
 
-            miRNAtable[line[0]] = {"values" : line[1:], "targets" : list()}
+            # "values" stays as text because it is written back out verbatim on
+            # every result row; "floats" is the same row parsed once, for the
+            # correlation.
+            miRNAtable[line[0]] = {"values" : line[1:], "targets" : list(),
+                                   "floats" : toFloats(line[1:])}
     inputDataFile.close()
 
     if dataFile_header is None:
@@ -148,7 +185,8 @@ def run(referenceFile, relevantReferenceFile, dataFile, geneExpresion, corrOutpu
             print("STEP 3. Processing mRNA expression file...")
             with open(geneExpresion, 'r') as inputDataFile:
                 for line in csv_reader(inputDataFile, delimiter="\t"):
-                    geneTable[line[0]] = line[1:]
+                    # Only ever read by getScore, so it can be stored parsed.
+                    geneTable[line[0]] = toFloats(line[1:])
             inputDataFile.close()
         else:
             print("STEP 3. No mRNA expression file was provided...")
@@ -166,17 +204,34 @@ def run(referenceFile, relevantReferenceFile, dataFile, geneExpresion, corrOutpu
                 print("Processed " + str(current*100/total) + "% of " + str(total) + " total miRNAs")
 
             miRNA_values = miRNAtable[miRNA_id]["values"]
+            miRNA_floats = miRNAtable[miRNA_id]["floats"]
             miRNA_targets = miRNAtable[miRNA_id]["targets"]
 
-            for target_id in miRNA_targets:
-                if useCorrelation:
-                    target_values = geneTable.get(target_id, None)
+            # Both are the same for every target of this miRNA, so they are
+            # built once here rather than once per pair.
+            rowPrefix = miRNA_id + "\t"
+            rowSuffix = "\t" + "\t".join(miRNA_values) + "\n"
 
-                    if method == "fc" or target_values is not None:
-                        score = getScore(miRNA_values, target_values, method)
-                        outputFile.write(miRNA_id + "\t" + target_id + "\t" + str(score) + "\t" + method + "\t" + "\t".join(miRNA_values) + "\n")
-                else:
-                    outputFile.write(miRNA_id + "\t" + target_id + "\t" + str(0) + "\t" + "Association" + "\t" + "\t".join(miRNA_values) + "\n")
+            # One writelines() per miRNA instead of one write() per pair. The
+            # rows are appended in the order they were produced, so the file is
+            # byte for byte the one the per-pair writes produced. The finally
+            # matters for the one case where that is not obvious: if a pair
+            # raises, the handler below keeps whatever is in the file, so the
+            # rows this miRNA already produced have to reach it -- otherwise a
+            # failing run would truncate at a different place than it used to.
+            rows = []
+            try:
+                for target_id in miRNA_targets:
+                    if useCorrelation:
+                        target_values = geneTable.get(target_id, None)
+
+                        if method == "fc" or target_values is not None:
+                            score = getScore(miRNA_floats, target_values, method)
+                            rows.append(rowPrefix + target_id + "\t" + str(score) + "\t" + method + rowSuffix)
+                    else:
+                        rows.append(rowPrefix + target_id + "\t" + str(0) + "\t" + "Association" + rowSuffix)
+            finally:
+                outputFile.writelines(rows)
     except Exception as e:
         print("Exception catched " +  str(e))
         pass
@@ -186,20 +241,88 @@ def run(referenceFile, relevantReferenceFile, dataFile, geneExpresion, corrOutpu
 
     return True
 
+
+def kendallTauB(x, y):
+    """
+    scipy.stats.kendalltau(x, y).correlation for the short numeric rows this
+    converter scores (n_conditions values per feature), bit for bit.
+
+    kendalltau spends most of its ~58 us per call on the p-value -- an exact
+    enumeration for short tie-free rows -- which the caller never reads; on
+    the shipped STATegra example that is 97,983 pairs. The concordant,
+    discordant and tied pair counts are the same integers scipy derives (its
+    dis from _kendall_dis, xtie/ytie/ntie from the dense ranks), and the
+    finish is scipy's own expression on them --
+    ``con_minus_dis / np.sqrt(tot - xtie) / np.sqrt(tot - ytie)`` clamped
+    with ``np.minimum(1., max(-1., tau))`` -- so the float, and its str()
+    that reaches the output file, are unchanged: verified against scipy over
+    120,000 random rows (ties, constants, perfect (anti)correlation, NaN,
+    lengths 1-12) and pinned by test_kendall_kernel_matches_scipy. Rows that
+    are not all numbers (a header or a text cell that toFloats() refused) go
+    to scipy itself, which compares them however it always did.
+    """
+    n = len(x)
+    if n != len(y) or n == 0:
+        return scipy.stats.kendalltau(x, y).correlation
+    for value in x:
+        if not isinstance(value, (int, float)):
+            return scipy.stats.kendalltau(x, y).correlation
+    for value in y:
+        if not isinstance(value, (int, float)):
+            return scipy.stats.kendalltau(x, y).correlation
+    for value in x:
+        if value != value:  # NaN propagates, as scipy's nan_policy does
+            return np.nan
+    for value in y:
+        if value != value:
+            return np.nan
+    tot = (n * (n - 1)) // 2
+    xtie = ytie = con = dis = 0
+    for i in range(n - 1):
+        xi = x[i]
+        yi = y[i]
+        for j in range(i + 1, n):
+            dx = xi - x[j]
+            dy = yi - y[j]
+            if dx == 0:
+                xtie += 1
+                if dy == 0:
+                    ytie += 1
+            elif dy == 0:
+                ytie += 1
+            elif (dx > 0) == (dy > 0):
+                con += 1
+            else:
+                dis += 1
+    if xtie == tot or ytie == tot:
+        return np.nan
+    con_minus_dis = con - dis
+    tau = con_minus_dis / np.sqrt(tot - xtie) / np.sqrt(tot - ytie)
+    return np.minimum(1., max(-1., tau))
+
+
 def getScore(values_1, values_2, method):
+    """The score for one (miRNA, target) pair.
+
+    Both arguments may arrive already parsed (run() does that once per row) or
+    as raw text (any other caller, and rows toFloats() refused); asFloats()
+    settles it. scipy is still the numeric authority for all three
+    correlations -- the same function, on the same values -- so the scores, and
+    therefore their str(), are unchanged.
+    """
     if method == "fc":
         #CALCULATE THE FOLD CHANGE
         import random
         return random.uniform(-1, 1)
     elif method == "spearman":
         #CALCULATE THE CORRELATION USING SPEARMAN
-        return scipy.stats.spearmanr([float(i) for i in values_1], [float(i) for i in values_2]).correlation
+        return scipy.stats.spearmanr(asFloats(values_1), asFloats(values_2)).correlation
     elif method == "kendall":
-        #CALCULATE THE CORRELATION USING KENDALL
-        return scipy.stats.kendalltau([float(i) for i in values_1], [float(i) for i in values_2]).correlation
+        #CALCULATE THE CORRELATION USING KENDALL (same value as scipy, see kendallTauB)
+        return kendallTauB(asFloats(values_1), asFloats(values_2))
     elif method == "pearson":
         #CALCULATE THE CORRELATION USING PEARSON
-        return scipy.stats.pearsonr([float(i) for i in values_1], [float(i) for i in values_2])[0]
+        return scipy.stats.pearsonr(asFloats(values_1), asFloats(values_2))[0]
 
 if __name__ == "__main__":
     main()

--- a/PaintomicsServer/src/paintomicsserver.py
+++ b/PaintomicsServer/src/paintomicsserver.py
@@ -107,6 +107,7 @@ class Application(object):
         KeggInformationManager(KEGG_DATA_DIR) #INITIALIZE THE SINGLETON
         JobInformationManager()#INITIALIZE THE SINGLETON
 
+        self.ensureIndexes()      #CREATE THE jobID INDEXES IF MISSING (IDEMPOTENT)
         self.startScheludeTasks() #CLEAN DATA EVERY N HOURS
 
         self.queue = Queue()
@@ -812,6 +813,38 @@ class Application(object):
         configureLogging(self.ROOT_DIRECTORY + 'conf/logging.cfg')
 
         #self.app.config['MAX_CONTENT_LENGTH'] = SERVER_MAX_CONTENT_LENGTH * pow(1024, 2)
+
+    def ensureIndexes(self):
+        # Idempotent and near-free when the indexes exist. Until now they were
+        # created only by the 24h cron, so a fresh deployment scanned
+        # collections for its first day -- and aiInterpretationCollection,
+        # which the AI status poll hits every few seconds, was never in that
+        # list.
+        #
+        # On a daemon thread, NOT the boot path. Boot did no MongoDB I/O at all
+        # before this call existed, and the two cases where it is slow are
+        # exactly the cases where the server most needs to come up: an
+        # unreachable mongod costs the 30 s server-selection timeout, and a
+        # deployment restored from a mongodump without indexes pays the whole
+        # build of a 2.85M-document featuresCollection index. Both used to
+        # happen on the cron's background thread; neither should hold the port
+        # closed. Daemon so it can never keep a shutting-down process alive.
+        def createIndexes():
+            from src.AdminTools.scripts.clean_databases import JOBID_INDEXES
+            from src.common.DBmanager import getSharedClient
+            from src.conf.serverconf import MONGODB_DATABASE
+            try:
+                database = getSharedClient()[MONGODB_DATABASE]
+                for collectionName, keys in JOBID_INDEXES:
+                    database[collectionName].create_index(keys)
+                logging.info("jobID indexes ensured.")
+            except Exception as ex:
+                # An unreachable database must not stop the server from
+                # serving; it did not before this call existed.
+                logging.warning("Could not ensure jobID indexes at startup: " + str(ex))
+
+        import threading
+        threading.Thread(target=createIndexes, name="ensureIndexes", daemon=True).start()
 
     def startScheludeTasks(self):
         from apscheduler.schedulers.background import BackgroundScheduler

--- a/PaintomicsServer/src/tests/test_combined_pvalue_kernels_match_scipy.py
+++ b/PaintomicsServer/src/tests/test_combined_pvalue_kernels_match_scipy.py
@@ -1,0 +1,103 @@
+"""The combined-p-value kernels are bit-identical to the scipy calls they replace.
+
+Statistics.calculateStoufferCombinedPvalue used scipy.stats.combine_pvalues
+(~145 us per call, mostly the axis/nan-policy wrapper) and
+calculateCombinedFisher used chi2.sf (~20 us); both run a few times per
+matched pathway. They now call the special functions those reduce to
+(ndtri/ndtr, chdtrc) with the same numpy operations and dtypes. This test
+pins the equality bit for bit -- not "close" -- over random cases that cover
+int, float, mixed and absent weights, extreme p-values and the exact clamps
+the callers apply (1e-300 floor, 0.9999999999 ceiling), plus the public
+functions themselves against the old formulae.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_combined_pvalue_kernels_match_scipy
+"""
+import math
+import os
+import random
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+import numpy as np
+from scipy.stats import chi2, combine_pvalues
+
+from src.common import Statistics
+
+
+def _randomCase(rng):
+    k = rng.randint(1, 8)
+    pvalues = [min(rng.random() ** rng.choice([1, 3, 10, 30, 100]), 0.9999999999)
+               for _ in range(k)]
+    if rng.random() < 0.2:
+        pvalues = [rng.choice([1e-300, 0.9999999999, 0.5, 1e-17, 1e-100])
+                   for _ in range(k)]
+    kind = rng.choice(["none", "int", "float", "mixed"])
+    if kind == "none":
+        weights = None
+    elif kind == "int":
+        weights = [rng.randint(0, 5) for _ in range(k)]
+    elif kind == "float":
+        weights = [rng.random() for _ in range(k)]
+    else:
+        weights = [rng.choice([1, 0.5, 2, 0.25]) for _ in range(k)]
+    if weights is not None and not any(weights):
+        weights[0] = 1
+    return pvalues, weights
+
+
+class StoufferKernelTest(unittest.TestCase):
+
+    def test_bit_identical_to_combine_pvalues(self):
+        rng = random.Random(20260817)
+        for _ in range(8000):
+            pvalues, weights = _randomCase(rng)
+            want = combine_pvalues(pvalues, "stouffer", weights)[1]
+            got = Statistics._stoufferPvalue(pvalues, weights)
+            self.assertEqual(repr(float(got)), repr(float(want)), (pvalues, weights))
+            self.assertIsInstance(got, np.floating)
+
+    def test_public_function_matches_the_old_formula(self):
+        rng = random.Random(4)
+        for _ in range(2000):
+            pvalues, weights = _randomCase(rng)
+            usable = [p for p in pvalues if 0 <= p <= 1]
+            curated = [min(p, 0.9999999999) for p in usable]
+            want = combine_pvalues(curated, "stouffer", weights)[1]
+            if not math.isfinite(want):
+                want = 1.0
+            got = Statistics.calculateStoufferCombinedPvalue(pvalues, weights)
+            self.assertEqual(repr(float(got)), repr(float(want)))
+
+    def test_degenerate_inputs_keep_their_old_answers(self):
+        self.assertEqual(Statistics.calculateStoufferCombinedPvalue([], None), 1.0)
+        self.assertEqual(Statistics.calculateStoufferCombinedPvalue([0.5, 0.1], [0, 0]), 1.0)
+        self.assertEqual(Statistics.calculateStoufferCombinedPvalue([-1.0, 2.0], [1, 1]), 1.0)
+
+
+class FisherKernelTest(unittest.TestCase):
+
+    def test_bit_identical_to_chi2_sf(self):
+        rng = random.Random(99)
+        for _ in range(8000):
+            pvalues, _ = _randomCase(rng)
+            if rng.random() < 0.1:
+                pvalues = pvalues + [0.0, 1.0]
+            accumulated = 0
+            for p in pvalues:
+                accumulated += math.log(max(p, 1e-300))
+            accumulated *= -2
+            want = chi2.sf(accumulated, 2 * len(pvalues))
+            got = Statistics.calculateCombinedFisher(pvalues)
+            self.assertEqual(repr(float(got)), repr(float(want)), pvalues)
+
+    def test_empty_and_unusable_lists_stay_one(self):
+        self.assertEqual(Statistics.calculateCombinedFisher([]), 1.0)
+        self.assertEqual(Statistics.calculateCombinedFisher([-1.0, float("nan")]), 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_compound_name_table_matches_mongo.py
+++ b/PaintomicsServer/src/tests/test_compound_name_table_matches_mongo.py
@@ -1,0 +1,162 @@
+"""The in-memory kegg_compounds table answers exactly like the MongoDB query.
+
+`findCompoundIDByFeatureName` used to run one case-insensitive substring
+$regex per metabolite name against the 93k-document kegg_compounds
+collection -- a full collection scan each (20-50 ms), 40 s for a 4,667-row
+file even across six workers. `_CompoundNameTable` answers the same
+`find({"name": {"$regex": ...}}).limit(n)` calls from a lower-cased
+haystack string in RAM. This test is the equivalence proof:
+
+  * against a FAKE collection with hand-picked tricky names, the table must
+    return the same documents in the same order as evaluating the regex over
+    the documents (what MongoDB does, natural order), for the substring
+    shape, the anchored exact shape, and an arbitrary pattern that takes the
+    generic fallback;
+  * against the REAL local MongoDB (skipped when it is not reachable), for
+    every distinct compound name in the bundled example files plus a set of
+    generic/metacharacter/placeholder names, the table and Mongo must agree
+    on the ordered list of (id, name) hits under the exact call sequence
+    findCompoundIDByFeatureName makes.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_compound_name_table_matches_mongo
+"""
+import glob
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from src.common import FeatureNamesToKeggIDsMapper as mapper
+
+
+TRICKY = ["Adenosine 5'-triphosphate", "NAD+", "NADH", "NADP+", "L-Leucine",
+          "Leucine", "D-Glucose", "Glucose", "Glucose 6-phosphate", "(R)-Lactate",
+          "Acid", "acid", "GlcA-β1,3-GlcNAc ", "20αH-PREDL ", "H2O", "h2o",
+          "a.b", "a*b", "[x]", "x|y", "$5", "^start", "end$", "back\\slash"]
+
+
+class _RegexCollection(object):
+    """What MongoDB does: evaluate the regex over the documents in order."""
+
+    def __init__(self, docs):
+        self.docs = docs
+
+    def find(self, query):
+        pattern = query["name"]["$regex"]
+        return mapper._CompoundNameCursor([d for d in self.docs if pattern.search(d["name"])])
+
+
+def _docs(names):
+    return [{"id": "C%05d" % i, "name": n} for i, n in enumerate(names)]
+
+
+def _lookupCalls(name):
+    """The exact patterns findCompoundIDByFeatureName issues for a name."""
+    substring = re.compile(re.escape(name), re.IGNORECASE)
+    exact = re.compile("^" + re.escape(name) + "$", re.IGNORECASE)
+    return substring, exact
+
+
+class TableAgreesWithRegexOnTrickyNamesTest(unittest.TestCase):
+
+    def setUp(self):
+        self.docs = _docs(TRICKY)
+        self.table = mapper._CompoundNameTable(self.docs)
+        self.reference = _RegexCollection(self.docs)
+
+    def _same(self, pattern, limit=None):
+        got = self.table.find({"name": {"$regex": pattern}})
+        want = self.reference.find({"name": {"$regex": pattern}})
+        if limit is not None:
+            got, want = got.limit(limit), want.limit(limit)
+        self.assertEqual(list(got), list(want), pattern.pattern)
+
+    def test_substring_and_exact_shapes_for_every_tricky_name(self):
+        for name in TRICKY + ["glucose", "acid", "a", "-", "leu", "GLC", "β1"]:
+            substring, exact = _lookupCalls(name)
+            self._same(substring)
+            self._same(exact)
+            self._same(substring, limit=3)
+
+    def test_the_fast_path_is_taken_for_escaped_literals(self):
+        substring, exact = _lookupCalls("(R)-Lactate")
+        self.assertEqual(self.table._literalOf(substring), ("(R)-Lactate", False))
+        self.assertEqual(self.table._literalOf(exact), ("(R)-Lactate", True))
+
+    def test_an_arbitrary_pattern_takes_the_generic_path_and_still_agrees(self):
+        for pattern in (re.compile(r"glu.*ose", re.IGNORECASE), re.compile(r"NAD[HP]")):
+            self.assertIsNone(self.table._literalOf(pattern)[0])
+            self._same(pattern)
+        # Escaped literals without IGNORECASE also take the generic path.
+        for pattern in (re.compile(r"^H2O$"), re.compile(r"acid", 0)):
+            self._same(pattern)
+
+    def test_findCompoundIDByFeatureName_gives_the_same_answer_through_the_table(self):
+        for name in TRICKY + ["glucose", "-", "acid"]:
+            viaTable = mapper.findCompoundIDByFeatureName("job", name, self.table)
+            viaRegex = mapper.findCompoundIDByFeatureName("job", name, type("DB", (), {"kegg_compounds": self.reference})())
+            self.assertEqual(viaTable, viaRegex, name)
+
+    def test_a_name_with_a_newline_disables_the_fast_path_safely(self):
+        table = mapper._CompoundNameTable(_docs(["ab\ncd", "abcd", "xx"]))
+        self.assertFalse(table._fastPathOK)
+        substring, _ = _lookupCalls("abcd")
+        self.assertEqual([d["name"] for d in table.find({"name": {"$regex": substring}})], ["abcd"])
+
+
+def _mongoAvailable():
+    try:
+        from pymongo import MongoClient
+        from src.conf.serverconf import MONGODB_HOST, MONGODB_PORT
+        client = MongoClient(MONGODB_HOST, MONGODB_PORT, serverSelectionTimeoutMS=1500)
+        return client["global-paintomics"].kegg_compounds.estimated_document_count() > 0
+    except Exception:
+        return False
+
+
+@unittest.skipUnless(_mongoAvailable(), "MongoDB with global-paintomics not reachable")
+class TableAgreesWithRealMongoTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        from pymongo import MongoClient
+        from src.conf.serverconf import MONGODB_HOST, MONGODB_PORT
+        cls.db = MongoClient(MONGODB_HOST, MONGODB_PORT)["global-paintomics"]
+        cls.table = mapper.getCompoundNameTable(cls.db)
+
+    def _exampleNames(self):
+        root = os.path.join(os.path.dirname(__file__), "..", "examplefiles", "datasets")
+        names = set()
+        for path in glob.glob(os.path.join(root, "*", "data", "metabolomics_values.tab")):
+            with open(path) as handle:
+                for line in handle:
+                    if line.startswith("#"):
+                        continue
+                    first = line.rstrip("\n").split("\t")[0]
+                    if first:
+                        names.add(first)
+        return sorted(names)
+
+    def test_every_example_and_probe_name_gets_the_same_hits(self):
+        probes = ["glucose", "acid", "a", "-", "?", "NAD+", "(R)-Lactate", "L-Leucine",
+                  "Leucine", "citrate", "Citric acid", "ATP", "H2O", "GlcA-β1,3-GlcNAc",
+                  "PREDL", "hydroxy", "N/A", "C00001", "c00002"]
+        names = self._exampleNames() + probes
+        self.assertGreater(len(names), 100)
+        checked = 0
+        for name in names:
+            got, gotFound = mapper.findCompoundIDByFeatureName("job", name, self.table)
+            want, wantFound = mapper.findCompoundIDByFeatureName("job", name, self.db)
+            self.assertEqual(gotFound, wantFound, name)
+            self.assertEqual([(d.get("id"), d.get("name")) for d in got],
+                             [(d.get("id"), d.get("name")) for d in want], name)
+            checked += 1
+        self.assertEqual(checked, len(names))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_dao_connection_cleanup.py
+++ b/PaintomicsServer/src/tests/test_dao_connection_cleanup.py
@@ -3,11 +3,24 @@
 
 Why this exists
 ---------------
-`DBmanager.openConnection` builds a **new `MongoClient` per DAO**, and PyMongo
-runs topology-monitor threads for each one. Measured on this machine: ten
-managers left unclosed take the process from 1 thread to 26, and closing them
-returns it to 1. A leaked DAO is therefore ~2.5 leaked threads plus its sockets,
-not merely an idle object waiting for the collector.
+It began as a thread leak. `DBmanager.openConnection` used to build a **new
+`MongoClient` per DAO**, each with its own PyMongo topology-monitor threads:
+measured on this machine, ten managers left unclosed took the process from 1
+thread to 26, and closing them returned it to 1. A leaked DAO was ~2.5 leaked
+threads plus its sockets.
+
+**That cost is gone.** `DBmanager` now hands out one process-wide client keyed
+on `(host, port, pid)`, `closeConnection` is a reference drop, and
+`getCollection` looks the client up on every call -- so an unclosed manager
+costs nothing at all. `SharedClientCostTest` below measures exactly that, and
+it is what the old `LeakCostTest` was replaced with: a test that asserted
+leaking still costs threads would now be asserting the bug this change removed.
+
+The finally rule above survives the reason it was written for. What it enforces
+now is that a DAO does not outlive the request that made it: a manager kept
+past its handler is the one way a stale client reference can still be carried
+across a `fork()` (the mapper and enrichment workers are forked children), and
+"close it in a finally" is the shape the codebase settled on for that.
 
 Several handlers closed theirs on the success path only:
 
@@ -36,6 +49,8 @@ import sys
 import unittest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from src.common import DBmanager as DBmanagerModule
 
 _SRC = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -98,52 +113,76 @@ class ConnectionCleanupTest(unittest.TestCase):
             + "\n  ".join(offending))
 
 
-class LeakCostTest(unittest.TestCase):
-    """The measurement behind the rule, so it is not taken on faith."""
+class SharedClientCostTest(unittest.TestCase):
+    """The measurement behind the rule, re-taken after the shared client.
 
-    def test_an_unclosed_manager_costs_threads(self):
-        import threading
-        from src.common.DBmanager import DBmanager
+    Replaces the old LeakCostTest, which asserted that unclosed managers cost
+    threads. They no longer do, and the old test only stayed green by running
+    before anything else had opened the process client -- so it would have gone
+    red the moment another Mongo-touching test sorted ahead of it, on a change
+    that is behaving perfectly.
+    """
 
+    def _warmedManager(self):
+        """A manager whose query has already built the process client."""
         try:
-            baseline = threading.active_count()
-            managers = []
-            for _ in range(5):
-                manager = DBmanager()
-                manager.getCollection("userCollection")
-                managers.append(manager)
-            leaked = threading.active_count()
+            manager = DBmanagerModule.DBmanager()
+            manager.getCollection("userCollection").find_one({})
+            return manager
         except Exception as exc:
             raise unittest.SkipTest("no reachable mongod: %s" % exc)
 
-        try:
-            self.assertGreater(
-                leaked, baseline,
-                "leaking DAO connections no longer costs threads; if PyMongo "
-                "changed, the finally rule above may be over-strict")
-        finally:
-            for manager in managers:
-                manager.closeConnection()
+    def test_unclosed_managers_cost_no_threads(self):
+        import threading
 
-    def test_closing_returns_the_threads(self):
+        self._warmedManager()          # the client (and its monitor) now exists
+
+        baseline = threading.active_count()
+        managers = []
+        for _ in range(10):
+            manager = DBmanagerModule.DBmanager()
+            manager.getCollection("userCollection").find_one({})
+            managers.append(manager)   # deliberately never closed
+
+        self.assertEqual(
+            threading.active_count(), baseline,
+            "ten unclosed DBmanagers cost threads again. They are supposed to "
+            "share one process-wide MongoClient; if each is building its own, "
+            "the connection-per-DAO regression is back")
+
+        self.assertEqual(
+            len({id(manager.getConnection()) for manager in managers}), 1,
+            "the managers did not all get the same client object")
+
+    def test_closing_does_not_disturb_the_process_client(self):
         import threading
         import time
-        from src.common.DBmanager import DBmanager
 
-        try:
-            baseline = threading.active_count()
-            managers = [DBmanager() for _ in range(5)]
-            for manager in managers:
-                manager.getCollection("userCollection")
-        except Exception as exc:
-            raise unittest.SkipTest("no reachable mongod: %s" % exc)
+        manager = self._warmedManager()
+        client = manager.getConnection()
 
-        for manager in managers:
-            manager.closeConnection()
-        time.sleep(1)
+        others = []
+        for _ in range(10):
+            other = DBmanagerModule.DBmanager()
+            other.getCollection("userCollection").find_one({})
+            others.append(other)
 
-        self.assertLessEqual(threading.active_count(), baseline + 2,
-                             "closing did not return the monitor threads")
+        baseline = threading.active_count()
+        for other in others:
+            other.closeConnection()
+        time.sleep(0.5)
+
+        self.assertEqual(threading.active_count(), baseline,
+                         "closeConnection tore something down; it is supposed "
+                         "to be a reference drop on a shared client")
+        self.assertIsNone(others[0].getConnection(),
+                          "closeConnection must still clear this manager's reference")
+
+        # the client is untouched and still serves the next caller
+        after = DBmanagerModule.DBmanager()
+        after.getCollection("userCollection").find_one({})
+        self.assertIs(after.getConnection(), client,
+                      "a closed manager took the process client with it")
 
 
 def main():

--- a/PaintomicsServer/src/tests/test_dao_layer_speedups.py
+++ b/PaintomicsServer/src/tests/test_dao_layer_speedups.py
@@ -1,0 +1,711 @@
+#!/usr/bin/env python3
+"""The MongoDB access layer changes: one shared client, one insert_many, one
+features query, one adaptBSON fast path.
+
+Every one of them is a pure performance change, so every test here is an
+*equivalence* test: the reference behaviour is spelled out in full (the HEAD
+implementation of adaptBSON is inlined below, the two-query feature load is
+replayed by hand) and the new code has to reproduce it exactly -- same
+documents, same order, same python types.
+
+Usage:
+    cd PaintomicsServer
+    PYTHONPATH=. python -m src.tests.test_dao_layer_speedups
+"""
+import ast
+import datetime
+import multiprocessing
+import os
+import sys
+import threading
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from bson.objectid import ObjectId
+from bson.int64 import Int64
+
+from src.common import DBmanager as DBmanagerModule
+from src.common.DBmanager import DBmanager, SharedClientHandle, getSharedClient
+from src.common.DAO.DAO import DAO
+from src.common.DAO.PathwayDAO import PathwayDAO
+from src.common.DAO.PathwayAcquisitionJobDAO import PathwayAcquisitionJobDAO
+from src.common.Util import adapt_string
+from src.classes.Pathway import Pathway
+
+
+# ---------------------------------------------------------------------------
+# The reference implementation: DAO.adaptBSON exactly as it stood before the
+# fast path. Every assertion below compares against this, not against a
+# hand-written expectation, so "identical" means identical to what shipped.
+# ---------------------------------------------------------------------------
+def referenceAdaptBSON(object):
+    if isinstance(object, dict):
+        newDict = {}
+        for (key, value) in object.items():
+            newDict[str(key)] = referenceAdaptBSON(value)
+        return newDict
+    elif isinstance(object, list):
+        newList = []
+        for value in object:
+            newList.append(referenceAdaptBSON(value))
+        return newList
+    elif isinstance(object, bool):
+        return bool(object)
+    elif isinstance(object, int):
+        return int(object)
+    elif isinstance(object, float):
+        return float(object)
+    else:
+        return adapt_string(object)
+
+
+def strictEqual(a, b, path="$"):
+    """Deep compare that also fails on a changed python type or key order."""
+    if a.__class__ is not b.__class__:
+        return "%s: type %s != %s" % (path, a.__class__.__name__, b.__class__.__name__)
+    if isinstance(a, dict):
+        if list(a.keys()) != list(b.keys()):
+            return "%s: keys %r != %r" % (path, list(a.keys()), list(b.keys()))
+        for key in a:
+            bad = strictEqual(a[key], b[key], "%s.%s" % (path, key))
+            if bad:
+                return bad
+        return None
+    if isinstance(a, list):
+        if len(a) != len(b):
+            return "%s: length %d != %d" % (path, len(a), len(b))
+        for i, (x, y) in enumerate(zip(a, b)):
+            bad = strictEqual(x, y, "%s[%d]" % (path, i))
+            if bad:
+                return bad
+        return None
+    if a != b:
+        return "%s: %r != %r" % (path, a, b)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+class FakeCollection(object):
+    """Records what a DAO asked the database to do."""
+
+    def __init__(self, documents=None):
+        self.documents = list(documents or [])
+        self.insertManyCalls = []
+        self.insertOneCalls = []
+        self.findCalls = []
+
+    def insert_many(self, documents, ordered=True):
+        self.insertManyCalls.append((list(documents), ordered))
+        self.documents.extend(documents)
+        return None
+
+    def insert_one(self, document):
+        self.insertOneCalls.append(document)
+        self.documents.append(document)
+        return None
+
+    def find(self, query=None, *args, **kwargs):
+        self.findCalls.append(dict(query or {}))
+        matched = []
+        for document in self.documents:
+            if all(document.get(key) == value for key, value in (query or {}).items()):
+                matched.append(dict(document))
+        return iter(matched)
+
+    def find_one(self, query=None, *args, **kwargs):
+        for document in self.find(query):
+            return document
+        return None
+
+    def delete_many(self, query=None):
+        return None
+
+
+class FakeDBmanager(object):
+    def __init__(self, collections):
+        self.collections = collections
+
+    def getCollection(self, collectionName):
+        return self.collections.setdefault(collectionName, FakeCollection())
+
+    def closeConnection(self):
+        return None
+
+
+def _childTakesTheSharedClient(queue):
+    """Run in a forked child: ask for a client and report back."""
+    try:
+        DBmanagerModule.getSharedClient("localhost", 27017)
+        queue.put("ok")
+    except BaseException as exc:                       # noqa: BLE001 - reported, not swallowed
+        queue.put("error: %r" % (exc,))
+
+
+# ---------------------------------------------------------------------------
+# E24 -- one shared, fork-aware client
+# ---------------------------------------------------------------------------
+class SharedClientTest(unittest.TestCase):
+
+    def setUp(self):
+        self.savedClients = dict(DBmanagerModule._sharedClients)
+        self.savedInherited = list(DBmanagerModule._inheritedClients)
+        self.realPid = os.getpid()
+
+    def tearDown(self):
+        DBmanagerModule._sharedClients.clear()
+        DBmanagerModule._sharedClients.update(self.savedClients)
+        DBmanagerModule._inheritedClients[:] = self.savedInherited
+
+    def _fakeClientFactory(self):
+        built = []
+
+        class FakeDatabase(object):
+            def __init__(self, client, name):
+                self.client = client
+                self.name = name
+
+            def __getitem__(self, collectionName):
+                return ("collection", self.name, collectionName)
+
+        class FakeClient(object):
+            def __init__(self, host, port):
+                self.host = host
+                self.port = port
+                self.closed = False
+                built.append(self)
+
+            def close(self):
+                self.closed = True
+
+            def __getitem__(self, name):
+                return FakeDatabase(self, name)
+
+        return FakeClient, built
+
+    def test_one_client_per_process(self):
+        FakeClient, built = self._fakeClientFactory()
+        DBmanagerModule._sharedClients.clear()
+        realMongoClient = DBmanagerModule.MongoClient
+        DBmanagerModule.MongoClient = FakeClient
+        try:
+            first = getSharedClient("h", 1)
+            for _ in range(50):
+                self.assertIs(getSharedClient("h", 1), first)
+            self.assertEqual(len(built), 1,
+                             "a second MongoClient was built for the same (host, port, pid)")
+        finally:
+            DBmanagerModule.MongoClient = realMongoClient
+
+    def test_a_different_pid_gets_a_different_client(self):
+        """The fork rule, simulated: os.getpid moves, the client must not."""
+        FakeClient, built = self._fakeClientFactory()
+        DBmanagerModule._sharedClients.clear()
+        realMongoClient = DBmanagerModule.MongoClient
+        DBmanagerModule.MongoClient = FakeClient
+        try:
+            parent = getSharedClient("h", 1)
+            with mock.patch("os.getpid", return_value=self.realPid + 1):  # "the child"
+                child = getSharedClient("h", 1)
+
+                self.assertIsNot(child, parent,
+                                 "a forked child reused the parent's MongoClient")
+                self.assertEqual(len(built), 2)
+                self.assertEqual([key[2] for key in DBmanagerModule._sharedClients],
+                                 [self.realPid + 1],
+                                 "the parent's entry must be dropped in the child, "
+                                 "and only the child's key may remain")
+            self.assertFalse(parent.closed,
+                             "the inherited client must never be closed in the child: "
+                             "that runs pymongo's teardown over a topology the parent owns")
+            self.assertIn(parent, DBmanagerModule._inheritedClients,
+                          "the inherited client must be parked, not released: nothing "
+                          "in the child should ever hand pymongo's finalisers an object "
+                          "whose state belongs to another process")
+        finally:
+            DBmanagerModule.MongoClient = realMongoClient
+
+    def test_get_collection_consults_the_pid_on_every_call(self):
+        """A manager alive across a fork must not keep using the parent's client."""
+        FakeClient, built = self._fakeClientFactory()
+        DBmanagerModule._sharedClients.clear()
+        realMongoClient = DBmanagerModule.MongoClient
+        DBmanagerModule.MongoClient = FakeClient
+        try:
+            manager = DBmanager()
+            manager.getCollection("userCollection")
+            parent = manager.getConnection()
+
+            with mock.patch("os.getpid", return_value=self.realPid + 1):
+                manager.getCollection("userCollection")     # same manager, "new process"
+                self.assertIsNot(
+                    manager.getConnection(), parent,
+                    "getCollection served the child out of a cached parent client; "
+                    "the pid key is only a guard if it is consulted every time")
+            self.assertEqual(len(built), 2)
+        finally:
+            DBmanagerModule.MongoClient = realMongoClient
+
+    def test_the_fork_hook_resets_the_lock_and_the_cache(self):
+        """The state a child must not inherit: a held lock and a stale cache."""
+        FakeClient, _ = self._fakeClientFactory()
+        DBmanagerModule._sharedClients.clear()
+        DBmanagerModule._inheritedClients[:] = []
+        realMongoClient = DBmanagerModule.MongoClient
+        DBmanagerModule.MongoClient = FakeClient
+        savedLock = DBmanagerModule._sharedClientsLock
+        try:
+            parent = getSharedClient("h", 1)
+            DBmanagerModule._sharedClientsLock.acquire()    # as if forked mid-critical-section
+
+            DBmanagerModule._resetSharedClientStateInForkChild()
+
+            self.assertIsNot(DBmanagerModule._sharedClientsLock, savedLock,
+                             "the child kept the parent's lock object")
+            self.assertTrue(DBmanagerModule._sharedClientsLock.acquire(blocking=False),
+                            "the child's lock is still held by a thread that does not exist")
+            DBmanagerModule._sharedClientsLock.release()
+            self.assertEqual(DBmanagerModule._sharedClients, {})
+            self.assertIn(parent, DBmanagerModule._inheritedClients)
+        finally:
+            if savedLock.locked():
+                savedLock.release()
+            DBmanagerModule._sharedClientsLock = savedLock
+            DBmanagerModule.MongoClient = realMongoClient
+
+    def test_a_child_forked_while_the_lock_is_held_does_not_deadlock(self):
+        """The real thing: fork with the lock held, child must still connect.
+
+        _matchPathways runs in a forked worker and reaches getSharedClient
+        through KeggInformationManager.loadOrganismData, so a lock inherited in
+        the locked state would hang a real job. Needs no mongod: constructing a
+        MongoClient does not connect.
+        """
+        if not hasattr(os, "register_at_fork"):
+            raise unittest.SkipTest("no os.register_at_fork on this platform")
+
+        context = multiprocessing.get_context("fork")
+        queue = context.Queue()
+        process = None
+        DBmanagerModule._sharedClientsLock.acquire()
+        try:
+            process = context.Process(target=_childTakesTheSharedClient, args=(queue,))
+            process.start()
+            try:
+                result = queue.get(timeout=20)
+            except Exception:
+                result = "TIMED OUT -- the child inherited the lock held"
+        finally:
+            DBmanagerModule._sharedClientsLock.release()
+            if process is not None:
+                process.join(10)
+                if process.is_alive():
+                    process.terminate()
+                    process.join(5)
+
+        self.assertEqual(result, "ok", "forked child did not get a client: %s" % result)
+
+    def test_close_connection_does_not_close_the_shared_client(self):
+        FakeClient, built = self._fakeClientFactory()
+        DBmanagerModule._sharedClients.clear()
+        realMongoClient = DBmanagerModule.MongoClient
+        DBmanagerModule.MongoClient = FakeClient
+        try:
+            manager = DBmanager()
+            manager.openConnection()
+            client = manager.getConnection()
+            manager.closeConnection()
+
+            self.assertFalse(client.closed,
+                             "closeConnection tore down the process-wide client")
+            self.assertIsNone(manager.getConnection(),
+                              "closeConnection must still drop this manager's reference")
+            manager.openConnection()
+            self.assertIs(manager.getConnection(), client,
+                          "reopening must hand back the same shared client")
+            self.assertEqual(len(built), 1)
+        finally:
+            DBmanagerModule.MongoClient = realMongoClient
+
+    def test_shared_client_handle_forwards_everything_but_close(self):
+        class FakeClient(object):
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+            def __getitem__(self, name):
+                return "database:" + name
+
+            def someMethod(self):
+                return "forwarded"
+
+        client = FakeClient()
+        handle = SharedClientHandle(client)
+        handle.close()
+        self.assertFalse(client.closed, "the handle closed the shared client")
+        self.assertEqual(handle["mmu-paintomics"], "database:mmu-paintomics")
+        self.assertEqual(handle.someMethod(), "forwarded")
+
+    def test_a_real_shared_client_is_reused_and_flat_in_threads(self):
+        try:
+            manager = DBmanager()
+            manager.getCollection("userCollection").find_one({})
+        except Exception as exc:
+            raise unittest.SkipTest("no reachable mongod: %s" % exc)
+
+        before = threading.active_count()
+        managers = []
+        for _ in range(30):
+            other = DBmanager()
+            other.getCollection("userCollection").find_one({})
+            managers.append(other)
+        self.assertLessEqual(
+            threading.active_count(), before + 1,
+            "30 DAOs still cost threads; they are supposed to share one client")
+        for other in managers:
+            other.closeConnection()
+
+
+# ---------------------------------------------------------------------------
+# E25 -- adaptBSON fast path
+# ---------------------------------------------------------------------------
+class AdaptBSONTest(unittest.TestCase):
+
+    def setUp(self):
+        self.dao = DAO()
+
+    def _assertMatchesReference(self, document):
+        expected = referenceAdaptBSON(document)
+        actual = self.dao.adaptBSON(document)
+        bad = strictEqual(expected, actual)
+        self.assertIsNone(bad, "fast path diverged from the shipped behaviour: %s" % bad)
+        return actual
+
+    def test_scalars(self):
+        for value in ["", "text", "0", 0, 1, -7, 2 ** 70, 0.0, 1.5, float("inf"),
+                      True, False]:
+            self._assertMatchesReference(value)
+
+    def test_none_still_becomes_the_string_none(self):
+        """193k leaves in foundFeaturesCollection depend on this."""
+        self.assertEqual(self.dao.adaptBSON(None), "None")
+        self.assertEqual(self.dao.adaptBSON({"a": None, "b": [None]}),
+                         {"a": "None", "b": ["None"]})
+        self._assertMatchesReference({"a": None, "b": [None, {"c": None}]})
+
+    def test_objectid_still_becomes_its_hex_string(self):
+        oid = ObjectId("69a7073bc5345423de5026f6")
+        self.assertEqual(self.dao.adaptBSON(oid), "69a7073bc5345423de5026f6")
+        document = {"_id": oid, "jobID": "BMDAO"}
+        self._assertMatchesReference(document)
+        self.assertEqual(self.dao.adaptBSON(document)["_id"], str(oid))
+
+    def test_bson_int64_and_other_int_subclasses_are_not_short_circuited(self):
+        """Int64 is an int subclass; the old code turned it into a plain int."""
+        document = {"big": Int64(9007199254740993), "small": 3}
+        actual = self._assertMatchesReference(document)
+        self.assertIs(type(actual["big"]), int)
+        self.assertIsNot(type(actual["big"]), Int64)
+
+    def test_exotic_leaves_keep_going_through_adapt_string(self):
+        for value in [b"bytes", datetime.datetime(2026, 8, 17, 12, 0, 0),
+                      (1, 2), {1, 2}, object]:
+            self._assertMatchesReference({"leaf": value})
+
+    def test_non_string_keys_are_still_stringified(self):
+        self._assertMatchesReference({1: "one", None: "none", 2.5: "float"})
+
+    def test_str_and_bool_subclasses_take_the_slow_path(self):
+        class MyStr(str):
+            pass
+
+        class MyInt(int):
+            pass
+
+        self._assertMatchesReference({"a": MyStr("x"), "b": MyInt(4)})
+        self.assertIs(type(self.dao.adaptBSON(MyStr("x"))), str)
+        self.assertIs(type(self.dao.adaptBSON(MyInt(4))), int)
+
+    def test_nested_documents_of_the_shape_this_database_stores(self):
+        document = {
+            "_id": ObjectId(),
+            "jobID": "BMDAO1",
+            "ID": "mmu:12345",
+            "featureType": "Gene",
+            "name": "Gene name",
+            "omicsValues": [
+                {"omicName": "Gene expression", "inputName": "probe1",
+                 "originalName": None, "relevant": [True, False],
+                 "values": [1.5, -2.0, 0.0], "isRelevant": True},
+                {"omicName": "Proteomics", "inputName": "p1",
+                 "originalName": "P1", "relevant": [False],
+                 "values": [3], "isRelevant": False},
+            ],
+            "matchingDB": {"KEGG": ["mmu:12345"], "Reactome": []},
+        }
+        self._assertMatchesReference(document)
+
+    def test_the_result_is_a_fresh_container(self):
+        """Callers get a copy today; they must keep getting one."""
+        document = {"a": {"b": [1, 2]}}
+        adapted = self.dao.adaptBSON(document)
+        self.assertIsNot(adapted, document)
+        self.assertIsNot(adapted["a"], document["a"])
+        self.assertIsNot(adapted["a"]["b"], document["a"]["b"])
+
+    def test_deeply_nested(self):
+        document = {"level0": {}}
+        node = document["level0"]
+        for depth in range(1, 12):
+            node["level%d" % depth] = {"leaf": None, "list": [depth, str(depth)]}
+            node = node["level%d" % depth]
+        self._assertMatchesReference(document)
+
+
+# ---------------------------------------------------------------------------
+# E10 -- PathwayDAO.insertAll
+# ---------------------------------------------------------------------------
+def buildPathway(index):
+    pathway = Pathway("bmd%03d" % index)
+    pathway.setName("Pathway %d" % index)
+    pathway.setClassification("Class %d" % (index % 3))
+    pathway.setSource("KEGG" if index % 2 else "Reactome")
+    pathway.matchedGenes = ["g%d" % index]
+    pathway.significanceValues = {"omic": [[10, index, 0.5]]}
+    return pathway
+
+
+class PathwayInsertAllTest(unittest.TestCase):
+
+    def test_one_insert_many_with_the_same_documents_in_the_same_order(self):
+        pathways = [buildPathway(i) for i in range(25)]
+
+        # what the old loop wrote: insert() per pathway
+        expected = []
+        for pathway in pathways:
+            document = pathway.toBSON()
+            document["jobID"] = "BMDAO_unit"
+            expected.append(document)
+
+        collections = {}
+        dao = PathwayDAO(dbManager=FakeDBmanager(collections))
+        self.assertTrue(dao.insertAll(pathways, {"jobID": "BMDAO_unit"}))
+
+        collection = collections["pathwaysCollection"]
+        self.assertEqual(len(collection.insertManyCalls), 1,
+                         "insertAll must issue exactly one insert_many")
+        self.assertEqual(collection.insertOneCalls, [],
+                         "insertAll must not fall back to insert_one")
+
+        documents, ordered = collection.insertManyCalls[0]
+        self.assertTrue(ordered, "insert_many must stay ordered=True")
+        self.assertIsNone(strictEqual(expected, documents))
+        self.assertEqual([d["ID"] for d in documents], ["bmd%03d" % i for i in range(25)])
+
+    def test_an_empty_list_writes_nothing(self):
+        collections = {}
+        dao = PathwayDAO(dbManager=FakeDBmanager(collections))
+        self.assertTrue(dao.insertAll([], {"jobID": "BMDAO_unit"}))
+        self.assertEqual(collections, {},
+                         "an empty insertAll issued a database call")
+
+    def test_an_empty_list_does_not_need_a_jobID(self):
+        """The old loop never read otherParams for an empty list."""
+        collections = {}
+        dao = PathwayDAO(dbManager=FakeDBmanager(collections))
+        self.assertTrue(dao.insertAll([], None))
+        self.assertTrue(dao.insertAll([], {}))
+        self.assertEqual(collections, {},
+                         "an empty insertAll must not even reach for a collection")
+
+    def test_a_generator_of_values_is_accepted(self):
+        """The callers pass dict .values(), not a list."""
+        pathways = {p.getID(): p for p in [buildPathway(i) for i in range(5)]}
+        collections = {}
+        dao = PathwayDAO(dbManager=FakeDBmanager(collections))
+        dao.insertAll(pathways.values(), {"jobID": "BMDAO_unit"})
+        documents, _ = collections["pathwaysCollection"].insertManyCalls[0]
+        self.assertEqual([d["ID"] for d in documents], list(pathways.keys()))
+
+    def test_the_graphical_data_branch_is_untouched(self):
+        pathways = [buildPathway(i) for i in range(4)]
+        for pathway in pathways:
+            pathway.graphicalOptions = None
+
+        collections = {}
+        dao = PathwayDAO(dbManager=FakeDBmanager(collections))
+
+        recorded = []
+
+        class RecordingGraphicalDataDAO(object):
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def insert(self, instance, otherParams=None):
+                recorded.append(otherParams.get("pathwayID"))
+
+        import src.common.DAO.PathwayDAO as pathwayDAOModule
+        realDAO = pathwayDAOModule.GraphicalDataDAO
+        pathwayDAOModule.GraphicalDataDAO = RecordingGraphicalDataDAO
+        try:
+            dao.insertAll(pathways, {"jobID": "BMDAO_unit", "saveGraphicalData": True})
+        finally:
+            pathwayDAOModule.GraphicalDataDAO = realDAO
+
+        collection = collections["pathwaysCollection"]
+        self.assertEqual(len(collection.insertOneCalls), 4,
+                         "the saveGraphicalData branch must stay per-pathway")
+        self.assertEqual(collection.insertManyCalls, [])
+        self.assertEqual(recorded, ["bmd%03d" % i for i in range(4)])
+
+
+# ---------------------------------------------------------------------------
+# E26 -- one features query on job load
+# ---------------------------------------------------------------------------
+class FindByIDPartitionTest(unittest.TestCase):
+
+    def _featureDocument(self, index, featureType):
+        return {
+            "_id": ObjectId(),
+            "jobID": "BMDAO_unit",
+            "ID": "%s%03d" % (featureType[0].lower(), index),
+            "name": "%s %d" % (featureType, index),
+            "featureType": featureType,
+            "omicsValues": [{"omicName": "o", "inputName": "in%d" % index,
+                             "originalName": None, "values": [float(index)],
+                             "relevant": [True]}],
+        }
+
+    def _collections(self, featureDocuments):
+        return {
+            "jobInstanceCollection": FakeCollection([{
+                "_id": ObjectId(), "jobID": "BMDAO_unit", "userID": None,
+                "organism": "mmu", "name": "unit job", "lastStep": 1,
+            }]),
+            "featuresCollection": FakeCollection(featureDocuments),
+            "foundFeaturesCollection": FakeCollection([]),
+            "pathwaysCollection": FakeCollection([]),
+        }
+
+    def test_one_query_and_the_same_order_as_two(self):
+        # Interleaved on purpose: a single find() returns them mixed, so the
+        # partition -- not the cursor -- is what has to restore the order.
+        documents = []
+        for index in range(20):
+            documents.append(self._featureDocument(index, "Gene"))
+            documents.append(self._featureDocument(index, "Compound"))
+
+        collections = self._collections(documents)
+        job = PathwayAcquisitionJobDAO(dbManager=FakeDBmanager(collections)).findByID("BMDAO_unit")
+        self.assertIsNotNone(job)
+
+        featureQueries = [q for q in collections["featuresCollection"].findCalls]
+        self.assertEqual(len(featureQueries), 1,
+                         "the job load must issue ONE features query, not one per type")
+        self.assertEqual(featureQueries[0], {"jobID": "BMDAO_unit"})
+
+        # what the two-query version produced
+        expectedGenes = [d["ID"] for d in documents if d["featureType"] == "Gene"]
+        expectedCompounds = [d["ID"] for d in documents if d["featureType"] == "Compound"]
+
+        self.assertEqual(list(job.getInputGenesData().keys()), expectedGenes)
+        self.assertEqual(list(job.getInputCompoundsData().keys()), expectedCompounds)
+
+    def test_an_unknown_feature_type_is_still_dropped(self):
+        """Neither old query matched it, so neither dict may gain it."""
+        documents = [self._featureDocument(0, "Gene"),
+                     self._featureDocument(1, "Region"),
+                     self._featureDocument(2, "Compound")]
+        documents[1]["ID"] = "unknown"
+        del documents[2]["featureType"]              # and one with no type at all
+        documents[2]["ID"] = "typeless"
+
+        collections = self._collections(documents)
+        job = PathwayAcquisitionJobDAO(dbManager=FakeDBmanager(collections)).findByID("BMDAO_unit")
+
+        self.assertEqual(list(job.getInputGenesData().keys()), ["g000"])
+        self.assertEqual(list(job.getInputCompoundsData().keys()), [])
+
+    def test_duplicate_ids_merge_in_the_original_order(self):
+        """addInputGeneData merges duplicates, so relative order is semantic."""
+        first = self._featureDocument(0, "Gene")
+        second = self._featureDocument(0, "Gene")
+        second["omicsValues"][0]["inputName"] = "second"
+        collections = self._collections([first, second])
+        job = PathwayAcquisitionJobDAO(dbManager=FakeDBmanager(collections)).findByID("BMDAO_unit")
+
+        self.assertEqual(list(job.getInputGenesData().keys()), ["g000"])
+        self.assertEqual(
+            [v.getInputName() for v in job.getInputGenesData()["g000"].getOmicsValues()],
+            ["in0", "second"],
+            "the merge order changed, so a duplicate feature's omic values moved")
+
+
+# ---------------------------------------------------------------------------
+# E30 -- indexes, and what the nightly cleanup is allowed to delete
+# ---------------------------------------------------------------------------
+class CleanDatabasesTest(unittest.TestCase):
+
+    def _source(self, relativePath):
+        return open(os.path.join(os.path.dirname(os.path.dirname(
+            os.path.abspath(__file__))), relativePath)).read()
+
+    def test_the_ai_collection_is_in_the_index_list(self):
+        from src.AdminTools.scripts.clean_databases import JOBID_INDEXES
+        self.assertIn(("aiInterpretationCollection", "jobID"), JOBID_INDEXES)
+
+    def test_rebuild_indexes_no_longer_calls_reindex(self):
+        """Removed in pymongo 4: `.reindex` resolves to a sub-collection there."""
+        self.assertNotIn(".reindex(", self._source("AdminTools/scripts/clean_databases.py"))
+
+    def test_the_gtf_cache_is_not_a_user_directory(self):
+        """Every directory under CLIENT_TMP that no user claims gets rmtree'd.
+
+        `<CLIENT_TMP>/gtfcache` is the shared GTF cache Bed2GeneJob writes, and
+        no user will ever own it, so without this exclusion every cleanup run
+        deleted the whole cache.
+        """
+        import re
+        from src.AdminTools.scripts.clean_databases import NON_USER_CLIENT_TMP_DIRS
+
+        self.assertIn("nologin", NON_USER_CLIENT_TMP_DIRS)
+
+        source = self._source("classes/JobInstances/Bed2GeneJob.py")
+        match = re.search(r'"cache_dir"\s*:\s*SERVER_CLIENT_TMP_DIR\s*\+\s*"([^"]+)"', source)
+        self.assertIsNotNone(
+            match, "Bed2GeneJob no longer builds its cache_dir from CLIENT_TMP; "
+                   "check whether the cleanup exclusion below is still the right name")
+        cacheDirName = match.group(1).strip("/")
+        self.assertIn(
+            cacheDirName, NON_USER_CLIENT_TMP_DIRS,
+            "the GTF cache directory Bed2GeneJob creates (%r) is not excluded from "
+            "the orphan-directory sweep in cleanDatabases, so the nightly cron will "
+            "delete it" % cacheDirName)
+
+    def test_the_directory_sweep_uses_the_exclusion_list(self):
+        source = self._source("AdminTools/scripts/clean_databases.py")
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "cleanDatabases":
+                body = ast.get_source_segment(source, node) or ""
+                self.assertIn("NON_USER_CLIENT_TMP_DIRS", body,
+                              "cleanDatabases stopped using the exclusion list")
+                self.assertNotIn('user_dirs.remove("nologin")', body,
+                                 "the hardcoded single exclusion is back")
+                return
+        self.fail("cleanDatabases no longer exists")
+
+
+def main():
+    suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    return 0 if result.wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/PaintomicsServer/src/tests/test_gtf_cache_and_attribute_parsing.py
+++ b/PaintomicsServer/src/tests/test_gtf_cache_and_attribute_parsing.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Regression tests for the three converter speedups that must not change a byte
+of any output file:
+
+  * the parsed-GTF sidecar cache in DHS_exon_association.run()
+  * extractAttribute(), which replaced two re.search calls per GTF row
+  * the once-per-row float conversion in miRNA2Target
+
+Run with:
+    cd <repo root> && PYTHONPATH=PaintomicsServer \
+        python3 PaintomicsServer/src/tests/test_gtf_cache_and_attribute_parsing.py
+
+The cache is the part with teeth. It is keyed by (format, absolute GTF path,
+mtime, size, gene tag, transcript tag, match table) and nothing else, so these
+tests pin two opposite failure modes: a key that forgets one of its inputs
+(serving the wrong annotation) and a cache file that cannot be read (taking the
+run down with it instead of parsing).
+"""
+
+import os
+import pickle
+import random
+import re
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from src.common.bioscripts import DHS_exon_association
+from src.common.bioscripts import miRNA2Target
+from src.common.bioscripts.DHS_exon_association import (
+    GTF_CACHE_FORMAT, extractAttribute, gtfCacheKey, gtfCachePath,
+    loadGtfCache, parseGTF, storeGtfCache, run)
+
+
+# A miniature annotation: two genes on two chromosomes, one of them on the
+# minus strand so the exon renumbering pass has something to reverse.
+GTF_ROWS = [
+    ('1\thavana\tgene\t100\t900\t.\t+\t.\tgene_id "G1"; gene_name "alpha";'),
+    ('1\thavana\ttranscript\t100\t900\t.\t+\t.\tgene_id "G1"; transcript_id "T1";'),
+    ('1\thavana\texon\t100\t200\t.\t+\t.\tgene_id "G1"; transcript_id "T1";'),
+    ('1\thavana\texon\t800\t900\t.\t+\t.\tgene_id "G1"; transcript_id "T1";'),
+    ('2\thavana\tgene\t500\t1500\t.\t-\t.\tgene_id "G2"; gene_name "beta";'),
+    ('2\thavana\ttranscript\t500\t1500\t.\t-\t.\tgene_id "G2"; transcript_id "T2";'),
+    ('2\thavana\texon\t500\t600\t.\t-\t.\tgene_id "G2"; transcript_id "T2";'),
+    ('2\thavana\texon\t1400\t1500\t.\t-\t.\tgene_id "G2"; transcript_id "T2";'),
+]
+
+REGION_ROWS = [
+    "#CHR\tstart\tend\tCond1",
+    "1\t150\t250\t1.5",
+    "2\t550\t650\t-2.25",
+]
+
+RUN_OPTIONS = {
+    "level": "gene", "distance": 10000, "tss": 200.0, "promoter": 1300.0,
+    "perc_area": 90, "perc_region": 50, "ignore_missing": False,
+    "gene_id_tag": "gene_id", "tran_id_tag": "transcript_id",
+    "presortedGTF": False,
+}
+
+
+def readFile(path):
+    with open(path) as handle:
+        return handle.read()
+
+
+def annotationFingerprint(genes, allTranscripts):
+    """A comparable, order-preserving summary of a parsed annotation.
+
+    Order is part of the contract: the region scan sorts each chromosome's gene
+    list with a stable sort, so two genes with the same start are reported in
+    the order the GTF listed them.
+    """
+    summary = []
+    for chromosome in sorted(genes):
+        for gene in genes[chromosome]:
+            transcripts = []
+            for transcript in gene.getTranscripts():
+                transcripts.append((
+                    transcript.getTranscriptID(),
+                    transcript.getStart(), transcript.getEnd(),
+                    [(exon.getStart(), exon.getEnd(), exon.getExon())
+                     for exon in transcript.getExons()]))
+            summary.append((chromosome, gene.getGeneID(), gene.getStrand(),
+                            gene.getStart(), gene.getEnd(), transcripts))
+    return (summary, sorted(allTranscripts))
+
+
+class GtfCacheKeyTest(unittest.TestCase):
+    """Every input the parse depends on has to be in the key, and nothing the
+    parse does not depend on should be."""
+
+    def setUp(self):
+        self.directory = tempfile.mkdtemp(prefix="gtfcachekey")
+        self.gtf = os.path.join(self.directory, "mini.gtf")
+        with open(self.gtf, "w") as handle:
+            handle.write("\n".join(GTF_ROWS) + "\n")
+
+    def tearDown(self):
+        shutil.rmtree(self.directory, ignore_errors=True)
+
+    def keyFor(self, **overrides):
+        arguments = {"gtf": self.gtf, "gene_id_tag": "gene_id",
+                     "tran_id_tag": "transcript_id", "matchTable": None}
+        arguments.update(overrides)
+        return gtfCacheKey(arguments["gtf"], arguments["gene_id_tag"],
+                           arguments["tran_id_tag"], arguments["matchTable"])
+
+    def testKeyIsStableForTheSameInputs(self):
+        self.assertEqual(self.keyFor(), self.keyFor())
+
+    def testKeyCarriesTheFormatVersion(self):
+        self.assertEqual(GTF_CACHE_FORMAT, self.keyFor()[0])
+
+    def testKeyChangesWithTheGeneTag(self):
+        self.assertNotEqual(self.keyFor(), self.keyFor(gene_id_tag="gene_name"))
+
+    def testKeyChangesWithTheTranscriptTag(self):
+        self.assertNotEqual(self.keyFor(),
+                            self.keyFor(tran_id_tag="havana_transcript"))
+
+    def testKeyChangesWithTheMatchTable(self):
+        matchTable = os.path.join(self.directory, "match.tab")
+        with open(matchTable, "w") as handle:
+            handle.write("1\tchr1\n2\tchr2\n")
+        withTable = self.keyFor(matchTable=matchTable)
+        self.assertNotEqual(self.keyFor(), withTable)
+
+        # ...and with its CONTENTS, not just its presence.
+        with open(matchTable, "w") as handle:
+            handle.write("1\tchrI\n2\tchrII\n")
+        os.utime(matchTable, (1_000_000, 1_000_000))
+        self.assertNotEqual(withTable, self.keyFor(matchTable=matchTable))
+
+    def testKeyChangesWhenTheGtfIsRewritten(self):
+        before = self.keyFor()
+        with open(self.gtf, "a") as handle:
+            handle.write(GTF_ROWS[0] + "\n")
+        self.assertNotEqual(before, self.keyFor())
+
+    def testKeyChangesOnMtimeAloneEvenAtTheSameSize(self):
+        """An edit that keeps the byte count is the case a size-only key would
+        miss -- a corrected coordinate is exactly that shape."""
+        before = self.keyFor()
+        contents = readFile(self.gtf).replace("\t100\t900\t", "\t101\t900\t")
+        with open(self.gtf, "w") as handle:
+            handle.write(contents)
+        os.utime(self.gtf, (2_000_000, 2_000_000))
+        self.assertEqual(os.path.getsize(self.gtf),
+                         before[3])  # same size, so mtime is what must differ
+        self.assertNotEqual(before, self.keyFor())
+
+    def testKeyIsNoneForAMissingGtf(self):
+        self.assertIsNone(self.keyFor(gtf=os.path.join(self.directory, "nope")))
+
+    def testKeyIsIndifferentToScanSettings(self):
+        """distance/tss/level and friends are consumed long after the
+        annotation is built. Putting them in the key would only cost hits."""
+        key = self.keyFor()
+        self.assertNotIn(10000, key)
+        self.assertNotIn("gene", key[4:])
+
+
+class GtfCacheRoundTripTest(unittest.TestCase):
+
+    def setUp(self):
+        self.directory = tempfile.mkdtemp(prefix="gtfcache")
+        self.cacheDir = os.path.join(self.directory, "cache")
+        self.gtf = os.path.join(self.directory, "mini.gtf")
+        with open(self.gtf, "w") as handle:
+            handle.write("\n".join(GTF_ROWS) + "\n")
+        self.key = gtfCacheKey(self.gtf, "gene_id", "transcript_id", None)
+        self.path = gtfCachePath(self.key, self.cacheDir)
+        self.parsed = parseGTF(self.gtf, "gene_id", "transcript_id", None)
+
+    def tearDown(self):
+        shutil.rmtree(self.directory, ignore_errors=True)
+
+    def testRoundTripRebuildsTheSameAnnotation(self):
+        self.assertTrue(storeGtfCache(self.path, self.key, self.parsed))
+        restored = loadGtfCache(self.path, self.key)
+        self.assertIsNotNone(restored)
+        self.assertEqual(annotationFingerprint(*self.parsed),
+                         annotationFingerprint(*restored))
+
+    def testRoundTripKeepsSharedObjectIdentity(self):
+        """The gene objects reachable from `genes` and the transcript objects
+        in `allTranscripts` are the SAME objects. Pickling the pair in one call
+        is what preserves that; pickling them separately would double the
+        memory and silently split the graph."""
+        self.assertTrue(storeGtfCache(self.path, self.key, self.parsed))
+        genes, allTranscripts = loadGtfCache(self.path, self.key)
+        for chromosome in genes:
+            for gene in genes[chromosome]:
+                for transcript in gene.getTranscripts():
+                    self.assertIs(allTranscripts[transcript.getTranscriptID()],
+                                  transcript)
+
+    def testCacheIsRejectedForADifferentKey(self):
+        self.assertTrue(storeGtfCache(self.path, self.key, self.parsed))
+        otherKey = gtfCacheKey(self.gtf, "gene_name", "transcript_id", None)
+        self.assertIsNone(loadGtfCache(self.path, otherKey))
+
+    def testCorruptCacheFallsBackInsteadOfRaising(self):
+        with open(self.path, "wb") as handle:
+            handle.write(b"this is not a pickle at all")
+        self.assertIsNone(loadGtfCache(self.path, self.key))
+
+    def testTruncatedCacheFallsBackInsteadOfRaising(self):
+        self.assertTrue(storeGtfCache(self.path, self.key, self.parsed))
+        with open(self.path, "rb") as handle:
+            whole = handle.read()
+        with open(self.path, "wb") as handle:
+            handle.write(whole[:len(whole) // 2])
+        self.assertIsNone(loadGtfCache(self.path, self.key))
+
+    def testAnEmptyAnnotationIsTreatedAsAMiss(self):
+        """({}, {}) is the right shape and the right key, and serving it means
+        either zero associations or the "incomplete GTF" abort -- a silent
+        wrong answer where a re-parse costs one parse."""
+        with open(self.path, "wb") as handle:
+            pickle.dump((self.key, ({}, {})), handle)
+        self.assertIsNone(loadGtfCache(self.path, self.key))
+
+    def testAWellFormedPickleOfTheWrongShapeIsRejected(self):
+        with open(self.path, "wb") as handle:
+            pickle.dump((self.key, "not a pair of dicts"), handle)
+        self.assertIsNone(loadGtfCache(self.path, self.key))
+
+    def testMissingCacheFileIsSimplyAMiss(self):
+        self.assertIsNone(loadGtfCache(self.path, self.key))
+
+    def testStoreDoesNotRaiseOnAnUnwritableDirectory(self):
+        unwritable = os.path.join(self.directory, "readonly")
+        os.makedirs(unwritable)
+        os.chmod(unwritable, 0o500)
+        try:
+            self.assertFalse(storeGtfCache(
+                os.path.join(unwritable, "x.rgcache"), self.key, self.parsed))
+        finally:
+            os.chmod(unwritable, 0o700)
+
+    def testStoreLeavesNoTemporaryFileBehind(self):
+        self.assertTrue(storeGtfCache(self.path, self.key, self.parsed))
+        leftovers = [name for name in os.listdir(self.cacheDir)
+                     if name.endswith(".tmp")]
+        self.assertEqual([], leftovers)
+
+
+class GtfCacheEndToEndTest(unittest.TestCase):
+    """run() twice over the same GTF must write the same output file, and the
+    second run must not have parsed anything."""
+
+    def setUp(self):
+        self.directory = tempfile.mkdtemp(prefix="gtfcacherun")
+        self.cacheDir = os.path.join(self.directory, "cache")
+        self.gtf = os.path.join(self.directory, "mini.gtf")
+        with open(self.gtf, "w") as handle:
+            handle.write("\n".join(GTF_ROWS) + "\n")
+        self.regions = os.path.join(self.directory, "regions.bed")
+        with open(self.regions, "w") as handle:
+            handle.write("\n".join(REGION_ROWS) + "\n")
+
+    def tearDown(self):
+        shutil.rmtree(self.directory, ignore_errors=True)
+
+    def runAssociation(self, name, **optionOverrides):
+        output = os.path.join(self.directory, name)
+        options = dict(RUN_OPTIONS)
+        options["cache_dir"] = self.cacheDir
+        options.update(optionOverrides)
+        run(self.gtf, self.regions, output, None, options)
+        return readFile(output)
+
+    def testSecondRunReadsTheCacheAndProducesIdenticalBytes(self):
+        first = self.runAssociation("first.txt")
+
+        calls = []
+        original = DHS_exon_association.parseGTF
+        DHS_exon_association.parseGTF = lambda *a, **k: (
+            calls.append(a) or original(*a, **k))
+        try:
+            second = self.runAssociation("second.txt")
+        finally:
+            DHS_exon_association.parseGTF = original
+
+        self.assertEqual(first, second)
+        self.assertEqual([], calls, "the second run re-parsed the GTF")
+
+    def testTouchingTheGtfInvalidatesTheCache(self):
+        self.runAssociation("first.txt")
+        with open(self.gtf, "a") as handle:
+            handle.write(
+                '3\thavana\tgene\t10\t99\t.\t+\t.\tgene_id "G3";\n'
+                '3\thavana\ttranscript\t10\t99\t.\t+\t.\tgene_id "G3"; transcript_id "T3";\n'
+                '3\thavana\texon\t10\t99\t.\t+\t.\tgene_id "G3"; transcript_id "T3";\n')
+
+        calls = []
+        original = DHS_exon_association.parseGTF
+        DHS_exon_association.parseGTF = lambda *a, **k: (
+            calls.append(a) or original(*a, **k))
+        try:
+            self.runAssociation("second.txt")
+        finally:
+            DHS_exon_association.parseGTF = original
+
+        self.assertEqual(1, len(calls), "an edited GTF was served from cache")
+
+    def testCorruptCacheStillProducesTheRightOutput(self):
+        expected = self.runAssociation("first.txt")
+        for name in os.listdir(self.cacheDir):
+            with open(os.path.join(self.cacheDir, name), "wb") as handle:
+                handle.write(b"\x80\x05 garbage")
+        self.assertEqual(expected, self.runAssociation("second.txt"))
+
+    def testAnUnwritableCacheDirectoryDoesNotStopTheRun(self):
+        blocked = os.path.join(self.directory, "blocked")
+        os.makedirs(blocked)
+        os.chmod(blocked, 0o500)
+        try:
+            # A second writable directory rather than cache_dir=None: the None
+            # fallback writes into <gettempdir()>/paintomics-gtfcache, which
+            # nothing here owns and nothing cleans, so every run of this suite
+            # would leave a sidecar behind under a fresh digest.
+            expected = self.runAssociation(
+                "plain.txt", cache_dir=os.path.join(self.directory, "other"))
+            self.assertEqual(
+                expected,
+                self.runAssociation("blocked.txt",
+                                    cache_dir=os.path.join(blocked, "cache")))
+        finally:
+            os.chmod(blocked, 0o700)
+
+    def testATornParseIsNotPersisted(self):
+        """If the GTF changes while it is being parsed, the annotation in
+        memory is a mixture of two files. Using it for this one job is what has
+        always happened; writing it to disk under the pre-change key would hand
+        the mixture to every later job."""
+        original = DHS_exon_association.parseGTF
+
+        def parseThenRewriteTheGtf(*arguments, **keywords):
+            result = original(*arguments, **keywords)
+            with open(self.gtf, "a") as handle:
+                handle.write(
+                    '3\thavana\tgene\t10\t99\t.\t+\t.\tgene_id "G3";\n')
+            return result
+
+        DHS_exon_association.parseGTF = parseThenRewriteTheGtf
+        try:
+            self.runAssociation("first.txt")
+        finally:
+            DHS_exon_association.parseGTF = original
+
+        self.assertEqual(
+            [], [name for name in os.listdir(self.cacheDir)
+                 if name.endswith(".rgcache")],
+            "a parse of a file that changed underneath it was cached")
+
+
+class ExtractAttributeTest(unittest.TestCase):
+    """extractAttribute() has one job: return what re.search(r'<tag>
+    \"?(.*?)\"?;') used to return, for every string, including the ugly ones."""
+
+    TRICKY = [
+        'gene_id "G1"; transcript_id "T1";',
+        'gene_id G1; transcript_id T1;',                      # unquoted
+        'gene_id "with space"; transcript_id "t 1";',
+        'gene_id ""; transcript_id "";',                      # empty, quoted
+        'gene_id ; transcript_id ;',                          # empty, unquoted
+        'gene_id "A;B"; transcript_id "T1";',                 # ';' inside quotes
+        'gene_id "A\'B"; transcript_id "T1";',
+        'gene_id "a"b"; transcript_id "T1";',                 # quote inside
+        'transcript_id "T1"; gene_id "G1";',                  # order swapped
+        'havana_gene "H"; gene_id "G1"; transcript_id "T1";',
+        'gene_id "G1"; gene_version "3"; transcript_id "T1"; exon_number "2";',
+        'gene_id "G1";transcript_id "T1";',                   # no space after ';'
+        'gene_id  "G1"; transcript_id  "T1";',                # two spaces
+        'gene_id "G1"; transcript_id "T1"',                   # no final ';'
+        'gene_id "tab\tinside"; transcript_id "T1";',
+        'gene_id "-"; transcript_id "-";',
+        'gene_id "ENSMUSG00000102693"; gene_version "1"; transcript_id '
+        '"ENSMUST00000193812"; exon_number "1"; tag "basic";',
+    ]
+
+    def referenceValue(self, attributes, tag):
+        """What the code did before: re.search(...).group(1), AttributeError
+        and all."""
+        pattern = re.compile(r"{0} \"?(.*?)\"?;".format(tag))
+        return re.search(pattern, attributes).group(1)
+
+    def testMatchesTheOldRegexOnEveryTrickyString(self):
+        for attributes in self.TRICKY:
+            for tag in ("gene_id", "transcript_id"):
+                try:
+                    expected = self.referenceValue(attributes, tag)
+                except AttributeError:
+                    expected = AttributeError
+                try:
+                    actual = extractAttribute(attributes, tag)
+                except AttributeError:
+                    actual = AttributeError
+                self.assertEqual(
+                    expected, actual,
+                    "tag %r in %r" % (tag, attributes))
+
+    # The alphabet that actually decides the answer: quotes, semicolons,
+    # spaces, the tag itself -- and '\n', which is the one character the two
+    # implementations can disagree about (re's '.' stops at it, str.find does
+    # not). It is in the alphabet on purpose: a fuzz test that omits the
+    # character it cannot survive is not evidence.
+    FUZZ_ALPHABET = ['"', ';', ' ', 'x', 'gene_id ', 'gene_id', '_', 'A', '\n']
+
+    def compare(self, attributes, tag="gene_id"):
+        """(old, new), with AttributeError standing in for a failed match."""
+        try:
+            expected = self.referenceValue(attributes, tag)
+        except AttributeError:
+            expected = AttributeError
+        try:
+            actual = extractAttribute(attributes, tag)
+        except AttributeError:
+            actual = AttributeError
+        return expected, actual
+
+    def fuzzStrings(self, count, seed):
+        generator = random.Random(seed)
+        for _ in range(count):
+            yield "".join(generator.choice(self.FUZZ_ALPHABET)
+                          for _ in range(generator.randint(1, 14)))
+
+    def testMatchesTheOldRegexOnRandomAttributeSoup(self):
+        """Every divergence the fuzz can produce contains a newline.
+
+        Newline-free strings must agree exactly; the newline-bearing ones are
+        allowed to differ, and the count is asserted to be non-zero so that
+        this test keeps documenting a real divergence rather than quietly
+        becoming vacuous.
+        """
+        divergences = 0
+        for attributes in self.fuzzStrings(6000, 20260817):
+            expected, actual = self.compare(attributes)
+            if expected == actual:
+                continue
+            divergences += 1
+            self.assertIn(
+                "\n", attributes,
+                "divergence without a newline: %r" % (attributes,))
+        self.assertGreater(divergences, 0,
+                           "the fuzz alphabet no longer reaches the known "
+                           "newline divergence -- check it still contains '\\n'")
+
+    def testTheNewlineDivergenceCannotSurviveAGtfRow(self):
+        """...and it is unreachable from the parser.
+
+        Both readers split the file on '\\n' before a row's attributes column
+        exists, so the only newline a row can carry is a trailing one with
+        nothing after it -- while a divergence needs a ';' AFTER the newline.
+        Fuzzing the two shapes the parser actually produces (a trailing '\\n'
+        from the file-object path, and none from the gz split) finds none.
+        """
+        for attributes in self.fuzzStrings(3000, 20260818):
+            row = attributes.replace("\n", " ")   # a row cannot contain one
+            for shaped in (row, row + "\n"):      # gz split / file iteration
+                expected, actual = self.compare(shaped)
+                self.assertEqual(expected, actual, repr(shaped))
+
+    def testTheKnownNewlineDivergenceIsTheOneInTheDocstring(self):
+        # The simple shape: re's '.' will not cross the newline, so the regex
+        # finds no match at all; str.find(';') crosses it and returns a value.
+        expected, actual = self.compare('gene_id a\nb;')
+        self.assertIs(AttributeError, expected)
+        self.assertEqual("a\nb", actual)
+
+        # And the shape where both find something, but not the same thing: the
+        # regex gives up at the first occurrence and matches the tag again
+        # inside 'havana_gene_id '.
+        expected, actual = self.compare('gene_id .\nhavana_gene_id x;')
+        self.assertEqual("x", expected)
+        self.assertEqual(".\nhavana_gene_id x", actual)
+
+    def testAMissingTagRaisesTheSameExceptionClassAsBefore(self):
+        attributes = 'transcript_id "T1"; exon_number "1";'
+        self.assertRaises(AttributeError,
+                          self.referenceValue, attributes, "gene_id")
+        self.assertRaises(AttributeError,
+                          extractAttribute, attributes, "gene_id")
+
+    def testATagWithNoSemicolonAfterItIsNotAMatch(self):
+        self.assertRaises(AttributeError,
+                          extractAttribute, 'x "1"; gene_id "G1"', "gene_id")
+
+    def testTheMessageNamesTheTagAndTheRow(self):
+        try:
+            extractAttribute('transcript_id "T1";', "gene_id")
+        except AttributeError as failure:
+            self.assertIn("gene_id", str(failure))
+            self.assertIn("transcript_id", str(failure))
+        else:
+            self.fail("no AttributeError raised")
+
+    def testParsedAnnotationIsUnchangedByTheNewExtraction(self):
+        """The end-to-end version of the above: parse a GTF with both readers
+        and compare the object graphs."""
+        directory = tempfile.mkdtemp(prefix="gtfparse")
+        try:
+            gtf = os.path.join(directory, "mini.gtf")
+            with open(gtf, "w") as handle:
+                handle.write("\n".join(GTF_ROWS) + "\n")
+
+            fresh = parseGTF(gtf, "gene_id", "transcript_id", None)
+
+            geneRe = re.compile(r"gene_id \"?(.*?)\"?;")
+            tranRe = re.compile(r"transcript_id \"?(.*?)\"?;")
+            original = DHS_exon_association.extractAttribute
+            DHS_exon_association.extractAttribute = (
+                lambda attributes, tag: re.search(
+                    geneRe if tag == "gene_id" else tranRe,
+                    attributes).group(1))
+            try:
+                viaRegex = parseGTF(gtf, "gene_id", "transcript_id", None)
+            finally:
+                DHS_exon_association.extractAttribute = original
+
+            self.assertEqual(annotationFingerprint(*viaRegex),
+                             annotationFingerprint(*fresh))
+        finally:
+            shutil.rmtree(directory, ignore_errors=True)
+
+
+class MiRNAFloatHoistTest(unittest.TestCase):
+    """Converting a value row once at read time instead of once per pair must
+    not move a single digit of any score."""
+
+    ROWS = [
+        ["1.0", "2.0", "3.0", "4.0"],
+        ["4.0", "3.0", "2.0", "1.0"],
+        ["1.0", "1.0", "1.0", "1.0"],          # constant: correlation is nan
+        ["1.0", "1.0", "2.0", "2.0"],          # ties
+        ["-0.5", "0", "1e-3", "2.5e2"],        # exponents and a bare zero
+        ["0.1", "0.2", "0.30000000000000004", "0.4"],
+    ]
+
+    def testScoresAreIdenticalWithPreConvertedRows(self):
+        for method in ("kendall", "spearman", "pearson"):
+            for left in self.ROWS:
+                for right in self.ROWS:
+                    old = miRNA2Target.getScore(left, right, method)
+                    new = miRNA2Target.getScore(miRNA2Target.toFloats(left),
+                                                miRNA2Target.toFloats(right),
+                                                method)
+                    # str() is what reaches the output file, and it is the
+                    # comparison that matters: 'nan' has to render as 'nan'
+                    # from both paths too.
+                    self.assertEqual(str(old), str(new),
+                                     "%s %s %s" % (method, left, right))
+
+    def testToFloatsParsesLikeTheOldInlineComprehension(self):
+        for row in self.ROWS:
+            self.assertEqual([float(cell) for cell in row],
+                             miRNA2Target.toFloats(row))
+
+    def testToFloatsKeepsANonNumericRowIntact(self):
+        """The gene expression file is read without skipping its header, so a
+        row of condition names is a real, expected input."""
+        header = ["T00h", "T02h", "T06h"]
+        self.assertEqual(header, miRNA2Target.toFloats(header))
+
+    def testANonNumericRowStillFailsWhereItUsedTo(self):
+        kept = miRNA2Target.toFloats(["T00h", "T02h", "T06h", "T12h"])
+        self.assertRaises(ValueError, miRNA2Target.getScore,
+                          [1.0, 2.0, 3.0, 4.0], kept, "kendall")
+
+    def testAsFloatsIsIdempotent(self):
+        converted = miRNA2Target.asFloats(["1.5", "2.5"])
+        self.assertEqual([1.5, 2.5], converted)
+        self.assertIs(converted, miRNA2Target.asFloats(converted))
+
+    def testAsFloatsHandlesAnEmptyRow(self):
+        self.assertEqual([], miRNA2Target.asFloats([]))
+
+
+class MiRNAKernelOutputTest(unittest.TestCase):
+    """The whole kernel, on a fixture small enough to write out by hand."""
+
+    def setUp(self):
+        self.directory = tempfile.mkdtemp(prefix="mirnakernel")
+
+        self.values = os.path.join(self.directory, "mirna_values.tab")
+        with open(self.values, "w") as handle:
+            handle.write("C1\tC2\tC3\tC4\n")
+            handle.write("mmu-miR-1\t1.0\t2.0\t3.0\t4.0\n")
+            handle.write("mmu-miR-2\t4.0\t3.0\t2.0\t1.0\n")
+            handle.write("mmu-miR-3\t1.0\t1.0\t1.0\t1.0\n")
+
+        self.reference = os.path.join(self.directory, "targets.tab")
+        with open(self.reference, "w") as handle:
+            handle.write("mmu-miR-1\tGENE_A\nmmu-miR-1\tGENE_B\n"
+                         "mmu-miR-2\tGENE_A\nmmu-miR-2\tGENE_MISSING\n"
+                         "mmu-miR-3\tGENE_B\n")
+
+        self.expression = os.path.join(self.directory, "genes.tab")
+        with open(self.expression, "w") as handle:
+            handle.write("#geneID\tC1\tC2\tC3\tC4\n")
+            handle.write("GENE_A\t4.0\t3.0\t2.0\t1.0\n")
+            handle.write("GENE_B\t1.0\t1.0\t2.0\t2.0\n")
+
+    def tearDown(self):
+        shutil.rmtree(self.directory, ignore_errors=True)
+
+    def testEveryPairIsScoredAndTheHeaderRowIsNotATarget(self):
+        for method in ("kendall", "spearman", "pearson"):
+            output = os.path.join(self.directory, "out_%s.txt" % method)
+            miRNA2Target.run(self.reference, None, self.values,
+                             self.expression, output, method)
+            lines = readFile(output).splitlines()
+            self.assertEqual(
+                "# miRNA_id\ttarget_id\tscore\tscore method\tC1\tC2\tC3\tC4",
+                lines[0])
+            # GENE_MISSING has no expression row, so its pair is skipped --
+            # four of the five reference rows survive.
+            self.assertEqual(4, len(lines) - 1)
+            pairs = [(line.split("\t")[0], line.split("\t")[1])
+                     for line in lines[1:]]
+            self.assertEqual([("mmu-miR-1", "GENE_A"), ("mmu-miR-1", "GENE_B"),
+                              ("mmu-miR-2", "GENE_A"), ("mmu-miR-3", "GENE_B")],
+                             pairs)
+
+    def testPerfectAnticorrelationScoresMinusOne(self):
+        output = os.path.join(self.directory, "out.txt")
+        miRNA2Target.run(self.reference, None, self.values,
+                         self.expression, output, "pearson")
+        row = [line for line in readFile(output).splitlines()
+               if line.startswith("mmu-miR-1\tGENE_A")][0]
+        self.assertEqual("-1.0", row.split("\t")[2])
+
+    def testAConstantRowStillWritesNan(self):
+        output = os.path.join(self.directory, "out.txt")
+        miRNA2Target.run(self.reference, None, self.values,
+                         self.expression, output, "pearson")
+        row = [line for line in readFile(output).splitlines()
+               if line.startswith("mmu-miR-3\t")][0]
+        self.assertEqual("nan", row.split("\t")[2])
+
+    def testTheValueColumnsAreTheRawTextFromTheInput(self):
+        """The row echoes the miRNA's own cells verbatim; they must not come
+        back as the repr of a float ('1.0' is fine, but a '1e-3' input would
+        turn into '0.001')."""
+        with open(self.values, "a") as handle:
+            handle.write("mmu-miR-4\t1e-3\t2E+2\t.5\t3.10\n")
+        with open(self.reference, "a") as handle:
+            handle.write("mmu-miR-4\tGENE_A\n")
+
+        output = os.path.join(self.directory, "out.txt")
+        miRNA2Target.run(self.reference, None, self.values,
+                         self.expression, output, "kendall")
+        row = [line for line in readFile(output).splitlines()
+               if line.startswith("mmu-miR-4\t")][0]
+        self.assertEqual(["1e-3", "2E+2", ".5", "3.10"], row.split("\t")[4:])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_kendall_kernel_matches_scipy.py
+++ b/PaintomicsServer/src/tests/test_kendall_kernel_matches_scipy.py
@@ -1,0 +1,90 @@
+"""miRNA2Target's Kendall kernel is bit-identical to scipy.stats.kendalltau.
+
+The miRNA-to-gene converter scores every (miRNA, target) pair -- 97,983 in
+the shipped STATegra example -- with kendalltau by default, and only reads
+`.correlation`. scipy spends most of each ~58 us call on the p-value (an
+exact enumeration for short tie-free rows) that is thrown away. The kernel
+counts concordant/discordant/tied pairs directly and finishes with scipy's
+own tau-b expression on the same integer counts, so the float -- and its
+str(), which is what reaches the output file -- is the same. This test pins
+that over random rows with heavy ties, constants, perfect (anti)correlation,
+NaNs and lengths 1-12, plus the fallback to scipy for rows that are not all
+numbers.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_kendall_kernel_matches_scipy
+"""
+import os
+import random
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+import numpy as np
+from scipy.stats import kendalltau
+
+from src.common.bioscripts import miRNA2Target
+
+
+def _randomRows(rng):
+    k = rng.randint(1, 12)
+    kind = rng.random()
+    if kind < 0.3:
+        x = [rng.randint(0, 3) * 1.0 for _ in range(k)]
+        y = [rng.randint(0, 3) * 1.0 for _ in range(k)]
+    elif kind < 0.6:
+        x = [round(rng.gauss(0, 1), rng.choice([1, 2, 6])) for _ in range(k)]
+        y = [round(rng.gauss(0, 1), rng.choice([1, 2, 6])) for _ in range(k)]
+    elif kind < 0.7:
+        x = [rng.choice([0.0, 1.0]) for _ in range(k)]
+        y = [rng.random() for _ in range(k)]
+    elif kind < 0.75:
+        x = [0.5] * k
+        y = [rng.random() for _ in range(k)]
+    elif kind < 0.8:
+        x = [rng.random() for _ in range(k)]
+        y = list(x) if rng.random() < 0.5 else [-v for v in x]
+    else:
+        x = [rng.uniform(-5, 5) for _ in range(k)]
+        y = [rng.uniform(-5, 5) for _ in range(k)]
+    if rng.random() < 0.03:
+        x[rng.randrange(k)] = float("nan")
+    return x, y
+
+
+class KendallKernelTest(unittest.TestCase):
+
+    def test_bit_identical_to_scipy_over_random_rows(self):
+        rng = random.Random(20260817)
+        for _ in range(20000):
+            x, y = _randomRows(rng)
+            want = kendalltau(x, y).correlation
+            got = miRNA2Target.kendallTauB(x, y)
+            self.assertEqual(repr(got), repr(want), (x, y))
+
+    def test_returns_the_same_type_as_scipy(self):
+        got = miRNA2Target.kendallTauB([0.1, 0.5, 0.3], [0.2, 0.9, 0.1])
+        self.assertIsInstance(got, np.floating)
+        self.assertEqual(str(got), str(kendalltau([0.1, 0.5, 0.3], [0.2, 0.9, 0.1]).correlation))
+
+    def test_getScore_uses_the_kernel_for_kendall(self):
+        x = [0.1, -0.5, 0.3, 0.7, -0.2, 0.9]
+        y = [0.2, 0.1, -0.4, 0.8, 0.0, -0.3]
+        self.assertEqual(str(miRNA2Target.getScore(x, y, "kendall")),
+                         str(kendalltau(x, y).correlation))
+        # Text rows are parsed exactly as before.
+        self.assertEqual(str(miRNA2Target.getScore(["0.1", "-0.5", "0.3"], ["0.2", "0.1", "-0.4"], "kendall")),
+                         str(kendalltau([0.1, -0.5, 0.3], [0.2, 0.1, -0.4]).correlation))
+
+    def test_non_numeric_rows_fall_back_to_scipy(self):
+        # A row toFloats() refused stays text; scipy compares strings
+        # lexicographically and so does the fallback (same call).
+        x = ["NA", "0.5", "0.3"]
+        y = [0.2, 0.9, 0.1]
+        self.assertEqual(repr(miRNA2Target.kendallTauB(x, y)), repr(kendalltau(x, y).correlation))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_statistics_guards.py
+++ b/PaintomicsServer/src/tests/test_statistics_guards.py
@@ -172,8 +172,10 @@ class NonFiniteBackstopTest(unittest.TestCase):
     """
 
     def test_fisher_backstop(self):
-        with mock.patch("src.common.Statistics.chi2") as chi2:
-            chi2.sf.return_value = NAN
+        # The combination is chdtrc(df, x) now (the function chi2.sf reduces
+        # to); the guard after it is what this test pins.
+        with mock.patch("src.common.Statistics._special") as special:
+            special.chdtrc.return_value = NAN
 
             result = calculateCombinedFisher([_entry(0.01), _entry(0.2)])
 
@@ -182,8 +184,11 @@ class NonFiniteBackstopTest(unittest.TestCase):
                          "Fisher; it would be serialised as invalid JSON")
 
     def test_stouffer_backstop(self):
-        with mock.patch("src.common.Statistics.combine_pvalues") as combine:
-            combine.return_value = (0.0, INF)
+        # Stouffer is computed by _stoufferPvalue (bit-identical to
+        # combine_pvalues, see test_combined_pvalue_kernels_match_scipy);
+        # the guard after it is what this test pins.
+        with mock.patch("src.common.Statistics._stoufferPvalue") as stouffer:
+            stouffer.return_value = INF
 
             result = calculateStoufferCombinedPvalue(
                 [_entry(0.01), _entry(0.2)], [1, 1])


### PR DESCRIPTION
## Summary

Speed overhaul of the analysis pipeline, gated on **results identical to master**. Every example dataset in `src/examplefiles/datasets/` (11 scenarios, all four pipelines) was run through a new headless benchmark harness before and after; the full report with per-phase medians and the equivalence method is in `PaintomicsServer/src/benchmarks/REPORT.md`.

**Local (M4 Pro, interleaved A/B, medians):**

| Scenario | master | branch | speed-up | strict equivalence |
|---|---:|---:|---:|:-:|
| gene-single-condition | 6.99 s | 3.47 s | 2.0× | IDENTICAL |
| gene-multi-condition | 7.79 s | 4.46 s | 1.75× | IDENTICAL |
| gene-multi-condition-relevance | 8.29 s | 4.54 s | 1.83× | IDENTICAL |
| multiomics-integration | 73.4 s | 12.1 s | **6.1×** | IDENTICAL |
| stategra-multiomics | 51.1 s | 15.6 s | **3.3×** | IDENTICAL |
| stategra-mirna | 15.0 s | 4.1 s | 3.7× | IDENTICAL |
| regulatory-mirna | 0.29 s | 0.10 s | 3.0× | IDENTICAL |
| stategra-regions | 8.10 s | 6.32 s | 1.28× | IDENTICAL |
| region-based | 1.47 s | 1.39 s | 1.05× | IDENTICAL |
| regulatory-more / stategra-more | unchanged code path | | ~1.0× | IDENTICAL |

"IDENTICAL" = bit-for-bit on every client-visible result (all p-values, adjusted/combined p-values, matched members, metagenes, hub/class results, step-3 graphical data, converter and MORE output files), master vs branch with one worker. Against master's 6-worker output the only differences are in fields where master's own output already depends on worker scheduling (which alias fills a symbol-keyed display slot, order of a feature's omics values, duplicate-compound merges) — the branch makes those deterministic; no statistic or membership differs anywhere.

## What changed (each proven equivalent; details in the commits and REPORT.md §3)

* **Identifier mapping** (98.9 % of step 1 on production): translation cache carried across omics (misses cached too); `$lookup` filtered on `dbname_id` inside the join (12,762 genes 5.7 → 1.1 s); `kegg_compounds` matched from an in-memory haystack with PR #32's escape/cap semantics (4,667 names 40.5 → 0.9 s); one hand-over per worker in worker order (results no longer depend on scheduling).
* **Step 2**: metagene R scripts run per omic in parallel (`PAINTOMICS_METAGENES_PARALLEL`, default 3); exact special-function kernels for Stouffer/Fisher (bit-identical to scipy over 80k cases); one result hand-over per enrichment worker; per-process compact cache of `kegg_interaction.json` (was ~1 GB transient per job on production); log/zip/png cleanups.
* **R scripts**: `PCA2GO.2.R` pre-splits the annotation (levels pinned to `go.sel`, positional lookup); `hubAnalysis.R` lists the directory once and codes membership per block — hub 13.7 → 2.0 s, byte-identical outputs.
* **DAO**: one shared fork-aware MongoClient (100 loads: +0 threads, was +300); `insert_many` for pathways; `adaptBSON` fast path preserving its `None→"None"`/ObjectId behaviour (332,869 real docs identical); one features query on load; jobID index on the AI collection; daily `reindex()` retired; startup index check off the boot path.
* **Converters**: parsed GTF cached across jobs (real 566 MB GTF job 8.4 → 5.4 s warm), regex attribute extraction replaced by an equivalent scanner; exact Kendall τ-b kernel for miRNA scoring (97,983 pairs 14.9 → 4.1 s).

## Behaviour notes for the release

* Mapping results are now deterministic (input order) — master's varied with worker scheduling.
* Bed2Genes matches the GTF tag literally; a tag with regex metacharacters used to be interpreted (wrong value or crash).
* New env knobs: `PAINTOMICS_METAGENES_PARALLEL` (default 3), `PAINTOMICS_GTF_CACHE_DEBUG`. New dir `<CLIENT_TMP>/gtfcache` (excluded from the admin cleanup).
* Pre-existing bugs found and left for separate fixes (they change bytes): gz BED reader drops the last character of every row; `PathwayAcquisitionJob.toBSON(recursive=True)` raises on DB-loaded jobs.

## Verification

* Strict full sweep (11 scenarios): 11/11 IDENTICAL. Unit suite: 142/151 (same 9 pre-existing/harness failures as master; 6 new test modules pass). Clean `git archive` compiles and imports.
* Chrome: STATegra 5-omic example run end to end on the branch server (compound disambiguation, results 887 found / 102 significant, hub + class panels, pathway painting with metagene trends), no console errors.
* paintomics.uv.es measured with the original code (REPORT.md §4); after-deploy numbers to be appended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
