### PR TITLE
Make the "Neighbouring features" button answer every click

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
@@ -7225,6 +7225,164 @@ var paSharedOmicHeader = function (jobModel, omicNames, columnCount) {
  * aggregation, one whose aggregation is stale, and one rendered by a caller
  * that never learned about modes.
  */
+/**
+ * Which neighbour list a "Neighbouring features" request resolves to, or the
+ * reason there is none -- in words the panel can print.
+ *
+ * The Step-4 details panel asked for the list inline and guarded each way it
+ * could come back empty with `console.warn(...); return`. Four of them, and the
+ * first one every user meets is the level box: it opens blank, so the very
+ * first click lands on `neighbourMap[featureID][""]`, warns to a console nobody
+ * has open, and draws nothing. From the outside that is a button that does not
+ * work, which is exactly how it was reported.
+ *
+ * Deciding here, and returning the reason rather than nothing, is what lets the
+ * panel say which of the four it hit. They are genuinely different situations:
+ * a level that was never typed is the user's next action, a species installed
+ * without hubData is not something they can fix, and a metabolite that KEGG's
+ * interaction network does not cover is a fact about the metabolite.
+ *
+ * `level` is checked against /^[1-4]$/ on the trimmed string rather than parsed:
+ * `parseInt("1.9")` and `parseInt("1e9")` are both 1, and the input is a
+ * number field the user can type anything into.
+ *
+ * @param {Object} request {featureID, featureType, neighbourMap, level}
+ * @return {Object} {ok:true, level, neighbours} | {ok:false, reason, message}
+ */
+var paNeighbourRequest = function (request) {
+	request = request || {};
+
+	var featureID = request.featureID;
+	var featureType = (request.featureType === undefined || request.featureType === null)
+		? "" : String(request.featureType).toLowerCase();
+	var neighbourMap = request.neighbourMap;
+	var typed = (request.level === undefined || request.level === null)
+		? "" : String(request.level).trim();
+
+	/* Feature type first: no level will ever help a gene box, so saying
+	   "enter a level" there would be a wrong instruction, not a partial one. */
+	if (featureType !== "" && featureType.indexOf("compound") === -1) {
+		return {
+			ok: false, reason: "not-a-metabolite",
+			message: "Neighbouring features are defined for metabolites only — " +
+				"they come from the KEGG compound interaction network. This box holds " +
+				"features of another type."
+		};
+	}
+
+	if (typed === "") {
+		return {
+			ok: false, reason: "no-level",
+			message: "Enter how many network steps to look out from this metabolite " +
+				"(1 to 4), then press Show Features."
+		};
+	}
+
+	if (!/^[1-4]$/.test(typed)) {
+		return {
+			ok: false, reason: "bad-level",
+			message: "Neighbours are held for 1 to 4 network steps. “" + typed +
+				"” is not one of them."
+		};
+	}
+
+	var level = parseInt(typed, 10);
+
+	if (!neighbourMap || Object.keys(neighbourMap).length === 0) {
+		return {
+			ok: false, reason: "no-map", level: level,
+			message: "No metabolite interaction network is available for this " +
+				"analysis. It comes from the species' hubData, which not every " +
+				"installed species ships."
+		};
+	}
+
+	/* JSON object keys are strings; the level is read back as a number above. */
+	var byStep = neighbourMap[featureID];
+	if (!byStep) {
+		return {
+			ok: false, reason: "not-in-network", level: level,
+			message: "This metabolite is not in the KEGG compound interaction " +
+				"network, so it has no neighbours to show."
+		};
+	}
+
+	var neighbours = byStep[level] !== undefined ? byStep[level] : byStep[String(level)];
+	if (!neighbours || !neighbours.length) {
+		return {
+			ok: false, reason: "no-neighbours-at-level", level: level,
+			message: "This metabolite has no neighbours at " + level + " step" +
+				(level === 1 ? "" : "s") + "."
+		};
+	}
+
+	return {ok: true, level: level, neighbours: neighbours};
+};
+
+/**
+ * OmicValues rendered as the plain rows the Step-4 details heatmap/plot pair
+ * reads -- the same shape `addTableEntrie()` builds.
+ *
+ * `globalExpressionData` arrives as JSON and `setGlobalExpressionData` turns
+ * every entry into an OmicValue, on which `isRelevant` and
+ * `isRelevantAssociation` are METHODS. The neighbours panel handed those
+ * instances straight to a renderer written for `addTableEntrie` rows, where the
+ * same two names are booleans. Nothing threw -- the names, ids and values are
+ * plain properties either way, so the charts drew -- but every test of them
+ * silently inverted:
+ *
+ *   `omicsValue.isRelevant === true`            a function is not true, so no
+ *                                               row ever got its `*` marker
+ *   `x.isRelevant || x.isRelevantAssociation`   a function is truthy, so the
+ *                                               "Only relevant" checkbox kept
+ *                                               all 69 rows and looked dead
+ *
+ * and `significance` was absent entirely, so the per-condition stars the rest
+ * of the panel draws were missing here. Converting at the boundary fixes all
+ * three at once and keeps one row shape in the renderer.
+ *
+ * @param {Array}  omicValues    OmicValue instances (or already-plain rows)
+ * @param {String} replicateMode "replicates" | "samples"
+ */
+var paNeighbourRows = function (omicValues, replicateMode) {
+	var rows = [];
+
+	for (var i = 0; i < (omicValues ? omicValues.length : 0); i++) {
+		var omicValue = omicValues[i];
+		if (!omicValue) {
+			continue;
+		}
+
+		var values = omicValue.getValues ? omicValue.getValues(replicateMode) : omicValue.values;
+
+		/* One boolean per drawn cell, same contract as addTableEntrie(). */
+		var significance = [];
+		for (var c = 0; c < (values ? values.length : 0); c++) {
+			significance.push(omicValue.isRelevant
+				? omicValue.isRelevant(c, replicateMode) === true
+				: false);
+		}
+
+		rows.push({
+			keggName: omicValue.keggName !== undefined ? omicValue.keggName : omicValue.inputName,
+			inputName: omicValue.inputName,
+			originalName: omicValue.originalName,
+			isRelevant: omicValue.isRelevant
+				? omicValue.isRelevant(undefined, replicateMode) === true
+				: omicValue.relevant === true,
+			isRelevantAssociation: omicValue.isRelevantAssociation
+				? omicValue.isRelevantAssociation() === true
+				: omicValue.relevantAssociation === true,
+			significance: significance,
+			/* No `sampleValues` on purpose: the mode is already applied above,
+			   and paValuesForHeader() would otherwise apply it a second time. */
+			values: values
+		});
+	}
+
+	return rows;
+};
+
 var paValuesForHeader = function (omicValue, omicHeader) {
 	/* Position 0 of a header row is the feature-id column. */
 	var labelled = (omicHeader && omicHeader.length > 1) ? omicHeader.length - 1 : 0;

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4Views.js
@@ -4048,6 +4048,18 @@ function PA_Step4DetailsView() {
 		var jobModelDV = this.getParent("PA_Step4JobView") ? this.getParent("PA_Step4JobView").getModel() : null;
 		var replicateModeDV = jobModelDV && jobModelDV.getReplicateMode ? jobModelDV.getReplicateMode() : "replicates";
 
+		// Offer "Neighbouring features" only where it can resolve to something:
+		// the neighbour lists are keyed by KEGG compound id. The panel is one
+		// instance reused for every box, so this is set on each model load, and
+		// stale output from the previous box goes with it.
+		var isMetaboliteSet = String(featureType || "").toLowerCase().indexOf("compound") > -1;
+		var neighbourSection = this.getComponent().queryById("neighbouringFeaturesSection");
+		if (neighbourSection) {
+			neighbourSection.setVisible(isMetaboliteSet);
+		}
+		$("#featureFamilyOverviewContainerRegulate").empty();
+		$("#inputLevel").val("");
+
 		/**
 		* This function fills recursively a table ordering by omicType
 		*/
@@ -4396,6 +4408,134 @@ function PA_Step4DetailsView() {
 		return plot;
 	};
 
+	/**
+	* Draw the neighbours of this feature set's metabolite at the requested
+	* network step -- or say why there are none.
+	*
+	* Every empty case used to be `console.warn(...); return`, so a click that
+	* resolved to nothing looked identical to a click that did nothing. The one
+	* users met first is the level box, which opens blank: the very first press
+	* of Show Features always landed there. See paNeighbourRequest(), which owns
+	* the decision and the wording, and paNeighbourRows(), which converts the
+	* OmicValues in globalExpressionData into the row shape this panel's
+	* heatmap/plot pair reads.
+	*/
+	this.showNeighbouringFeatures = function () {
+		var me = this;
+		var elem = $("#featureFamilyOverviewContainerRegulate");
+		elem.empty();
+
+		var note = function (message) {
+			elem.append('<div class="contentbox paEmptyNote"><p>' +
+				Ext.String.htmlEncode(message) + '</p></div>');
+		};
+
+		var features = this.getModel() ? this.getModel().getFeatures() : null;
+		var mainFeature = (features && features.length && features[0].getFeature)
+			? features[0].getFeature() : null;
+
+		if (!mainFeature || !mainFeature.getID()) {
+			note("This box carries no identified feature, so its neighbours cannot be looked up.");
+			return;
+		}
+
+		var jobModel = this.getParent("PA_Step4JobView") ? this.getParent("PA_Step4JobView").getModel() : null;
+		var request = paNeighbourRequest({
+			featureID: mainFeature.getID(),
+			featureType: mainFeature.getFeatureType(),
+			neighbourMap: jobModel ? jobModel.getCompoundRegulateFeatures() : null,
+			level: $("#inputLevel").val()
+		});
+
+		if (!request.ok) {
+			note(request.message);
+			return;
+		}
+
+		/* Same floor the resize handler applies to every .PA_step5_plotContainer
+		   in this panel: the container is about 370px wide, so the bare
+		   `width - 400` this used to emit was a negative CSS length. */
+		var divWidth = Math.max(300, elem.width() - 400);
+		var distributionSummaries = this.getParent("PA_Step4PathwayView").getDataDistributionSummaries();
+		var visualOptions = this.getParent("PA_Step4PathwayView").getVisualOptions();
+		var replicateMode = (jobModel && jobModel.getReplicateMode) ? jobModel.getReplicateMode() : "replicates";
+		var globalExpressionData = jobModel ? jobModel.getGlobalExpressionData() : {};
+
+		/* One block per omic the neighbours can carry values in: neighbours are
+		   gene ids, and a KEGG compound id can also name a measured metabolite. */
+		var blocks = [
+			{omicName: "Gene expression", divId: "Gene_expression_heatmapContainer_regulate",
+			 source: globalExpressionData.inputGene},
+			{omicName: "Metabolomics", divId: "Compound_expression_heatmapContainer_regulate",
+			 source: globalExpressionData.inputCompound}
+		];
+
+		var painted = 0;
+
+		for (var b = 0; b < blocks.length; b++) {
+			var block = blocks[b];
+			var measured = [];
+
+			for (var i = 0; i < request.neighbours.length; i++) {
+				var omicValue = block.source ? block.source[request.neighbours[i]] : undefined;
+				if (omicValue) {
+					measured.push(omicValue);
+				}
+			}
+
+			var rows = paNeighbourRows(measured, replicateMode);
+			if (rows.length === 0) {
+				continue;
+			}
+			painted++;
+
+			elem.append(
+				"<div class='contentbox'>" +
+				"  <h3>" + block.omicName + "<span><input type='checkbox' id='" + block.divId + "_cb_relevant' value='" + block.omicName + "'/>Only relevant</span></h3>" +
+				"  <div class='PA_step5_heatmapContainer' id='" + block.divId + "' style='height: " + ((rows.length * 30) + 100) + "px'><i class='fa fa-cog fa-spin'></i> Loading..</div>" +
+				"  <div class='PA_step5_plotContainer' id='" + block.divId + "_plotContainer' style='width:" + divWidth + "px;height: " + ((rows.length * 30) + 100) + "px'><i class='fa fa-cog fa-spin'></i> Loading..</div>" +
+				"</div>");
+
+			/* Bound per block so each checkbox redraws its own pair. Highcharts
+			   appends to whatever is in renderTo, so the previous chart is
+			   destroyed rather than left underneath the new one. */
+			(function (block, rows) {
+				var charts = [];
+
+				var draw = function (visibleRows) {
+					for (var c = 0; c < charts.length; c++) {
+						charts[c] && charts[c].destroy();
+					}
+					$("#" + block.divId).height(visibleRows.length * 30 + 100);
+					charts = [
+						me.generateHeatmap(block.divId, block.omicName, visibleRows, distributionSummaries, visualOptions),
+						me.generatePlot(block.divId + "_plotContainer", block.omicName, visibleRows, distributionSummaries, block.divId + "_plotlegendContainer", visualOptions)
+					];
+				};
+
+				draw(rows);
+
+				$("#" + block.divId + "_cb_relevant").change(function () {
+					/* Highcharts does not hide the y labels of hidden series, so
+					   redrawing beats toggling visibility. isRelevant is a
+					   boolean on these rows -- paNeighbourRows() resolved the
+					   OmicValue methods, which is what the old
+					   `x.isRelevant || x.isRelevantAssociation` never did. */
+					draw($(this).is(":checked")
+						? rows.filter(function (row) { return row.isRelevant || row.isRelevantAssociation; })
+						: rows);
+				});
+			})(block, rows);
+		}
+
+		if (painted === 0) {
+			note("This metabolite has " + request.neighbours.length + " neighbour" +
+				(request.neighbours.length === 1 ? "" : "s") + " at " + request.level +
+				" step" + (request.level === 1 ? "" : "s") +
+				", but none of them carry measured values in the omics you uploaded.");
+		}
+	};
+
 	this.initComponent = function () {
 		var me = this;
 
@@ -4433,14 +4573,21 @@ function PA_Step4DetailsView() {
 					{xtype: 'box', html: "<div id='featureFamilyOverviewContainer'></div>"},
 
 
-					{xtype: "box", html: '<h2>Neighbouring features</h2>'},
-					{
-						xtype: "box", html:
-							'  <div>' +
-							'    Please enter a level (1-4): <input type="number" style="width:80px;height:30px"  id="inputLevel">' +
-							'    <a class="button btn-info helpTip" id="showFeatureButton" title="Show Features"><i class="fa fa-search"></i> Show Features</a>' +
-							'    <div class="applyWaitMessage" style="color:#4c4c4c; margin: 10px;"> Searching...<i class="fa fa-cog fa-spin" style=" float: left; margin-right: 10px; "></i></div>' +
-							'  </div>'
+					/* Metabolites only -- neighbours come from the KEGG compound
+					   interaction network, so a gene box has nothing to look up.
+					   Hidden by default and revealed in updateObserver() for the
+					   feature sets it applies to; it used to be offered on every
+					   box, where pressing it could only ever do nothing.
+					   The "Searching..." spinner that sat under the button is
+					   gone: div.applyWaitMessage is display:none in main.css and
+					   nothing ever faded this one in, so it promised feedback
+					   the button did not give. */
+					{xtype: "box", itemId: "neighbouringFeaturesSection", hidden: true, html:
+						'<h2>Neighbouring features</h2>' +
+						'  <div>' +
+						'    Please enter a level (1-4): <input type="number" min="1" max="4" style="width:80px;height:30px"  id="inputLevel">' +
+						'    <a class="button btn-info helpTip" id="showFeatureButton" title="Show the neighbours of this metabolite at the given number of network steps"><i class="fa fa-search"></i> Show Features</a>' +
+						'  </div>'
 					},
 					{xtype: 'box', html: "<div id='featureFamilyOverviewContainerRegulate'></div>"}
 
@@ -4460,123 +4607,7 @@ function PA_Step4DetailsView() {
 						me.shrink();
 					});
 					$("#showFeatureButton").click(function () {
-						let elem = $("#featureFamilyOverviewContainerRegulate");
-						elem.empty();
-						let divWidth = elem.width() - 400;
-
-						let features = me.getModel().features;
-						if (!features || features.length === 0) { console.warn('No features'); return; }
-						if (!features[0].feature || !features[0].feature.ID) { console.warn('No feature ID'); return; }
-						let featureID = features[0].feature.ID
-						let compoundRegulateFeatures = me.getParent().getParent().model.compoundRegulateFeatures;
-						if (!compoundRegulateFeatures || !compoundRegulateFeatures[featureID]) { console.warn('No regulate data for', featureID); return; }
-						compoundRegulateFeatures = compoundRegulateFeatures[featureID]
-						let inputLevel = document.getElementById('inputLevel').value
-						if (!compoundRegulateFeatures[inputLevel]) { console.warn('No data for input level', inputLevel); return; }
-						let regulateFeatures = compoundRegulateFeatures[inputLevel]
-						let divId = ["Gene_expression_heatmapContainer_regulate", "Compound_expression_heatmapContainer_regulate"]
-						let omicName = ["Gene expression", "Metabolomics"]
-						let distributionSummaries = me.getParent("PA_Step4PathwayView").getDataDistributionSummaries()
-						let visualOptions = me.getParent("PA_Step4PathwayView").getVisualOptions()
-						let regulateOmicsValueGene = []
-						let regulateOmicsValueComp = []
-						let omicValues, featureName;
-						let entriesTable = {}, entriesTableMetagenes = {};
-
-						for (let i = 0; i < regulateFeatures.length; i++) {
-							let regulateFeature = regulateFeatures[i]
-							try {
-								regulateOmicsValueGene.push(me.getParent().getParent().model.globalExpressionData['inputGene'][regulateFeature])
-							} catch (e) {
-								console.log('No expression data for: ' + regulateFeature)
-							}
-						}
-
-						for (let i = 0; i < regulateFeatures.length; i++) {
-							let regulateFeature = regulateFeatures[i]
-							try {
-								regulateOmicsValueComp.push(me.getParent().getParent().model.globalExpressionData['inputCompound'][regulateFeature])
-							} catch (e) {
-								console.log('No expression data for: ' + regulateFeature)
-							}
-						}
-
-
-						regulateOmicsValueComp = regulateOmicsValueComp.filter(function (x) {
-								return x !== undefined;
-							}
-						);
-						regulateOmicsValueGene = regulateOmicsValueGene.filter(function (x) {
-								return x !== undefined;
-							}
-						);
-
-						if (regulateOmicsValueGene.length > 0) {
-							htmlCode =
-								"<div class='contentbox'>" +
-								"  <h3>" + omicName[0] + "<span><input type='checkbox' id='" + divId[0] + "_cb_relevant' value='" + omicName[0] + "'/>Only relevant</span></h3>" +
-								"  <div class='PA_step5_heatmapContainer' id='Gene_expression_heatmapContainer_regulate'  style='height: " + ((regulateOmicsValueGene.length * 30) + 100) + "px'><i class='fa fa-cog fa-spin'></i> Loading..</div>" +
-								"  <div class='PA_step5_plotContainer' id='" + divId[0] + "_plotContainer'  style='width:" + divWidth + "px;height: " + ((regulateOmicsValueGene.length * 30) + 100) + "px'><i class='fa fa-cog fa-spin'></i> Loading..</div>" +
-								"</div>";
-							elem.append(htmlCode);
-							heatmapGene = me.generateHeatmap(divId[0], omicName[0], regulateOmicsValueGene, distributionSummaries, visualOptions)
-							plot = me.generatePlot(divId[0] + "_plotContainer", omicName[0], regulateOmicsValueGene, distributionSummaries, divId[0] + "_plotlegendContainer", visualOptions);
-
-							// Link event individually to save heatmap reference
-							$("#"+divId[0]+"_cb_relevant").change(function () {
-								let onlyRelevants = $(this).is(":checked");
-
-								// Highcharts does not automatically hide Y labels when hiding series, so it is easier and faster
-								// to recreate the whole graphic.
-								let omicValues = regulateOmicsValueGene;
-
-								if (onlyRelevants) {
-									omicValues = omicValues.filter(x => x.isRelevant || x.isRelevantAssociation);
-								}
-
-								$('#' + divId[0]).height(omicValues.length * 30 + 100);
-
-								heatmapGene = me.generateHeatmap(divId[0], omicName[0], omicValues, distributionSummaries, visualOptions)
-								plot = me.generatePlot(divId[0] + "_plotContainer", omicName[0], omicValues, distributionSummaries, divId[0] + "_plotlegendContainer", visualOptions);
-
-							});
-
-						}
-
-
-						if (regulateOmicsValueComp.length > 0) {
-							htmlCode =
-								"<div class='contentbox'>" +
-								"  <h3>" + omicName[1] + "<span><input type='checkbox' id='" + divId[1] + "_cb_relevant' value='" + omicName[1] + "'/>Only relevant</span></h3>" +
-								"  <div class='PA_step5_heatmapContainer' id='Compound_expression_heatmapContainer_regulate'  style='height: " + ((regulateOmicsValueComp.length * 30) + 100) + "px'><i class='fa fa-cog fa-spin'></i> Loading..</div>" +
-								"  <div class='PA_step5_plotContainer' id='" + divId[1] + "_plotContainer'  style='width:" + divWidth + "px;height: " + ((regulateOmicsValueComp.length * 30) + 100) + "px'><i class='fa fa-cog fa-spin'></i> Loading..</div>" +
-
-								"</div>";
-							elem.append(htmlCode);
-							heatmapComp =me.generateHeatmap(divId[1], omicName[1], regulateOmicsValueComp, distributionSummaries, visualOptions)
-							plot = me.generatePlot(divId[1] + "_plotContainer", omicName[1], regulateOmicsValueComp, distributionSummaries, divId[1] + "_plotlegendContainer", visualOptions);
-
-							$("#"+divId[1]+"_cb_relevant").change(function () {
-								let onlyRelevants = $(this).is(":checked");
-
-								// Highcharts does not automatically hide Y labels when hiding series, so it is easier and faster
-								// to recreate the whole graphic.
-								let omicValues = regulateOmicsValueComp;
-
-								if (onlyRelevants) {
-									omicValues = omicValues.filter(x => x.isRelevant || x.isRelevantAssociation);
-								}
-
-								$('#' + divId[1]).height(omicValues.length * 30 + 100);
-
-								heatmapComp = me.generateHeatmap(divId[1], omicName[1], omicValues, distributionSummaries, visualOptions)
-								plot = me.generatePlot(divId[1] + "_plotContainer", omicName[1], omicValues, distributionSummaries, divId[1] + "_plotlegendContainer", visualOptions);
-
-							});
-
-						}
-
-
+						me.showNeighbouringFeatures();
 					});
 					initializeTooltips(".helpTip");
 				},

--- a/PaintomicsServer/src/classes/JobInstances/PathwayAcquisitionJob.py
+++ b/PaintomicsServer/src/classes/JobInstances/PathwayAcquisitionJob.py
@@ -2479,32 +2479,21 @@ class PathwayAcquisitionJob(Job):
         from collections import defaultdict
 
         brPath = os.path.dirname(__file__) + "/../../common/br08001.json"
-        interactionJSONPath = os.path.join(KEGG_DATA_DIR, "current", self.organism, "hubData", "kegg_interaction.json")
 
         # Load classification File
         with open(brPath, 'r') as f:
             temp = json.loads(f.read())
 
-        # The whole compound -> neighbour map, served from a per-process cache
-        # of the file (see _loadCompoundNeighbourMap); {} when the species has
-        # no hubData or the file is not a compound map -- both already warned.
-        # The file covers every compound KEGG knows about - 79 MB for mmu - and
-        # the whole map used to be handed to the browser on every step 3. Only
-        # the compounds in this analysis can ever be looked up, so the rest is
-        # dropped before it reaches the response or the in-memory job cache.
-        neighbourMap = _loadCompoundNeighbourMap(interactionJSONPath)
-        inputCompoundIDs = set(self.inputCompoundsData.keys())
-        matchedNeighbourIDs = inputCompoundIDs & set(neighbourMap.keys())
-
-        if neighbourMap and not matchedNeighbourIDs:
-            logging.warning("HUB ANALYSIS - none of the %d input compounds appear in %s; "
-                            "check that both use KEGG compound IDs.",
-                            len(inputCompoundIDs), interactionJSONPath)
-
-        compoundRegulateFeatures = {
-            compoundID: json.loads(neighbourMap[compoundID])
-            for compoundID in matchedNeighbourIDs
-        }
+        # The compound -> neighbour map for this job's compounds, from the
+        # per-process cache of kegg_interaction.json; {} when the species has no
+        # hubData or the file is not a compound map -- both already warned.
+        # One implementation, in getCompoundRegulateFeatures(), because the
+        # recovery path needs the same derivation: the field is cache-only, so
+        # reading the attribute there gave a reopened job nothing. Cleared first
+        # so re-running step 2 with a different compound selection recomputes
+        # rather than returning what the previous run cached.
+        self.compoundRegulateFeatures = None
+        compoundRegulateFeatures = self.getCompoundRegulateFeatures()
 
         temp2 = temp["children"]
 
@@ -2623,6 +2612,64 @@ class PathwayAcquisitionJob(Job):
         self.compoundRegulateFeatures = compoundRegulateFeatures
 
         return self.mappingComp, self.pValueInDict, self.classificationDict, self.exprssionMetabolites, self.adjustPvalue, self.totalRelevantFeaturesInCategory, self.featureSummary, self.compoundRegulateFeatures
+
+    def getCompoundRegulateFeatures(self):
+        """
+        {compoundID: {"1": [geneID, ...], ..., "4": [...]}} for this job's
+        compounds -- the input to Step 4's "Neighbouring features" panel and to
+        the Step 3 hub-analysis Paint column.
+
+        Derived, not stored. The field is in PAINTOMICS4_LARGE_FIELDS (2.67 MB
+        on the six-omic example), so it is never written to MongoDB and the
+        attribute is None on any process that did not run step 2 itself -- i.e.
+        on every job opened from its URL after a restart. Returning the
+        attribute there made both panels dead, silently.
+
+        Nothing needs storing: the map is `kegg_interaction.json` (static per
+        organism, parsed once per process by _loadCompoundNeighbourMap)
+        intersected with `inputCompoundsData`, and inputCompoundsData is
+        persisted. This is the same arrangement getGlobalExpressionData() has
+        always had, which is why that field -- in the same LARGE_FIELDS set --
+        survives a reopen and this one did not.
+
+        A job with no compounds returns {} without touching the file: it is
+        34 MB locally and 79 MB for production mmu, and gene-only jobs are the
+        common case.
+
+        The dict check is the whole point of the guard, not defensiveness:
+        DAO.adaptBSON turns every None leaf into the STRING "None" -- documented
+        there, depended on across the database -- so a reopened job arrives with
+        `compoundRegulateFeatures == "None"`, which is truthy. Testing
+        truthiness alone returned that string, the servlet's _as_dict() turned
+        it into {}, and the recovery path was exactly as dead as before.
+        Measured: `repr(job.compoundRegulateFeatures)` after loadJobInstance is
+        `'None'`, four characters.
+        """
+        if isinstance(self.compoundRegulateFeatures, dict) and self.compoundRegulateFeatures:
+            return self.compoundRegulateFeatures
+
+        inputCompoundIDs = set((self.inputCompoundsData or {}).keys())
+        if not inputCompoundIDs:
+            return {}
+
+        interactionJSONPath = os_path.join(
+            KEGG_DATA_DIR, "current", self.organism, "hubData",
+            "kegg_interaction.json")
+
+        neighbourMap = _loadCompoundNeighbourMap(interactionJSONPath)
+        matchedNeighbourIDs = inputCompoundIDs & set(neighbourMap.keys())
+
+        if neighbourMap and not matchedNeighbourIDs:
+            logging.warning("HUB ANALYSIS - none of the %d input compounds appear in %s; "
+                            "check that both use KEGG compound IDs.",
+                            len(inputCompoundIDs), interactionJSONPath)
+
+        self.compoundRegulateFeatures = {
+            compoundID: _json.loads(neighbourMap[compoundID])
+            for compoundID in matchedNeighbourIDs
+        }
+
+        return self.compoundRegulateFeatures
 
     def getGlobalExpressionData(self):
         globalExpressionDataGene = defaultdict(dict)

--- a/PaintomicsServer/src/servlets/PathwayAcquisitionServlet.py
+++ b/PaintomicsServer/src/servlets/PathwayAcquisitionServlet.py
@@ -855,7 +855,12 @@ def pathwayAcquisitionRecoverJob(request, response, QUEUE_INSTANCE):
         safe_adjustPvalue = _as_dict_or_list(jobInstance.adjustPvalue)
         safe_totalRelevantFeaturesInCategory = _as_dict_or_list(jobInstance.totalRelevantFeaturesInCategory)
         safe_featureSummary = jobInstance.featureSummary if isinstance(jobInstance.featureSummary, list) else [0, 0]
-        safe_compoundRegulateFeatures = _as_dict(jobInstance.compoundRegulateFeatures)
+        # Derived from kegg_interaction.json + inputCompoundsData, not read back
+        # from the document: the field is cache-only (PAINTOMICS4_LARGE_FIELDS),
+        # so the attribute is None on any process that did not run step 2 and
+        # Step 4's "Neighbouring features" panel had nothing to work with on
+        # every job opened from its link. See getCompoundRegulateFeatures().
+        safe_compoundRegulateFeatures = _as_dict(jobInstance.getCompoundRegulateFeatures())
         safe_globalExpressionData = _as_dict(jobInstance.getGlobalExpressionData())
         safe_hubAnalysisResult = _as_dict(jobInstance.hubAnalysisResult)
 

--- a/PaintomicsServer/src/tests/test_neighbouring_features_button.py
+++ b/PaintomicsServer/src/tests/test_neighbouring_features_button.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Step 4's "Neighbouring features" button must always say what it did.
+
+Why this exists
+---------------
+The button (Feature set overview -> "Please enter a level (1-4)" -> Show
+Features) resolved its neighbour list inline and guarded every empty case the
+same way:
+
+    if (!features || features.length === 0) { console.warn('No features'); return; }
+    if (!compoundRegulateFeatures || !compoundRegulateFeatures[featureID]) {
+        console.warn('No regulate data for', featureID); return; }
+    if (!compoundRegulateFeatures[inputLevel]) {
+        console.warn('No data for input level', inputLevel); return; }
+
+Four returns, no pixels. Reproduced in Chrome on a freshly run six-omic STATegra
+job (e6rwH1sB3o), L-Glutamic acid in mmu00250:
+
+    click Show Features with the level box as it opens (empty)
+      -> PA_Step4Views.js:4474 "No data for input level "   nothing drawn
+    type 1, click again
+      -> 69-row gene-expression heatmap + plot
+
+So the feature worked; the first click on it never did, because the level box
+opens blank. That is what "the button doesn't work" was.
+
+Two more silent inversions in the same block, from feeding OmicValue instances
+to a renderer written for `addTableEntrie` rows -- where `isRelevant` is a
+boolean, not a method:
+
+  - `omicsValues[i].isRelevant === true` is false for a function, so no row ever
+    showed the `*` relevant marker the rest of the panel uses.
+  - `x.isRelevant || x.isRelevantAssociation` is truthy for a function, so
+    "Only relevant" filtered nothing. Measured in the browser before the fix:
+    69 series before ticking it, 69 after.
+
+These tests run the two extracted helpers in node -- the real functions, taken
+out of the shipped file, not a re-implementation of them.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_neighbouring_features_button
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+CLIENT = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), "..", "..", "..",
+    "PaintomicsClient", "public_html"))
+
+STEP3_VIEWS = os.path.join(CLIENT, "app", "view", "PathwayAcquisitionViews",
+                           "PA_Step3Views.js")
+STEP4_VIEWS = os.path.join(CLIENT, "app", "view", "PathwayAcquisitionViews",
+                           "PA_Step4Views.js")
+
+HELPERS = ("paNeighbourRequest", "paNeighbourRows")
+
+
+def read(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def extract(source, name):
+    """The text of `var <name> = function ... };`, brace-matched."""
+    match = re.search(r"var\s+%s\s*=\s*function" % re.escape(name), source)
+    if match is None:
+        raise AssertionError("%s() is not defined in %s" % (name, STEP3_VIEWS))
+
+    opening = source.index("{", match.end())
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[match.start():index + 1] + ";"
+    raise AssertionError("unbalanced braces in %s()" % name)
+
+
+def run_in_node(body):
+    """Evaluate `body` with both helpers in scope; return its parsed stdout."""
+    source = read(STEP3_VIEWS)
+    script = "\n".join(extract(source, name) for name in HELPERS) + "\n" + body
+    directory = tempfile.mkdtemp(prefix="paintomics-neighbours-")
+    try:
+        path = os.path.join(directory, "check.js")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(script)
+        completed = subprocess.run(
+            ["node", path], capture_output=True, text=True, timeout=60)
+        if completed.returncode != 0:
+            raise AssertionError("node failed:\n%s" % completed.stderr)
+        return json.loads(completed.stdout)
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+NETWORK_JS = """
+var NETWORK = {
+  "C00025": {"1": ["11302", "12974"], "2": ["11302", "12974", "71832"],
+             "3": ["11302"], "4": []},
+  "C00026": {"1": ["104112"], "2": [], "3": [], "4": []}
+};
+"""
+
+
+class SourceStructureTest(unittest.TestCase):
+    """Holds with or without a JavaScript runtime available."""
+
+    def neighbours_method(self):
+        """The text of `this.showNeighbouringFeatures = function () {...}`."""
+        source = read(STEP4_VIEWS)
+        start = source.index("this.showNeighbouringFeatures = function")
+        opening = source.index("{", start)
+        depth = 0
+        for index in range(opening, len(source)):
+            if source[index] == "{":
+                depth += 1
+            elif source[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    return source[start:index + 1]
+        raise AssertionError("unbalanced braces in showNeighbouringFeatures()")
+
+    def section_markup(self):
+        """The Ext item that holds the level box and the button."""
+        source = read(STEP4_VIEWS)
+        start = source.index('itemId: "neighbouringFeaturesSection"')
+        return source[start:source.index("featureFamilyOverviewContainerRegulate", start)]
+
+    def test_both_helpers_are_defined(self):
+        source = read(STEP3_VIEWS)
+        for name in HELPERS:
+            self.assertIsNotNone(
+                re.search(r"var\s+%s\s*=\s*function" % re.escape(name), source),
+                "%s() has been renamed or removed" % name)
+
+    def test_the_button_no_longer_returns_without_drawing(self):
+        """Pinning the absence of the old guards, not just the presence of the
+        new helper: one of them coming back reinstates the silent click."""
+        source = read(STEP4_VIEWS)
+        for gone in ("console.warn('No features')",
+                     "console.warn('No feature ID')",
+                     "console.warn('No regulate data for'",
+                     "console.warn('No data for input level'"):
+            self.assertNotIn(gone, source,
+                             "the silent guard %s is back" % gone)
+
+    def test_the_button_asks_the_helper(self):
+        source = read(STEP4_VIEWS)
+        self.assertIn("paNeighbourRequest(", source)
+        self.assertIn("paNeighbourRows(", source)
+
+    def test_the_relevance_filter_reads_a_boolean(self):
+        """`x.isRelevant` without the parentheses is the bug this replaced, and
+        it is only a bug on OmicValues -- the sibling "Values by omic type"
+        checkbox filters addTableEntrie rows, where the same name really is a
+        boolean. So this is scoped to the neighbours method.
+        """
+        body = self.neighbours_method()
+        code = re.sub(r"/\*.*?\*/", "", body, flags=re.S)
+        code = re.sub(r"//[^\n]*", "", code)
+        self.assertNotIn("x.isRelevant", code)
+        self.assertIn("row.isRelevant || row.isRelevantAssociation", code)
+
+    def test_the_dead_spinner_markup_is_gone(self):
+        """div.applyWaitMessage is display:none in main.css and this one was
+        never faded in, so it could only ever be invisible markup promising
+        feedback the button did not give. Scoped to the section's own markup:
+        the Find Features panel has one of these that it does fade in.
+        """
+        section = self.section_markup()
+        self.assertIn("Show Features", section,
+                      "the section markup is not where this test thinks")
+        self.assertNotIn("applyWaitMessage", section)
+
+    def test_the_section_is_gated_on_the_feature_type(self):
+        """A gene box must not be offered a control that cannot work for it."""
+        source = read(STEP4_VIEWS)
+        self.assertIn("neighbouringFeaturesSection", source)
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class NeighbourRequestTest(unittest.TestCase):
+
+    def resolve(self, **request):
+        body = NETWORK_JS + """
+var request = %s;
+if (request.neighbourMap === "NETWORK") { request.neighbourMap = NETWORK; }
+process.stdout.write(JSON.stringify(paNeighbourRequest(request)));
+""" % json.dumps(request)
+        return run_in_node(body)
+
+    def test_an_empty_level_is_reported_not_swallowed(self):
+        """The reported failure: the box opens blank and the first click is
+        this."""
+        result = self.resolve(featureID="C00025", featureType="Compound",
+                              neighbourMap="NETWORK", level="")
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["reason"], "no-level")
+        self.assertIn("1 to 4", result["message"])
+
+    def test_a_missing_level_property_behaves_the_same(self):
+        result = self.resolve(featureID="C00025", featureType="Compound",
+                              neighbourMap="NETWORK")
+        self.assertEqual(result["reason"], "no-level")
+
+    def test_a_level_outside_one_to_four_is_reported(self):
+        for level in ("0", "5", "9", "-1"):
+            result = self.resolve(featureID="C00025", featureType="Compound",
+                                  neighbourMap="NETWORK", level=level)
+            self.assertEqual(result["reason"], "bad-level", "level %r" % level)
+
+    def test_a_level_that_only_looks_numeric_is_rejected(self):
+        """parseInt would take all three of these for 1."""
+        for level in ("1.9", "1e9", "1 2"):
+            result = self.resolve(featureID="C00025", featureType="Compound",
+                                  neighbourMap="NETWORK", level=level)
+            self.assertEqual(result["reason"], "bad-level", "level %r" % level)
+
+    def test_whitespace_around_a_good_level_is_accepted(self):
+        result = self.resolve(featureID="C00025", featureType="Compound",
+                              neighbourMap="NETWORK", level=" 2 ")
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["level"], 2)
+        self.assertEqual(result["neighbours"], ["11302", "12974", "71832"])
+
+    def test_a_numeric_level_is_accepted(self):
+        """The DOM gives a string; a caller reading a number must work too."""
+        result = self.resolve(featureID="C00025", featureType="Compound",
+                              neighbourMap="NETWORK", level=1)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["neighbours"], ["11302", "12974"])
+
+    def test_a_gene_box_is_told_the_control_is_not_for_it(self):
+        result = self.resolve(featureID="11302", featureType="Gene",
+                              neighbourMap="NETWORK", level="1")
+        self.assertEqual(result["reason"], "not-a-metabolite")
+
+    def test_the_type_is_decided_before_the_level(self):
+        """Otherwise a gene box with an empty level is told to type one."""
+        result = self.resolve(featureID="11302", featureType="Gene",
+                              neighbourMap="NETWORK", level="")
+        self.assertEqual(result["reason"], "not-a-metabolite")
+
+    def test_an_unknown_feature_type_is_not_blocked(self):
+        """Metagene boxes and anything else unlabelled fall through to the data
+        rather than being refused on a name."""
+        result = self.resolve(featureID="C00025", featureType="",
+                              neighbourMap="NETWORK", level="1")
+        self.assertTrue(result["ok"])
+
+    def test_an_empty_network_is_reported(self):
+        """What a species installed without hubData looks like."""
+        result = self.resolve(featureID="C00025", featureType="Compound",
+                              neighbourMap={}, level="1")
+        self.assertEqual(result["reason"], "no-map")
+
+    def test_a_metabolite_outside_the_network_is_reported(self):
+        result = self.resolve(featureID="C99999", featureType="Compound",
+                              neighbourMap="NETWORK", level="1")
+        self.assertEqual(result["reason"], "not-in-network")
+
+    def test_an_empty_step_is_reported_with_its_level(self):
+        result = self.resolve(featureID="C00026", featureType="Compound",
+                              neighbourMap="NETWORK", level="3")
+        self.assertEqual(result["reason"], "no-neighbours-at-level")
+        self.assertEqual(result["level"], 3)
+        self.assertIn("3 steps", result["message"])
+
+    def test_one_step_is_singular(self):
+        result = self.resolve(featureID="C00026", featureType="Compound",
+                              neighbourMap={"C00026": {"1": []}}, level="1")
+        self.assertIn("1 step.", result["message"])
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class NeighbourRowTest(unittest.TestCase):
+    """paNeighbourRows against stand-ins shaped like the real OmicValue: the
+    two relevance names are methods, which is the whole point."""
+
+    OMIC_VALUES_JS = """
+function omicValue(keggName, values, relevant, association, sampleValues) {
+  return {
+    keggName: keggName, inputName: keggName + "_input", originalName: keggName + "_input",
+    values: values, relevant: relevant, relevantAssociation: association,
+    sampleValues: sampleValues || null,
+    getValues: function (mode) {
+      return (mode === "samples" && this.sampleValues) ? this.sampleValues : this.values;
+    },
+    isRelevant: function (index, mode) {
+      if (index !== undefined && Array.isArray(this.relevant)) {
+        if (this.relevant.length <= 1) { return false; }
+        return this.relevant[index] === true;
+      }
+      if (Array.isArray(this.relevant)) { return this.relevant.some(function (x) { return x === true; }); }
+      return this.relevant === true;
+    },
+    isRelevantAssociation: function () { return this.relevantAssociation === true; }
+  };
+}
+"""
+
+    def rows(self, body):
+        return run_in_node(self.OMIC_VALUES_JS + body)
+
+    def test_relevance_becomes_a_boolean(self):
+        result = self.rows("""
+var rows = paNeighbourRows([
+  omicValue("Gad1", [1, 2], [true, false], false),
+  omicValue("Gad2", [1, 2], [false, false], false)
+], "replicates");
+process.stdout.write(JSON.stringify(rows.map(function (r) {
+  return {name: r.keggName, isRelevant: r.isRelevant, sig: r.significance};
+})));
+""")
+        self.assertEqual(result[0]["isRelevant"], True)
+        self.assertEqual(result[0]["sig"], [True, False])
+        self.assertEqual(result[1]["isRelevant"], False)
+        self.assertEqual(result[1]["sig"], [False, False])
+
+    def test_the_only_relevant_filter_now_separates_the_rows(self):
+        """The measured symptom: the old expression kept every row."""
+        result = self.rows("""
+var rows = paNeighbourRows([
+  omicValue("Gad1", [1, 2], [true, false], false),
+  omicValue("Gad2", [1, 2], [false, false], false),
+  omicValue("Gad3", [1, 2], [false, false], true)
+], "replicates");
+var kept = rows.filter(function (x) { return x.isRelevant || x.isRelevantAssociation; });
+process.stdout.write(JSON.stringify({total: rows.length, kept: kept.map(function (r) { return r.keggName; })}));
+""")
+        self.assertEqual(result["total"], 3)
+        self.assertEqual(result["kept"], ["Gad1", "Gad3"])
+
+    def test_the_sample_mode_is_applied_once(self):
+        """`values` must already be in the drawn space and `sampleValues` must
+        not ride along, or paValuesForHeader() would aggregate a second time."""
+        result = self.rows("""
+var rows = paNeighbourRows([omicValue("Gad1", [1, 2, 3, 4], [false], false, [1.5, 3.5])], "samples");
+process.stdout.write(JSON.stringify({
+  values: rows[0].values,
+  hasSampleValues: rows[0].sampleValues !== undefined,
+  sig: rows[0].significance
+}));
+""")
+        self.assertEqual(result["values"], [1.5, 3.5])
+        self.assertFalse(result["hasSampleValues"])
+        self.assertEqual(result["sig"], [False, False])
+
+    def test_null_entries_are_dropped_not_rendered(self):
+        result = self.rows("""
+process.stdout.write(JSON.stringify(paNeighbourRows(
+  [null, omicValue("Gad1", [1], [true], false), undefined], "replicates").length));
+""")
+        self.assertEqual(result, 1)
+
+    def test_no_omic_values_yields_no_rows(self):
+        result = self.rows("""
+process.stdout.write(JSON.stringify([
+  paNeighbourRows([], "replicates").length,
+  paNeighbourRows(null, "replicates").length,
+  paNeighbourRows(undefined, "replicates").length
+]));
+""")
+        self.assertEqual(result, [0, 0, 0])
+
+    def test_a_plain_row_still_converts(self):
+        """Not every caller has to hand over OmicValue instances."""
+        result = self.rows("""
+var rows = paNeighbourRows([{keggName: "Gad1", inputName: "x", values: [1, 2],
+                             relevant: true, relevantAssociation: false}], "replicates");
+process.stdout.write(JSON.stringify(rows[0]));
+""")
+        self.assertEqual(result["isRelevant"], True)
+        self.assertEqual(result["values"], [1, 2])
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class EditedFilesParseTest(unittest.TestCase):
+
+    def test_both_client_files_parse(self):
+        for path in (STEP3_VIEWS, STEP4_VIEWS):
+            completed = subprocess.run(
+                ["node", "--check", path], capture_output=True, text=True,
+                timeout=60)
+            self.assertEqual(completed.returncode, 0,
+                             "%s does not parse:\n%s" % (path, completed.stderr))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_neighbouring_features_survive_reopen.py
+++ b/PaintomicsServer/src/tests/test_neighbouring_features_survive_reopen.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""The metabolite neighbour map must still be there when a job is reopened.
+
+Why this exists
+---------------
+Step 4's "Neighbouring features" panel (Feature set overview -> enter a level
+1-4 -> Show Features) reads `compoundRegulateFeatures` off the job model. The
+field is in `PAINTOMICS4_LARGE_FIELDS`, so it is never written to MongoDB, and
+`pa_recover_job` returned `jobInstance.compoundRegulateFeatures` verbatim --
+which is `None` on any process that did not run step 2 itself. Measured on this
+machine against the six-omic STATegra example, job e6rwH1sB3o:
+
+    same process as the run:  crf=57  gedGene=25770  hub=156
+    after a server restart:   crf=0   gedGene=25770  hub=156
+
+`globalExpressionData` is in the same LARGE_FIELDS set and survives, because
+`getGlobalExpressionData()` *recomputes* it from `inputGenesData` on every call
+instead of returning a stored attribute. The neighbour map has exactly the same
+property and was the one field that did not use it: it is
+`kegg_interaction.json` (static per organism, already parsed once per process
+by `_loadCompoundNeighbourMap`) intersected with `inputCompoundsData` -- and
+both of those survive a reopen. Nothing had to be stored; it had to be derived.
+
+So the button was dead on every job opened from its link, and the failure was
+silent: the click handler's guard is `console.warn('No regulate data for', id);
+return`, which from the outside is a button that does nothing.
+
+These tests pin the two halves:
+
+  - `getCompoundRegulateFeatures()` derives the map, so a job with a cleared
+    cache still resolves its compounds' neighbours.
+  - `pa_recover_job` calls the getter rather than reading the attribute; the
+    servlet assertion is a string check because standing up a request needs a
+    live MongoDB, and the regression being prevented is precisely someone
+    putting `jobInstance.compoundRegulateFeatures` back.
+
+A job with no compounds must not touch the filesystem at all: the file is 34 MB
+locally and 79 MB on production mmu, and gene-only jobs are the majority.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_neighbouring_features_survive_reopen
+"""
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from src.classes.JobInstances import PathwayAcquisitionJob as job_module
+from src.classes.JobInstances.PathwayAcquisitionJob import (
+    PathwayAcquisitionJob, PAINTOMICS4_LARGE_FIELDS)
+
+SERVLET = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), "..", "servlets", "PathwayAcquisitionServlet.py"))
+
+# Shaped exactly like kegg_interaction.json: {compoundID: {step: [geneID, ...]}}
+# with the steps as the string keys "1".."4" (checked against the installed ath
+# and mmu files, both of which key them that way).
+NETWORK = {
+    "C00025": {"1": ["11302", "12974"], "2": ["11302", "12974", "71832"],
+               "3": ["11302"], "4": ["11302"]},
+    "C00026": {"1": ["104112"], "2": ["104112"], "3": ["104112"],
+               "4": ["104112"]},
+    # In the network but not in this job's input -- must not be emitted.
+    "C99999": {"1": ["1"], "2": ["1"], "3": ["1"], "4": ["1"]},
+}
+
+
+class _Compound(object):
+    """Stands in for src.classes.Feature.Compound: only the key matters here."""
+
+    def __init__(self, compoundID):
+        self.ID = compoundID
+
+
+class NeighbourMapDerivationTest(unittest.TestCase):
+
+    def setUp(self):
+        self.directory = tempfile.mkdtemp(prefix="paintomics-hubdata-")
+        self.organism = "tst"
+        hubData = os.path.join(self.directory, "current", self.organism, "hubData")
+        os.makedirs(hubData)
+        self.interactionPath = os.path.join(hubData, "kegg_interaction.json")
+        with open(self.interactionPath, "w", encoding="utf-8") as handle:
+            json.dump(NETWORK, handle)
+
+        # _loadCompoundNeighbourMap keeps one organism per process; a stale
+        # entry from another test would make this pass for the wrong reason.
+        job_module._compoundNeighbourCache["key"] = None
+        job_module._compoundNeighbourCache["map"] = None
+
+        self.keggDataDir = job_module.KEGG_DATA_DIR
+        job_module.KEGG_DATA_DIR = self.directory
+
+    def tearDown(self):
+        job_module.KEGG_DATA_DIR = self.keggDataDir
+        job_module._compoundNeighbourCache["key"] = None
+        job_module._compoundNeighbourCache["map"] = None
+        shutil.rmtree(self.directory, ignore_errors=True)
+
+    def _job(self, compoundIDs):
+        instance = PathwayAcquisitionJob("NBRTEST", None, self.directory)
+        instance.setOrganism(self.organism)
+        instance.inputCompoundsData = dict(
+            (compoundID, _Compound(compoundID)) for compoundID in compoundIDs)
+        return instance
+
+    def test_the_field_is_still_cache_only(self):
+        """Premise: if it ever gets persisted, these tests are answering a
+        question nobody is asking any more."""
+        self.assertIn("compoundRegulateFeatures", PAINTOMICS4_LARGE_FIELDS)
+
+    def test_the_getter_exists(self):
+        self.assertTrue(
+            hasattr(PathwayAcquisitionJob, "getCompoundRegulateFeatures"),
+            "getCompoundRegulateFeatures() has been renamed or removed")
+
+    def test_a_cold_cache_still_resolves_the_neighbours(self):
+        instance = self._job(["C00025", "C00026"])
+        # Exactly the state a reopened job is in: the attribute never came back
+        # from MongoDB.
+        instance.compoundRegulateFeatures = None
+
+        resolved = instance.getCompoundRegulateFeatures()
+
+        self.assertEqual(sorted(resolved.keys()), ["C00025", "C00026"])
+        self.assertEqual(resolved["C00025"]["1"], ["11302", "12974"])
+        self.assertEqual(resolved["C00025"]["2"], ["11302", "12974", "71832"])
+
+    def test_compounds_outside_the_input_are_dropped(self):
+        instance = self._job(["C00025"])
+        instance.compoundRegulateFeatures = None
+
+        self.assertEqual(list(instance.getCompoundRegulateFeatures()), ["C00025"])
+
+    def test_the_string_none_a_reopened_job_carries_is_not_mistaken_for_data(self):
+        """DAO.adaptBSON turns every None leaf into the STRING "None" -- its own
+        comment says so and ~193k leaves in foundFeaturesCollection depend on
+        it. So a reopened job's attribute is `'None'`, which is truthy: a guard
+        that only tested truthiness handed that string back, the servlet's
+        _as_dict() turned it into {}, and the panel stayed as dead as it was.
+        Measured against the real job e6rwH1sB3o after a restart:
+
+            repr(job.compoundRegulateFeatures) == 'None'
+            pa_recover_job -> crf=0
+        """
+        instance = self._job(["C00025"])
+        instance.compoundRegulateFeatures = "None"
+
+        resolved = instance.getCompoundRegulateFeatures()
+
+        self.assertIsInstance(resolved, dict)
+        self.assertEqual(resolved["C00025"]["1"], ["11302", "12974"])
+
+    def test_any_other_non_dict_is_also_recomputed(self):
+        for junk in ("{}", "", 0, [], None):
+            instance = self._job(["C00025"])
+            instance.compoundRegulateFeatures = junk
+            self.assertEqual(
+                sorted(instance.getCompoundRegulateFeatures().keys()), ["C00025"],
+                "%r was taken for a neighbour map" % (junk,))
+
+    def test_an_already_populated_map_is_returned_untouched(self):
+        """The step-2 path must keep handing over what it computed -- and must
+        not pay for the file again."""
+        instance = self._job(["C00025"])
+        instance.compoundRegulateFeatures = {"C00025": {"1": ["sentinel"]}}
+
+        self.assertEqual(instance.getCompoundRegulateFeatures(),
+                         {"C00025": {"1": ["sentinel"]}})
+
+    def test_a_gene_only_job_never_reads_the_file(self):
+        instance = self._job([])
+        instance.compoundRegulateFeatures = None
+
+        opened = []
+        realOpen = job_module.open if hasattr(job_module, "open") else open
+
+        def tracking_open(path, *args, **kwargs):
+            opened.append(path)
+            return realOpen(path, *args, **kwargs)
+
+        job_module.open = tracking_open
+        try:
+            self.assertEqual(instance.getCompoundRegulateFeatures(), {})
+        finally:
+            del job_module.open
+
+        self.assertEqual(
+            [path for path in opened if "kegg_interaction" in str(path)], [],
+            "a job with no compounds parsed the interaction file anyway")
+
+    def test_a_species_without_hubdata_degrades_to_empty(self):
+        os.remove(self.interactionPath)
+        instance = self._job(["C00025"])
+        instance.compoundRegulateFeatures = None
+
+        self.assertEqual(instance.getCompoundRegulateFeatures(), {})
+
+    def test_the_result_is_json_safe(self):
+        """It goes straight into a response body."""
+        instance = self._job(["C00025", "C00026"])
+        instance.compoundRegulateFeatures = None
+
+        json.dumps(instance.getCompoundRegulateFeatures())
+
+
+class RecoverJobUsesTheGetterTest(unittest.TestCase):
+
+    def setUp(self):
+        with open(SERVLET, encoding="utf-8") as handle:
+            self.source = handle.read()
+
+    def test_the_servlet_is_where_this_test_thinks(self):
+        self.assertIn("safe_compoundRegulateFeatures", self.source)
+
+    def test_recovery_derives_the_map_instead_of_reading_the_attribute(self):
+        self.assertIn("getCompoundRegulateFeatures()", self.source,
+                      "pa_recover_job is not deriving the neighbour map")
+        self.assertNotIn("_as_dict(jobInstance.compoundRegulateFeatures)",
+                         self.source,
+                         "pa_recover_job is back to reading the cache-only "
+                         "attribute, which is None on a reopened job")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The report

"Neighbouring features button seems not work."

## What was happening

Step 4's **Feature set overview** panel offers *Please enter a level (1-4)* and a **Show Features** button. Every way the request could come back empty was guarded the same way:

```js
if (!compoundRegulateFeatures[inputLevel]) {
    console.warn('No data for input level', inputLevel); return; }
```

Four such returns, none of them drawing anything. The one every user meets is the level box, because **it opens blank** — so the first press of Show Features always landed on that guard and did nothing at all.

Reproduced in Chrome on a fresh six-omic STATegra run, L-Glutamic acid in `mmu00250`:

| action | result |
|---|---|
| click Show Features as the panel opens (level empty) | `PA_Step4Views.js:4474 "No data for input level "`, no pixels |
| type `1`, click again | 69-row gene-expression heatmap + plot |

The feature worked. The first click on it never did.

### And it was permanent for reopened jobs

`compoundRegulateFeatures` is in `PAINTOMICS4_LARGE_FIELDS`, so it is never written to MongoDB, and `pa_recover_job` returned the attribute verbatim — `None` on any process that did not run step 2 itself. Measured on job `e6rwH1sB3o`:

```
same process as the run:  crf=57  gedGene=25770
after a server restart:   crf=0   gedGene=25770
```

`globalExpressionData` is in the *same* set and survives, because `getGlobalExpressionData()` **recomputes** it from `inputGenesData` rather than reading a stored attribute. The neighbour map has exactly the same property and was the one field not using it: `kegg_interaction.json` (static per organism, already parsed once per process) intersected with `inputCompoundsData` — and both of those survive a reopen. Nothing needed storing; it needed deriving.

The new guard tests for a **dict**, not for truthiness, and that is the point: `DAO.adaptBSON` turns every `None` leaf into the *string* `"None"` — its own comment says so and ~193k leaves in `foundFeaturesCollection` depend on it — so a reopened job arrives with `compoundRegulateFeatures == "None"`, which is truthy. Handing that back left the panel exactly as dead as before. Verified live: `crf` went 0 → 57.

### Two silent inversions in the same block

From feeding `OmicValue` instances to a renderer written for `addTableEntrie` rows, where the two relevance names are booleans, not methods:

- `omicsValue.isRelevant === true` is false for a function → **no neighbour row ever showed the `*` relevant marker** the rest of the panel uses. Now 20 of 69 rows carry it.
- `x.isRelevant || x.isRelevantAssociation` is truthy for a function → **"Only relevant" filtered nothing**: 69 series before ticking, 69 after. Now 69 → 20 → 69, with the previous chart destroyed rather than stacked under the new one.

## The change

- **`paNeighbourRequest()`** owns the decision and the wording, and returns the *reason* instead of nothing: `not-a-metabolite`, `no-level`, `bad-level`, `no-map`, `not-in-network`, `no-neighbours-at-level`. The level is matched against `/^[1-4]$/` on the trimmed string, because `parseInt` takes `"1.9"`, `"1e9"` and `"1 2"` all for 1.
- **`paNeighbourRows()`** converts OmicValues to the panel's row shape at the boundary, which fixes the marker, the filter and the per-condition stars at once.
- **`getCompoundRegulateFeatures()`** derives the map; `pa_recover_job` and `compundsClassification` both go through it, so there is one implementation. A job with no compounds returns `{}` without opening the file (34 MB locally, 79 MB for production mmu).
- The section is **hidden for feature sets that are not metabolites**, where no level could ever have worked, and its `Searching...` spinner is gone — `main.css` has `div.applyWaitMessage` at `display:none` and nothing ever faded this one in, so it promised feedback the button did not give.

The same derivation fixes the **Step 3 hub-analysis Paint column**, which showed *"Re-run the analysis to see them"* on every reopened job and now paints.

## Verification

Chrome, on a **reopened** job after a server restart (so the cold-cache path is the one under test):

| case | before | after |
|---|---|---|
| empty level | nothing | "Enter how many network steps to look out from this metabolite (1 to 4), then press Show Features." |
| level `7` | nothing | "Neighbours are held for 1 to 4 network steps. “7” is not one of them." |
| level `1` | nothing (reopened job) | 69 rows, 20 starred |
| Only relevant | 69 → 69 | 69 → 20 → 69, one chart container |
| gene box | section offered, click dead | section hidden, stale output cleared |
| no measured neighbours | dangling heading | "This metabolite has 4 neighbours at 1 step, but none of them carry measured values in the omics you uploaded." (fault-injected) |
| Step 3 hub Paint | "Re-run the analysis" note | Gene expression + Metabolomics blocks |

No console errors.

**Tests** — `test_neighbouring_features_button.py` runs both helpers in node (the real functions, extracted from the shipped file) over every reason code, the sample-mode double-aggregation trap and the relevance filter; `test_neighbouring_features_survive_reopen.py` unit-tests the getter against a cold cache, against the `"None"` string, and against a gene-only job that must not open the file. 38 tests, all passing, plus the surrounding suite (`test_step2_compound_panel`, `test_hub_analysis_survives_reopen`, `test_cached_job_model_restore`, `test_versioned_assets_are_bumped`) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)