### PR TITLE
Archive why a tool call failed, and run three verify waves (measured)

### DIFF
--- a/PaintomicsServer/src/classes/AIInterpret/agent_loop.py
+++ b/PaintomicsServer/src/classes/AIInterpret/agent_loop.py
@@ -590,10 +590,27 @@ VERIFY_PREFETCH = (os.getenv("AI_AGENT_VERIFY_PREFETCH") or "1").strip().lower()
 # contains the sentence a specific claim needs -- so the citation arrives
 # unquotable and the net strips it. That is most of the grounding gap.
 FULLTEXT_MAX_PAPERS = int(os.getenv("AI_AGENT_FULLTEXT_MAX", "24"))
-# Verify->correct rounds at the gate. 2 = one verification pass, one
-# correction, one re-verification -- the 600 s budget does not fit the
-# workflow arm's 3 (its own no-progress rule usually stops at 2 anyway).
-VERIFY_ITERATIONS = min(int(os.getenv("AI_AGENT_VERIFY_ITERATIONS", "2")),
+# Verify->correct rounds at the gate. 3 = two correction passes.
+#
+# This was 2, justified as "the 600 s budget does not fit the workflow arm's 3".
+# Round 57 measured that claim and it is false at current speeds: 8 replicates
+# at 3 gave a median span of 450 s with a maximum of 470 and none over the bar.
+#
+# The third wave is not marginal. Paired within each run -- wave 3's input is
+# wave 2's output, so no baseline is involved -- ungrounded citations fell
+# 4.00 -> 1.20, removing 70% of what wave 2 left, and all five runs that reached
+# a third wave improved. One finished with zero ungrounded citations out of 33.
+#
+# Grounding failure here is overshoot, not fabrication: across 1038 archived
+# verdicts the quote is real in 99.5% of cases and 37.8% are a real quote
+# attached to a claim it does not support. Overshoot is repairable by rewriting
+# the sentence, which is what a correction wave does, which is why more waves
+# keep paying.
+#
+# Two of the eight corrections were still cancelled mid-flight for want of
+# budget, and those runs pay for a wave and get no repair. That is a fault of
+# the whole-report rewrite, not of the wave; see the sentence-repair retest.
+VERIFY_ITERATIONS = min(int(os.getenv("AI_AGENT_VERIFY_ITERATIONS", "3")),
                         AI_MAX_VERIFICATION_ITERATIONS)
 
 TOPUP_ENABLED = (os.getenv("AI_AGENT_TOPUP") or "1").strip().lower() \

--- a/PaintomicsServer/src/classes/AIInterpret/agent_loop.py
+++ b/PaintomicsServer/src/classes/AIInterpret/agent_loop.py
@@ -776,6 +776,10 @@ def _trace(ctx, tool, args_summary, result, started):
     _hb(ctx, "interpreting", percent, "Agent: %s" % tool)
 
 
+# Stamps whose result is archived whole. See the note inside _trace_gate.
+VERBATIM_TRACE_STAMPS = frozenset(("__config__", "__outcome__", "__stats__"))
+
+
 def _trace_gate(ctx, tool, args_summary, result, started):
     """Archive a GATE-side LLM call (verification, quotes) as its own event.
 
@@ -795,10 +799,17 @@ def _trace_gate(ctx, tool, args_summary, result, started):
         "gate": True,
         "tool": tool,
         "args": str(args_summary)[:120],
-        # The config stamp is the one event whose whole value IS its text; the
-        # 160-char cap cut its JSON mid-string and made every run unparseable by
-        # the analyzer that the stamp exists to feed.
-        "result": (str(result) if tool == "__config__" else str(result)[:160]),
+        # Some stamps are not a summary of an event -- their whole value IS the
+        # text, and half of a JSON object is not half as useful, it is
+        # unparseable. The 160-char cap once cut `__config__` mid-string and
+        # made every run unreadable to the analyzer that stamp exists to feed.
+        #
+        # Kept as a SET rather than `== "__config__"` because the next such
+        # stamp is the failure this comment describes, one exemption too late.
+        # `__outcome__` currently fits in 160 chars with seven fields and would
+        # break silently on the eighth.
+        "result": (str(result) if tool in VERBATIM_TRACE_STAMPS
+                   else str(result)[:160]),
         "ms": int((time.time() - started) * 1000),
     })
     _archive_trace(ctx)
@@ -3187,6 +3198,38 @@ async def _run_loop_async(job_instance, job_id, experiment_design, budgets,
         # ref_index, a report that is not a string -- is worth discarding the
         # interpretation for. Log and hand back the report.
         logging.warning("[AGENT] outcome stamp failed: %s", exc)
+    # And stamp the stats dict itself, DERIVED rather than hand-listed.
+    #
+    # `__outcome__` above names seven fields by hand. Everything else this run
+    # measured -- why the top-up was rejected, what it dropped, which stage
+    # timed out -- goes only into Mongo, and Mongo keeps ONE interpretation per
+    # JOB. Measured: 218 runs in the archive, 81 interpretation documents for 81
+    # jobs, and of those, `topup_s` survives in 3 and `topup_rejected` in 1. So
+    # of 23 top-up calls the archive can price, the REASON each one added
+    # nothing survives for at most three, because every later run on the same
+    # job overwrote it.
+    #
+    # This is the same bug `__config__` had: a hand-written list that reports
+    # exactly the fields someone thought to add and silently omits the one a
+    # later question needs. That was fixed by deriving the config from the
+    # module source (12 hand-listed flags became 34). Derive here too -- take
+    # every scalar the run recorded, whatever it is called -- so the next
+    # question does not need this line edited before it can be asked.
+    try:
+        scalars = {}
+        for k, v in (stats or {}).items():
+            if isinstance(v, bool) or isinstance(v, (int, float)):
+                scalars[k] = v
+            elif isinstance(v, str) and len(v) <= 120:
+                scalars[k] = v
+            # dicts/lists (verification, pathwayIndex, topup_added_refs) are
+            # deliberately skipped: they are large, they are already elsewhere,
+            # and one of them is what makes a trace file worth megabytes.
+        if scalars:
+            _trace_gate(ctx, "__stats__", "%d scalars" % len(scalars),
+                        json.dumps(scalars, sort_keys=True), time.time())
+    except Exception as exc:                      # same contract as above
+        logging.warning("[AGENT] stats stamp failed: %s", exc)
     if hooks.get("notebook") and ctx.notebook:
         try:
             hooks["notebook"](list(ctx.notebook))

--- a/PaintomicsServer/src/tests/run_all.py
+++ b/PaintomicsServer/src/tests/run_all.py
@@ -106,6 +106,16 @@ def main(argv=None):
                    for p in glob.glob(os.path.join(_ROOT, "src/tests/test_*.py")))
     if args.only:
         names = [n for n in names if args.only in n]
+        # A filter that matches nothing used to print "0 suites | 0 pass |
+        # 0 INTRODUCED" and exit 0 -- a green result that ran no tests, which
+        # is the single failure this runner exists to prevent. It reads as
+        # success at a glance and as success to a shell. `--only` is a
+        # SUBSTRING, so a comma-separated list matches nothing and silently
+        # passes.
+        if not names:
+            print("--only %r matched no suite (it is a substring, not a list)"
+                  % args.only, file=sys.stderr)
+            return 2
 
     results = [run_one(n, args.timeout) for n in names]
     bad = [r for r in results if r["state"] != "PASS"]

--- a/PaintomicsServer/src/tests/test_a_run_archives_why_a_tool_failed.py
+++ b/PaintomicsServer/src/tests/test_a_run_archives_why_a_tool_failed.py
@@ -1,0 +1,111 @@
+"""The archive must record WHY a tool call failed, not just that it ran.
+
+Measured before this test existed: 218 runs in the trace archive, and every one
+of them carried tool calls with no stats at all. The diagnostics -- why the
+top-up added nothing, what it dropped, which stage timed out -- went only to
+Mongo, which keeps ONE interpretation per JOB. Of 81 interpretation documents
+for 81 jobs, `topup_s` survived in 3 and `topup_rejected` in 1. So of the 23
+top-up calls the archive could price by duration, the reason each one added
+nothing was recoverable for at most three.
+
+That is the difference between "which tool is useful" (answerable) and "how do
+I make this tool better" (not answerable), and it is the second question that
+decides what to build.
+"""
+import json
+import os
+import re
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SERVER = os.path.dirname(os.path.dirname(HERE))
+SRC = os.path.join(SERVER, "src", "classes", "AIInterpret", "agent_loop.py")
+
+
+class RunArchivesWhyAToolFailed(unittest.TestCase):
+
+    def setUp(self):
+        with open(SRC) as fh:
+            self.src = fh.read()
+
+    def test_the_stats_stamp_is_derived_not_hand_listed(self):
+        """A hand-written field list reports what someone thought to add.
+
+        `__outcome__` names seven fields by hand. `__config__` used to name
+        about fifteen flags the same way and silently omitted the rest -- 35
+        flags existed, 12 had ever been archived -- which is why it was changed
+        to derive them from the module source. The stats stamp must derive too,
+        or it inherits exactly that failure.
+        """
+        block = self.src.split('_trace_gate(ctx, "__stats__"')[0][-1600:]
+        self.assertIn("for k, v in (stats or {}).items()", block,
+                      "the stats stamp must iterate the stats dict, not name "
+                      "individual keys")
+        # No literal stat name should appear as a key being picked out.
+        self.assertNotRegex(
+            block, r'scalars\[\s*"[a-z_]+"\s*\]\s*=',
+            "the stats stamp assigns a named key -- that is a hand-written "
+            "list wearing a loop")
+
+    def test_scalars_only_so_a_trace_file_stays_small(self):
+        """verification/pathwayIndex/topup_added_refs are large and elsewhere."""
+        block = self.src.split('_trace_gate(ctx, "__stats__"')[0][-1600:]
+        self.assertIn("isinstance(v, (int, float))", block)
+        self.assertIn("isinstance(v, str)", block)
+        self.assertNotIn("isinstance(v, (dict, list))", block,
+                         "dicts and lists must be skipped, not archived")
+
+    def test_the_stats_stamp_is_not_truncated(self):
+        """160 chars holds about six scalars. A run records far more.
+
+        This is the failure `__config__` already hit: the cap cut its JSON
+        mid-string and made every archived run unparseable by the analyzer the
+        stamp exists to feed. A truncated JSON object is not a partial answer,
+        it is no answer.
+        """
+        self.assertIn("VERBATIM_TRACE_STAMPS", self.src)
+        m = re.search(r"VERBATIM_TRACE_STAMPS\s*=\s*frozenset\(\(([^)]*)\)\)",
+                      self.src)
+        self.assertIsNotNone(m, "the exempt set must be a literal frozenset")
+        for stamp in ("__config__", "__outcome__", "__stats__"):
+            self.assertIn(stamp, m.group(1),
+                          "%s dumps JSON and must be archived whole" % stamp)
+
+    def test_the_exemption_is_a_set_not_a_chain_of_equality_tests(self):
+        """`== "__config__"` is how this bug reached a second stamp."""
+        self.assertNotIn('tool == "__config__"', self.src,
+                         "a single-tool equality test does not survive the "
+                         "next stamp; use the set")
+
+    def test_the_stamp_cannot_lose_a_finished_report(self):
+        """It runs on the return path of a run that already spent its budget."""
+        tail = self.src.split('_trace_gate(ctx, "__stats__"')[1][:600]
+        self.assertIn("except Exception", tail,
+                      "the stats stamp must not be able to discard a report")
+        self.assertIn("logging.warning", tail)
+
+    def test_a_json_dump_of_real_stats_survives_the_cap(self):
+        """End-to-end on the actual rule, with a realistic stats dict."""
+        stats = {"topup_added": 0, "topup_rejected": True,
+                 "topup_dropped_existing": 4, "topup_s": 92.13,
+                 "themes_retrieved": 13, "themes_cited": 10,
+                 "gateway_retries": 2, "gateway_rate_limited": 0,
+                 "timed_out_at_stage": "", "loop_s": 130.5,
+                 "tool_chars": 48211, "search_budget_spent": 14}
+        scalars = {k: v for k, v in stats.items()
+                   if isinstance(v, bool) or isinstance(v, (int, float))
+                   or (isinstance(v, str) and len(v) <= 120)}
+        dumped = json.dumps(scalars, sort_keys=True)
+        self.assertGreater(len(dumped), 160,
+                           "if this fits in 160 chars the test proves nothing")
+        verbatim = frozenset(("__config__", "__outcome__", "__stats__"))
+        kept = dumped if "__stats__" in verbatim else dumped[:160]
+        self.assertEqual(json.loads(kept), scalars,
+                         "the archived stats must round-trip")
+
+
+if __name__ == "__main__":
+    r = unittest.TextTestRunner(verbosity=2).run(
+        unittest.TestLoader().loadTestsFromTestCase(RunArchivesWhyAToolFailed))
+    sys.exit(0 if r.wasSuccessful() else 1)

--- a/PaintomicsServer/src/tests/test_agent_loop_budgets.py
+++ b/PaintomicsServer/src/tests/test_agent_loop_budgets.py
@@ -341,19 +341,29 @@ def test_outcome_stamp_never_costs_the_report():
     import ast, inspect
     src = inspect.getsource(L)
     tree = ast.parse(src)
-    fn = next(n for n in ast.walk(tree)
-              if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
-              and "__outcome__" in (ast.get_source_segment(src, n) or ""))
+    # Every function that mentions the stamp, not `next(...)` on the first one.
+    # A COMMENT naming __outcome__ is enough to match, and _trace_gate now
+    # carries one explaining why the stamp is exempt from the 160-char cap --
+    # so the old `next()` inspected _trace_gate, found no try/except there, and
+    # failed while the guard it checks was present and correct in the real
+    # function. A structural test must not be decidable by prose.
+    fns = [n for n in ast.walk(tree)
+           if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+           and "__outcome__" in (ast.get_source_segment(src, n) or "")]
+    assert fns, "no function mentions the __outcome__ stamp at all"
     guarded = False
-    for node in ast.walk(fn):
-        if not isinstance(node, ast.Try):
-            continue
-        seg = ast.get_source_segment(src, node) or ""
-        if "__outcome__" not in seg:
-            continue
-        if any(h.type is None or getattr(h.type, "id", "") == "Exception"
-               for h in node.handlers):
-            guarded = True
+    for fn in fns:
+        for node in ast.walk(fn):
+            if not isinstance(node, ast.Try):
+                continue
+            seg = ast.get_source_segment(src, node) or ""
+            # The CALL, not a mention: a comment inside an unrelated try would
+            # otherwise satisfy this.
+            if '_trace_gate(ctx, "__outcome__"' not in seg:
+                continue
+            if any(h.type is None or getattr(h.type, "id", "") == "Exception"
+                   for h in node.handlers):
+                guarded = True
     assert guarded, "the __outcome__ stamp must sit inside try/except Exception"
 
 

--- a/PaintomicsServer/src/tests/test_ai_agent_loop_endtoend.py
+++ b/PaintomicsServer/src/tests/test_ai_agent_loop_endtoend.py
@@ -35,9 +35,22 @@ Usage:
 import json
 import os
 import sys
+import tempfile
 import threading
 import unittest
 from http.server import BaseHTTPRequestHandler, HTTPServer
+
+# Redirect the trace archive BEFORE any src import: serverconf reads
+# PAINTOMICS_CLIENT_TMP at import time, and _archive_trace writes one JSONL per
+# run into <CLIENT_TMP>/ai_traces.
+#
+# This suite drives the real workflow entry point rather than building a
+# LoopContext by hand, so every replicate it runs used to land in the LIVE
+# measurement corpus -- 7 files in a single suite run, each stamped
+# `"label": "stub-e2e"`, `verify_iterations: 1`, no top-up. Those are the
+# corpus every round in docs/ai-agent-benchmark.md is measured from, and a
+# short stub run pollutes exactly the aggregates that decide what ships.
+os.environ["PAINTOMICS_CLIENT_TMP"] = tempfile.mkdtemp(prefix="stub_e2e_tmp_")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 

--- a/PaintomicsServer/src/tests/test_ai_agent_loop_endtoend.py
+++ b/PaintomicsServer/src/tests/test_ai_agent_loop_endtoend.py
@@ -40,21 +40,27 @@ import threading
 import unittest
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
-# Redirect the trace archive BEFORE any src import: serverconf reads
-# PAINTOMICS_CLIENT_TMP at import time, and _archive_trace writes one JSONL per
-# run into <CLIENT_TMP>/ai_traces.
+# Redirect the trace archive. `_archive_trace` writes one JSONL per run into
+# <CLIENT_TMP_DIR>/ai_traces, and this suite drives the REAL workflow entry
+# point rather than building a LoopContext by hand -- so every replicate it ran
+# landed in the LIVE measurement corpus. Measured: 61 of 234 archived traces
+# (26%) were this suite's, each stamped `"label": "stub-e2e"`,
+# `verify_iterations: 1`. That is the corpus every round in
+# docs/ai-agent-benchmark.md is scored from.
 #
-# This suite drives the real workflow entry point rather than building a
-# LoopContext by hand, so every replicate it runs used to land in the LIVE
-# measurement corpus -- 7 files in a single suite run, each stamped
-# `"label": "stub-e2e"`, `verify_iterations: 1`, no top-up. Those are the
-# corpus every round in docs/ai-agent-benchmark.md is measured from, and a
-# short stub run pollutes exactly the aggregates that decide what ships.
-os.environ["PAINTOMICS_CLIENT_TMP"] = tempfile.mkdtemp(prefix="stub_e2e_tmp_")
+# Setting PAINTOMICS_CLIENT_TMP does NOT work and was tried first: serverconf
+# hardcodes CLIENT_TMP_DIR as an absolute path (it is generated at bootstrap,
+# so the variable matters when the file is WRITTEN, not when it is imported).
+# Rebinding the module attribute does work, because _archive_trace imports the
+# name INSIDE the function and therefore re-reads it on every call.
+_TRACE_TMP = tempfile.mkdtemp(prefix="stub_e2e_tmp_")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 from src.tests.test_ai_agent_endtoend import _instanceFor, _storedJobID
+
+import src.conf.serverconf as _serverconf          # noqa: E402
+_serverconf.CLIENT_TMP_DIR = _TRACE_TMP
 
 DRAFT = """## Key Findings
 - The submitted omic layers move together across the time course [1].

--- a/PaintomicsServer/src/tests/test_tests_do_not_write_to_the_trace_archive.py
+++ b/PaintomicsServer/src/tests/test_tests_do_not_write_to_the_trace_archive.py
@@ -43,7 +43,18 @@ def _suites_that_trace():
         if os.path.basename(path) == os.path.basename(__file__):
             continue
         src = open(path).read()
-        if "LoopContext(" not in src:
+        # A suite traces if it builds a LoopContext by hand OR drives a workflow
+        # entry point that builds one internally.
+        #
+        # This used to be `"LoopContext(" not in src: continue`, which detected
+        # the easy case and missed the important one:
+        # test_ai_agent_loop_endtoend runs the REAL entry point against a stub
+        # gateway and never names LoopContext, so it slipped the check and wrote
+        # SEVEN runs into the live corpus in a single suite pass. The detector
+        # was skipping precisely the suite most likely to trace.
+        if not ("LoopContext(" in src
+                or "run_agent_loop_workflow" in src
+                or "run_agent_workflow" in src):
             continue
         if not re.search(r"L\._trace|_trace\(|_pathway_block|_upgrade_chunk_papers"
                          r"|_screen_papers|read_paper|search_literature", src):
@@ -85,6 +96,44 @@ def test_the_redirect_reaches_the_writer():
                        "see it: %s" % ", ".join(wrong))
 
 
+def test_the_live_archive_holds_no_stub_runs():
+    """Source checks are fallible; the corpus itself is the evidence.
+
+    Every detector in this file infers from source text, and the one above
+    silently excluded the suite that mattered. This one asks the archive
+    directly: a stub run stamps `"label": "stub-e2e"` into its __config__
+    event, so a labelled run in the live corpus is proof a test wrote there --
+    whatever the source says.
+    """
+    # Read the live path the same way the writer does, rather than importing a
+    # name this module does not have.
+    from src.conf.serverconf import CLIENT_TMP_DIR as _live
+    arch = os.path.join(_live, "ai_traces")
+    if not os.path.isdir(arch):
+        return
+    bad = []
+    for f in glob.glob(os.path.join(arch, "*.jsonl")):
+        try:
+            with open(f) as fh:
+                for line in fh:
+                    # The config stamp is a JSON STRING inside a JSON field,
+                    # so its quotes arrive escaped: \"label\": \"stub-e2e\".
+                    # Matching '"stub-e2e"' finds nothing and the guard passes
+                    # on a polluted corpus -- which is how the first version of
+                    # this check reported 0 while 7 stub runs sat in the archive.
+                    if "stub-e2e" in line or "label\\\": \\\"test" in line:
+                        bad.append(os.path.basename(f))
+                        break
+                    if '"__config__"' in line:
+                        break          # config is event 1; stop after it
+        except OSError:
+            continue
+    assert not bad, (
+        "%d stub/test run(s) are in the live measurement corpus, which every "
+        "round in docs/ai-agent-benchmark.md is scored from: %s"
+        % (len(bad), ", ".join(sorted(bad)[:8])))
+
+
 def test_the_live_archive_holds_no_probe_runs():
     """The corpus itself, checked. Skips when it is not present."""
     try:
@@ -113,10 +162,15 @@ def _check(name, fn):
 
 
 def main():
-    for t in (test_every_tracing_suite_redirects_the_archive,
-              test_the_redirect_reaches_the_writer,
-              test_the_live_archive_holds_no_probe_runs):
-        _check(t.__name__, t)
+    # Collected, not hand-listed. A hand-written tuple runs exactly the tests
+    # someone remembered to add: test_the_live_archive_holds_no_stub_runs was
+    # defined, correct, and silently never executed -- reporting "Passed: 3 / 3"
+    # while 61 stub runs sat in the corpus it was written to detect.
+    tests = [(n, o) for n, o in sorted(globals().items())
+             if n.startswith("test_") and callable(o)]
+    assert tests, "no tests collected"
+    for name, t in tests:
+        _check(name, t)
     print("\nPassed: %d / %d" % (len(_PASSED), len(_PASSED) + len(_FAILED)))
     if _FAILED:
         for name, msg in _FAILED:

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -4990,3 +4990,75 @@ capped at 160.
 **0** when the filter matched nothing. `--only` is a substring, so a
 comma-separated list matches nothing and passes silently -- the exact failure the
 runner exists to prevent, inside the runner. Now exits 2 with a message.
+
+## Round 57 — the correction loop works, and it stops one wave early
+
+### What the verifier actually reports
+
+`verify_citation_prefetched` returns two booleans, and the archive has 1038 of
+them across 40 runs:
+
+| verdict | calls | share |
+|---------|-------|-------|
+| `match=True  supports=True`  | 641 | 61.8% |
+| `match=True  supports=False` | 392 | **37.8%** |
+| `match=False supports=False` |   5 |  0.5% |
+
+Fabrication is essentially nil -- the quote exists in 99.5% of calls. The
+grounding problem is entirely **overshoot**: a real quote attached to a claim it
+does not support. That is 37.8% of citations, about 10 per run, and the verifier
+already detects every one.
+
+### The correction loop is effective
+
+A `supports=False` with a real quote is tagged `mode: "claim"` -- "a real quote
+with an oversold sentence needs the SENTENCE changed, not the quote" -- and
+triggers a correction rewrite, then a re-verification. For the 305 citations
+that were re-verified:
+
+| outcome | n | share |
+|---------|---|-------|
+| FIXED     (fail -> pass) | 229 | **75%** |
+| still bad (fail -> fail) |  51 | 17% |
+| regressed (pass -> fail) |  25 |  8% |
+
+This is one of the few unambiguously good mechanisms measured in this document.
+
+### But it always stops at two waves
+
+Median waves per run **2.0, max 2, in 26 of 26 runs**. `VERIFY_ITERATIONS`
+defaults to 2, and the constant carries its reason in a comment:
+
+> 2 = one verification pass, one correction, one re-verification -- the 600 s
+> budget does not fit the workflow arm's 3
+
+That premise was true when it was written and is not true now. Round 55 measured
+median span **314 s with 0 of 40 runs over the 600 s bar**. A third wave costs
+one correction rewrite (measured at 117 s) plus its verification, projecting a
+median around **502 s** -- inside the bar.
+
+So the loop quits with a mean **4.50 ungrounded citations per run** still on the
+table, immediately after demonstrating a 75% fix rate on exactly that population.
+
+### Pre-registration
+
+`AI_AGENT_VERIFY_ITERATIONS=3`. **No code change** -- the knob exists and
+`AI_MAX_VERIFICATION_ITERATIONS` already permits 3.
+
+**Unit: the citation, not the run.** Round 56 was withdrawn for pre-registering
+in a unit the instrument cannot see; per-run ungrounded count has sd 3.51 on a
+mean of 4.50 and would need n=101 per arm. Per citation, the population is the
+~2 per run that survive wave 2, and each run is its own before/after -- no
+control arm is needed, because wave 3's input is wave 2's output.
+
+**Predictions**
+1. Wave 3 fixes **>=50%** of the citations wave 2 left failing.
+2. Net ungrounded per run **falls** -- fixes must exceed the regressions wave 3
+   introduces (waves 1->2 regressed 8%, so this is not free).
+3. Median span stays **under 600 s**.
+
+**Falsifier:** if fixes roughly equal regressions (net unchanged), the loop has
+converged at 2 and the remaining 4.5 are not reachable by rewriting -- revert,
+and record that the no-progress rule was already doing the right thing. If
+median span crosses 600 s, revert regardless of the grounding gain: the
+ten-minute bar is a requirement, not a preference.

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -5169,3 +5169,60 @@ recorded anywhere in this document, and the one that would make a third wave
 affordable.
 
 Queued as the next round, after 57 completes.
+
+## Round 57 SCORED — all three predictions held; the default moves to 3
+
+`AI_AGENT_VERIFY_ITERATIONS=3`, 8 replicates, `sentence_repair=False`.
+
+```
+rep  job          failures per wave      w3 fix   final
+r1   1354co025T   13 -> 3 -> 1              67%       1
+r2   73I734364H    7 -> 1                cancelled    1
+r3   4rofHV6613   11 -> 9                cancelled    9
+r4   31qPRO6hF3   15 -> 4 -> 1              75%       1
+r5   1354co025T   21 -> 5 -> 0             100%       0
+r6   73I734364H   13 -> 5 -> 3              40%       3
+r7   4rofHV6613   11 -> 0                 not needed  0
+r8   31qPRO6hF3    8 -> 3 -> 1              67%       1
+```
+
+| prediction | result | verdict |
+|---|---|---|
+| wave 3 fixes >=50% of what wave 2 left | 67/75/100/40/67, mean **70%** | **HELD** |
+| net ungrounded per run falls | 4.50 -> **2.00**, median 1.0 | **HELD** |
+| median span under 600 s | **450 s**, max 470, **0/8 over** | **HELD** |
+
+**The evidence that carries this is paired and baseline-free.** Prediction 2
+compares against 26 archived runs of a different configuration and is the
+weakest leg. It is not needed: wave 3's input IS wave 2's output, so each run is
+its own control --
+
+| | before wave 3 | after wave 3 |
+|---|---|---|
+| ungrounded citations | 3, 4, 5, 5, 3 (mean **4.00**) | 1, 1, 0, 3, 1 (mean **1.20**) |
+
+**70% of remaining failures removed, and all 5 runs improved.** The within-round
+split of ran-vs-did-not (1.20 vs 3.33) is confounded -- r7 had nothing to fix and
+r3's correction was cancelled -- and is not relied on.
+
+**Cost.** `verify_loop_s` mean 192 s of a 450 s run (43%). Median span rose
+314 -> 450 s, still 150 s inside the bar, with the slowest run at 470 s.
+
+### What this does NOT fix
+
+**2 of 8 corrections were still cancelled mid-flight** ("loop correction rewrite
+exceeded 46.3s"). Those runs pay for a wave and get no repair -- r3 finished at
+**9** ungrounded, the worst in the round, and is the entire reason the mean is
+2.00 rather than ~1.2.
+
+**Top-up and the third wave compete for the same 600 s.** `topup_s` median
+95.5 s. Every run with a slow top-up got two waves; the run that reached zero
+ungrounded did both because its top-up took 59 s. The framework has no policy
+for this trade -- it simply spends on whichever comes first.
+
+Both point at the same place: the correction is a whole-report regeneration.
+The queued sentence-repair retest (round 36's owed rerun, falsifier inherited:
+*if citations fall again, it is dead*) would make the correction cheap enough
+that neither problem arises.
+
+**Default changed to 3.**

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -5062,3 +5062,48 @@ converged at 2 and the remaining 4.5 are not reachable by rewriting -- revert,
 and record that the no-progress rule was already doing the right thing. If
 median span crosses 600 s, revert regardless of the grounding gain: the
 ten-minute bar is a requirement, not a preference.
+
+## Round 57b — auditing what the tools TELL the model
+
+The nine module-level `function_tool`s all carry real descriptions (109-531
+chars, none empty) -- the `"""...""" % X` failure that once produced an EMPTY
+description is not present anywhere else.
+
+But a description is not a label, it is **advice**, and advice can be wrong.
+
+### The advice that cannot be tested
+
+`search_literature` tells the Lead:
+
+> Keep queries BROAD: two or three gene symbols joined by OR, AND at most one
+> biological term ... Extra AND clauses return nothing and still cost budget.
+
+Across 558 recent queries: **545 use exactly one AND, 13 use none, and ZERO use
+two or more.** The claim "extra AND clauses return nothing" is obeyed perfectly
+and therefore **cannot be falsified from the archive** -- there are no
+counterexamples, because the description prevents the data that would test it.
+
+That is a general trap in tool-building worth stating plainly: *advice embedded
+in a tool description becomes unfalsifiable the moment the model follows it.*
+Obedience reads as evidence. Testing such a claim requires deliberately relaxing
+it in an arm, which is a different experiment from anything run so far.
+
+### The advice that IS wrong
+
+The same sentence says "AND **at most** one biological term", which sanctions
+zero. Measured over the full archive:
+
+| queries | n | mean new papers |
+|---------|---|-----------------|
+| 0 AND clauses (the broadest) |   169 | **2.36** |
+| 1+ AND clause                | 2 702 | **3.75** |
+
+Difference **1.39 new papers, 2*se = 0.34 -- RESOLVED.** A query of OR'd gene
+symbols with no biological term at all retrieves **37% fewer new papers** than
+one with a single term. The description pushes toward breadth, and at its own
+permitted extreme, breadth costs retrieval.
+
+**Queued, not applied:** "at most one" -> "exactly one". Worth roughly one extra
+new paper per run (169 of 2 871 queries use zero). Deliberately NOT changed
+while round 57's verify-wave round is in flight -- a tool description change
+mid-round confounds the arm being measured.

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -5107,3 +5107,65 @@ permitted extreme, breadth costs retrieval.
 new paper per run (169 of 2 871 queries use zero). Deliberately NOT changed
 while round 57's verify-wave round is in flight -- a tool description change
 mid-round confounds the arm being measured.
+
+## Round 57 interim — the third wave is not the expensive part
+
+Four replicates in (`AI_AGENT_VERIFY_ITERATIONS=3`, `sentence_repair=False`
+per the run's own config stamp), and the arm is **half confounded**:
+
+```
+r1 1354co025T  13 -> 3 -> 1     wave 3 fixed 2 of 3
+r2 73I734364H   7 -> 1          no wave 3 -- correction cancelled
+r3 4rofHV6613  11 -> 9          checked went 20 -> 37
+rewrites cancelled: 2 of 4      ("loop correction rewrite exceeded 46.3s")
+```
+
+Three things this shows that the pre-registration did not anticipate.
+
+**The correction is a whole-report regeneration, not a repair.** r3's wave 2
+took the report from 20 cited claims to **37** and cut failures only 11 -> 9. A
+rewrite introduces new citations, which arrive with new failures; that is the
+mechanism behind the 8% pass->fail regression measured across waves 1->2.
+
+**The 600 s budget binds by CANCELLATION, not by the iteration cap.** Earlier
+rounds recorded the verify deadline as never firing -- true at 2 waves. At 3 it
+fires in **half** the runs, and it fires *after* the wave has been paid for:
+`correction_budget` falls under the per-call timeout and the rewrite is
+cancelled mid-flight. The run spends the time and gets none of the repair. So
+the comment on `VERIFY_ITERATIONS` ("the 600 s budget does not fit 3") is
+correct about the outcome and silent about the cause: it is the **rewrite** that
+does not fit, not the wave.
+
+**The cheap correction already exists and is off.**
+`SENTENCE_REPAIR` (`AI_SENTENCE_REPAIR`, default "0", in `agent.py`, used by
+BOTH arms) repairs the failed sentences themselves, in parallel across 6
+workers, and leaves the rest of the report -- References, quotes, tables --
+untouched. It cannot introduce a citation, so it cannot introduce a regression.
+
+### An owed experiment
+
+Round 36 tested repair and scored it a FAIL: citations -22% (base) / -34%
+(agent), redactions +38% / +187%. But that round diagnosed its own cause and
+committed to a rerun:
+
+> The guardrails let a repaired sentence drop its `[N]` marker ... right for a
+> TEXT failure and wrong for DRIFT ... **Fixed AFTER this round launched, so the
+> round could not benefit. Repair gets exactly one retest with the fix; if
+> citations fall again, it is dead.**
+
+**That retest was never run.** The summary table still carries round 36's
+numbers and "flag left off". The fix is present in the code today:
+
+```python
+marker = "[%d]" % fc.get("ref_index", 0)
+if fc.get("mode") != "text" and marker not in text:
+    rejected += 1          # a DRIFT repair must keep its citation
+```
+
+The falsifier is already written and is inherited unchanged: **if citations fall
+again, repair is dead.** Round 36 also measured its upside -- `verify_loop_s`
+-92% and wall -23% in the agent arm -- which is the largest single time lever
+recorded anywhere in this document, and the one that would make a third wave
+affordable.
+
+Queued as the next round, after 57 completes.

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -5226,3 +5226,69 @@ The queued sentence-repair retest (round 36's owed rerun, falsifier inherited:
 that neither problem arises.
 
 **Default changed to 3.**
+
+## Round 58 — 26% of the measurement corpus was test output
+
+Found while reading round 57's stats: fifteen runs carried archived stats when
+only eight replicates had been launched. Seven files had appeared in the live
+archive **in the previous five minutes**, while the test suite was running.
+
+```
+archive                 234 files
+stub-e2e test runs       61   (26%)
+my own probe leak         1
+real benchmark/servlet  172
+```
+
+Every round in this document is scored from that directory.
+
+### Three failures, each one hiding the next
+
+**The suite that traced most was the one the guard skipped.** The guard began:
+
+```python
+if "LoopContext(" not in src:
+    continue
+```
+
+`test_ai_agent_loop_endtoend` drives the REAL workflow entry point against a
+stub HTTP gateway and never names `LoopContext`, so it was excluded by
+construction -- and it writes one trace per replicate, seven per suite run. The
+detector found the suites that build a context by hand and missed the only one
+that runs the actual pipeline. The suite itself had no `CLIENT_TMP_DIR`
+handling at all.
+
+**The new check could not match its own marker.** A stub stamps
+`"label": "stub-e2e"` into `__config__` -- but that stamp is a JSON *string
+inside* a JSON field, so it arrives escaped as `\"stub-e2e\"`. The first version
+of the corpus check searched for `'"stub-e2e"'`, matched nothing, and reported a
+clean corpus while 61 polluted files sat in it. `grep -l '"stub-e2e"'` returned
+0 for the same reason.
+
+**The new check never ran.** `main()` hand-lists its tests, so the new one was
+defined, correct, and silently skipped -- printing `Passed: 3 / 3`. This is the
+same hand-written-list failure as `__config__`'s flag dict and `__outcome__`'s
+field list, for the third time in this document. `main()` now collects
+`test_*` from `globals()`.
+
+The guard is now verified in BOTH directions: it fails with one stub file
+restored to the archive and passes once removed. A guard that has only been
+seen to pass has not been tested.
+
+### Did the pollution change any published result?
+
+Round 57b's finding was computed over the full archive, so it was rechecked:
+
+| | 0 AND | 1+ AND | diff | 2*se | verdict |
+|---|---|---|---|---|---|
+| with stubs (as published) | 2.28 (n=177) | 3.74 | 1.46 | 0.33 | RESOLVED |
+| **real runs only** | **1.66** (n=116) | 3.74 | **2.07** | 0.33 | RESOLVED |
+
+**It survives and is stronger.** Stub runs contributed only to the 0-AND group
+and diluted the effect; the published conclusion held and understated it.
+
+Round 57's own result is unaffected -- it reads the eight labelled replicate
+logs, not the archive aggregate.
+
+The 62 files are quarantined in `CLIENT_TMP/ai_traces_stub_quarantine/`, not
+deleted.

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -4900,3 +4900,93 @@ record that duration does not distinguish dwelling from work.
 This is correlational, n=23, and split after the fact -- the weakest evidence
 class in this document. It is written down as a prediction precisely because
 three correlations recorded above evaporated on resampling.
+
+## Round 56 — the round-55 experiment is withdrawn, and why the archive could not settle it
+
+### Withdrawing the pre-registration
+
+Round 55 pre-registered `AI_AGENT_TOPUP_DEADLINE` at 60 s, predicting run span
+would fall by >=10 s. That experiment is **withdrawn before running**, on two
+independent grounds.
+
+**It is unrunnable as specified.** Span across the 40 most recent runs has
+sd **168.8 s** on a mean of 235.3 s. Resolving a 10 s difference needs
+**n = 4,558 per arm** -- roughly a year of continuous gateway time per arm. The
+cap also does nothing at all in **25 of 40** runs, diluting a 92 s per-call
+saving into 13.8 s/run (sd 18.7). The prediction was written in a unit the
+instrument cannot see. This document already records the rule it broke:
+[[a prediction needs a baseline that recorded it]] -- and the unit is part of
+the baseline.
+
+**It is wrong on mechanism.** Reading the implementation rather than the
+telemetry: the top-up is a SINGLE LLM call that rewrites the whole report, and a
+guard then accepts or rejects the candidate wholesale --
+
+```python
+if (len(candidate) > 0.6 * len(str(report))
+        and added > len(cited_now) and not dropped):
+    report = candidate ...
+else:
+    stats["topup_rejected"] = True
+```
+
+A deadline cannot salvage a partial result from one call. Capping at 60 s
+returns *nothing* from a 92 s call, not its early citations. The fast/slow split
+does not mean "capping preserves yield" -- fast and slow are different
+situations, and accepted calls do EXTRA work afterwards
+(`_upgrade_new_citations`), so the causal story runs backwards from the one the
+correlation suggested.
+
+Reading 60 lines of source refuted in minutes what an unrunnable experiment
+would not have settled in a year.
+
+### Why the archive could not answer the follow-up
+
+The obvious next question -- of the 8 zero-yield top-ups, how many were
+`topup_rejected`, how many `topup_dropped_existing` -- cannot be asked:
+
+```
+trace archive   218 runs   stats dicts carried: 0
+Mongo           81 docs / 81 jobs (one interpretation PER JOB)
+                topup_s survives in 3, topup_added in 2, topup_rejected in 1
+```
+
+Every trace event carries `seq/t/gate/tool/args/result/ms` and nothing else. The
+diagnostics the code computes -- with paragraphs explaining that
+`topup_refs` is "the only way to ask WHERE in the top-up's sequence its failures
+fall" -- go only to Mongo, which keeps one interpretation per job and is
+overwritten by the next run on that job. Two jobs carried forty runs.
+
+So the framework can answer **which tool is useful** (calls, duration, yield --
+all in the archive) and cannot answer **how to make this tool better** (why a
+call failed). The second question is the one that decides what to build.
+
+### The fix, and the bug class it belongs to
+
+`__outcome__` hand-lists seven fields. `__config__` used to hand-list about
+fifteen flags, silently omitting the rest -- 35 existed, 12 had ever been
+archived -- and was fixed by deriving them from the module source. The outcome
+stamp never got that treatment.
+
+Added `__stats__`: every scalar the run recorded, **derived not hand-listed**,
+dicts and lists skipped so a trace file stays small.
+
+One latent bug found on the way. `_trace_gate` capped every result at 160 chars
+except `__config__`, exempted by name after the cap "cut its JSON mid-string and
+made every run unparseable by the analyzer that the stamp exists to feed".
+`__outcome__` dumps JSON too and is at **160 chars with seven fields** -- all 40
+archived stamps parse today, and the eighth field would have broken them
+silently. The exemption is now a set, `VERBATIM_TRACE_STAMPS`, not an equality
+test against one name.
+
+Verified at runtime, not by reading the diff: the stamp archives 193 chars
+whole, round-trips exactly, keeps `topup_rejected` and `topup_dropped_existing`,
+excludes the verification dict and the ref list, and non-exempt stamps are still
+capped at 160.
+
+### A false green in the runner
+
+`run_all --only <filter>` printed `0 suites | 0 pass | 0 INTRODUCED` and exited
+**0** when the filter matched nothing. `--only` is a substring, so a
+comma-separated list matches nothing and passes silently -- the exact failure the
+runner exists to prevent, inside the runner. Now exits 2 with a message.

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -5292,3 +5292,68 @@ logs, not the archive aggregate.
 
 The 62 files are quarantined in `CLIENT_TMP/ai_traces_stub_quarantine/`, not
 deleted.
+
+## Round 58b — the overshoot figure was never polluted
+
+The 37.8% overshoot rate is quoted in `VERIFY_ITERATIONS`'s comment and in PR
+#48, and it came from the archive that round 58 found was 26% test output. It
+was rechecked against the cleaned corpus.
+
+| | verify calls | quote real | overshoot |
+|---|---|---|---|
+| as published (last 40 runs) | 1 038 | 99.5% | 37.8% |
+| clean corpus (all 172 runs) | **4 699** | 99.3% | **35.2%** |
+
+The 62 quarantined stub runs contributed **zero** verify calls -- they stop long
+before the gate. The 37.8 / 35.2 difference is the measurement WINDOW (recent 40
+runs vs all 172), not contamination. The committed claim is accurate for the
+window it names, and the conclusion is unchanged: fabrication is negligible,
+overshoot is the whole grounding problem, and overshoot is what a correction
+wave repairs.
+
+## Round 59 pre-registration — the owed sentence-repair retest
+
+`AI_SENTENCE_REPAIR=1`, agent arm only, `VERIFY_ITERATIONS=3` (the new default).
+
+**Why now.** Round 57 showed the third wave pays (ungrounded 4.00 -> 1.20,
+paired) but that **2 of 8 corrections were cancelled mid-flight** -- those runs
+buy a wave and get no repair. The cause is that a correction REGENERATES THE
+WHOLE REPORT: measured at 117 s, and r3's rewrite took a report from 20 cited
+claims to 37 while cutting failures only 11 -> 9. Sentence repair fixes the
+failed sentences in parallel and cannot introduce a citation, so it cannot
+introduce that regression.
+
+It also resolves a budget conflict nothing currently arbitrates: top-up (median
+95.5 s) and the third wave compete for the same 600 s. Every round-57 run with a
+slow top-up got two waves; the run that reached ZERO ungrounded did both,
+because its top-up took 59 s.
+
+**The falsifier is inherited verbatim from round 36 and is not being softened:**
+
+> Repair gets exactly one retest with the fix; **if citations fall again, it is
+> dead.**
+
+Round 36 measured repair as FAIL -- citations -22% (base) / -34% (agent),
+redactions +38% / +187% -- and diagnosed the cause as repaired DRIFT sentences
+dropping their `[N]` marker. That guard is in the code now:
+
+```python
+marker = "[%d]" % fc.get("ref_index", 0)
+if fc.get("mode") != "text" and marker not in text:
+    rejected += 1          # a DRIFT repair must keep its citation
+```
+
+**Predictions**
+1. `citations_in_body` does **not** fall versus round 57's runs. (Round 36's
+   killing metric. This is the falsifier; a fall ends repair for good.)
+2. Corrections cancelled falls from **2/8** to **0**.
+3. Median span falls below round 57's **450 s** -- repair replaces a 117 s
+   whole-report rewrite with parallel per-sentence edits.
+4. Final ungrounded citations per run stays at or below round 57's **2.00**.
+
+**Unit note.** Predictions 2 and 4 are per run and n=8 is small; 1 and 3 are the
+load-bearing ones and both were large effects in round 36 (-34%, -23%). Round 56
+was withdrawn for pre-registering an effect the instrument could not resolve, so
+this is stated plainly: with n=8, only effects of round-36 magnitude are
+detectable here, and a null result on 2 or 4 will be reported as "not resolved",
+not as "no effect".


### PR DESCRIPTION
Two changes. The first made the second measurable.

## 1. Archive WHY a tool call failed, not just that it ran

The trace archive held **218 runs** and not one carried a stats dict — every event had `seq/t/gate/tool/args/result/ms` and nothing else. The diagnostics the code computes go only to Mongo, which keeps **one interpretation per job**:

```
trace archive   218 runs   stats dicts: 0
Mongo            81 docs / 81 jobs
                 topup_s survives in 3, topup_added in 2, topup_rejected in 1
```

Two jobs carried forty runs, so each overwrote the last. Of 23 top-up calls the archive could price by duration, the *reason* each added nothing was recoverable for at most three.

`__stats__` now carries every scalar a run records, **derived rather than hand-listed** — the same fix `__config__` needed when its hand-written list of ~15 flags was found to be omitting 20 of 35.

**It paid off immediately.** Round 57's runs are the first to archive 60 scalars each, and they answered the question that was unanswerable a round earlier: a top-up that added nothing was `topup_rejected: True` with `topup_dropped_existing: 2` — the guard firing, not the model refusing. Different problem, different fix, previously invisible.

A latent bug found on the way: `_trace_gate` capped every result at 160 chars *except* `__config__`, exempted **by name** after the cap once "cut its JSON mid-string and made every run unparseable". `__outcome__` dumps JSON too and sits at exactly 160 chars with seven fields — all 40 archived stamps parse today, and an eighth field would have broken them silently. Now a set, not an equality test.

## 2. Three verify waves by default

`VERIFY_ITERATIONS` was 2, justified in its own comment as *"the 600 s budget does not fit 3"*. Measured across 8 replicates, that is false at current speeds.

| prediction (pre-registered) | result | verdict |
|---|---|---|
| wave 3 fixes ≥50% of what wave 2 left | 67/75/100/40/67 — mean **70%** | **HELD** |
| net ungrounded per run falls | 4.50 → **2.00** | **HELD** |
| median span under 600 s | **450 s**, max 470, **0/8 over** | **HELD** |

The carrying evidence is **paired and baseline-free** — wave 3's input is wave 2's output, so each run is its own control:

| | before wave 3 | after wave 3 |
|---|---|---|
| ungrounded citations | 3, 4, 5, 5, 3 (mean **4.00**) | 1, 1, 0, 3, 1 (mean **1.20**) |

**70% of remaining failures removed; all five runs improved.** One finished with **zero** ungrounded citations out of 33 checked.

This works because grounding failure here is **overshoot, not fabrication**: across 1038 archived verdicts the quote is real in 99.5% of cases, and 37.8% are a real quote attached to a claim it doesn't support. Overshoot is exactly what rewriting the sentence fixes.

### What it does not fix

**2 of 8 corrections were cancelled mid-flight** — those runs pay for a wave and get no repair (r3 finished at 9 ungrounded, the worst of the round, and is why the mean is 2.00 rather than ~1.2). The correction is a *whole-report regeneration*: r3's rewrite took a report from 20 cited claims to 37 while barely improving grounding.

**Top-up and the third wave compete for the same 600 s.** Every run with a slow top-up (102 s, 108 s) got two waves; the run that reached zero did both because its top-up took 59 s. There is no policy for this trade.

Both point at the queued sentence-repair retest — round 36's owed rerun, falsifier inherited unchanged.

## Verification

Runtime, not diff-reading: the stamp archives 193 chars whole, round-trips, keeps `topup_rejected`/`topup_dropped_existing`, excludes the verification dict, and non-exempt stamps are still capped at 160.

Suites: loop/agent/gate/correct/repair/trace/tool/flag/archive all pass, 0 introduced. New suite `test_a_run_archives_why_a_tool_failed` (6 tests). Also hardened `test_outcome_stamp_never_costs_the_report`, which located the stamp with `next()` over any function *mentioning* `__outcome__` — a comment naming it redirected the test to the wrong function and failed it while the guard it checks was present and correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)