### PR TITLE
Mapper: two indexed finds instead of a $lookup sub-pipeline (MongoDB 4.4 hang)

### DIFF
--- a/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
+++ b/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
@@ -186,50 +186,40 @@ def findIDsByFeaturesName(jobID, featureNames, db, databaseConvertion_id):
 
     notCachedIds = set(featureNames).difference(set(cachedFeatureIDs.keys()))
 
-    # One xref document per input name, its mates resolved by a $lookup whose
-    # sub-pipeline filters on the target dbname_id INSIDE the join, so mongod
-    # walks the (dbname_id, _id) index and never materialises the mates that
-    # belong to other databases. The previous form -- $unwind every mate, look
-    # each one up by _id in full, THEN drop the ~90% with the wrong dbname_id
-    # -- was measured 3-4.5x slower on the same batches (mmu, 12,762 names:
-    # 4.05 s -> 1.24 s per database), and these round trips are ~98% of the
-    # identifier-mapping phase.
-    #
-    # The result must be the same as the old form to the last detail: one
-    # display_id per (input name, matching mate) pair, in the order of the
-    # input's mates array, concatenated over the input's documents in scan
-    # order. The join returns hits in index order, so they are re-walked here
-    # in mates order (a duplicated mate would be emitted twice, as $unwind
-    # did). Verified identical, per-name list order included, on the bundled
-    # gene, protein and symbol lookups.
-    listMongoPipeline = [
-        {"$match": {"display_id": {"$in": list(notCachedIds)}}},
-        {"$lookup": {
-            "from": "xref",
-            "let": {"m": {"$ifNull": ["$mates", []]}},
-            "pipeline": [
-                {"$match": {"$expr": {"$and": [
-                    {"$eq": ["$dbname_id", databaseConvertion_id]},
-                    {"$in": ["$_id", "$$m"]}]}}},
-                {"$project": {"_id": 1, "display_id": 1}}
-            ],
-            "as": "hits"
-        }},
-        {"$match": {"hits.0": {"$exists": True}}},
-        {"$project": {"_id": 0, "display_id": 1, "mates": 1, "hits": 1}}
-    ]
-
+    # Two indexed finds instead of one aggregation. The names' xref documents
+    # come off the display_id index; the union of their mates is then looked
+    # up with the target dbname_id on the (dbname_id, _id) index, and the
+    # mates are re-walked in array order, one row per matching mate
+    # occurrence -- exactly what the previous $match / $unwind / $lookup /
+    # $match aggregation produced (which fetched EVERY mate document by _id
+    # and only then dropped the ~90% belonging to other databases). Measured
+    # identical, per-name order included, on MongoDB 8.2 and on production's
+    # MongoDB 4.4, where this form is ~9x faster than the aggregation
+    # (2,000 names: 4.2 s -> 0.46 s). A $lookup sub-pipeline with $expr/$in
+    # was tried first: fast on 8.2, but 4.4 cannot index it and every batch
+    # turned into collection scans of the 1.1M-document xref -- mapping
+    # workers hung for hours on paintomics.uv.es (2026-08-17). Plain finds
+    # behave the same on every server version.
     matchedFeatures = defaultdict(list)
 
     try:
         if len(notCachedIds):
-            listResultCursor = db.xref.aggregate(listMongoPipeline, batchSize = 2000)
+            nameDocuments = list(db.xref.find({"display_id": {"$in": list(notCachedIds)}},
+                                              {"display_id": 1, "mates": 1}))
+            allMates = list({mate for document in nameDocuments for mate in (document.get("mates") or [])})
+            hitsByID = {}
+            for start_ in range(0, len(allMates), 5000):
+                for hit in db.xref.find({"dbname_id": databaseConvertion_id,
+                                         "_id": {"$in": allMates[start_:start_ + 5000]}},
+                                        {"display_id": 1}):
+                    hitsByID[hit.get("_id")] = hit.get("display_id")
 
-            for foundFeature in listResultCursor:
-                hitsByID = {hit.get("_id"): hit.get("display_id") for hit in foundFeature.get("hits", [])}
-                translations = matchedFeatures[foundFeature.get("display_id")]
-                for mate in foundFeature.get("mates", []):
+            for document in nameDocuments:
+                translations = None
+                for mate in (document.get("mates") or []):
                     if mate in hitsByID:
+                        if translations is None:
+                            translations = matchedFeatures[document.get("display_id")]
                         translations.append(str(hitsByID[mate]))
 
             # Record the misses too, as empty lists -- in the returned table


### PR DESCRIPTION
## Summary
PR #33's `$lookup` sub-pipeline (`$expr`/`$in` over the mates array) is fast on MongoDB 8.2 but MongoDB 4.4 (production) cannot index it: every 250-name batch became a collection scan of the 1.1M-document `xref` and mapping workers hung for hours on paintomics.uv.es right after the deploy (hot-fixed live by restoring the classic pipeline).

The lookup is now two plain indexed `find`s (names off `display_id`, mates off `(dbname_id, _id)`), re-walked in mates order — same rows, same order, on every server version.

## Evidence
- production MongoDB 4.4, 2,000 names: classic aggregation 4.2 s → 0.46 s (KEGG), 5.7 s → 0.30 s (symbols), output identical incl. per-name order
- MongoDB 8.2: 12,762-gene mapping 0.8 s (classic 5.7 s, sub-pipeline 1.1 s); function-level dump identical to master; strict harness runs of 4 pathway scenarios IDENTICAL; PR #32 contract tests OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)