### PR TITLE
Let a large pathway export past Werkzeug's form-memory limit

### DIFF
--- a/PaintomicsServer/src/paintomicsserver.py
+++ b/PaintomicsServer/src/paintomicsserver.py
@@ -31,6 +31,15 @@ from src.common import DatabaseAvailability
 
 from src.conf.serverconf import *
 
+# Defensive: serverconf.py is gitignored and installed once, so a deployment
+# upgraded in place still carries a config written before this setting existed.
+# The star import above leaves the name simply undefined there, which would
+# surface as a NameError at app construction rather than at import.
+try:
+    from src.conf.serverconf import SERVER_MAX_FORM_MEMORY_SIZE
+except ImportError:
+    SERVER_MAX_FORM_MEMORY_SIZE = SERVER_MAX_CONTENT_LENGTH
+
 from src.servlets.PathwayAcquisitionServlet import *
 from src.servlets.DataManagementServlet import *
 from src.servlets.UserManagementServlet import *
@@ -102,6 +111,25 @@ class Application(object):
         self.app = Flask(__name__)
 
         self.app.config['MAX_CONTENT_LENGTH'] =  SERVER_MAX_CONTENT_LENGTH
+        # Werkzeug 3.1 (pinned by the Flask upgrade in d6bcf643) gave
+        # max_form_memory_size a 500 kB default and started applying it to
+        # application/x-www-form-urlencoded bodies, not just multipart non-file
+        # fields. MAX_CONTENT_LENGTH never gets a say: FormDataParser
+        # ._parse_urlencoded compares Content-Length against this limit alone.
+        #
+        # /pa_save_image posts the whole pathway SVG -- background raster
+        # inlined as a base64 data: URI -- as one urlencoded form field, so
+        # every large map (map01100 urlencodes to 3.2 MB, map04820 to 1.1 MB,
+        # 22 of 1172 KEGG images bust 500 kB on the background alone) came back
+        # as "RequestEntityTooLarge ... 413" from request.form.get("jobID"),
+        # the first form access in the handler.
+        #
+        # Keeping the two limits equal restores the pre-upgrade behaviour and
+        # leaves one number in charge; nginx's client_max_body_size still caps
+        # the request ahead of Flask. File uploads were never affected -- the
+        # multipart parser sets field_size to None for File parts and skips the
+        # check. Pinned by src/tests/test_form_memory_limit.py.
+        self.app.config['MAX_FORM_MEMORY_SIZE'] = SERVER_MAX_FORM_MEMORY_SIZE
         configureJSONSerialisation(self.app)
 
         KeggInformationManager(KEGG_DATA_DIR) #INITIALIZE THE SINGLETON

--- a/PaintomicsServer/src/resources/example_serverconf.py
+++ b/PaintomicsServer/src/resources/example_serverconf.py
@@ -75,6 +75,10 @@ SERVER_PORT_NUMBER        = int(os.getenv("SERVER_PORT_NUMBER", "8000"))
 SERVER_ALLOW_DEBUG        = os.getenv("SERVER_ALLOW_DEBUG", "false").lower() == "true"  # NEVER true in production
 SERVER_SUBDOMAIN          = os.getenv("SERVER_SUBDOMAIN", "")          # e.g. "paintomics" if served at myserver.com/paintomics
 SERVER_MAX_CONTENT_LENGTH = 100 * pow(1024, 2)                         # Must match nginx client_max_body_size
+# Werkzeug 3.1 defaults max_form_memory_size to 500 kB and applies it to
+# urlencoded bodies, which is below a large pathway SVG export. Keep it equal
+# to SERVER_MAX_CONTENT_LENGTH so one limit governs the request size.
+SERVER_MAX_FORM_MEMORY_SIZE = SERVER_MAX_CONTENT_LENGTH
 ADMIN_ACCOUNTS            = os.getenv("ADMIN_ACCOUNTS", "admin")
 
 # ========== FILES SETTINGS ==========

--- a/PaintomicsServer/src/tests/test_form_memory_limit.py
+++ b/PaintomicsServer/src/tests/test_form_memory_limit.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""A pathway image export must survive Werkzeug's form-memory limit.
+
+WHAT BROKE
+----------
+`d6bcf643` ("Upgrade the Flask stack") pinned `Werkzeug==3.1.8`. Werkzeug 3.1
+changed `max_form_memory_size` in two ways at once:
+
+  * its default went from unlimited to 500_000 bytes, and
+  * it is now applied to `application/x-www-form-urlencoded` bodies, where
+    before it only bounded non-file fields of a *multipart* body.
+
+    # werkzeug/formparser.py -- FormDataParser._parse_urlencoded
+    if (self.max_form_memory_size is not None
+            and content_length is not None
+            and content_length > self.max_form_memory_size):
+        raise RequestEntityTooLarge()
+
+`paintomicsserver.py` set only `MAX_CONTENT_LENGTH` (100 MB), so the 100 MB
+never got a say: the urlencoded branch compares Content-Length against
+`max_form_memory_size` alone.
+
+`PathwayController.js` posts the whole pathway SVG as one urlencoded form
+field, with the pathway background inlined as a base64 `data:` URI, so the
+bodies are large by construction. Measured in Chrome against a live job
+(mmu01100, STATegra):
+
+    background raster   4961 x 3199 px
+    data: URI           3,650,422 chars
+    serialised SVG      4,130,099 chars
+    urlencoded body     4,408,629 bytes      <- 8.8x over the 500 kB default
+
+Every such export came back as
+
+    RequestEntityTooLarge: AT PathwayAcquisitionServlet.py:
+    pathwayAcquisitionSaveImage. ERROR MESSAGE: 413 Request Entity Too Large
+
+raised by the *first* `request.form` access in the handler
+(`request.form.get("jobID")`) and reformatted by `handleException`, which is
+why it reached users as an in-app message rather than a browser-level failure.
+22 of the 1172 KEGG pathway images bust 500 kB on the background alone, so it
+failed per-pathway -- big overview maps only -- and looked intermittent.
+
+WHAT THESE TESTS ASSERT
+-----------------------
+`testTheDefaultRejectsAnExportSizedBody` is the control. It is the same
+request against an app that sets only MAX_CONTENT_LENGTH, and it fails with 413
+-- without it the positive test would pass on any Werkzeug whose default is
+generous, and stop meaning anything.
+
+File uploads are deliberately not covered: the multipart parser sets
+`field_size = None` for `File` parts and skips the check entirely, so Step 1
+was never affected by this and does not need pinning here.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_form_memory_limit
+"""
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from flask import Flask, request
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+_SERVER_SOURCE = os.path.join(
+    _REPO_ROOT, "PaintomicsServer", "src", "paintomicsserver.py")
+_CONFIG_TEMPLATE = os.path.join(
+    _REPO_ROOT, "PaintomicsServer", "src", "resources", "example_serverconf.py")
+
+# The body measured in Chrome for mmu01100, rounded down. Any limit at or below
+# this reintroduces the bug for the maps that motivated the fix.
+MEASURED_EXPORT_BODY_BYTES = 4408629
+
+
+def _buildApp(formMemoryLimit):
+    """A Flask app configured the way Application.__init__ configures its own."""
+    app = Flask(__name__)
+    app.config["MAX_CONTENT_LENGTH"] = 100 * pow(1024, 2)
+    if formMemoryLimit is not None:
+        app.config["MAX_FORM_MEMORY_SIZE"] = formMemoryLimit
+
+    @app.route("/pa_save_image", methods=["POST"])
+    def saveImage():
+        # The handler's first form access is what raises, so touch .form here.
+        return {"svgCodeLength": len(request.form.get("svgCode") or "")}
+
+    return app.test_client()
+
+
+def _exportShapedBody(payloadBytes):
+    """The four fields PathwayController.js posts, with a payload of a given size."""
+    return {"jobID": "TESTJOB000",
+            "fileName": "Metabolic pathways",
+            "format": "png",
+            "svgCode": "<svg>" + ("a" * payloadBytes)}
+
+
+def _readTemplate():
+    with open(_CONFIG_TEMPLATE) as handle:
+        return handle.read()
+
+
+class FormMemoryLimitTest(unittest.TestCase):
+
+    def testTheDefaultRejectsAnExportSizedBody(self):
+        """Control: without the setting, Werkzeug 3.1 refuses the real payload.
+
+        If this ever stops failing, the positive tests below are vacuous.
+        """
+        client = _buildApp(formMemoryLimit=None)
+
+        response = client.post("/pa_save_image", data=_exportShapedBody(1 << 20))
+
+        self.assertEqual(
+            413, response.status_code,
+            "expected Werkzeug's 500 kB max_form_memory_size default to reject a "
+            "1 MB urlencoded body; got %s. If this Werkzeug no longer applies the "
+            "limit to urlencoded data, update this file rather than deleting it."
+            % response.status_code)
+
+    def testConfiguredAppAcceptsAMeasuredExport(self):
+        """The payload that produced the user-visible 413 must now parse."""
+        client = _buildApp(formMemoryLimit=100 * pow(1024, 2))
+
+        payload = MEASURED_EXPORT_BODY_BYTES
+        response = client.post("/pa_save_image", data=_exportShapedBody(payload))
+
+        self.assertEqual(200, response.status_code,
+                         "a %d-byte export body was rejected with %s"
+                         % (payload, response.status_code))
+        self.assertEqual(payload + len("<svg>"),
+                         response.get_json()["svgCodeLength"],
+                         "the field arrived truncated")
+
+    def testServerWiresTheFormLimit(self):
+        """The app must set MAX_FORM_MEMORY_SIZE, not just MAX_CONTENT_LENGTH."""
+        with open(_SERVER_SOURCE) as handle:
+            source = handle.read()
+
+        self.assertIn("MAX_FORM_MEMORY_SIZE", source,
+                      "paintomicsserver.py no longer configures "
+                      "MAX_FORM_MEMORY_SIZE, so Werkzeug's 500 kB default "
+                      "applies again and large pathway exports return 413")
+        self.assertRegex(
+            source,
+            r"config\[.MAX_FORM_MEMORY_SIZE.\]\s*=\s*SERVER_MAX_FORM_MEMORY_SIZE",
+            "MAX_FORM_MEMORY_SIZE must be driven by the serverconf setting so "
+            "deployments can change it without editing code")
+
+    def testServerFallsBackWhenTheSettingIsAbsent(self):
+        """serverconf.py is gitignored, so upgraded deployments predate the key.
+
+        `from src.conf.serverconf import *` leaves the name undefined rather
+        than raising, which would surface as a NameError at app construction.
+        """
+        with open(_SERVER_SOURCE) as handle:
+            source = handle.read()
+
+        self.assertRegex(
+            source,
+            r"except\s+ImportError:\s*\n\s*SERVER_MAX_FORM_MEMORY_SIZE\s*=\s*"
+            r"SERVER_MAX_CONTENT_LENGTH",
+            "a config written before this setting existed must fall back "
+            "rather than break app construction")
+
+    def testTemplateDeclaresTheSetting(self):
+        """What a fresh deployment installs has to carry the key."""
+        template = _readTemplate()
+
+        self.assertTrue(
+            re.search(r"^SERVER_MAX_FORM_MEMORY_SIZE\s*=", template, re.M),
+            "example_serverconf.py must define SERVER_MAX_FORM_MEMORY_SIZE")
+
+    def testTemplateLimitCoversAMeasuredExport(self):
+        """The shipped default must be above the payloads that motivated it."""
+        namespace = {"__file__": _CONFIG_TEMPLATE, "__name__": "example_serverconf"}
+        exec(compile(_readTemplate(), _CONFIG_TEMPLATE, "exec"), namespace)
+
+        configured = namespace["SERVER_MAX_FORM_MEMORY_SIZE"]
+
+        self.assertGreater(
+            configured, MEASURED_EXPORT_BODY_BYTES,
+            "SERVER_MAX_FORM_MEMORY_SIZE (%d) is below the %d-byte body measured "
+            "for mmu01100, so that export would still fail"
+            % (configured, MEASURED_EXPORT_BODY_BYTES))
+        self.assertEqual(
+            namespace["SERVER_MAX_CONTENT_LENGTH"], configured,
+            "the two limits are meant to stay equal so one number governs the "
+            "request size; nginx's client_max_body_size tracks the same value")
+
+    def testNginxBodyLimitStillCoversIt(self):
+        """The proxy caps the request before Flask sees it, so it must agree."""
+        nginxConf = os.path.join(_REPO_ROOT, "deploy", "nginx", "paintomics.conf")
+        if not os.path.isfile(nginxConf):
+            self.skipTest("nginx config not present in this checkout")
+
+        with open(nginxConf) as handle:
+            content = handle.read()
+
+        match = re.search(r"client_max_body_size\s+(\d+)m\s*;", content)
+        self.assertIsNotNone(
+            match, "client_max_body_size is not declared in megabytes")
+        self.assertGreater(
+            int(match.group(1)) * pow(1024, 2), MEASURED_EXPORT_BODY_BYTES,
+            "nginx would reject the export before Flask's limit mattered")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The report

```
RequestEntityTooLarge: AT PathwayAcquisitionServlet.py: pathwayAcquisitionSaveImage.
ERROR MESSAGE: 413 Request Entity Too Large: The data value transmitted exceeds the capacity limit.
```

## Root cause

Not `MAX_CONTENT_LENGTH`, and not nginx. `d6bcf643` ("Upgrade the Flask stack") pinned
`Werkzeug==3.1.8`, and Werkzeug 3.1 changed `max_form_memory_size` in two ways at once:

* the default went from **unlimited to 500,000 bytes**, and
* it is now applied to **`application/x-www-form-urlencoded`** bodies, where before it only
  bounded non-file fields of a *multipart* body.

```python
# werkzeug/formparser.py -- FormDataParser._parse_urlencoded
if (self.max_form_memory_size is not None
        and content_length is not None
        and content_length > self.max_form_memory_size):
    raise RequestEntityTooLarge()
```

`paintomicsserver.py` set only `MAX_CONTENT_LENGTH` (100 MB), so the 100 MB never got a say —
the urlencoded branch compares Content-Length against `max_form_memory_size` alone.

`PathwayController.js` posts the whole pathway SVG, background raster inlined as a base64
`data:` URI, as one urlencoded form field. Measured in Chrome against a live job
(mmu01100, STATegra):

| | |
|---|---|
| background raster | 4961 × 3199 px |
| `data:` URI | 3,650,422 chars |
| serialised SVG | 4,130,099 chars |
| **urlencoded body** | **4,408,629 bytes** — 8.8× over the default |

The 413 was raised by the *first* `request.form` access in the handler
(`request.form.get("jobID")`) and reformatted by `handleException`, which is why it reached
users as an in-app message rather than a browser-level failure.

**Why it looked intermittent:** 22 of the 1172 KEGG pathway images bust 500 kB on the
background alone, so only the big overview maps failed — map01100, map01110, map01120,
map01060, map02020, map04820, map05202… Small maps exported fine throughout.

## The fix

Set `MAX_FORM_MEMORY_SIZE` from a new `SERVER_MAX_FORM_MEMORY_SIZE`, equal to
`SERVER_MAX_CONTENT_LENGTH` so one number governs the request size; nginx's
`client_max_body_size 100m` still caps the request ahead of Flask.

**The image is untouched** — the export stays at full resolution rather than being shrunk to
fit the limit.

`serverconf.py` is gitignored and installed once, so the import is guarded: a deployment
upgraded in place carries a config written before this setting existed, and
`from src.conf.serverconf import *` would leave the name undefined until app construction
raised `NameError`.

## Not affected

* **Omics uploads** — the multipart parser sets `field_size = None` for `File` parts and
  skips the check entirely.
* **`pa_save_visual_options`, `pa_adjust_pvalues`, `pa_apply_replicate_mapping`** — these post
  `contentType: "application/json"`, which bypasses form parsing. `svgCode` is the only large
  urlencoded form field in the codebase.

## Verification (Chrome, against a running server)

Job `e6rwH1sB3o` (STATegra, 5 omics), pathway mmu01100 painted and exported:

* `POST /pa_save_image` → **200** (was 413)
* output: **14883 × 9597 PNG, 142.8 MP, 15.5 MB**
* background carried at native KEGG resolution (4961 × 3199), no re-encode loss
* **all 74 feature overlays present** — sampled 24 at their computed export coordinates and
  each renders the metabolite box with its data fill, border and significance badge
* sprites are 140 px sources drawn at 42 px, so they are over-sampled and sharp
* "Created with PaintOmics 4" watermark intact, not clipped
* 99.91% opaque, no transparency artefacts; **0 refused external references**

Also verified with `SERVER_MAX_FORM_MEMORY_SIZE` **removed** from the config, to exercise the
defensive fallback the way an upgraded deployment would: server starts with no `NameError`,
the export returns 200, and the PNG is **byte-identical** to the run with the setting present
(`607cedf829e7ce0d…`).

## Tests

New `src/tests/test_form_memory_limit.py`, 7 tests, all passing. It includes a **control**
(`testTheDefaultRejectsAnExportSizedBody`) that asserts an app *without* the setting still
gets a 413 — without it the positive tests would pass on any Werkzeug with a generous default
and stop meaning anything.

Also re-run green: `test_release_hygiene` (5/5), `test_svg_export_is_sandboxed`,
`test_save_image_filename`, `test_save_image_authorisation`, `test_job_endpoint_validation`,
`test_mutating_handlers_check_session`, `test_flask3_compat`. Clean-checkout import gate
(`git archive HEAD` → `import src.launch_server`) passes.

`test_dependencies_declared` reports 2/3 — pre-existing on `origin/master`, unrelated
(`common_build_database`, `wrap`, imported by two other test files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
