### PR TITLE
Document how to choose a MORE regulatory model

### DIFF
--- a/docs/4_6_Regulatory_omics.md
+++ b/docs/4_6_Regulatory_omics.md
@@ -59,3 +59,78 @@ Figure 3A and 3B show the visualisation of the regulatory omics inside the pathw
 
 
 
+
+## The MORE joint model: choosing a regulatory model
+
+When a regulatory omic is submitted through the **MORE** option, PaintOmics fits
+one model per target feature, using the experimental design and that feature's
+candidate regulators. Two statistical methods are available, and each can run on
+either of two implementations, so the **Regulatory model** drop-down offers four
+choices. The list shown is what *this* server can actually run: an option the
+host is missing stays visible but greyed out, with the reason, rather than
+disappearing.
+
+| Regulatory model | Method | Implementation | When to choose it |
+| --- | --- | --- | --- |
+| **PLS1 — Rust engine** | PLS1 | Rust | The default. Recommended for almost everything. |
+| **PLS1 — R engine** | PLS1 | R (MORE package) | To reproduce a published run against the reference implementation. |
+| **MLR — R engine** | MLR | R (MORE package) | The reference for MLR. |
+| **MLR — Rust engine** | MLR | Rust | MLR, roughly an order of magnitude faster — see the caveat below. |
+
+### PLS1 or MLR?
+
+**PLS1 is the better default, including for the reason most people pick MLR.**
+The usual argument for multiple linear regression is that it returns real
+p-values and interpretable effect sizes. In MORE that is not the case: the MLR
+path reports a coefficient per regulator and no p-value at all, because a
+regulator is "relevant" precisely when elastic-net shrinkage left its
+coefficient non-zero. There is no stepwise selection anywhere in it. This is why
+the **Alpha (significance)** and **VIP threshold** fields disappear when you
+select an MLR model — neither applies.
+
+PLS1, by contrast, produces both a VIP score and a jackknife p-value, and a
+regulator is significant only when it passes both. Prefer MLR when you have many
+more samples than candidate regulators per gene, which is the regime it suits.
+
+### Rust engine or R engine?
+
+The Rust engine is a reimplementation of MORE's modelling kernel. It is not a
+different model — it is the same model, written to run faster and to work on
+servers where the R package is not installed.
+
+* **For PLS1 the two are byte-identical.** Every output file matches the R
+  engine exactly on the bundled datasets, which is why the Rust engine is the
+  default and is used without asking.
+
+* **For MLR they agree on every decision, but not on the last digits.** MORE's
+  MLR makes random draws — which of a group of correlated regulators represents
+  that group, and how cross-validation folds are assigned — and the Rust engine
+  reproduces R's random number generator exactly, so those choices come out the
+  same. What differs is arithmetic: MORE runs the underlying solver at a
+  tolerance where it has not fully converged, and at that tolerance the R engine
+  does not reproduce itself either (simply presenting the same regulators in a
+  different order changes its answer by more than the two engines differ from
+  each other). On the bundled real dataset the two engines agree on 99.1% of the
+  reported regulator–target pairs.
+
+  Because of that, **MLR is never switched to the Rust engine on your behalf**.
+  Choosing "MLR — R engine", or submitting a job that does not name an engine at
+  all, always runs R. Pick the Rust engine deliberately when you want the speed;
+  pick the R engine when you need to match numbers you have already published.
+
+### If an option is greyed out
+
+The R engines need the MORE R package installed on the server, and the Rust
+engines need the `more-rs` binary. Where one is missing, its options are listed
+but disabled and give the reason, so that a missing option reads as "not
+installed here" rather than "does not exist". If you submit a job for an engine
+this server cannot run, it is refused up front with the same explanation instead
+of failing part-way through the analysis.
+
+### A note on very large submissions
+
+MORE fits one model per target feature, so its cost grows with the number of
+genes, with the number of candidate regulators per gene, and with the size of
+the experimental design. PaintOmics estimates the runtime before queueing and
+refuses a submission it predicts cannot finish inside the queue's time limit,
+explaining what to reduce, rather than letting it run and be killed at the end.


### PR DESCRIPTION
The regulatory-model drop-down has offered a method/implementation choice for a while and the user documentation never mentioned it existed. It now has four entries, so this closes the gap properly rather than adding one line.

Covers the two questions a user actually has:

**PLS1 or MLR?** PLS1 is the better default *including for the reason most people reach for MLR*. MORE's MLR reports **no p-values** — relevance there is "elastic-net shrinkage left the coefficient non-zero", and there is no stepwise selection anywhere in it. That is also why the Alpha and VIP fields disappear when an MLR model is selected.

**Rust engine or R engine?** The same model, written to run faster and to work where the R package is not installed. Byte-identical for PLS1; for MLR it agrees on every *decision* but not on the last digits — which is why MLR is never switched to the port on the user's behalf.

The MLR caveat is put in the user's terms rather than solver terms: the R engine does not reproduce *itself* either, because presenting the same regulators in a different order changes its answer by more than the two engines differ from each other. They agree on 99.1% of reported pairs on the bundled real dataset.

Also documents why an option can be greyed out *with a reason* rather than vanishing, and why a large submission may be refused before queueing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)