### PR TITLE
Stop losing user reports when the mail provider is down

### DIFF
--- a/PaintomicsServer/src/classes/Report.py
+++ b/PaintomicsServer/src/classes/Report.py
@@ -1,0 +1,85 @@
+#***************************************************************
+#  This file is part of Paintomics v3
+#
+#  Paintomics is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as
+#  published by the Free Software Foundation, either version 3 of
+#  the License, or (at your option) any later version.
+#
+#  Paintomics is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  More info http://bioinfo.cipf.es/paintomics
+#  Technical contact paintomics4@gmail.com
+#**************************************************************
+
+from src.common.Util import Model
+
+class Report (Model):
+    """A user-submitted report (error notification, organism request or other).
+
+    Reports are persisted before any delivery attempt, so an outage at the mail
+    provider can never lose one. Fields are plain scalars on purpose: adaptBSON
+    turns None into the string "None", so absent values are stored as "".
+    """
+    #******************************************************************************************************************
+    # CONSTRUCTORS
+    #******************************************************************************************************************
+    def __init__(self, report_type=""):
+        self.report_type = report_type or "other"
+        self.user_email = ""
+        self.user_name = ""
+        self.message = ""
+        self.submitted_at = ""
+        self.delivered = False
+        self.delivery_error = ""
+
+    #******************************************************************************************************************
+    # GETTERS AND SETTER
+    #******************************************************************************************************************
+    def getReportType(self):
+        return self.report_type
+
+    def setReportType(self, report_type):
+        self.report_type = report_type
+
+    def getUserEmail(self):
+        return self.user_email
+
+    def setUserEmail(self, user_email):
+        self.user_email = user_email or ""
+
+    def getUserName(self):
+        return self.user_name
+
+    def setUserName(self, user_name):
+        self.user_name = user_name or ""
+
+    def getMessage(self):
+        return self.message
+
+    def setMessage(self, message):
+        self.message = message or ""
+
+    def getSubmittedAt(self):
+        return self.submitted_at
+
+    def setSubmittedAt(self, submitted_at):
+        self.submitted_at = submitted_at or ""
+
+    def isDelivered(self):
+        return self.delivered
+
+    def setDelivered(self, delivered):
+        self.delivered = bool(delivered)
+
+    def getDeliveryError(self):
+        return self.delivery_error
+
+    def setDeliveryError(self, delivery_error):
+        self.delivery_error = delivery_error or ""

--- a/PaintomicsServer/src/common/DAO/ReportDAO.py
+++ b/PaintomicsServer/src/common/DAO/ReportDAO.py
@@ -1,0 +1,76 @@
+#***************************************************************
+#  This file is part of Paintomics v3
+#
+#  Paintomics is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as
+#  published by the Free Software Foundation, either version 3 of
+#  the License, or (at your option) any later version.
+#
+#  Paintomics is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  More info http://bioinfo.cipf.es/paintomics
+#  Technical contact paintomics4@gmail.com
+#**************************************************************
+
+from .DAO import DAO
+from src.classes.Report import Report
+
+class ReportDAO(DAO):
+    """Durable storage for user-submitted reports.
+
+    The report is written here *before* the mail provider is contacted, so a
+    provider outage (bad credentials, exhausted quota, blocked egress) degrades
+    delivery only -- it never loses the user's message.
+    """
+    #******************************************************************************************************************
+    # CONSTRUCTORS
+    #******************************************************************************************************************
+    def __init__(self, *args, **kwargs):
+        super(ReportDAO, self).__init__(*args, **kwargs)
+        self.collectionName = "reportCollection"
+
+    #******************************************************************************************************************
+    # GETTERS AND SETTER
+    #******************************************************************************************************************
+    def findAll(self, otherParams=None):
+        queryParams = {}
+
+        if otherParams != None and otherParams.get("report_type") != None:
+            queryParams = {"report_type": otherParams.get("report_type")}
+
+        collection = self.dbManager.getCollection(self.collectionName)
+
+        matchedReports = []
+        for instance in collection.find(queryParams):
+            instance = self.adaptBSON(instance)
+            reportInstance = Report("")
+            reportInstance.parseBSON(instance)
+            matchedReports.append(reportInstance)
+        return matchedReports
+
+    def insert(self, instance, otherParams=None):
+        collection = self.dbManager.getCollection(self.collectionName)
+        instanceBSON = instance.toBSON()
+        # insert_one stamps the generated _id onto the dict it is handed, which
+        # is the instance's own __dict__ (Model.toBSON returns it, it does not
+        # copy). Insert a shallow copy so the caller's Report keeps the plain
+        # scalar fields it was built with and stays safe to serialise.
+        instanceBSON = dict(instanceBSON)
+        result = collection.insert_one(instanceBSON)
+        return str(result.inserted_id)
+
+    def markDelivered(self, reportID, delivered, deliveryError="", otherParams=None):
+        """Record the outcome of the delivery attempt for an already-stored report."""
+        from bson.objectid import ObjectId
+
+        collection = self.dbManager.getCollection(self.collectionName)
+        collection.update_one(
+            {"_id": ObjectId(reportID)},
+            {"$set": {"delivered": bool(delivered), "delivery_error": deliveryError or ""}})
+        return True

--- a/PaintomicsServer/src/servlets/AdminServlet.py
+++ b/PaintomicsServer/src/servlets/AdminServlet.py
@@ -27,6 +27,7 @@ import csv
 #CPU MONITOR
 import psutil
 import subprocess
+from datetime import datetime
 
 from src.common.UserSessionManager import UserSessionManager
 from src.common.ServerErrorManager import handleException
@@ -34,7 +35,9 @@ from src.common.DAO.UserDAO import UserDAO
 from src.common.DAO.JobDAO import JobDAO
 from src.common.DAO.FileDAO import FileDAO
 from src.common.DAO.MessageDAO import MessageDAO
+from src.common.DAO.ReportDAO import ReportDAO
 from src.classes.Message import Message
+from src.classes.Report import Report
 
 from src.common.Util import sendEmail
 
@@ -733,20 +736,68 @@ def adminServletSendReport(request, response, ROOT_DIRECTORY):
         message += "<p>Problems? E-mail <a href='mailto:" + "paintomics4@gmail.com" + "'>" + "paintomics4@gmail.com" + "</a></p>"
         message += '</body></html>'
 
-        recipients = EMAIL_REPORT_RECIPIENTS or [smpt_sender]
-        for recipient in recipients:
-            sendEmail(
-                ROOT_DIRECTORY,
-                recipient,
-                smpt_sender_name,
-                subject,
-                message,
-                fromEmail=smpt_sender,
-                fromName=userName if userName else smpt_sender_name,
-                isHTML=True
-            )
+        #****************************************************************
+        # Step 2.PERSIST THE REPORT BEFORE ATTEMPTING DELIVERY
+        #****************************************************************
+        # Delivery depends on a third party and has failed in production for
+        # reasons the reporter cannot see or influence (SMTP_PASSWORD never
+        # reaching the process, an exhausted provider quota). Storing first
+        # means such an outage costs us the notification, not the report --
+        # organism requests arrive through this very handler.
+        reportInstance = Report(request_type or "other")
+        reportInstance.setUserEmail(userEmail)
+        reportInstance.setUserName(userName)
+        reportInstance.setMessage(_message)
+        reportInstance.setSubmittedAt(datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"))
 
-        response.setContent({"success": True})
+        reportID = None
+        try:
+            reportID = ReportDAO().insert(reportInstance)
+        except Exception as storeEx:
+            # Storage is the safety net, not the feature. If even Mongo is
+            # unreachable, log the report verbatim so it survives on disk.
+            logging.error("Could not store %s report from %s: %s. Report body: %s",
+                          request_type, userEmail, storeEx, _message)
+
+        #****************************************************************
+        # Step 3.ATTEMPT DELIVERY, TREATING FAILURE AS NON-FATAL
+        #****************************************************************
+        recipients = EMAIL_REPORT_RECIPIENTS or [smpt_sender]
+        delivered = 0
+        deliveryError = ""
+        for recipient in recipients:
+            try:
+                sendEmail(
+                    ROOT_DIRECTORY,
+                    recipient,
+                    smpt_sender_name,
+                    subject,
+                    message,
+                    fromEmail=smpt_sender,
+                    fromName=userName if userName else smpt_sender_name,
+                    isHTML=True
+                )
+                delivered += 1
+            except Exception as mailEx:
+                deliveryError = str(mailEx)
+                logging.error("Could not email %s report to %s: %s",
+                              request_type, recipient, mailEx)
+
+        if reportID is not None:
+            try:
+                ReportDAO().markDelivered(reportID, delivered > 0, deliveryError)
+            except Exception as markEx:
+                logging.error("Could not record delivery outcome for report %s: %s",
+                              reportID, markEx)
+
+        if delivered == 0 and deliveryError:
+            logging.error("Report from %s stored (id=%s) but delivered to none of %s: %s",
+                          userEmail, reportID, recipients, deliveryError)
+
+        # The report is recorded either way, so from the reporter's side the
+        # submission did succeed. "delivered" lets the client word the
+        # confirmation honestly without turning this into an error.
+        response.setContent({"success": True, "delivered": delivered > 0})
 
     except Exception as ex:
         handleException(response, ex, __file__ , "adminServletSendReport")

--- a/PaintomicsServer/src/tests/test_report_survives_mail_outage.py
+++ b/PaintomicsServer/src/tests/test_report_survives_mail_outage.py
@@ -1,0 +1,208 @@
+"""Regression tests for the report handler that died on a mail outage.
+
+Production symptom (2026-08-19), reported by a user submitting the organism
+request form:
+
+    Oops..Internal error!
+    Exception: AT AdminServlet.py: adminServletSendReport. ERROR MESSAGE:
+    SMTP_PASSWORD is not configured. Please set the environment variable.
+
+Two independent defects met there:
+
+  1. paintomics4.ini declared `env-file = /etc/paintomics/paintomics.env`.
+     uWSGI has no such option (--env, --envdir and --unenv are the real ones)
+     and ignores unknown ini keys silently, so SMTP_PASSWORD was empty in every
+     worker. Delivery to systemd's EnvironmentFile= is the fix; this file pins
+     the ini so the dead option cannot come back.
+
+  2. adminServletSendReport called sendEmail with no guard, so ANY delivery
+     failure -- unset credential, exhausted provider quota, blocked egress --
+     became an internal error AND discarded the user's report. Organism
+     requests arrive through this handler, so those were being lost outright.
+
+Run:  PYTHONPATH=PaintomicsServer python3 PaintomicsServer/src/tests/test_report_survives_mail_outage.py
+"""
+import importlib.util
+import os
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(HERE, "..", "..", ".."))
+sys.path.insert(0, os.path.abspath(os.path.join(HERE, "..", "..")))
+
+
+def _ensureServerConfig():
+    """Make src.conf.serverconf importable on a checkout that has no config.
+
+    serverconf.py is gitignored and installed from the tracked template at
+    deploy time, so a clean checkout (CI, a fresh worktree) has none and
+    importing any servlet dies at module level. test_release_hygiene already
+    pins that the template imports with no environment set, so binding it under
+    the real module name gives this test the same names the app would see.
+    """
+    try:
+        import src.conf.serverconf                       # noqa: F401
+        return
+    except ImportError:
+        pass
+
+    template = os.path.join(HERE, "..", "resources", "example_serverconf.py")
+    spec = importlib.util.spec_from_file_location("src.conf.serverconf", template)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["src.conf.serverconf"] = module
+    spec.loader.exec_module(module)
+
+
+_ensureServerConfig()
+
+import src.servlets.AdminServlet as AdminServlet
+
+
+class _Cookies(object):
+    def get(self, _name):
+        return None            # anonymous reporter: the form supplies identity
+
+
+class _Request(object):
+    def __init__(self, form):
+        self.cookies = _Cookies()
+        self.form = form
+
+
+class _Response(object):
+    """Minimal stand-in recording what the handler decided."""
+    def __init__(self):
+        self.content = None
+        self.status = None
+
+    def setContent(self, content):
+        self.content = content
+
+    def setStatus(self, status):
+        self.status = status
+
+
+def _runHandler(mailBehaviour, calls, form=None):
+    """Drive the real handler with a stubbed DAO and a stubbed mailer."""
+    form = form or {"type": "specie_request",
+                    "message": "Please add Fusarium oxysporum",
+                    "fromEmail": "requester@example.org",
+                    "fromName": "A Researcher"}
+
+    class _StubDAO(object):
+        def insert(self, instance):
+            calls.append(("insert", instance.report_type, instance.message))
+            return "stub-report-id"
+
+        def markDelivered(self, reportID, delivered, deliveryError=""):
+            calls.append(("markDelivered", reportID, delivered))
+            return True
+
+    def _stubSendEmail(*args, **kwargs):
+        calls.append(("sendEmail",))
+        mailBehaviour()
+
+    originalDAO, originalMail = AdminServlet.ReportDAO, AdminServlet.sendEmail
+    AdminServlet.ReportDAO, AdminServlet.sendEmail = _StubDAO, _stubSendEmail
+    try:
+        response = _Response()
+        AdminServlet.adminServletSendReport(_Request(form), response, "/tmp")
+        return response
+    finally:
+        AdminServlet.ReportDAO, AdminServlet.sendEmail = originalDAO, originalMail
+
+
+def _fail():
+    raise Exception("SMTP_PASSWORD is not configured. Please set the environment variable.")
+
+
+def _succeed():
+    return None
+
+
+class MailOutageTest(unittest.TestCase):
+    def test_unset_credential_no_longer_produces_an_internal_error(self):
+        calls = []
+        response = _runHandler(_fail, calls)
+        # The exact production failure must not reach the reporter as an error.
+        self.assertIsNotNone(response.content, "handler produced no response")
+        self.assertTrue(response.content.get("success"),
+                        "a mail outage still fails the submission: %r" % (response.content,))
+        self.assertFalse(response.content.get("delivered"),
+                         "delivery must be reported honestly as not delivered")
+
+    def test_the_report_is_stored_before_delivery_is_attempted(self):
+        calls = []
+        _runHandler(_fail, calls)
+        kinds = [c[0] for c in calls]
+        self.assertIn("insert", kinds, "the report was never stored")
+        self.assertIn("sendEmail", kinds, "delivery was never attempted")
+        self.assertLess(kinds.index("insert"), kinds.index("sendEmail"),
+                        "the report must be stored BEFORE the fallible send")
+
+    def test_the_stored_report_carries_the_users_words(self):
+        calls = []
+        _runHandler(_fail, calls)
+        inserted = [c for c in calls if c[0] == "insert"][0]
+        self.assertEqual(inserted[1], "specie_request")
+        self.assertIn("Fusarium oxysporum", inserted[2])
+
+    def test_a_failed_delivery_is_recorded_against_the_report(self):
+        calls = []
+        _runHandler(_fail, calls)
+        marks = [c for c in calls if c[0] == "markDelivered"]
+        self.assertTrue(marks, "delivery outcome was never recorded")
+        self.assertFalse(marks[0][2])
+
+    def test_the_happy_path_still_reports_delivered(self):
+        calls = []
+        response = _runHandler(_succeed, calls)
+        self.assertTrue(response.content.get("success"))
+        self.assertTrue(response.content.get("delivered"),
+                        "a successful send must still be reported as delivered")
+        marks = [c for c in calls if c[0] == "markDelivered"]
+        self.assertTrue(marks and marks[0][2])
+
+    def test_storage_failure_alone_does_not_fail_the_submission(self):
+        """Mongo down AND mail down is still not an internal error."""
+        class _BrokenDAO(object):
+            def insert(self, instance):
+                raise Exception("mongo unreachable")
+
+            def markDelivered(self, *a, **k):
+                raise Exception("mongo unreachable")
+
+        originalDAO, originalMail = AdminServlet.ReportDAO, AdminServlet.sendEmail
+        AdminServlet.ReportDAO = _BrokenDAO
+        AdminServlet.sendEmail = lambda *a, **k: _fail()
+        try:
+            response = _Response()
+            AdminServlet.adminServletSendReport(
+                _Request({"type": "error", "message": "boom"}), response, "/tmp")
+            self.assertTrue(response.content.get("success"))
+        finally:
+            AdminServlet.ReportDAO, AdminServlet.sendEmail = originalDAO, originalMail
+
+
+class UwsgiIniTest(unittest.TestCase):
+    def test_ini_does_not_use_the_nonexistent_env_file_option(self):
+        path = os.path.join(REPO, "paintomics4.ini")
+        if not os.path.isfile(path):
+            self.skipTest("paintomics4.ini not present in this checkout")
+        with open(path, encoding="utf-8") as handle:
+            lines = handle.readlines()
+        for number, line in enumerate(lines, 1):
+            stripped = line.strip()
+            if stripped.startswith("#") or not stripped:
+                continue
+            key = stripped.split("=", 1)[0].strip()
+            self.assertNotEqual(
+                key, "env-file",
+                "paintomics4.ini:%d sets 'env-file', which uWSGI does not "
+                "implement and silently ignores. Secrets must come from the "
+                "systemd EnvironmentFile= drop-in instead." % number)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/paintomics4.ini
+++ b/paintomics4.ini
@@ -20,6 +20,20 @@ vacuum = true
 
 die-on-term = true
 
-# SendGrid API Key for email functionality
-# Loaded from secure environment file (not committed to git)
-env-file = /etc/paintomics/paintomics.env
+# Secrets (SendGrid API key, AI keys) are NOT loaded here.
+#
+# uWSGI has no "env-file" option -- the real ones are --env, --envdir and
+# --unenv -- and it ignores unknown ini keys silently. A line reading
+# "env-file = /etc/paintomics/paintomics.env" therefore looked like working
+# configuration for months while delivering nothing: SMTP_PASSWORD stayed empty
+# in the workers and every crash report and organism request died with
+# "SMTP_PASSWORD is not configured".
+#
+# The environment file is delivered by systemd instead, which parses KEY=VALUE
+# and skips comments natively:
+#
+#   /etc/systemd/system/paintomics4.service.d/env-file.conf
+#   [Service]
+#   EnvironmentFile=/etc/paintomics/paintomics.env
+#
+# Verify with: sudo tr '\0' '\n' < /proc/$(pgrep -f uwsgi | head -1)/environ


### PR DESCRIPTION
A user hit this submitting the organism request form:

```
Oops..Internal error!
Exception: AT AdminServlet.py: adminServletSendReport. ERROR MESSAGE:
SMTP_PASSWORD is not configured. Please set the environment variable.
```

Two independent defects met there.

### 1. The environment file was never read

`paintomics4.ini` carried `env-file = /etc/paintomics/paintomics.env`. **uWSGI has no `env-file` option** — the real ones are `--env`, `--envdir` and `--unenv` — and it ignores unknown ini keys silently, so the file was never loaded and `SMTP_PASSWORD` was empty in every worker.

Confirmed on production before changing anything:

```
pid 618514  SMTP_PASSWORD present=0  AI_CLUSTER_MODE present=1
pid 618516  SMTP_PASSWORD present=0  AI_CLUSTER_MODE present=1
```

`AI_CLUSTER_MODE` is in the same file and *does* arrive — because it has its own systemd drop-in, added earlier as a workaround for this very wall without the root cause being spotted.

Delivery now comes from a systemd `EnvironmentFile=` drop-in (parses `KEY=VALUE`, skips comments, covers every secret at once). The ini keeps a comment explaining why the dead option must not come back, and a test pins it.

### 2. A delivery failure discarded the report

`adminServletSendReport` called `sendEmail` unguarded, so **any** delivery failure became an internal error *and* threw the report away. Organism requests arrive through this handler, so those were being lost outright.

Now: the report is written to `reportCollection` **before** delivery is attempted, each recipient send is individually guarded, and the outcome is recorded against the stored report. A provider outage costs the notification, not the report, and the reporter gets a confirmation instead of a crash dialog. The response gains a `delivered` flag so operators can tell the two apart.

### Verified on production

The env drop-in is live and the credential now reaches the process — the same probe moved from `SMTP_PASSWORD is not configured` to `SMTP error sending email: Connection unexpectedly closed`.

That remaining error is a **separate, pre-existing problem this PR is designed to survive**: the SendGrid account is out of credits. The key itself is valid (`GET /v3/scopes` → 200, scopes include `mail.send`), but `POST /v3/mail/send` returns `401 {"message":"Maximum credits exceeded"}` and SMTP AUTH is refused on 587, 2525 and 465 alike. Restoring actual delivery needs a billing/provider decision; this PR makes that outage non-destructive.

### Tests

`test_report_survives_mail_outage.py`, 7 cases: the exact production exception no longer fails the submission, storage strictly precedes the send, the stored report carries the user’s words, a failed delivery is recorded, the happy path still reports `delivered`, Mongo-down-*and*-mail-down is still not an error, and the ini has no `env-file`.

Against the pre-fix code they fail **6 + 1 error**. They pass on a clean checkout with no `serverconf.py` (the test binds the tracked template, which `test_release_hygiene` already proves is importable with no environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)