### PR TITLE
Let the operator calibrate the MORE cost estimate to the host

### DIFF
--- a/PaintomicsServer/src/common/MORECostModel.py
+++ b/PaintomicsServer/src/common/MORECostModel.py
@@ -189,6 +189,36 @@ _DEFAULT_DESIGN_EXPONENT = 0.29
 # them no way to find out it would have worked.
 SAFETY = 1.0
 
+# Host calibration. Every constant above was fitted on one developer machine
+# (an M4 Pro), and the estimate is only as good as that machine resembles the
+# one running the job. It often does not. Measured 2026-08-18 on
+# paintomics.uv.es -- 6 QEMU vCPUs -- against the same 957-target dataset:
+#
+#   | method | dev machine | paintomics.uv.es | ratio |
+#   | PLS1   |  ~1 s       |    3 s           |  ~3x  |
+#   | MLR    |   25 s      |  571 s           |  23x  |
+#
+# The asymmetry is the point. A merely slower box would slow both by the same
+# factor; MLR slowing 8x more than PLS1 is the port's allocation-heavy inner
+# loops meeting musl's allocator across rayon threads on few cores, which is a
+# property of the *build and host*, not of the model. No single fitted constant
+# can carry across that, so it is an operator setting rather than a guess.
+#
+# Set `PAINTOMICS_MORE_COST_SCALE` to (this host's seconds) / (the estimate) for
+# a job you have actually timed. Above 1 makes the guard more willing to refuse.
+# Leaving it at 1.0 reproduces the previous behaviour exactly.
+#
+# Getting this wrong low is the failure that matters: the job is accepted, runs
+# past MORE_JOB_TIMEOUT and is killed, and the user waits out the whole timeout
+# to learn nothing. Getting it wrong high refuses an analysis that would have
+# fitted -- worse than nothing, but visible and immediately fixable.
+try:
+    HOST_SCALE = float(os.getenv("PAINTOMICS_MORE_COST_SCALE", "1") or 1)
+except (TypeError, ValueError):
+    HOST_SCALE = 1.0
+if not (HOST_SCALE > 0):
+    HOST_SCALE = 1.0
+
 # An unknown (method, engine) must not silently become "free". Falls back to
 # the most expensive known combination, so a method added to runMORE.R without
 # being calibrated here is gated conservatively rather than waved through.
@@ -482,7 +512,7 @@ def estimateSeconds(shape, method, engine):
         _PER_GENE_SECONDS.get((method, "r"), _FALLBACK_PER_GENE))
 
     if (method, engine) == ("MLR", "rust"):
-        return SAFETY * perGene * shape.modelledGenes * _rustMlrShapeTerm(shape)
+        return SAFETY * HOST_SCALE * perGene * shape.modelledGenes * _rustMlrShapeTerm(shape)
 
     regTerm = 1.0
     if shape.regPerGene > 0:
@@ -494,7 +524,7 @@ def estimateSeconds(shape, method, engine):
         designTerm = ((shape.samples * shape.groups) / (N0 * G0)) ** (
             _DESIGN_EXPONENT.get(method, _DEFAULT_DESIGN_EXPONENT))
 
-    return SAFETY * perGene * shape.modelledGenes * regTerm * designTerm
+    return SAFETY * HOST_SCALE * perGene * shape.modelledGenes * regTerm * designTerm
 
 
 def _rustMlrShapeTerm(shape):

--- a/PaintomicsServer/src/tests/test_more_cost_model.py
+++ b/PaintomicsServer/src/tests/test_more_cost_model.py
@@ -29,10 +29,13 @@ import os
 import shutil
 import sys
 import tempfile
+import importlib
 import unittest
+from unittest import mock
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
+from src.common import MORECostModel
 from src.common.MORECostModel import (
     MOREShape, checkBudget, estimateSeconds, probeShape)
 
@@ -462,6 +465,67 @@ class RustMlrShapeModel(unittest.TestCase):
         self.assertAlmostEqual(estimateSeconds(shape, "MLR", "r"), 1198.0, places=3)
         self.assertAlmostEqual(estimateSeconds(shape, "PLS1", "r"), 607.0, places=3)
 
+
+
+class HostScale(unittest.TestCase):
+    """The operator knob that carries the estimate to a machine it was not fitted on.
+
+    Measured on paintomics.uv.es (6 QEMU vCPUs) against the 957-target STATegra
+    dataset: PLS1 3 s where the dev machine takes ~1 s, MLR 571 s where the dev
+    machine takes 25 s. A uniformly slower box would move both by the same
+    factor; MLR moving 8x further is the port's allocation-heavy inner loops
+    meeting musl's allocator across rayon threads, which no fitted exponent
+    describes. Hence a setting, not a constant.
+    """
+
+    def shape(self, genes=1000, regPerGene=30.0, samples=36, groups=12):
+        return MOREShape(modelledGenes=genes, samples=samples, groups=groups,
+                         regPerGene=regPerGene)
+
+    def setUp(self):
+        self._scale = MORECostModel.HOST_SCALE
+
+    def tearDown(self):
+        MORECostModel.HOST_SCALE = self._scale
+
+    def test_default_is_one_so_behaviour_is_unchanged(self):
+        self.assertEqual(MORECostModel.HOST_SCALE, 1.0)
+
+    def test_it_scales_every_engine_and_method(self):
+        shape = self.shape()
+        before = {(m, e): estimateSeconds(shape, m, e)
+                  for m in ("PLS1", "MLR") for e in ("r", "rust")}
+        MORECostModel.HOST_SCALE = 10.0
+        for key, was in before.items():
+            self.assertAlmostEqual(estimateSeconds(shape, *key), was * 10.0, places=6,
+                                   msg="%s did not scale" % (key,))
+
+    def test_the_measured_uv_ratio_stops_a_job_that_would_hit_the_timeout(self):
+        """The concrete hazard: on UV, MLR runs ~9x the unscaled estimate.
+
+        6,000 genes at 3 regulators each is quoted well inside the 1800 s budget
+        unscaled, and would then be killed at the timeout. With the host scale
+        set it is refused up front instead, which is the whole point of the
+        module.
+        """
+        shape = self.shape(genes=6000, regPerGene=3.0)
+        self.assertIsNone(checkBudget(shape, "MLR", "rust", 1800),
+                          "unscaled, this job is accepted")
+        MORECostModel.HOST_SCALE = 10.0
+        self.assertIsNotNone(checkBudget(shape, "MLR", "rust", 1800),
+                             "with the measured host scale it must be refused")
+
+    def test_a_nonsense_setting_falls_back_to_one_rather_than_disabling_the_guard(self):
+        for bad in ("", "abc", "0", "-3", None):
+            with mock.patch.dict(os.environ,
+                                 {} if bad is None else {"PAINTOMICS_MORE_COST_SCALE": bad},
+                                 clear=False):
+                if bad is None:
+                    os.environ.pop("PAINTOMICS_MORE_COST_SCALE", None)
+                importlib.reload(MORECostModel)
+                self.assertEqual(MORECostModel.HOST_SCALE, 1.0,
+                                 "setting %r must not disable the guard" % (bad,))
+        importlib.reload(MORECostModel)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #44, from deploying it and then measuring the result rather than assuming it.

## What the deploy showed

Every constant in `MORECostModel` was fitted on one developer machine. On `paintomics.uv.es` — 6 QEMU vCPUs — that fit does not carry. Same 957-target STATegra dataset, same binary:

| method | dev machine | paintomics.uv.es | ratio |
| --- | --- | --- | --- |
| PLS1 | ~1 s | 3 s | ~3× |
| MLR | 25 s | **571 s** | **23×** |

The asymmetry is what makes this a *setting* rather than another constant. A uniformly slower box moves both by the same factor. MLR moving 8× further than PLS1 is the port's allocation-heavy inner loops meeting **musl's allocator across rayon threads on few cores** — a property of the build and the host, which no fitted exponent describes. That the musl build had never been timed was a recorded gap; it is measured now.

## Why it mattered immediately

Rust MLR on UV runs ~9× the unscaled estimate. So a 6,000-gene job at 3 regulators each is quoted comfortably inside the 1800 s budget, accepted, and then killed at the timeout — the exact outcome this module exists to prevent, with the user waiting out the full timeout to learn nothing.

## The change

`PAINTOMICS_MORE_COST_SCALE` multiplies the final estimate.

- Default `1.0`, so behaviour is unchanged anywhere it is not set.
- A nonsense or non-positive value falls back to `1.0` rather than silently disabling the guard.
- Set it to (this host's measured seconds) / (the estimate) for a job you have actually timed.

Getting it wrong low is the failure that matters — accepted then killed. Wrong high refuses an analysis that would have fitted: worse than nothing, but visible and immediately fixable.

## Tests

4 new, pinning: the default is 1.0; it scales every method/engine pair; the measured UV ratio flips that 6,000-gene job from accepted to refused; and bad input cannot turn the guard off. Full MORE suite (12 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)