### PR TITLE
Fix AI report citation order and the status poll that died on one dropped request

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
@@ -771,18 +771,47 @@ function PA_Step3JobView() {
 		messageDialog.show();
 	};
 
+	// The poll is a self-rescheduling chain, so every answer -- including the
+	// ones that are not answers -- has to decide what happens next. This
+	// rescheduled only from `success` and declared no `error` handler at all,
+	// so a single request that did not land ended the chain for good.
+	// Measured in Chrome against a real job: five healthy polls, a server
+	// restart, a sixth answering `ERR http=0`, and the page never issued
+	// another status request. The interpretation finished and was stored,
+	// while the widget sat at "Generating interpretation..." with an empty
+	// message area until the page was reloaded -- which is exactly how the bug
+	// was reported. A run polls every 3s for 5-15 minutes, so one blip (a
+	// deploy, a sleep/wake, a VPN reconnect) was enough to trigger it.
+	//
+	// Only done/error/cancelled end the chain now. A transport failure backs
+	// off so a server that is down is not hammered, and the normal cadence
+	// returns as soon as it answers again.
 	this.pollAIStatus = function() {
 		var me = this;
+		var BACKOFF_CEILING = 30000;
+		var schedule = function(delay) {
+			if (!me.aiWidget) { return; }   // widget gone: nothing left to update
+			me.pollTimerID = setTimeout(function() { me.pollAIStatus(); }, delay);
+		};
 		$.ajax({
 			type: "POST", url: SERVER_URL_AI_INTERPRET_STATUS,
 			data: { jobID: me.getModel().getJobID() },
 			success: function(r) {
-				if (r.success && me.aiWidget) {
-					me.aiWidget.updateProgress(r.status, r.percent, r.detail);
-					if (r.status !== "done" && r.status !== "error" && r.status !== "cancelled") {
-						me.pollTimerID = setTimeout(function() { me.pollAIStatus(); }, AI_POLL_INTERVAL);
-					}
+				if (!me.aiWidget) { return; }
+				// success:false is what the servlet returns for any handled
+				// exception -- an expired session, a Mongo hiccup. It is not a
+				// statement about the job, so keep watching.
+				if (!r || !r.success) { schedule(AI_POLL_INTERVAL); return; }
+				me.aiPollFailures = 0;
+				me.aiWidget.updateProgress(r.status, r.percent, r.detail);
+				if (r.status !== "done" && r.status !== "error" && r.status !== "cancelled") {
+					schedule(AI_POLL_INTERVAL);
 				}
+			},
+			error: function() {
+				me.aiPollFailures = (me.aiPollFailures || 0) + 1;
+				schedule(Math.min(AI_POLL_INTERVAL * Math.pow(2, me.aiPollFailures - 1),
+				                  BACKOFF_CEILING));
 			}
 		});
 	};

--- a/PaintomicsServer/src/classes/AIInterpret/agent.py
+++ b/PaintomicsServer/src/classes/AIInterpret/agent.py
@@ -54,6 +54,7 @@ from src.classes.AIInterpret.context_builder import (
 from src.classes.AIInterpret.pubmed_client import PubMedClient
 from src.classes.AIInterpret.verification import (
     verify_report_v2, redact_unverified_v2, renumber_citations,
+    sort_references_section,
     parse_references_section, render_references_section,
     normalize_citation_markers, resolve_pmid_mentions, count_body_citations,
 )
@@ -1821,6 +1822,15 @@ async def _run_async(job_instance, job_id, experiment_design, budgets, stats,
         report, removed = redact_unverified_v2(report, final["failed_citations"])
         final["redacted_count"] = removed
     report, citation_mapping = renumber_citations(report)
+    # ...and then put the entries back in the order of the labels they now
+    # carry. Renumbering rewrites the markers where they stand, so a section
+    # rendered in ascending old index order ends up printed as [1], [5], [3],
+    # [2], [4] -- every entry pointing at the right paper, the list itself
+    # unreadable. Nothing downstream can catch it, because the citations are
+    # all still valid; only the reader sees it. This call existed in
+    # pipeline.py (0616e2df) and was dropped when the SDK workflow replaced
+    # that module, so every report shipped since has been scrambled.
+    report = sort_references_section(report)
     if citation_mapping:
         kept = []
         for p in unique_papers:

--- a/PaintomicsServer/src/tests/test_ai_status_poll_survives_a_failed_request.py
+++ b/PaintomicsServer/src/tests/test_ai_status_poll_survives_a_failed_request.py
@@ -1,0 +1,188 @@
+"""The AI status poll must survive a request that does not land.
+
+``pollAIStatus`` (PA_Step3Views.js) is a self-rescheduling chain: each answer
+schedules the next poll. It rescheduled only from its ``success`` handler and
+declared no ``error`` handler at all, so the chain was one dropped request from
+being over -- permanently, and silently.
+
+Measured in Chrome against a real job (2026-08-17): five healthy polls, the
+server restarted, the sixth answered ``ERR http=0``, and the page never issued
+another status request. The interpretation finished and was stored; the widget
+sat at "Generating interpretation..." with an empty message area until the user
+reloaded the page. That is the whole of the reported bug -- the finished report
+only appearing after a refresh -- and an AI run is 5 to 15 minutes of polling
+every 3 seconds, so one blip (a deploy, a sleep/wake, a VPN reconnect) is
+enough.
+
+A non-answer is not a verdict about the job. Only ``done``, ``error`` and
+``cancelled`` end the chain; everything else must try again.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_ai_status_poll_survives_a_failed_request
+"""
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+CLIENT_ROOT = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), "..", "..", "..",
+    "PaintomicsClient", "public_html"))
+STEP3_VIEWS = os.path.join(CLIENT_ROOT, "app", "view",
+                           "PathwayAcquisitionViews", "PA_Step3Views.js")
+
+HEADER = "this.pollAIStatus = function()"
+
+
+def read(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def extract_block(source, header):
+    """`header` plus the brace-matched block that follows it."""
+    start = source.find(header)
+    if start == -1:
+        raise AssertionError("%s is missing from PA_Step3Views.js" % header)
+    opening = source.index("{", start + len(header) - 1)
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start:index + 1]
+    raise AssertionError("unbalanced braces after %s" % header)
+
+
+# The real function, lifted out and driven by a stubbed jQuery. `respond`
+# decides what the single ajax call does, which is the only variable here.
+HARNESS = """
+const results = {};
+
+function drive(respond) {
+    const scheduled = [];
+    const calls = [];
+    const setTimeout_ = function (fn, delay) { scheduled.push({delay: delay}); return scheduled.length; };
+    const AI_POLL_INTERVAL = 3000;
+    const SERVER_URL_AI_INTERPRET_STATUS = "/ai_interpret_status";
+
+    const $ = function () { return {}; };
+    $.ajax = function (opts) {
+        calls.push(opts.url);
+        respond(opts);
+    };
+
+    function View() {
+        this.aiWidget = {updateProgress: function () {}};
+        this.getModel = function () { return {getJobID: function () { return "JOB"; }}; };
+        const setTimeout = setTimeout_;
+        %(poll)s
+    }
+
+    const view = new View();
+    view.pollAIStatus();
+    return {polls: calls.length, scheduled: scheduled.length,
+            firstDelay: scheduled.length ? scheduled[0].delay : null};
+}
+
+// A request that never landed: jQuery calls `error`, or nothing at all when no
+// error handler was declared.
+results.transportFailure = drive(function (opts) {
+    if (opts.error) { opts.error({status: 0}); }
+});
+
+// The server answered, but with success:false (the servlet does this for any
+// handled exception -- an expired session, a Mongo hiccup).
+results.unsuccessfulAnswer = drive(function (opts) {
+    opts.success({success: false});
+});
+
+// Healthy in-progress answer: the chain must continue.
+results.stillRunning = drive(function (opts) {
+    opts.success({success: true, status: "interpreting", percent: 45, detail: "..."});
+});
+
+// Terminal answers: the chain must stop.
+results.done = drive(function (opts) {
+    opts.success({success: true, status: "done", percent: 100, detail: "Ready"});
+});
+results.cancelled = drive(function (opts) {
+    opts.success({success: true, status: "cancelled", percent: 0, detail: ""});
+});
+results.errored = drive(function (opts) {
+    opts.success({success: true, status: "error", percent: 0, detail: "boom"});
+});
+
+console.log(JSON.stringify(results));
+"""
+
+
+def run_node(script):
+    directory = tempfile.mkdtemp(prefix="paintomics-poll-")
+    try:
+        path = os.path.join(directory, "check.js")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(script)
+        completed = subprocess.run(["node", path], capture_output=True,
+                                   text=True, timeout=60)
+        if completed.returncode != 0:
+            raise AssertionError("node failed:\n%s" % completed.stderr)
+        return json.loads(completed.stdout)
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class StatusPollChainTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        block = extract_block(read(STEP3_VIEWS), HEADER)
+        cls.results = run_node(HARNESS % {"poll": block})
+
+    def test_a_dropped_request_does_not_end_the_chain(self):
+        """The measured bug: one ERR http=0 and the widget never updates again."""
+        outcome = self.results["transportFailure"]
+        self.assertEqual(
+            outcome["scheduled"], 1,
+            "a status request that did not land scheduled no retry, so the "
+            "poll chain is dead: the report will only appear if the user "
+            "reloads the page")
+
+    def test_an_unsuccessful_answer_does_not_end_the_chain(self):
+        outcome = self.results["unsuccessfulAnswer"]
+        self.assertEqual(
+            outcome["scheduled"], 1,
+            "success:false ended the poll chain; the servlet returns that for "
+            "any handled exception, which says nothing about the job")
+
+    def test_a_running_job_keeps_polling(self):
+        self.assertEqual(self.results["stillRunning"]["scheduled"], 1)
+
+    def test_terminal_states_stop_the_chain(self):
+        for state in ("done", "cancelled", "errored"):
+            with self.subTest(state=state):
+                self.assertEqual(
+                    self.results[state]["scheduled"], 0,
+                    "%s is terminal; polling on after it wastes requests "
+                    "forever" % state)
+
+    def test_the_retry_is_not_faster_than_the_normal_cadence(self):
+        """A failing server must not be hammered harder than a healthy one."""
+        delay = self.results["transportFailure"]["firstDelay"]
+        self.assertIsNotNone(delay, "no retry was scheduled at all")
+        self.assertGreaterEqual(delay, 3000, "retry is faster than AI_POLL_INTERVAL")
+
+
+def main():
+    suite = unittest.TestLoader().loadTestsFromModule(__import__(__name__))
+    return 0 if unittest.TextTestRunner(verbosity=2).run(suite).wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/PaintomicsServer/src/tests/test_reference_section_ordering.py
+++ b/PaintomicsServer/src/tests/test_reference_section_ordering.py
@@ -161,6 +161,33 @@ def test_ten_sorts_after_nine_not_before_it():
     assert _labels(out) == list(range(1, 12)), _labels(out)
 
 
+# ---------------------------------------------------------------------------
+# The wiring, which is the part that actually broke.
+#
+# Every test above calls sort_references_section itself, through the local
+# _pipeline helper -- so all of them passed while not one shipped report was
+# sorted. The sorter was wired into pipeline.py (0616e2df); the Agents SDK
+# rewrite (8a6a7dbd) replaced that module and did not carry the call across,
+# leaving a function whose only remaining caller was this test file. A helper
+# that reimplements the production sequence proves nothing about the
+# production sequence, so this asserts against the real one.
+# ---------------------------------------------------------------------------
+
+def test_the_agent_workflow_sorts_after_renumbering():
+    import inspect
+    from src.classes.AIInterpret import agent
+
+    source = inspect.getsource(agent._run_async)
+    assert "renumber_citations(" in source, "phase 6 no longer renumbers at all"
+    assert "sort_references_section(" in source, (
+        "the agent workflow never calls sort_references_section, so every "
+        "shipped report prints its References in render order while the body "
+        "is numbered by first mention")
+    assert (source.index("renumber_citations(")
+            < source.index("sort_references_section(")), (
+        "the sort has to run after the renumbering, or it orders the old labels")
+
+
 def main():
     for t in (test_renumbering_alone_leaves_the_section_scrambled,
               test_final_section_reads_in_order,
@@ -170,7 +197,8 @@ def main():
               test_an_already_ordered_section_is_untouched,
               test_report_without_references_is_untouched,
               test_single_entry_is_untouched,
-              test_ten_sorts_after_nine_not_before_it):
+              test_ten_sorts_after_nine_not_before_it,
+              test_the_agent_workflow_sorts_after_renumbering):
         _check(t.__name__, t)
 
     print("\nPassed: %d / %d" % (len(_PASSED), len(_PASSED) + len(_FAILED)))


### PR DESCRIPTION
Two independent bugs in the AI interpretation feature, both reported from use.

## 1. The References section was printed out of order

`render_references_section` emits entries in ascending index order, then
`renumber_citations` rewrites every `[N]` marker **in place**, in order of first
mention in the body. Neither step moves an entry, so the two compose into a
bibliography that is individually correct and collectively unreadable.

`sort_references_section` exists for exactly this and was wired into
`pipeline.py` in 0616e2df. The Agents SDK rewrite (8a6a7dbd) replaced that
module with `agent.py` and never carried the call across, so its only remaining
caller was its own unit test — which is why the tests stayed green while every
shipped report was scrambled.

Measured on stored reports here — job `Hv4o0bP4JY` printed:

```
References: [6, 7, 2, 3, 10, 11, 12, 13, 4, 14, 15, 16, 5]
body cites:  1, 2, 3, 4, 5, ... in order
```

Nothing downstream could catch it: every marker still resolves to the right
paper, so verification passes and the job reports `done`. Only the reader sees
it.

The fix is the one call `pipeline.py` used to make, in the same position.

## 2. The finished report only appeared after a page refresh

`pollAIStatus` is a self-rescheduling chain — each answer schedules the next
poll. It rescheduled **only** from its `success` handler and declared no
`error` handler at all, so a single request that did not land ended the chain
permanently, silently.

Measured in Chrome against a real job:

```
req 16:25:43   ok status=interpreting      (x5, healthy)
req 16:26:02   ERR http=0                  <- one failed request
<no further request, ever>
```

The interpretation finished and was stored; the widget sat at "Generating
interpretation..." with an empty message area until the page was reloaded. A
run polls every 3s for 5-15 minutes, so one blip — a deploy, a sleep/wake, a
VPN reconnect — was enough.

Only `done`/`error`/`cancelled` end the chain now. A transport failure retries
with exponential backoff capped at 30s; `success:false` (what the servlet
returns for any handled exception) is no longer treated as a verdict about the
job either.

## Testing

Both fixes have a test that fails before and passes after:

- `test_reference_section_ordering.py` — the existing tests all called the
  sorter themselves through a local `_pipeline` helper that reimplements the
  production sequence, so none of them could notice the sequence losing a step.
  The new test asserts against `agent.py`'s actual finalisation.
- `test_ai_status_poll_survives_a_failed_request.py` — new; lifts the real
  `pollAIStatus` out of the shipped file and drives it under node with a stubbed
  jQuery, covering a dropped request, `success:false`, a running job and each
  terminal state.

Local run: reference ordering 10/10, poll chain 5/5, agent end-to-end 8/8,
module imports 3/3, plus versioned-assets, citation grounding / marker
normalisation / remapping, AI servlet handlers, consent enforcement and SDK
transport all green. Clean-checkout import gate (`git archive` + generated
serverconf) passes; `node --check` passes on the edited client file.

Verified in Chrome, not just in tests:

- The poll experiment was re-run after the fix — retries at +3s, +6s, +12s,
  +24s across a ~45s outage, then `ok status=done` and the report rendered with
  no reload.
- A real 4.5-minute run against the CSIC gateway on job `Hv4o0bP4JY` stored its
  References as `[1..20, 22]`, matching body order, rendered ascending in the
  widget, and appeared on a page that had not been touched since before the run
  was queued.

`PA_Step3Views.js` is loaded by `app.js`'s `loadModule` through jQuery's script
dataType, which cache-busts itself, so there is no `?v=` marker to bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)