### PR TITLE
Offer MLR on the Rust engine, opt-in

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -4725,7 +4725,18 @@ var MORE_ENGINES_FALLBACK = [
 	 unavailableReason: "", label: "MLR — R engine",
 	 detail: "Elastic-net multiple linear regression. Slower than PLS1 and " +
 	         "harder to reproduce, and it reports no p-values, so the alpha " +
-	         "and VIP thresholds do not apply."}
+	         "and VIP thresholds do not apply."},
+	/* Listed last and labelled opt-in, mirroring the server. The port
+	   reproduces R's random draws exactly, so collinear regulators are grouped
+	   and represented identically; it does not reproduce R's rounding, because
+	   MORE runs the solver at a tolerance where it has not converged. A few
+	   borderline regulators can therefore differ. */
+	{id: "rust-mlr", method: "MLR", engine: "rust", available: true,
+	 unavailableReason: "", label: "MLR — Rust engine (opt-in)",
+	 detail: "The same elastic-net model, reimplemented and much faster. It " +
+	         "reproduces R's random draws exactly but not R's rounding, so a " +
+	         "small number of borderline regulators can differ from the R " +
+	         "engine."}
 ];
 
 /* Fills `combo` from /more_backends, and selects the server's default. */

--- a/PaintomicsServer/src/common/MORECostModel.py
+++ b/PaintomicsServer/src/common/MORECostModel.py
@@ -125,6 +125,36 @@ _PER_GENE_SECONDS = {
     ("MLR", "rust"): 0.263,
 }
 
+# MORE's own cross-validation fold rule (`mynfolds`, auxFunctions.R:452), which
+# the port reproduces exactly. It is a *step* function and it steps DOWN: below
+# 50 samples MORE cross-validates leave-one-out, so the fold count equals the
+# sample count, and at 50 it collapses to 5.
+def _moreFolds(samples):
+    samples = int(samples or 0)
+    if samples < 50:
+        return max(samples, 1)
+    if samples < 100:
+        return 5
+    if samples < 200:
+        return 7
+    return 10
+
+
+# Fold count at the reference shape (36 samples -> leave-one-out).
+_FOLDS0 = _moreFolds(N0)
+
+# Above this many regulators per gene the port's MLR cost stops rising. With
+# `interactions = TRUE` the design carries G + p*G columns, so by p ~ 12 on a
+# 12-group study it already exceeds the sample count and glmnet's active set is
+# bounded by n rather than by p. Measured at n=36, G=12, 200 targets:
+#
+#   p =  3 -> 0.0518 s/gene      p = 20 -> 0.2346 s/gene
+#   p =  6 -> 0.1220 s/gene      p = 30 -> 0.2257 s/gene
+#   p = 12 -> 0.2254 s/gene
+#
+# i.e. linear to p=12 and flat after, which no single exponent expresses.
+_RUST_MLR_P_SATURATION = 12.0
+
 # Exponent on regulators-per-gene, fitted per method over p = 5..30. Both well
 # under 1 -- see the module docstring for why the obvious O(p^2) reading is
 # wrong.
@@ -451,6 +481,9 @@ def estimateSeconds(shape, method, engine):
         # than a fast port, so prefer that row before the global fallback.
         _PER_GENE_SECONDS.get((method, "r"), _FALLBACK_PER_GENE))
 
+    if (method, engine) == ("MLR", "rust"):
+        return SAFETY * perGene * shape.modelledGenes * _rustMlrShapeTerm(shape)
+
     regTerm = 1.0
     if shape.regPerGene > 0:
         regTerm = (shape.regPerGene / P0) ** _REG_EXPONENT.get(
@@ -462,6 +495,45 @@ def estimateSeconds(shape, method, engine):
             _DESIGN_EXPONENT.get(method, _DEFAULT_DESIGN_EXPONENT))
 
     return SAFETY * perGene * shape.modelledGenes * regTerm * designTerm
+
+
+def _rustMlrShapeTerm(shape):
+    """Shape multiplier for MLR on the port, which the R exponents get wrong.
+
+    The R rows fit a power law in `samples * groups`. That form cannot describe
+    the port, because the port's cost is dominated by the fold count and MORE's
+    fold rule steps *down* at 50 samples. Measured, 60 targets, p = 30:
+
+    | samples | groups | folds | measured s/gene | R-exponent model |
+    | --- | --- | --- | --- | --- |
+    | 36 | 12 | 36 (LOO) | 0.2257 | 0.2630 |
+    | 48 | 12 | 48 (LOO) | 0.3204 | 0.2842  **under by 1.13x** |
+    | 48 | 16 | 48 (LOO) | 0.4143 | 0.3072  **under by 1.35x** |
+    | 51 | 17 | 5        | 0.0504 | 0.3174  over by 6.3x |
+
+    Under-prediction is the failure that matters: it waves through a job that
+    then runs to the queue timeout, which is exactly what this module exists to
+    prevent. A power law cannot avoid it here, because a 60-sample study is
+    *cheaper* than a 36-sample one (5 folds against 36) while `samples*groups`
+    says the opposite -- measured 0.0391 against 0.1928 s/gene at p = 12.
+
+    So the port's MLR cost is modelled on the terms that actually drive it:
+    linear in `folds + 1` (the folds plus the full-data fit), linear in groups,
+    and linear in regulators-per-gene up to the saturation point above. Against
+    every shape measured -- including the two real datasets, `rand1` at 0.2347
+    and the STATegra example at 0.0261 s/gene -- this over-predicts by between
+    1.08x and 2.55x and never under-predicts.
+    """
+    folds = _moreFolds(shape.samples) if shape.samples > 0 else _FOLDS0
+    foldTerm = (folds + 1.0) / (_FOLDS0 + 1.0)
+
+    groupTerm = (shape.groups / G0) if shape.groups > 0 else 1.0
+
+    regTerm = 1.0
+    if shape.regPerGene > 0:
+        regTerm = min(shape.regPerGene, _RUST_MLR_P_SATURATION) / _RUST_MLR_P_SATURATION
+
+    return foldTerm * groupTerm * regTerm
 
 
 def _formatDuration(seconds):

--- a/PaintomicsServer/src/servlets/MOREServlet.py
+++ b/PaintomicsServer/src/servlets/MOREServlet.py
@@ -110,12 +110,28 @@ MORE_ENGINES = [
         "engine": "r",
         "label": "MLR — R engine",
         # Every clause here was read out of the MORE sources rather than
-        # recalled: the random representative is `sample(correlacionados, 1)`
-        # at MORE_MLR.R:811, :860 and :1049; the single `coefficient` column is
-        # built at :689-691, against MORE_PLS.R:599 which builds `coefficient`
+        # recalled: the single `coefficient` column is built at
+        # MORE_MLR.R:689-691, against MORE_PLS.R:599 which builds `coefficient`
         # AND `pvalue`; and `grep -rn 'step(\|stepAIC\|regsubsets' MORE/R` is
         # empty, so nothing here may describe MLR as stepwise however natural
         # that assumption is.
+        #
+        # The RNG claim used to read "sample(correlacionados, 1) at :811, :860
+        # and :1049". Two of those were wrong. Established by shimming
+        # base::sample and tracing a live more() run rather than by grepping --
+        # a plain grep for `sample(` misses :811 and :860 if it also filters out
+        # lines containing `#`, because both carry a trailing comment. The
+        # reachable draws on this path are:
+        #
+        #   MORE_MLR.R:811  sample(correlacionados, 1)   nrow(mycor) == 1, once
+        #   MORE_MLR.R:860  sample(correlacionados, 1)   once per COMPLETE clique
+        #   MORE_MLR.R:922  sample(names(which(sums == max(sums))), 1)
+        #                                                only on a degree+sum tie
+        #   glmnet cv.glmnet  foldid = sample(rep(seq(nfolds), length = N))
+        #                                                11 per target
+        #
+        # :1049/:1098/:1160 are the same three inside CollinearityFilter2, which
+        # `GetMLR` never reaches -- it passes col.filter = 'cor'.
         #
         # The last point is why this option is listed third rather than second.
         # The usual reason given for choosing MLR is that it returns real
@@ -129,6 +145,45 @@ MORE_ENGINES = [
                    "alpha and VIP thresholds do not apply. Prefer PLS1 unless "
                    "you have many more samples than candidate regulators per "
                    "gene."),
+    },
+    {
+        "id": "rust-mlr",
+        "method": "MLR",
+        "engine": "rust",
+        "label": "MLR — Rust engine (opt-in)",
+        # Listed last, and opt-in rather than default, for a reason that is
+        # measured rather than cautious. The port reproduces R's *decisions* on
+        # this path exactly -- it reimplements R's Mersenne-Twister and
+        # `R_unif_index`, so `set.seed(123)` and every draw after it match:
+        # 8157/8157 draws on the bundled STATegra example, 2830/2830 on the
+        # simulated one, and zero collinearity-representative mismatches on
+        # either. Two of the four output files come out byte-identical.
+        #
+        # What it does not reproduce is R's *arithmetic*, and that is not a
+        # defect that can be fixed. MORE runs glmnet at `epsilon = 1e-5`, where
+        # coordinate descent has not converged: on one fit glmnet's own
+        # objective falls 2.682616e-02 -> 2.640738e-02 as `thres` goes 1e-5 ->
+        # 1e-14. At 1e-5 its answer is not even a function of the data -- merely
+        # permuting the design columns, which cannot move the optimum, shifts
+        # the objective by 3.0e-03 relative (against 5.4e-07 once converged).
+        # So a cross-validated (alpha, lambda) tie can fall either way, and a
+        # handful of edges differ: edge Jaccard 0.991 on the real example,
+        # 0.886-0.923 on the simulated one. The port's disagreement with R is
+        # smaller than R's disagreement with itself under that neutral
+        # permutation, which is the only bar an independent implementation can
+        # be held to.
+        #
+        # Hence: offered, labelled, and never substituted silently. PLS1 earned
+        # a silent default by being byte-identical; this has not.
+        "detail": ("The same elastic-net model as the R engine, reimplemented, "
+                   "and roughly 8-30x faster. It reproduces R's random draws "
+                   "exactly, so collinear regulators are grouped and "
+                   "represented identically. It does not reproduce R's "
+                   "rounding: MORE runs the solver at a tolerance where it has "
+                   "not converged, and where R does not reproduce itself "
+                   "either, so a small number of borderline regulators can "
+                   "differ. Choose it for speed, or the R engine to match "
+                   "numbers you have already published."),
     },
 ]
 
@@ -155,8 +210,10 @@ def engineIdFor(method, engine=None):
     for entry in MORE_ENGINES:
         if entry["method"] == method and entry["engine"] == normalised:
             return entry["id"]
-    # A recognised method with an engine that cannot run it -- MLR on the port
-    # is the only case -- falls back to the engine that can.
+    # A recognised method with an engine that cannot run it falls back to the
+    # engine that can. No pair reaches this today (the catalogue covers both
+    # methods on both engines), but it is what keeps an unknown engine string
+    # from becoming a None the callers have to special-case.
     for entry in MORE_ENGINES:
         if entry["method"] == method:
             return entry["id"]
@@ -190,20 +247,29 @@ def _resolveMOREBackend(method, rScript, binaryPath=None, engine=None):
     invisible to whoever reads the results, which is what makes a silent
     default legitimate.
 
-    R's MLR path is **not** deterministic. It draws from the RNG in three
-    places, the visible one being ``sample(correlacionados, 1)``, which picks
-    which member of a collapsed clique of correlated regulators survives as the
-    group representative. The port implements MLR in full -- elastic net,
-    collinearity grouping and all -- but it cannot be byte-equal to something
-    that is not equal to itself: R's own answer moves between seeds, and the
-    port was measured to sit *inside that seed band* rather than on any one
-    point in it. Group membership is deterministic and the expansion reports
-    every member, so the edge set is stable either way; what moves is which
-    member a collapsed group's coefficients are attributed to. That is a
-    difference worth opting into and a bad one to impose, so MLR keeps the
-    engine whose numbers its users have already seen. Any method this function
-    does not recognise goes to R for the blunter reason that R owns the full
-    method surface.
+    R's MLR path draws from the RNG, and the port now reproduces that stream
+    rather than merely sitting inside its spread: it reimplements R's
+    Mersenne-Twister, ``set.seed``'s scrambling and ``R_unif_index``'s rejection
+    sampling, so every draw matches -- 8157 of 8157 on the bundled STATegra
+    example, 2830 of 2830 on the simulated one, with zero
+    collinearity-representative mismatches on either. Two of the four output
+    files come out byte-identical.
+
+    It still does not get a silent default, and the reason is arithmetic rather
+    than randomness. MORE hands glmnet ``epsilon = 1e-5``, at which coordinate
+    descent has not converged -- glmnet's own objective on one fit falls
+    2.682616e-02 to 2.640738e-02 as ``thres`` goes 1e-5 to 1e-14 -- and at that
+    tolerance its answer is not a function of the data: permuting the design
+    columns, which cannot move the optimum, shifts the objective by 3.0e-03
+    relative against 5.4e-07 once converged. A cross-validated (alpha, lambda)
+    tie can therefore fall either way, and a few edges differ (edge Jaccard
+    0.991 on the real example). The port's gap to R is smaller than R's gap to
+    itself under that permutation, which is the only bar an independent
+    implementation can be held to -- but it is not byte-equality, so MLR goes to
+    the port only when a caller names ``rust``. PLS1 earned its silent default
+    by being byte-identical; this has not. Any method this function does not
+    recognise goes to R for the blunter reason that R owns the full method
+    surface.
 
     R also wins whenever the port cannot actually be run:
 
@@ -240,7 +306,11 @@ def _resolveMOREBackend(method, rScript, binaryPath=None, engine=None):
     # ` PLS1 ` both exit with "must be PLS1 or MLR" -- so normalising here
     # would route a value the port refuses away from the backend that might
     # accept it, turning a slow analysis into a failed one.
-    if method == "PLS1":
+    # PLS1 may reach the port without being asked for, because swapping it is
+    # invisible (byte-identical output). MLR may not: it goes to the port only
+    # when the engine was named, so `auto` -- an older client, a stored job, a
+    # scripted POST -- keeps the numbers its users have already seen.
+    if method == "PLS1" or (method == "MLR" and wanted == "rust"):
         # Blank means "go and find one", not "use R". Only an explicit path is
         # worth warning about when it fails to resolve -- a host with no binary
         # at all is the ordinary case and has to stay quiet, unless the engine

--- a/PaintomicsServer/src/tests/test_more_backend_endtoend.py
+++ b/PaintomicsServer/src/tests/test_more_backend_endtoend.py
@@ -197,5 +197,40 @@ class MoreRsEndToEndTest(unittest.TestCase):
         self.assertGreater(checked, 0, "no rows were checked")
 
 
+class MoreRsMlrEndToEndTest(MoreRsEndToEndTest):
+    """The same job on the MLR path, which reaches the port only by name.
+
+    Subclassed so every assertion in the PLS1 case is re-run against MLR: the
+    output contract (`MORE_output_*` carrying every input pair, unfiltered, and
+    the star file staying significance-filtered) is method-independent, and it
+    was method-independent code that broke last time.
+
+    `engine = "rust"` is not decoration. `_resolveMOREBackend` sends MLR to the
+    port **only** when a caller names it -- with `auto`, or with no engine at
+    all, MLR stays on R so that stored jobs and older clients keep the numbers
+    they have already seen. If that invariant ever inverts, this test starts
+    passing for the wrong reason, so `test_mlr_without_an_explicit_engine_uses_r`
+    guards the other side of it.
+    """
+
+    def setUp(self):
+        super(MoreRsMlrEndToEndTest, self).setUp()
+        self.job.method = "MLR"
+        self.job.engine = "rust"
+
+    def test_the_backend_actually_chosen_is_the_port(self):
+        """Otherwise this whole class could be silently exercising R."""
+        backend = MOREServlet._resolveMOREBackend(
+            "MLR", "runMORE.R", binaryPath=BINARY, engine="rust")
+        self.assertEqual(backend, [BINARY])
+
+    def test_mlr_without_an_explicit_engine_uses_r(self):
+        for engine in (None, "auto"):
+            backend = MOREServlet._resolveMOREBackend(
+                "MLR", "runMORE.R", binaryPath=BINARY, engine=engine)
+            self.assertEqual(backend[0], "Rscript",
+                             "MLR with engine=%r must stay on R" % (engine,))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_more_cost_model.py
+++ b/PaintomicsServer/src/tests/test_more_cost_model.py
@@ -238,9 +238,10 @@ class Estimate(unittest.TestCase):
         wins only ~4.7x, and that purely from rayon. An earlier draft
         extrapolated the MLR row from the PLS1 ratio and got 0.0040 s/gene
         against a measured 0.263: a 30-minute job quoted at 30 seconds, in
-        exactly the case this module exists to catch. Latent only because
-        _resolveMOREBackend sends MLR to R unconditionally -- so lock it here,
-        where a future engine change cannot quietly re-open it.
+        exactly the case this module exists to catch. No longer latent --
+        `rust-mlr` is a catalogue entry and _resolveMOREBackend routes MLR to
+        the port when a caller names `rust` -- so this is now guarding a live
+        code path rather than a dormant one.
         """
         shape = self.shape()
         pls1Speedup = (estimateSeconds(shape, "PLS1", "r")
@@ -387,5 +388,83 @@ class Budget(unittest.TestCase):
         self.assertIn("association file", message)
 
 
+class RustMlrShapeModel(unittest.TestCase):
+    """The port's MLR cost against every shape actually measured.
+
+    The R rows fit a power law in `samples * groups`. That form cannot describe
+    the port, because its cost is dominated by the cross-validation fold count
+    and MORE's fold rule (`mynfolds`, auxFunctions.R:452) is a step function
+    that steps **down** at 50 samples: below 50 it is leave-one-out, at 50 it
+    collapses to 5. Measured consequence, p = 12: a 60-sample study costs
+    0.0391 s/gene where a 36-sample one costs 0.1928 -- five times *less* work
+    from more data, while `samples * groups` says 1.7x more.
+
+    With the R exponents the estimate under-predicted rust MLR by up to 1.35x
+    just below the fold cliff, and under-prediction is the failure that matters:
+    it waves a job through to die on the queue timeout, which is the exact
+    outcome this module exists to prevent.
+    """
+
+    def shape(self, genes, regPerGene, samples, groups):
+        return MOREShape(modelledGenes=genes, samples=samples, groups=groups,
+                         regPerGene=regPerGene)
+
+    # (label, genes, regPerGene, samples, groups, measured seconds-per-gene).
+    # Synthetic rows are 60-200 target sweeps on this machine; `rand1` and
+    # `stategra` are the two real datasets.
+    MEASURED = [
+        ("p=3",              200,  3.00, 36, 12, 0.05180),
+        ("p=6",              200,  6.00, 36, 12, 0.12200),
+        ("p=12",             200, 12.00, 36, 12, 0.22540),
+        ("p=20",             200, 20.00, 36, 12, 0.23460),
+        ("p=30",             200, 30.00, 36, 12, 0.22570),
+        ("rand1",             98, 29.71, 36, 12, 0.23469),
+        ("stategra",         957,  3.04, 36, 12, 0.02612),
+        ("n=48 G=12 (LOO)",   60, 30.00, 48, 12, 0.32042),
+        ("n=48 G=16 (LOO)",   60, 30.00, 48, 16, 0.41430),
+        ("n=51 G=17 (5-fold)", 60, 30.00, 51, 17, 0.05040),
+        ("n=60 G=12 (5-fold)", 100, 12.00, 60, 12, 0.03912),
+    ]
+
+    def test_never_under_predicts_any_measured_shape(self):
+        """Over-prediction refuses a job that would have fitted; that is
+        recoverable and visible. Under-prediction accepts one that cannot, and
+        the user waits out the whole timeout to learn nothing."""
+        for label, genes, reg, samples, groups, measured in self.MEASURED:
+            est = estimateSeconds(self.shape(genes, reg, samples, groups),
+                                  "MLR", "rust") / genes
+            self.assertGreaterEqual(
+                est, measured,
+                "%s: model %.5f s/gene under-predicts the measured %.5f"
+                % (label, est, measured))
+
+    def test_does_not_over_predict_by_more_than_a_factor_of_three(self):
+        """A guard that quotes ten times the truth refuses analyses a
+        scientist is entitled to run, which is its other failure mode."""
+        for label, genes, reg, samples, groups, measured in self.MEASURED:
+            est = estimateSeconds(self.shape(genes, reg, samples, groups),
+                                  "MLR", "rust") / genes
+            self.assertLess(est / measured, 3.0,
+                            "%s: model over-predicts by %.2fx"
+                            % (label, est / measured))
+
+    def test_the_fold_cliff_makes_more_samples_cheaper(self):
+        """The property no power law in samples*groups can express."""
+        loo = estimateSeconds(self.shape(100, 12.0, 48, 12), "MLR", "rust")
+        fiveFold = estimateSeconds(self.shape(100, 12.0, 51, 12), "MLR", "rust")
+        self.assertLess(fiveFold, loo,
+                        "51 samples cross-validates 5-fold and 48 samples "
+                        "leave-one-out, so the larger study must be cheaper")
+
+    def test_the_r_rows_are_untouched_by_the_rust_shape_model(self):
+        """The new term is scoped to ("MLR", "rust"); R's calibration stands."""
+        shape = self.shape(1000, 30.0, 36, 12)
+        self.assertAlmostEqual(estimateSeconds(shape, "MLR", "r"), 1198.0, places=3)
+        self.assertAlmostEqual(estimateSeconds(shape, "PLS1", "r"), 607.0, places=3)
+
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+

--- a/PaintomicsServer/src/tests/test_more_engine_choice.py
+++ b/PaintomicsServer/src/tests/test_more_engine_choice.py
@@ -65,15 +65,17 @@ class EngineIdTest(unittest.TestCase):
         self.assertEqual(MOREServlet.engineIdFor("PLS1", "r"), "r-pls1")
         self.assertEqual(MOREServlet.engineIdFor("PLS1", "rust"), "rust-pls1")
 
-    def test_mlr_on_the_port_falls_back_to_the_engine_that_can_run_it(self):
+    def test_mlr_on_the_port_resolves_to_the_port(self):
         """There is no rust-MLR entry, and asking for one is not an error.
 
-        Not because the port lacks MLR -- it implements it in full -- but
-        because R's MLR draws its group representative from the RNG
-        (`sample(correlacionados, 1)`, MORE_MLR.R:811/:860/:1049), so the port
-        can sit inside R's seed band and never on a given run of it.
+        The port reproduces R's RNG stream now -- R's Mersenne-Twister,
+        `set.seed`'s scrambling and `R_unif_index`'s rejection sampling -- so
+        the collinearity representatives that `sample()` picks match exactly and
+        the catalogue can offer the pair. It is still opt-in rather than the
+        default, because reproducing R's *draws* is not reproducing R's
+        *rounding*; see `test_mlr_defaults_to_r_even_with_a_binary_installed`.
         """
-        self.assertEqual(MOREServlet.engineIdFor("MLR", "rust"), "r-mlr")
+        self.assertEqual(MOREServlet.engineIdFor("MLR", "rust"), "rust-mlr")
 
     def test_an_unknown_method_resolves_to_nothing_rather_than_something(self):
         """None is the answer that lets a caller tell "not offered" apart from
@@ -144,11 +146,40 @@ class ResolveWithAnExplicitEngineTest(unittest.TestCase):
                                                 engine="rust"),
                 ["Rscript", R_SCRIPT])
 
-    def test_asking_for_rust_for_mlr_runs_mlr_on_r(self):
+    def test_asking_for_rust_for_mlr_runs_mlr_on_the_port(self):
         self.assertEqual(
             MOREServlet._resolveMOREBackend("MLR", R_SCRIPT, self.binary,
                                             engine="rust"),
-            ["Rscript", R_SCRIPT])
+            [self.binary])
+
+    def test_mlr_defaults_to_r_even_with_a_binary_installed(self):
+        """The invariant that protects numbers users have already seen.
+
+        PLS1 goes to the port unasked because swapping it is invisible --
+        byte-identical output. MLR does not: MORE runs glmnet at a tolerance
+        where coordinate descent has not converged, and where permuting the
+        design columns moves glmnet's own answer by 3.0e-03 relative, so a
+        cross-validated (alpha, lambda) tie can fall either way and a few edges
+        differ. A stored job, an older client and a scripted POST all arrive
+        here with no engine or with `auto`, and every one of them must keep
+        getting R.
+        """
+        for engine in (None, "", "auto", "AUTO"):
+            self.assertEqual(
+                MOREServlet._resolveMOREBackend("MLR", R_SCRIPT, self.binary,
+                                                engine=engine),
+                ["Rscript", R_SCRIPT],
+                "MLR with engine=%r must stay on R" % (engine,))
+
+    def test_rust_mlr_falls_back_to_r_when_no_binary_is_installed(self):
+        """Same rule as PLS1: a host without the port answers slowly, not with
+        an error. `engineRefusal` is what turns this into a message; this is the
+        belt to that's braces."""
+        with mock.patch.object(MOREServlet, "_discoverMoreRs", return_value=""):
+            self.assertEqual(
+                MOREServlet._resolveMOREBackend("MLR", R_SCRIPT, "",
+                                                engine="rust"),
+                ["Rscript", R_SCRIPT])
 
     def test_the_off_switch_still_beats_an_explicit_rust_request(self):
         """`off` is the operator's decision and outranks the user's."""
@@ -206,23 +237,35 @@ class AvailabilityTest(unittest.TestCase):
              mock.patch.object(MOREServlet, "_rustBinary", return_value=binary):
             return MOREServlet.describeMOREBackends()
 
-    def test_everything_installed_offers_all_three(self):
+    def test_everything_installed_offers_all_four(self):
         report = self._describe(ALL_INSTALLED, "/usr/local/bin/more-rs")
         self.assertEqual([e["id"] for e in report["engines"] if e["available"]],
-                         ["rust-pls1", "r-pls1", "r-mlr"])
+                         ["rust-pls1", "r-pls1", "r-mlr", "rust-mlr"])
         self.assertEqual(report["default"], "rust-pls1")
+
+    def test_the_catalogue_covers_both_methods_on_both_engines(self):
+        """A missing cell reads as "does not exist" rather than "not installed
+        here", which is the whole reason unavailable entries stay listed."""
+        pairs = {(e["method"], e["engine"]) for e in MOREServlet.MORE_ENGINES}
+        self.assertEqual(pairs, {("PLS1", "r"), ("PLS1", "rust"),
+                                 ("MLR", "r"), ("MLR", "rust")})
 
     def test_r_present_but_its_packages_absent_disables_both_r_engines(self):
         """The deploy image, exactly.
 
-        Note *both*: it is easy to think only MLR is at risk, because MLR is
+        Note *both*: it is easy to think only MLR is at risk, because MLR was
         the R-only method. R PLS1 is equally dead there, and a check that
         disabled MLR alone would leave a reference option that cannot run.
+
+        Since `rust-mlr` exists this image can run MLR at all for the first
+        time -- the static musl binary needs neither R nor the MORE package,
+        both of which are absent there.
         """
         report = self._describe(DRAGO, "/opt/paintomics/more-rs")
         available = {e["id"]: e["available"] for e in report["engines"]}
         self.assertEqual(available,
-                         {"rust-pls1": True, "r-pls1": False, "r-mlr": False})
+                         {"rust-pls1": True, "r-pls1": False,
+                          "r-mlr": False, "rust-mlr": True})
         self.assertEqual(report["default"], "rust-pls1")
         for entry in report["engines"]:
             if not entry["available"]:


### PR DESCRIPTION
## What

`MORE_ENGINES` gains a fourth entry, `rust-mlr`, and `_resolveMOREBackend` routes MLR to the Rust port — **but only when a caller names `rust`**. Depends on TianYuan-Liu/MORE#1, which is what makes it possible.

| id | method | engine | default? |
| --- | --- | --- | --- |
| `rust-pls1` | PLS1 | rust | yes (silent, byte-identical to R) |
| `r-pls1` | PLS1 | r | reference |
| `r-mlr` | MLR | r | **yes for MLR** — `auto`, stored jobs, older clients |
| `rust-mlr` | MLR | rust | opt-in only |

## Why opt-in rather than the default

The port now reproduces R's random draws **exactly** — 8157/8157 on the bundled real dataset, 2830/2830 on the simulated one — so collinear regulators are grouped and represented identically (**0 of 1555** representative mismatches). Two of the four output files come out byte-identical.

What it does not reproduce is R's *arithmetic*, and that is not fixable. MORE hands glmnet `epsilon = 1e-5`, at which coordinate descent has not converged — glmnet's own objective on one fit falls 2.682616e-02 → 2.640738e-02 as `thres` goes 1e-5 → 1e-14. At that tolerance its answer is not a function of the data: permuting the design columns, which cannot move the optimum, shifts the objective by 3.0e-03 relative against 5.4e-07 once converged. So a cross-validated `(alpha, lambda)` tie can fall either way and a few borderline regulators differ — edge Jaccard **0.991** on the real example, 0.886–0.923 on the simulated one. The port's disagreement with R is smaller than R's disagreement with itself under that neutral permutation.

PLS1 earned a silent default by being byte-identical. This has not, so nothing is substituted silently and numbers users have already published are safe.

## MORECostModel needed a real fix, not a constant

Its power law in `samples * groups` cannot describe the port, because the port's cost is dominated by the cross-validation fold count and MORE's own rule (`mynfolds`, auxFunctions.R:452) is a step function that steps **down** at 50 samples. Measured at p=12: a 60-sample study costs 0.0391 s/gene where a 36-sample one costs 0.1928 — five times *less* work from more data, while `samples * groups` predicts 1.7× more.

With the R exponents the estimate **under-predicted rust MLR by up to 1.35×** just below that cliff, and under-prediction is the failure this module exists to prevent: it waves a job through to die on the queue timeout. `_rustMlrShapeTerm` models what actually drives the cost — linear in folds+1, linear in groups, linear in regulators-per-gene up to a measured saturation at ~12. Against all eleven measured shapes, including both real datasets, it now over-predicts by 1.08×–2.55× and never under-predicts. The R rows are untouched.

## Also corrected

The `r-mlr` catalogue comment cited `sample(correlacionados, 1)` at `MORE_MLR.R:811/:860/:1049` and claimed three RNG sites. Two were right; the third is unreachable (`CollinearityFilter2`, which `GetMLR` never enters); and it missed the star-peel tie-break at `:922`. Established by shimming `base::sample` and tracing a live run — a grep for `sample(` that also filters lines containing `#` misses `:811` and `:860`, because both carry a trailing comment.

## Verification

- **18 MORE test files, 386 assertions, all passing.**
- `test_more_engine_choice` gains catalogue-completeness and the MLR-stays-on-R-by-default invariant.
- `test_more_backend_endtoend` now runs its whole output-contract suite on the **MLR** path through the real binary, not just PLS1 (5 → 12 tests).
- `test_more_cost_model` pins the port's MLR cost against every measured shape, from both directions.
- Clean-checkout import gate passes (`git archive` + import every servlet).
- **Browser-verified end to end**: picker offers "MLR — Rust engine (opt-in)", selecting it posts `more_engine=rust-mlr`, the servlet runs `more-rs --method MLR`, the job finishes in 25 s writing 1562 significant pairs (matching R's 1562), and the RegulationPerCondition table and Regulator–Target Network render — 776 pathways, 101 significant, no console errors.

## Deployment note

The host needs a `more-rs` build with the MORE#1 changes, pointed at by `PAINTOMICS_MORE_RS`. Without it, `rust-mlr` degrades to R with a warning and `engineRefusal` greys the option out — so this merges safely ahead of the binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)