### PR TITLE
Show the matched gene symbol on Reactome pathway views, not the input ID

### DIFF
--- a/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
+++ b/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
@@ -290,6 +290,31 @@ def resolveDatabaseIds(organism, databases, db=None):
     try:
         databaseConvertion_ids = {dbname: db.dbname.find_one({"dbname": gene_databases.get(dbname)}, {"item": 1, "qty": 1}).get("_id") for dbname in databases}
         databaseGeneSymbol_ids = {dbname: db.dbname.find_one({"dbname": symbol_databases.get(dbname)}, {"item": 1, "qty": 1}).get("_id") for dbname in databases}
+
+        # Some databases declare THEMSELVES as their symbol database (every
+        # Reactome entry and three MapMan entries in organismDB map e.g.
+        # reactome_gene_id -> reactome_gene_id). Translating a feature ID
+        # through the very database it came from is the identity at best, so
+        # matched clones kept the user's raw input identifier as their display
+        # name and the Reactome pathway views painted "ENSMUSG..." on every
+        # gene box. The xref mates graph does link those feature IDs to the
+        # organism's real symbol table (mmu: GNAI3 -> Gnai3 via
+        # refseq_gene_symbol), so such databases borrow a configured symbol
+        # database that is not its own ID database -- KEGG's by explicit
+        # preference (it is the one true gene-symbol table in every current
+        # organism config), never by dict order. Organisms without one (cfa)
+        # keep the old behaviour.
+        degenerate = [dbname for dbname in databases
+                      if symbol_databases.get(dbname) == gene_databases.get(dbname)]
+        realSymbolDB = next((symbolDB for dbname, symbolDB
+                             in sorted(symbol_databases.items(),
+                                       key=lambda entry: entry[0] != "KEGG")
+                             if symbolDB != gene_databases.get(dbname)), None)
+        if degenerate and realSymbolDB is not None:
+            realSymbolDoc = db.dbname.find_one({"dbname": realSymbolDB}, {"item": 1, "qty": 1})
+            if realSymbolDoc is not None:
+                for dbname in degenerate:
+                    databaseGeneSymbol_ids[dbname] = realSymbolDoc.get("_id")
     finally:
         if client is not None:
             client.close()
@@ -396,6 +421,10 @@ def mapFeatureIdentifiers(jobID, organism, databases, featureList,  matchedFeatu
         # Cache all database results upfront
         allCacheFeatureIDS = {}
         allCacheSymbolsIDS = {}
+        # Databases whose symbol cache was additionally keyed by input name
+        # below, and only those, may use the per-name fallback when naming a
+        # clone.
+        nameKeyedSymbolDatabases = set()
 
         for databaseConvertion_name in databases:
             # Reset the cache per database
@@ -406,10 +435,13 @@ def mapFeatureIdentifiers(jobID, organism, databases, featureList,  matchedFeatu
             databaseConvertion_id = databaseConvertion_ids.get(databaseConvertion_name)
             databaseGeneSymbol_id = databaseGeneSymbol_ids.get(databaseConvertion_name)
 
-            # Check if ID and symbol databases are the same to avoid duplicate queries
-            # This happens with Reactome where both map to 'reactome_gene_id'
-            sameDatabase = (gene_databases.get(databaseConvertion_name) ==
-                          symbol_databases.get(databaseConvertion_name))
+            # Skip the symbol pass only when it would query the ID database
+            # itself (an identity translation). Compared on the RESOLVED ids:
+            # resolveDatabaseIds redirects databases configured as their own
+            # symbol database (Reactome, some MapMan) to the organism's real
+            # symbol table, and those must run the second query or matched
+            # clones keep the raw input identifier as their display name.
+            sameDatabase = (databaseConvertion_id == databaseGeneSymbol_id)
 
             # Populate the feature and symbol cache
             for featureNameBatch in featureNamesBatches:
@@ -425,6 +457,30 @@ def mapFeatureIdentifiers(jobID, organism, databases, featureList,  matchedFeatu
                     # Query for symbols separately
                     newSymbolIDs = findIDsByFeaturesName(jobID, list(chain.from_iterable(newFeatureIDs.values())), db,
                                                          databaseGeneSymbol_id)
+
+                    # A symbol table can be populated for a DIFFERENT id space
+                    # than the one being translated -- Reactome's gene IDs are
+                    # matched against KEGG's gene-symbol table, where mmu's
+                    # GNAI3 has a mate (Gnai3) but GNA12 has none at all
+                    # (3.5k of STATegra's 8.4k Reactome clones). The INPUT
+                    # name's own xref group does carry the symbol
+                    # (ENSMUSG00000000149 -> Gna12), so a name with ANY
+                    # symbol-less matched feature ID is looked up as well and
+                    # used as the per-feature fallback below (ANY, not all:
+                    # one name can resolve to several feature IDs and only
+                    # some of them carry a symbol -- 73 extra raw-ID clones
+                    # on STATegra when this asked for all of them).
+                    # Decided on the RESULTS, never on the organism config:
+                    # normalising organismDB.py to say what this code does
+                    # must not silently switch the fallback off.
+                    namesWithoutSymbol = [
+                        name for name, featureIDs in newFeatureIDs.items()
+                        if any(not newSymbolIDs.get(featureID)
+                               for featureID in featureIDs)]
+                    if namesWithoutSymbol:
+                        newSymbolIDs.update(findIDsByFeaturesName(
+                            jobID, namesWithoutSymbol, db, databaseGeneSymbol_id))
+                        nameKeyedSymbolDatabases.add(databaseConvertion_name)
 
                 cacheSymbolsIDS.update(newSymbolIDs)
 
@@ -502,8 +558,15 @@ def mapFeatureIdentifiers(jobID, organism, databases, featureList,  matchedFeatu
                         # For some IDs there might be more than one symbol, select the first
                         # one from the set. A cached entry can legitimately be an empty
                         # list (species installed with symbols=0), which indexed [0] and
-                        # aborted the whole mapping.
-                        cachedSymbols = cacheSymbolsIDS.get(featureID) or [featureClone.getName()]
+                        # aborted the whole mapping. Databases redirected to a borrowed
+                        # symbol table fall back to the input name's own symbol (its xref
+                        # group carries one even when the feature ID's does not), and only
+                        # then to the raw input name.
+                        cachedSymbols = cacheSymbolsIDS.get(featureID)
+                        if not cachedSymbols and databaseConvertion_name in nameKeyedSymbolDatabases:
+                            cachedSymbols = cacheSymbolsIDS.get(originalName)
+                        if not cachedSymbols:
+                            cachedSymbols = [featureClone.getName()]
                         featureName = cachedSymbols[0]
 
                         featureClone.setName(featureName)

--- a/PaintomicsServer/src/tests/test_reactome_matches_get_symbol_names.py
+++ b/PaintomicsServer/src/tests/test_reactome_matches_get_symbol_names.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Reactome/MapMan matched genes must display gene symbols, not input IDs.
+
+For every organism whose Reactome (or MapMan) entry in
+src/conf/organismDB.py maps both the ID database and the "symbol" database
+to the same xref table (e.g. mmu Reactome: reactome_gene_id twice), the
+symbol pass in mapFeatureIdentifiers was a no-op: the symbols cache ended
+up keyed by input name, the featureID lookup missed, and the matched clone
+kept the raw input identifier as its display name. A full STATegra job
+stored 8,396 of 25,870 gene features named "ENSMUSG..." — every one of
+them a Reactome match — and the Reactome pathway views painted Ensembl IDs
+on every gene box while the KEGG views showed symbols.
+
+The fix resolves symbols for such databases against a real symbol database
+of the organism (mmu: refseq_gene_symbol); the xref mates graph links the
+Reactome gene IDs to it (GNAI3 -> Gnai3).
+
+Needs the local MongoDB with the mmu species database installed.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_reactome_matches_get_symbol_names
+"""
+import os
+import sys
+import unittest
+import uuid
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from src.classes.Feature import Gene
+from src.common.FeatureNamesToKeggIDsMapper import (
+    mapFeatureIdentifiers, resolveDatabaseIds)
+
+
+ORGANISM = "mmu"
+DATABASES = ["KEGG", "Reactome"]
+# Ensembl gene IDs with a known refseq_gene_symbol translation. The first
+# three have the symbol in their Reactome gene ID's xref group; the last
+# three only carry it in the INPUT name's group (GNA12/SDHD/DLAT have no
+# refseq_gene_symbol mate), which exercises the per-name fallback.
+INPUTS = {
+    "ENSMUSG00000000001": "Gnai3",
+    "ENSMUSG00000000028": "Cdc45",
+    "ENSMUSG00000000184": "Ccnd2",
+    "ENSMUSG00000000149": "Gna12",
+    "ENSMUSG00000000171": "Sdhd",
+    "ENSMUSG00000000168": "Dlat",
+}
+
+
+def mongoAvailable():
+    try:
+        from pymongo import MongoClient
+        from src.conf.serverconf import MONGODB_HOST, MONGODB_PORT
+        client = MongoClient(MONGODB_HOST, MONGODB_PORT,
+                             serverSelectionTimeoutMS=2000)
+        names = client.list_database_names()
+        client.close()
+        return (ORGANISM + "-paintomics") in names
+    except Exception:
+        return False
+
+
+@unittest.skipUnless(mongoAvailable(), "local MongoDB with mmu not available")
+class ReactomeMatchesGetSymbolNames(unittest.TestCase):
+
+    def mapInputs(self):
+        featureList = []
+        for name in INPUTS:
+            gene = Gene("")
+            gene.setName(name)
+            featureList.append(gene)
+        matched, notMatched, found = [], [], []
+        mapFeatureIdentifiers("TEST" + uuid.uuid4().hex[:8], ORGANISM,
+                              DATABASES, featureList, matched, notMatched,
+                              found, "genes")
+        return matched
+
+    def test_symbol_database_ids_differ_from_id_database_ids(self):
+        """resolveDatabaseIds must never hand a worker the identity mapping."""
+        idDBs, symbolDBs = resolveDatabaseIds(ORGANISM, DATABASES)
+        self.assertNotEqual(
+            idDBs["Reactome"], symbolDBs["Reactome"],
+            "Reactome symbol lookups run against the ID database itself; "
+            "the symbol pass is a no-op and matched genes keep their raw "
+            "input identifier as display name.")
+        self.assertEqual(
+            symbolDBs["Reactome"], symbolDBs["KEGG"],
+            "Reactome must borrow KEGG's gene-symbol table, not whichever "
+            "symbol database the organism config happens to list first.")
+
+    def test_reactome_clones_are_named_with_the_gene_symbol(self):
+        matched = self.mapInputs()
+        self.assertTrue(matched, "no features matched; mmu data missing?")
+        reactomeClones = [f for f in matched
+                          if "Reactome" in str(f.getMatchingDB())]
+        self.assertTrue(reactomeClones,
+                        "no Reactome matches; mmu Reactome data missing?")
+        badlyNamed = sorted({f.getName() for f in reactomeClones
+                             if f.getName().startswith("ENSMUSG")})
+        self.assertEqual(
+            badlyNamed, [],
+            "Reactome-matched clones still display raw input IDs: %s"
+            % badlyNamed)
+
+    def test_clone_names_are_the_expected_symbols(self):
+        """Every clone of the three inputs must carry one of their symbols."""
+        matched = self.mapInputs()
+        expected = {symbol.lower() for symbol in INPUTS.values()}
+        actual = {feature.getName().lower() for feature in matched}
+        self.assertTrue(
+            actual and actual.issubset(expected),
+            "matched clones are named %s, expected only symbols from %s"
+            % (sorted(actual), sorted(expected)))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Problem

Reactome pathway views painted the user's raw input identifier on every gene box (`ENSMUSG00000000001`, …) while the KEGG views of the same job showed gene symbols.

Root cause: in `organismDB.py` every Reactome entry (and three MapMan entries) declares **itself** as its gene-symbol database — `reactome_gene_id -> reactome_gene_id`. The mapper's symbol pass was therefore an identity translation, it was skipped as a "duplicate query", and each matched clone kept its input name as display name.

On the STATegra 5-omic example that was **8,396 of 25,870** gene features, every one of them a Reactome match.

## Fix

* `resolveDatabaseIds` redirects such a database to a real gene-symbol table, preferring **KEGG's explicitly** rather than whichever entry the config happens to list first. Organisms with no real symbol database (`cfa`) keep the old behaviour.
* A borrowed symbol table is populated for another id space, so many feature IDs have no mate in it (mmu: `GNAI3 -> Gnai3` resolves, `GNA12` has none at all). The input name's own xref group does carry it (`ENSMUSG00000000149 -> Gna12`), so any name with a symbol-less matched feature ID is looked up there too and used as the fallback. That decision is made on the query **results**, never on the organism config — so normalising `organismDB.py` to say what the code does cannot silently switch the fallback back off.

Server-side only; no client change.

## Verification

Full STATegra 5-omic example re-run through the real pipeline (887 pathways), before vs after:

| | before | after |
|---|---|---|
| gene features named with a raw ID | 8,396 | **30** |
| KEGG / Reactome / merged feature counts | 17,344 / 8,426 / 100 | 17,344 / 8,426 / 100 |
| KEGG feature names changed | — | **0** |

The 30 residuals are pseudogenes and IG/HLA segments with no symbol anywhere in their xref group. Each Reactome ID gets its **own** symbol — `FYN->Fyn`, `LYN->Lyn`, `PTPN6->Ptpn6`, `PTPN11->Ptpn11` — not a shared one.

Checked in the browser on a job built with this code: the GPVI-mediated activation cascade now paints `Lyn`, `Syk`, `Pik3r1`, `Plcg2`, `Vav2/3`, `Cdc42`, `Rhog`, `Ptpn6`, `Lat`, `Lck`, `Clec1b` where it painted `ENSMUSG…` before; the global heatmap pairs them correctly (`Syk (SYK)`, `Fyn (FYN)`); a KEGG pathway (Cytokine-cytokine receptor interaction) is unchanged; no console errors.

New test `src/tests/test_reactome_matches_get_symbol_names.py` (3 cases) fails on master and passes here — including when `organismDB.py` is normalised to `reactome_gene_id -> refseq_gene_symbol`, which is the edit that would otherwise silently reintroduce the bug. Existing mapper/enrichment/compound suites and the clean-archive import gate all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
