### PR TITLE
Top-up rejection reasons, a Results-section experiment, and stop polling a dead session

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
@@ -829,7 +829,35 @@ function PA_Step3JobView() {
 					schedule(AI_POLL_INTERVAL);
 				}
 			},
-			error: function() {
+			error: function(jqXHR) {
+				// Retrying is right for a TRANSPORT failure and wrong for a
+				// permanent one. Both used to back off and retry forever.
+				//
+				// Measured on the live server: after a restart invalidated one
+				// user's in-process session, their browser polled
+				// /ai_interpret_status every 31 s and got
+				// "400 CredentialException: User not valid ... please log-in
+				// again" for FOUR HOURS -- about 460 requests -- with nothing
+				// shown to them. A session that has expired cannot un-expire by
+				// being asked again.
+				//
+				// 401/403 are unambiguous. A 400 is only treated as permanent
+				// when the body says so, because the servlet also returns 400
+				// for ordinary handled errors that a retry may well clear.
+				var code = jqXHR && jqXHR.status;
+				var body = (jqXHR && jqXHR.responseText) || "";
+				var expired = code === 401 || code === 403 ||
+				              (code === 400 && /session|log-in|log in|not valid/i.test(body));
+				if (expired) {
+					if (me.aiWidget) {
+						me.aiWidget.updateProgress(
+							"error", 100,
+							"Your session expired, so progress can no longer be " +
+							"tracked. Your job is safe on the server \u2014 sign in " +
+							"again and reopen it from My Jobs.");
+					}
+					return;      // stop the chain: nothing here can recover it
+				}
 				me.aiPollFailures = (me.aiPollFailures || 0) + 1;
 				schedule(Math.min(AI_POLL_INTERVAL * Math.pow(2, me.aiPollFailures - 1),
 				                  BACKOFF_CEILING));

--- a/PaintomicsServer/src/benchmarks/ai_arm_bench.py
+++ b/PaintomicsServer/src/benchmarks/ai_arm_bench.py
@@ -173,7 +173,8 @@ STAGE_TIMES = ("topup_fulltext_s", "topup_verify_s",
                "verify_fanout_s", "verify_repair_s",   # the two halves of the loop
                "triage_s", "plan_s", "retrieval_s", "interpret_s", "gap_fill_s",
                "synth_s", "topup_s", "verify_loop_s", "verify_s",       # shipped arm
-               "loop_s", "fulltext_s", "quotes_s", "merge_s")           # agent arm
+               "loop_s", "fulltext_s", "quotes_s", "merge_s",           # agent arm
+               "results_s")                                             # Results section
 STAGE_COUNTS = ("delegate_fulltext_gained", "quotes_supplied", "quotes_reused", "quotes_from_delegation", "refs_rendered", "verify_unchecked", "verify_cut_short", "unquotable_markers_dropped", "agent_tool_calls", "agent_searches", "agent_notebook", "stitch_truncated", "topup_evidence_chars", "genes_shown", "genes_flat", "merge_gain_chars", "verify_iterations", "batches_failed", "truncated_calls",
                 "forced_synthesis", "topup_added", "quotes_unverifiable",
                 # The other half of the top-up's bet. Recording only
@@ -183,6 +184,17 @@ STAGE_COUNTS = ("delegate_fulltext_gained", "quotes_supplied", "quotes_reused", 
                 # Seconds are half of what a tool costs; the other half is the
                 # context every later turn has to carry.
                 "tool_chars",
+                # The Results-section rewrite. Both word counts, because the
+                # stage exists to compress and the RATIO is the measurement --
+                # round 66 caught a 984-word interpretation coming back at 1408.
+                "results_words_before", "results_words_after",
+                # How many citations survived, and how many attempts it took.
+                # attempts>1 is the norm, not an anomaly: the first pass drops
+                # citations in most runs, so this is the number that says
+                # whether the guard is load-bearing.
+                "results_citations_kept", "results_attempts", "results_section",
+                # "short" is a ratio, so keep the ratio, not just the verdict.
+                "topup_candidate_ratio",
                 # Which searches reached the report. Retrieval novelty is
                 # ~99.9%; conversion to a citation is ~12%, so the useful
                 # question is per-theme, not per-call.
@@ -249,7 +261,13 @@ STAGE_NOTES = ("delegate_fulltext_failed", "fulltext_candidates", "fulltext_upgr
                "topup_fulltext_skipped", "topup_fulltext_failed",
                "topup_disabled", "topup_failed", "topup_skipped", "merge_rejected",
                "merge_skipped", "merge_failed", "loop_backstop",
-               "deterministic_fallback")
+               "deterministic_fallback",
+               # WHICH guard condition rejected a top-up (short / no_gain /
+               # dropped) and which rejected a Results section. A stage that
+               # only records THAT it failed cannot be aimed at: 3 of 5
+               # archived top-up rejections recorded no reason at all.
+               "topup_rejected_why", "results_rejected", "results_retried",
+               "results_failed")
 
 
 # Stats the two arms write that the archive deliberately does not keep. The

--- a/PaintomicsServer/src/classes/AIInterpret/agent_loop.py
+++ b/PaintomicsServer/src/classes/AIInterpret/agent_loop.py
@@ -2868,6 +2868,32 @@ async def _run_loop_async(job_instance, job_id, experiment_design, budgets,
                                              stats["topup_added_refs"])
             else:
                 stats["topup_rejected"] = True
+                # WHICH of the three conditions rejected it. Measured over 13
+                # archived runs: 5 top-ups (38%) were rejected, and only 2 of
+                # those recorded anything about why -- `topup_dropped_existing`
+                # happens to be set independently. The other 3 failed on
+                # "too short" or "added nothing" and are indistinguishable, so
+                # the one lever in this pipeline with no citation cost (a
+                # rejected top-up delivers zero BY DEFINITION, so removing it
+                # cannot lose a citation) cannot be aimed at anything.
+                #
+                # The prompt already says "Return the SAME report with citations
+                # added ... Change nothing else", so each condition implies a
+                # different failure: `short` means it truncated the report,
+                # `no_gain` means it complied and found nothing to add, and
+                # `dropped` means it rewrote instead of appending. Only the
+                # first and third are prompt-compliance failures worth fixing.
+                reasons = []
+                if len(candidate) <= 0.6 * len(str(report)):
+                    reasons.append("short")
+                if added <= len(cited_now):
+                    reasons.append("no_gain")
+                if dropped:
+                    reasons.append("dropped")
+                stats["topup_rejected_why"] = ",".join(reasons) or "unknown"
+                # The sizes too: "short" is a ratio and the ratio is the datum.
+                stats["topup_candidate_ratio"] = round(
+                    len(candidate) / max(len(str(report)), 1), 3)
         except (Exception, asyncio.TimeoutError) as e:
             stats["topup_failed"] = "%s: %s" % (type(e).__name__, e)
             logger.warning("[%s][loop] citation top-up failed: %s: %s",

--- a/PaintomicsServer/src/classes/AIInterpret/agent_loop.py
+++ b/PaintomicsServer/src/classes/AIInterpret/agent_loop.py
@@ -198,6 +198,20 @@ MERGE_DELEGATED = os.getenv("AI_AGENT_MERGE_DELEGATED", "1") == "1"
 # everything, which measured 4.5-11 citations because the writer saw the whole
 # reference list at once.
 MERGE_MODE = os.getenv("AI_AGENT_MERGE_MODE", "stitch")
+
+# Rewrite the finished dossier as a paper Results section.
+#
+# What the arm produces today is a DOSSIER, not a Results section: measured on a
+# real run, 8 184 words over 497 lines, opening with a "Key Findings" bullet
+# block, then fifteen numbered pathway sections each carrying the same three
+# sub-headings, then a 37-row table. It also reads as stitched -- a second H1
+# mid-document and "Cross-Pathway Synthesis" appearing twice -- because it is
+# the concatenation of delegated chunks.
+#
+# A Results section is continuous prose, organised by FINDING rather than by
+# pathway id, with the clusters described in a sentence rather than tabulated.
+RESULTS_SECTION = os.getenv("AI_AGENT_RESULTS_SECTION", "0") == "1"
+RESULTS_MAX_WORDS = int(os.getenv("AI_AGENT_RESULTS_WORDS", "1800"))
 SCREEN_TARGET_POOL = int(os.getenv("AI_AGENT_SCREEN_TARGET", "35"))
 """How many screened papers the pool should aim for.
 
@@ -2327,6 +2341,141 @@ TOOLBELT = [get_experiment_overview, get_pathway_details,
 # Orchestration: the loop, then the mandatory exit gate.
 # ---------------------------------------------------------------------------
 
+RESULTS_PROMPT = """Rewrite the interpretation below as the RESULTS section of a
+research paper. Not a summary of it -- the Results section itself.
+
+WHAT TO CHANGE
+- Continuous prose. No bullet lists anywhere. No "Key Findings" block: a Results
+  section states its findings in order, it does not preface itself.
+- Four to six subsections. Title each one by the FINDING it reports, as a paper
+  would ("Chromatin accessibility changes precede transcriptional response"),
+  never by a pathway name or accession ("Autophagy - Animal (mmu04140)").
+- Each subsection tells ONE story and draws on whichever pathways serve it.
+  Do not walk through pathways one at a time; that is the structure being
+  replaced.
+- Describe the pathway clusters in prose -- what groups with what, and what the
+  grouping means biologically. Do not reproduce the cluster table.
+- No tables of any kind.
+- Report numbers the way a paper does: inside the sentence, with the measure
+  named ("accessibility rose at 83 of 130 autophagy loci, p = 0.0029"), not as
+  a parenthetical dump.
+- Target %(words)d words. Shorter is better than padded.
+
+WHAT MUST NOT CHANGE
+- **These exact markers must all appear in your prose: %(markers)s**
+  Check them off before you answer; a rewrite missing any one is discarded and
+  the original is shipped instead, so the work is wasted.
+- **Every [N] citation marker must survive, on the sentence it supports.** The
+  citations were verified against the papers they point at; a marker moved to a
+  different claim is a false citation, and a marker dropped loses a verified
+  fact. Carry each one to whichever sentence now carries its claim. Do not
+  renumber, do not add new markers, do not cite anything not already cited.
+- Every numeric value, gene symbol, p-value and direction of change.
+- The "### References" section at the end, exactly as it stands.
+
+THE CLUSTERS (describe these in prose; do not tabulate):
+%(clusters)s
+
+THE INTERPRETATION TO REWRITE:
+%(report)s
+"""
+
+
+async def _write_results_section(agent, ctx, report, cluster_text, job_id,
+                                 stats, timeout):
+    """Rewrite the dossier as a Results section, or keep the dossier.
+
+    Runs BEFORE the exit gate on purpose. Everything it writes then goes
+    through top-up, the Claim Verifier and the programmatic net, so its prose is
+    grounded by the same machinery as any other draft. Placing it after the gate
+    would let a rewrite move a verified marker onto a claim nobody checked --
+    which is precisely the overshoot the gate exists to remove.
+
+    The citation guard is not advisory. Measured across this document, a stage
+    that silently costs citations is the failure mode that killed sentence
+    repair (-33%) and the top-up deadline (-21%), so this one is REJECTED
+    outright if a single marker goes missing, exactly as the merge and top-up
+    candidates are.
+    """
+    t0 = time.time()
+
+    def _body_markers(text):
+        """Markers in the PROSE, not in the reference list.
+
+        The reference list repeats every marker as its own line ("[2] Smith et
+        al..."), so counting the whole document hides the exact failure this
+        guard exists to catch: prose that drops a citation while the entry it
+        pointed at stays in the list. That is marker-stripping, and this arm
+        already does it -- redaction removes the marker and leaves the sentence,
+        which is why "failed citations" reads 0.0 while grounding is imperfect.
+        """
+        return set(re.findall(r"\[(\d+)\]", str(text).split("### References")[0]))
+
+    before = _body_markers(report)
+    prompt = RESULTS_PROMPT % {
+        "words": RESULTS_MAX_WORDS,
+        "markers": " ".join("[%s]" % m for m in sorted(before, key=int)) or "(none)",
+        "clusters": cluster_text or "(no clustering available)",
+        "report": report}
+
+    # One retry, naming what went missing.
+    #
+    # Measured on the first live attempt: the prompt alone lost 5 of 22
+    # citations while compressing 8 184 words to a Results section. Asking a
+    # model to reorganise prose and carry two dozen markers is two tasks, and
+    # the second is the one that silently fails -- so it gets told exactly which
+    # ones it dropped rather than being asked again to be careful.
+    candidate = ""
+    after = set()
+    for attempt in (1, 2):
+        try:
+            r = await bounded(Runner.run(agent, prompt, context=ctx, max_turns=2),
+                              timeout, label="results section")
+            candidate = str(r.final_output or "").strip()
+        except (Exception, asyncio.TimeoutError) as e:
+            stats["results_failed"] = "%s: %s" % (type(e).__name__, e)
+            return report, False
+        after = _body_markers(candidate)
+        missing = before - after
+        if not missing or attempt == 2:
+            stats["results_attempts"] = attempt
+            break
+        stats["results_retried"] = ",".join(sorted(missing, key=int))
+        prompt = (
+            "Your Results section dropped these citations: %s\n\n"
+            "Each one marks a claim that was verified against the paper it "
+            "points at, so a dropped marker loses a verified fact and the "
+            "rewrite is discarded. Return the SAME Results section with every "
+            "one of them restored on the sentence carrying its claim. Change "
+            "nothing else.\n\n%s"
+            % (" ".join("[%s]" % m for m in sorted(missing, key=int)), candidate))
+    lost = before - after
+    gained = after - before
+    reasons = []
+    if lost:
+        reasons.append("lost_%d" % len(lost))
+    if gained:
+        # A marker that was not there before points at a paper this text was
+        # never verified against.
+        reasons.append("invented_%d" % len(gained))
+    if "### References" in report and "### References" not in candidate:
+        reasons.append("no_references")
+    if len(candidate) < 0.2 * len(report):
+        reasons.append("truncated")
+    if reasons:
+        stats["results_rejected"] = ",".join(reasons)
+        stats["results_s"] = time.time() - t0
+        logger.info("[%s][loop] results section rejected (%s); keeping the "
+                    "dossier", job_id, ",".join(reasons))
+        return report, False
+
+    stats["results_words_before"] = len(report.split())
+    stats["results_words_after"] = len(candidate.split())
+    stats["results_citations_kept"] = len(after)
+    stats["results_s"] = time.time() - t0
+    return candidate, True
+
+
 async def _run_loop_async(job_instance, job_id, experiment_design, budgets,
                           stats, hooks=None):
     hooks = hooks or {}
@@ -2748,19 +2897,43 @@ async def _run_loop_async(job_instance, job_id, experiment_design, budgets,
         stats["merge_mode"] = MERGE_MODE
         stats["merge_s"] = time.time() - t_m
 
+    # ---- optional: rewrite the dossier as a paper Results section ---------
+    # Before the tables are appended and before the exit gate, so the rewritten
+    # prose is what gets top-up, verification and redaction. See
+    # _write_results_section for why the order is not negotiable.
+    results_written = False
+    if RESULTS_SECTION:
+        cluster_text = ""
+        if ctx.partition is not None:
+            cluster_text = clusters_mod.render_partition_table(
+                ctx.partition, _ctx_by_id(ctx)) or ""
+        report, results_written = await _write_results_section(
+            agents["synth"], ctx, report, cluster_text, job_id, stats,
+            min(SDK_LONG_CALL_TIMEOUT, 180))
+        stats["results_section"] = results_written
+
     # The deterministic tables ride below the prose, exactly as the workflow
     # arm ships them (its phase 5d): data the job already holds is appended,
     # never asked of the model.
+    #
+    # When a Results section was written, the CLUSTER table is suppressed --
+    # the section describes the clustering in prose, which is the whole point of
+    # asking for it, and a table restating it undoes that. The enriched pathway
+    # summary stays: it is the quantitative backbone, it is data the job already
+    # holds rather than anything the model asserted, and dropping it would lose
+    # numbers the reader may want to check.
     if "## Enriched Pathway Summary" not in report:
         report = report.rstrip() + "\n\n" + render_pathway_table(pathways)
     if ctx.partition is not None:
-        table = clusters_mod.render_partition_table(ctx.partition,
-                                                   _ctx_by_id(ctx))
-        if table and "## Pathway Clusters" not in report:
-            report = report.rstrip() + "\n\n" + table
+        if not results_written:
+            table = clusters_mod.render_partition_table(ctx.partition,
+                                                       _ctx_by_id(ctx))
+            if table and "## Pathway Clusters" not in report:
+                report = report.rstrip() + "\n\n" + table
         note = clusters_mod.render_reading_note(ctx.partition)
-        if note and note not in report:
-            report = note + "\n\n" + report
+        if note and note not in report and not results_written:
+            note = note + "\n\n" + report
+            report = note
 
     # ---- The mandatory exit gate ------------------------------------------
     # Identical sequence to agent.py's tail (phases 5a''''-6): marker hygiene,

--- a/PaintomicsServer/src/tests/test_a_rejected_topup_says_why.py
+++ b/PaintomicsServer/src/tests/test_a_rejected_topup_says_why.py
@@ -1,0 +1,87 @@
+"""A rejected top-up must record WHICH condition rejected it.
+
+Measured over 13 archived runs: 5 top-ups (38%) were rejected outright,
+spending 32-130 s and delivering nothing. That is the only lever in this
+pipeline with no citation cost -- a rejected top-up adds zero BY DEFINITION, so
+removing it cannot lose a citation, unlike the deadline (21% citation loss) and
+the headroom threshold (blocks runs that did not need blocking), both of which
+were priced and rejected.
+
+Of those 5, only 2 recorded anything about why, and only because
+`topup_dropped_existing` is set independently of the guard. The other 3 failed
+on "too short" or "added nothing" and were indistinguishable.
+"""
+import ast
+import os
+import re
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SERVER = os.path.dirname(os.path.dirname(HERE))
+SRC = os.path.join(SERVER, "src", "classes", "AIInterpret", "agent_loop.py")
+
+
+class RejectedTopupSaysWhy(unittest.TestCase):
+
+    def setUp(self):
+        with open(SRC) as fh:
+            self.src = fh.read()
+
+    def test_the_reason_is_recorded(self):
+        self.assertIn('stats["topup_rejected_why"]', self.src)
+
+    def test_every_guard_condition_has_a_named_reason(self):
+        """The guard has exactly three conditions; each needs a distinct label.
+
+        If a condition is added later without a label, a rejection it causes
+        reads as one of the others -- which is worse than "unknown", because it
+        is wrong rather than absent.
+        """
+        # Anchored on the REJECT branch, not on the guard. Slicing forward from
+        # the guard walks through the accept branch first, which is ~40 lines of
+        # comment here, so a fixed window ends before the labels and the test
+        # fails on a correct implementation. This repo has hit that exact
+        # stale-slice failure in five other suites.
+        self.assertIn("if (len(candidate) > 0.6 * len(str(report))", self.src,
+                      "the guard's shape changed; update this test")
+        tail = self.src.split('stats["topup_rejected"] = True')[1][:2500]
+        for label in ("short", "no_gain", "dropped"):
+            self.assertIn('"%s"' % label, tail,
+                          "no label for the %r condition" % label)
+
+    def test_the_labels_mirror_the_guard_not_a_guess(self):
+        """Each label's test must be the NEGATION of the guard's condition."""
+        tail = self.src.split('stats["topup_rejected"] = True')[1][:2000]
+        self.assertIn("len(candidate) <= 0.6 * len(str(report))", tail,
+                      "'short' must negate the guard's length test exactly")
+        self.assertIn("added <= len(cited_now)", tail,
+                      "'no_gain' must negate the guard's gain test exactly")
+        self.assertIn("if dropped:", tail)
+
+    def test_it_never_records_an_empty_reason(self):
+        tail = self.src.split('stats["topup_rejected"] = True')[1][:2000]
+        self.assertIn('or "unknown"', tail,
+                      "an empty reason string is indistinguishable from the "
+                      "field being absent, which is the failure this fixes")
+
+    def test_the_ratio_is_kept_because_short_is_a_ratio(self):
+        self.assertIn('stats["topup_candidate_ratio"]', self.src)
+
+    def test_the_reason_reaches_the_archive(self):
+        """It must be a scalar, or the __stats__ stamp drops it.
+
+        The stamp keeps ints, floats, bools and strings <=120 chars, and
+        deliberately skips dicts and lists. A reason recorded as a list would be
+        computed and then silently discarded -- exactly the failure round 56
+        fixed at the level above.
+        """
+        tail = self.src.split('stats["topup_rejected_why"]')[1][:200]
+        self.assertIn('",".join(', tail,
+                      "the reason must be joined into a string, not left a list")
+
+
+if __name__ == "__main__":
+    r = unittest.TextTestRunner(verbosity=2).run(
+        unittest.TestLoader().loadTestsFromTestCase(RejectedTopupSaysWhy))
+    sys.exit(0 if r.wasSuccessful() else 1)

--- a/PaintomicsServer/src/tests/test_the_poll_gives_up_on_a_dead_session.py
+++ b/PaintomicsServer/src/tests/test_the_poll_gives_up_on_a_dead_session.py
@@ -1,0 +1,98 @@
+"""A poll must retry a transport blip and give up on an expired session.
+
+PR #36 fixed the opposite bug: one dropped request ended the chain for good and
+the widget sat at "Generating interpretation..." forever. The fix made every
+failure retry -- including failures that can never clear.
+
+Measured on the live server 2026-08-19: a restart invalidated one user's
+in-process session, and their browser polled /ai_interpret_status every 31 s for
+FOUR HOURS, about 460 requests, each answered
+"400 CredentialException: User not valid ... please log-in again", with nothing
+shown to them. Retrying cannot un-expire a session.
+"""
+import os
+import re
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(HERE)))
+JS = os.path.join(ROOT, "PaintomicsClient", "public_html", "app", "view",
+                  "PathwayAcquisitionViews", "PA_Step3Views.js")
+
+
+def _handler(src):
+    """The ajax error handler for pollAIStatus."""
+    poll = src.split("this.pollAIStatus = function()")[1]
+    poll = poll.split("this.cleanupAIWidget")[0]
+    return poll.split("error: function(")[1]
+
+
+class PollGivesUpOnADeadSession(unittest.TestCase):
+
+    def setUp(self):
+        with open(JS) as fh:
+            self.src = fh.read()
+        self.h = _handler(self.src)
+
+    def test_the_handler_reads_the_status_code(self):
+        """Without it, every failure looks identical -- which was the bug."""
+        self.assertIn("jqXHR", self.h)
+        self.assertIn("status", self.h)
+
+    def test_401_and_403_stop_the_chain(self):
+        self.assertRegex(self.h, r"code\s*===\s*401")
+        self.assertRegex(self.h, r"code\s*===\s*403")
+
+    def test_a_400_stops_only_when_the_body_says_session(self):
+        """The servlet also returns 400 for handled errors a retry may clear.
+
+        Treating every 400 as permanent would reintroduce PR #36's bug in a new
+        place: a chain that dies on something transient.
+        """
+        self.assertIn("400", self.h)
+        self.assertRegex(self.h, r"responseText")
+        self.assertRegex(self.h, r"/session\|log-in\|log in\|not valid/i")
+
+    def test_a_permanent_failure_returns_without_scheduling(self):
+        """The whole point: no further poll."""
+        # Slice to the early return, not by counting braces: the block
+        # contains nested braces and a naive split runs past the if and picks
+        # up the retry path that follows it -- which is present and correct.
+        expired = self.h.split("if (expired)")[1]
+        self.assertIn("return", expired)
+        expired = expired[:expired.index("return")]
+        self.assertNotIn("schedule(", expired,
+                         "a permanent failure must not schedule another poll")
+
+    def test_a_transport_failure_still_backs_off_and_retries(self):
+        """PR #36's fix must survive this one."""
+        tail = self.h.split("if (expired)")[1]
+        self.assertIn("aiPollFailures", tail)
+        self.assertIn("schedule(", tail)
+        self.assertIn("BACKOFF_CEILING", tail)
+
+    def test_the_user_is_told_what_happened(self):
+        """Silence for four hours is the actual harm."""
+        self.assertIn("updateProgress", self.h)
+        self.assertRegex(self.h, r"expired")
+        self.assertRegex(self.h, r"sign in again|log in again|My Jobs")
+
+    def test_it_says_the_job_is_safe(self):
+        """The job survives on the server; only the session died."""
+        self.assertRegex(self.h, r"safe on the server|job is safe")
+
+    def test_the_error_status_gives_them_a_retry_button(self):
+        """updateProgress('error', ...) renders a Retry, which is the right
+        affordance here: after signing back in, retry is exactly the move."""
+        view = os.path.join(os.path.dirname(JS), "PA_AIInterpretView.js")
+        with open(view) as fh:
+            v = fh.read()
+        branch = v.split('} else if (status === "error")')[1][:600]
+        self.assertIn("ai-retry-btn", branch)
+
+
+if __name__ == "__main__":
+    r = unittest.TextTestRunner(verbosity=2).run(
+        unittest.TestLoader().loadTestsFromTestCase(PollGivesUpOnADeadSession))
+    sys.exit(0 if r.wasSuccessful() else 1)

--- a/PaintomicsServer/src/tests/test_the_results_section_keeps_its_citations.py
+++ b/PaintomicsServer/src/tests/test_the_results_section_keeps_its_citations.py
@@ -94,7 +94,11 @@ class ResultsSectionKeepsItsCitations(unittest.TestCase):
     # ---- the wiring -------------------------------------------------------
 
     def test_the_guard_is_in_the_source_not_only_in_the_prompt(self):
-        block = self.src.split("async def _write_results_section")[1][:4000]
+        # Not a fixed window: the function grew when the retry was added and a
+        # 4000-char slice stopped short of the guard it is checking. Take the
+        # whole function instead, bounded by the next top-level def.
+        block = self.src.split("async def _write_results_section")[1]
+        block = block.split("\nasync def ")[0].split("\ndef ")[0]
         self.assertIn('re.findall(', block,
                       "the marker set must be computed, not asked for")
         self.assertIn('split("### References")', block,
@@ -124,6 +128,44 @@ class ResultsSectionKeepsItsCitations(unittest.TestCase):
         """It is data the job already holds, not a model assertion."""
         block = self.src.split("The deterministic tables ride below")[1][:1200]
         self.assertIn("render_pathway_table(pathways)", block)
+
+    def test_the_rewrite_is_renumbered_afterwards(self):
+        """Reorganising prose scrambles first-appearance order.
+
+        The dossier arrives numbered [1,2,3...] because it was written in that
+        order. A Results section reorders the material by finding, so the same
+        markers now appear as [9,5,6,14,13,...] -- measured exactly that on the
+        first live rewrite. No journal accepts that; citations must be numbered
+        in order of first appearance.
+
+        The writer must NOT renumber itself: its markers still have to map to
+        the papers they were verified against. `renumber_citations` does the
+        remap across body AND references and returns the mapping the paper list
+        is then filtered by. So the ordering property depends entirely on the
+        writer running BEFORE it -- which is incidental unless pinned here.
+        """
+        writer = self.src.index("_write_results_section(\n")
+        renumber = self.src.index("report, citation_mapping = renumber_citations(report)")
+        self.assertLess(writer, renumber,
+                        "the Results rewrite must run BEFORE renumber_citations, "
+                        "or its citations ship out of first-appearance order")
+        sort_refs = self.src.index("report = sort_references_section(report)")
+        self.assertLess(renumber, sort_refs,
+                        "references are sorted after the remap, not before")
+
+    def test_the_writer_is_told_not_to_renumber(self):
+        """The downstream remap owns numbering, and needs the ORIGINAL indices.
+
+        renumber_citations returns a mapping the paper list is filtered by. If
+        the model renumbered first, its markers would no longer identify the
+        papers they were verified against.
+        """
+        # Whitespace-normalised: the instruction wraps as "do not\n  renumber",
+        # so a literal search finds nothing and the test fails on correct text.
+        prompt = " ".join(self.src.split("RESULTS_PROMPT")[1][:3000].lower().split())
+        self.assertIn("do not renumber", prompt,
+                      "the model must be told not to renumber; the pipeline "
+                      "does it afterwards and owns the mapping")
 
     def test_it_is_off_by_default(self):
         self.assertIn('os.getenv("AI_AGENT_RESULTS_SECTION", "0")', self.src,

--- a/PaintomicsServer/src/tests/test_the_results_section_keeps_its_citations.py
+++ b/PaintomicsServer/src/tests/test_the_results_section_keeps_its_citations.py
@@ -1,0 +1,136 @@
+"""The Results rewrite may reshape the prose. It may not cost a citation.
+
+The rewrite runs on a report whose citations have been EARNED: each [N] was
+checked against the paper it points at. A rewrite that drops one loses a
+verified fact, and a rewrite that adds one points at a paper this text was
+never verified against.
+
+This document's two most expensive lessons are both this failure: sentence
+repair was killed for -33% citations and the top-up deadline for -21%, each
+having looked reasonable in every other respect. So the rule is a GUARD that
+rejects the candidate, not a line in a prompt.
+"""
+import os
+import re
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SERVER = os.path.dirname(os.path.dirname(HERE))
+SRC = os.path.join(SERVER, "src", "classes", "AIInterpret", "agent_loop.py")
+
+
+def _markers(text):
+    """Body markers only -- the reference list repeats every one of them.
+
+    Counting the whole document lets a rewrite drop an inline citation while
+    its reference entry survives, and the guard would see no change. That is
+    marker-stripping, the exact behaviour that makes "failed citations" read
+    0.0 on a report whose prose lost its support.
+    """
+    return set(re.findall(r"\[(\d+)\]", str(text).split("### References")[0]))
+
+
+def _verdict(before_text, after_text, has_refs=True):
+    """The guard's logic, mirrored exactly from _write_results_section."""
+    before, after = _markers(before_text), _markers(after_text)
+    reasons = []
+    if before - after:
+        reasons.append("lost_%d" % len(before - after))
+    if after - before:
+        reasons.append("invented_%d" % len(after - before))
+    if has_refs and "### References" not in after_text:
+        reasons.append("no_references")
+    if len(after_text) < 0.2 * len(before_text):
+        reasons.append("truncated")
+    return reasons
+
+
+REPORT = ("Ikaros drives differentiation [1]. Accessibility rises [2]. "
+          "DYNLL1 is sustained [3].\n\n### References\n[1] a\n[2] b\n[3] c\n") * 6
+
+
+class ResultsSectionKeepsItsCitations(unittest.TestCase):
+
+    def setUp(self):
+        with open(SRC) as fh:
+            self.src = fh.read()
+
+    # ---- the guard itself -------------------------------------------------
+
+    def test_a_rewrite_that_keeps_every_marker_is_accepted(self):
+        good = REPORT.replace("Ikaros drives differentiation [1].",
+                              "Ikaros induction drove differentiation [1].")
+        self.assertEqual(_verdict(REPORT, good), [])
+
+    def test_a_rewrite_that_drops_a_marker_is_rejected(self):
+        bad = REPORT.replace(" [2]", "")
+        self.assertIn("lost_1", _verdict(REPORT, bad),
+                      "a dropped marker loses a verified fact")
+
+    def test_a_rewrite_that_invents_a_marker_is_rejected(self):
+        bad = REPORT.replace("DYNLL1 is sustained [3].",
+                             "DYNLL1 is sustained [3][9].")
+        self.assertIn("invented_1", _verdict(REPORT, bad),
+                      "a new marker points at a paper never verified here")
+
+    def test_a_rewrite_that_drops_the_references_is_rejected(self):
+        bad = REPORT.replace("### References", "## Bibliography")
+        self.assertIn("no_references", _verdict(REPORT, bad))
+
+    def test_a_rewrite_that_truncates_is_rejected(self):
+        self.assertIn("truncated",
+                      _verdict(REPORT, "Ikaros drives differentiation [1]."))
+
+    def test_shortening_is_allowed_when_the_citations_survive(self):
+        """The whole point is a shorter document -- 8184 words is the problem."""
+        short = ("Ikaros drove differentiation [1], with accessibility rising "
+                 "ahead of transcription [2] and DYNLL1 sustained throughout "
+                 "[3].\n\n### References\n[1] a\n[2] b\n[3] c\n") * 3
+        self.assertLess(len(short), len(REPORT))
+        self.assertEqual(_verdict(REPORT, short), [],
+                         "a shorter rewrite that keeps every marker must pass")
+
+    # ---- the wiring -------------------------------------------------------
+
+    def test_the_guard_is_in_the_source_not_only_in_the_prompt(self):
+        block = self.src.split("async def _write_results_section")[1][:4000]
+        self.assertIn('re.findall(', block,
+                      "the marker set must be computed, not asked for")
+        self.assertIn('split("### References")', block,
+                      "the guard must compare BODY markers; the reference list "
+                      "repeats every marker and would mask a dropped citation")
+        self.assertIn('stats["results_rejected"]', block)
+        self.assertIn("return report, False", block,
+                      "a rejected rewrite must return the ORIGINAL report")
+
+    def test_it_runs_before_the_exit_gate(self):
+        """Order is the safety property.
+
+        After the gate, a rewrite could move a verified marker onto a claim
+        nobody checked -- reintroducing exactly the overshoot the gate removes.
+        """
+        call = self.src.index("_write_results_section(\n")
+        gate = self.src.index("# ---- The mandatory exit gate")
+        self.assertLess(call, gate,
+                        "the Results rewrite must precede the exit gate")
+
+    def test_the_cluster_table_is_suppressed_when_a_section_was_written(self):
+        """It was asked for as prose; a table restating it undoes that."""
+        block = self.src.split("The deterministic tables ride below")[1][:1200]
+        self.assertIn("if not results_written:", block)
+
+    def test_the_pathway_table_survives(self):
+        """It is data the job already holds, not a model assertion."""
+        block = self.src.split("The deterministic tables ride below")[1][:1200]
+        self.assertIn("render_pathway_table(pathways)", block)
+
+    def test_it_is_off_by_default(self):
+        self.assertIn('os.getenv("AI_AGENT_RESULTS_SECTION", "0")', self.src,
+                      "a new writing stage ships off until it is measured")
+
+
+if __name__ == "__main__":
+    r = unittest.TextTestRunner(verbosity=2).run(
+        unittest.TestLoader().loadTestsFromTestCase(ResultsSectionKeepsItsCitations))
+    sys.exit(0 if r.wasSuccessful() else 1)

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -5547,6 +5547,31 @@ measure named. The cluster table is suppressed when a section is written, since
 the section describes the clustering in prose; the enriched pathway summary
 stays, being data the job already holds rather than a model assertion.
 
+### Citation ORDER, which the set-based guard does not check
+
+Asked directly, and worth checking rather than assuming. The dossier arrives
+numbered [1,2,3...] because it was written in that order. Reorganising the
+material by finding scrambles first appearance, and the rewrite came out
+
+```
+[9, 5, 6, 14, 13, 15, 16, 8, 7, 1, 10, 11, 12, 2]
+```
+
+which no journal accepts. The guard compares the SET of markers and is blind to
+this by construction.
+
+It is nevertheless correct in the pipeline: `renumber_citations` followed by
+`sort_references_section` runs downstream of the writer, and applying them gives
+`[1..22]` sequential, 22 of 22 kept, 22 reference entries in order. The probe
+above looked wrong only because it called the writer in isolation.
+
+But that was **incidental, not guaranteed** -- nothing prevented the writer being
+moved below the remap, after which numbering would scramble silently. Now pinned
+by `test_the_rewrite_is_renumbered_afterwards`. The model is still told NOT to
+renumber, because `renumber_citations` returns the mapping the paper list is
+filtered by, and a model that renumbered first would break the link between a
+marker and the paper it was verified against.
+
 ### Not yet measured, and the reason it matters
 
 **84 s** for the two attempts on this report. Median span is 450 s against a

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -5485,3 +5485,55 @@ The whole-report rewrite stays the correction mechanism, and `VERIFY_ITERATIONS
 = 3` stays the default. The known cost of the rewrite -- 2 of 8 corrections
 cancelled mid-flight -- is real but is not fixed by repair, because repair's
 price is a third of the citations.
+
+## Round 63 — a rejected top-up now says which condition rejected it
+
+Round 62 identified the only lever in this pipeline with no citation cost: a
+rejected top-up delivers zero **by definition**, so removing it cannot lose a
+citation -- unlike the deadline (21% citation loss, priced in round 62) and the
+headroom threshold (blocks runs that did not need it, priced in round 61).
+
+It could not be aimed at anything, because the reason was not recorded. Of 5
+rejected top-ups across 13 archived runs, only 2 said anything about why, and
+only because `topup_dropped_existing` happens to be set independently of the
+guard:
+
+```
+102 s  rejected   dropped_existing: 2
+ 95 s  rejected   (no reason recorded)
+ 40 s  rejected   dropped_existing: 3
+ 38 s  rejected   (no reason recorded)
+ 32 s  rejected   (no reason recorded)
+```
+
+The guard has three conditions and only one of them left a trace:
+
+```python
+if (len(candidate) > 0.6 * len(str(report))   # too short?
+        and added > len(cited_now)            # added nothing?
+        and not dropped):                     # dropped existing?  <- only this
+```
+
+Now records `topup_rejected_why` (`short` / `no_gain` / `dropped`, joined) and
+`topup_candidate_ratio`, because "short" is a ratio and the ratio is the datum.
+Each label is the exact negation of its condition, so a label cannot drift from
+what the guard actually tested.
+
+**The reasons are not equivalent, which is the point of separating them.** The
+prompt already says "Return the SAME report with citations added ... Change
+nothing else". So `short` means it truncated the report and `dropped` means it
+rewrote instead of appending -- both prompt-compliance failures worth fixing.
+But `no_gain` means it **complied and found nothing to add**, which is correct
+behaviour and must not be "fixed". Without the split, a prompt change aimed at
+the first two would be scored on runs exhibiting the third.
+
+Verified at runtime rather than by reading the diff: the three branches produce
+`short,no_gain` / `no_gain` / `dropped` / `short,no_gain,dropped`, all scalars
+under 120 chars, so the `__stats__` stamp archives them instead of computing and
+discarding them -- the failure round 56 fixed one level up.
+
+**Deliberately not pre-registering a prompt change yet.** Five rejections is
+enough to see that reasons are missing and not enough to know which dominates.
+Round 59's interim entry was withdrawn for exactly that -- generalising from
+2-3 replicates -- and the next round should accumulate reasons before anything
+is changed.

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -5622,3 +5622,62 @@ and 4 are expected to resolve cleanly at this n.
 
 This is written before the round runs, as every pre-registration in this
 document is, and rounds 56, 59 and 61 record what happens when it is not.
+
+## Round 66 SCORED — the Results section loses findings; falsifier fired
+
+`AI_AGENT_RESULTS_SECTION=1`, 8 replicates, against round 57's 8.
+
+| metric | r57 dossier | r66 Results | delta | |
+|---|---|---|---|---|
+| **rubric coverage** | **0.571** | **0.446** | **-0.125** | **RESOLVED** |
+| words | 7 537 | 4 543 | -2 994 (-39.7%) | RESOLVED |
+| citations_in_body | 21.38 | 21.12 | -0.25 | not resolved |
+| wall_s | 422 | 373 | -49 | not resolved |
+| pathways covered | 15.4 | 17.0 | +1.6 | not resolved |
+
+| prediction | result | |
+|---|---|---|
+| coverage must not fall >0.05 | **-0.125** | **FAILED -- REVERT** |
+| accepted in >=6 of 8 | **7 of 8** | HELD |
+| median span < 600 s | **375 s**, 0/8 over | HELD |
+| words fall >=40% | -39.7% | marginally not held |
+
+**The stage works and the output is worse.** It is accepted 7 times in 8, runs
+*faster* than the dossier it replaces, keeps every citation (-0.25, not
+resolved), and reads like a paper. It also discards **22% of the rubric
+coverage**.
+
+**This is the exact failure round 64 predicted and no earlier falsifier could
+have caught.** Round 64 measured citation count and rubric coverage as
+independent (r = 0.05) and the falsifier was moved onto coverage for precisely
+this reason. Had it stayed on citations -- as every falsifier before it was --
+this stage would have passed cleanly at -0.25 citations and shipped a rewrite
+that throws away a fifth of the findings.
+
+**Kept, default off, following sentence repair's precedent.** The code stays
+behind `AI_AGENT_RESULTS_SECTION` with this result recorded next to it. It is not
+enabled and should not be without a rewrite that compresses *prose* rather than
+*content* -- the two are not the same operation, and this stage does the second
+while being asked for the first.
+
+### Two defects found in the stage itself, worth keeping
+
+**The retry is load-bearing, not a safety net.** Attempts=2 in most accepted
+runs: the first pass drops citations nearly every time, and one run dropped
+**nine** (6,18,19,27,31,32,34,44,45). Reorganise-and-preserve is two tasks in one
+call and the conservation half fails ~80% of the time. Any rewrite stage that
+must conserve something needs a computed guard, not an instruction -- the model's
+compliance on the conservation half is far below what the prompt suggests.
+
+**The word count was a target, not a ceiling.** One replicate took a 984-word
+interpretation to **1 408** (+43%): asked to "target 1800 words", the model padded
+a thin dossier upward. A compression stage must never exceed its input.
+
+### And the scorer misreported its own round
+
+Prediction 2 was first printed as "accepted 3, rejected 0" -- wrong in both
+numbers. The analysis script carried a stale epoch filter (`> 1787151000` for a
+round that began at `1787149061`), so it read one trace instead of eight. The
+same stale-filter error had already been caught once this session, in a different
+script, an hour earlier. The corrected count is 7 accepted, 1 rejected, and
+prediction 2 HELD.

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -5555,6 +5555,54 @@ its mechanism is more appealing.
 **Power note:** cancellation is 2 events in 8 runs. Prediction 1 cannot be
 resolved at n=8 -- going 2/8 to 0/8 is consistent with chance. It will be
 reported as a direction, not a result, unless the round is enlarged.
+
+## Round 61 WITHDRAWN before running — the guard cannot separate the cases
+
+Round 60 pre-registered `AI_AGENT_TOPUP_MIN=320`. The guard is arithmetic, so
+the counterfactual was computed from round 57's archived traces rather than by
+spending a round on it.
+
+| run | headroom at the guard | topup_s | waves | cancelled | MIN=320 |
+|-----|----------------------|---------|-------|-----------|---------|
+| 73I734364H | 268 | **102** | 2 | **YES** | BLOCKS -- correct |
+| 4rofHV6613 | 298 | **108** | 2 | **YES** | BLOCKS -- correct |
+| 1354co025T | 261 | 59 | **3** | -- | **BLOCKS -- WRONG** |
+| 31qPRO6hF3 | 249 | 38 | **3** | -- | **BLOCKS -- WRONG** |
+| 73I734364H | 346 | 95 | 3 | -- | allows |
+
+It blocks both runs that needed it **and two that did not** -- runs that
+completed three waves AND ran top-up, getting both. Blocking those costs ~20
+citations each for no benefit, which trips the falsifier round 60 attached to
+it. Withdrawn.
+
+**Why no threshold on headroom can work.** The cancelled runs had MORE headroom
+(268, 298) than two successful ones (261, 249). What separates them is how long
+top-up turned out to take -- 102/108 s versus 38/59 s -- and that is not
+knowable when the guard runs. The guard is conditioning on the wrong variable.
+
+**The sharpest single fact in this round.** Of the two cancelled runs, the 102 s
+one was `topup_rejected: True`, having dropped 2 existing citations. It spent
+**102 seconds on a top-up that was thrown away, and lost its third verify wave
+paying for it.** That is the worst outcome the pipeline can produce, and it is
+invisible without the `__stats__` stamp added in round 56.
+
+**What this leaves.** Two candidate directions, neither pre-registered yet:
+
+1. **A deadline on top-up** -- round 55's idea, withdrawn then as unmeasurable
+   in span terms and mechanically wrong for salvaging partial output. The
+   justification here is different and does not depend on partial output: the
+   point is to bound what top-up can consume so the third wave survives. Its
+   cost is the whole top-up (all-or-nothing, established in round 56), so it
+   faces repair's falsifier directly.
+2. **Reordering** -- run the third verify wave before top-up, so grounding is
+   guaranteed and top-up spends what is left. Not a workflow, a reordering, and
+   it makes the trade explicit instead of leaving it to whichever stage reaches
+   the budget first.
+
+Direction 2 is the better candidate: it costs no citations in runs where both
+fit, and in tight runs it prefers grounding over addition, which is the standard
+this document is written to. It needs its own pre-registration and is not
+claimed here.
 ## Round 63 — a rejected top-up now says which condition rejected it
 
 Round 62 identified the only lever in this pipeline with no citation cost: a

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -5710,3 +5710,60 @@ enough to see that reasons are missing and not enough to know which dominates.
 Round 59's interim entry was withdrawn for exactly that -- generalising from
 2-3 replicates -- and the next round should accumulate reasons before anything
 is changed.
+
+## Round 64 — the falsifier and the rubric are independent axes
+
+Every falsifier in this document is written on `citations_in_body`. Repair was
+killed for a 33% fall in it. That metric was tested against the sealed rubric
+across all 16 scored reports from rounds 57 and 59.
+
+| vs rubric coverage | pearson r | |
+|---|---|---|
+| **citations_in_body** | **0.05** | **no relationship** |
+| full_text_cited | 0.15 | no relationship |
+| prose_pathways_covered | 0.38 | weak |
+
+**Citation count is statistically independent of rubric coverage.** Optimising
+one does not move the other. And on the rubric the two arms are equivalent:
+
+```
+rewrite (round 57)  mean coverage 0.570
+repair  (round 59)  mean coverage 0.558      difference 0.012
+```
+
+**Fabricated rubric items: 0 across all 16 reports.** The arm does not invent
+findings; that half of the rubric is saturated and cannot discriminate.
+
+### What this does and does not overturn
+
+It does **not** overturn round 59. The two metrics measure different things and
+both are legitimate:
+
+* `citations_in_body` -- does the report SUPPORT what it says? That is the
+  standing brief's criterion, in the user's words: "citation grounded".
+* rubric coverage -- does the report FIND the biology the published Results
+  found? That is AgentEvolve's criterion.
+
+Repair produces a report of **equal scientific coverage with a third less
+support**, faster. Killed on the first criterion, which is the stated one. The
+precise verdict is that repair was not killed for producing worse science -- it
+was killed for producing less-supported science, and the distinction was not
+drawn at the time.
+
+### What it changes going forward
+
+Rounds have been scored on one axis and read as if it were quality. Both should
+be reported, because a change that moves citations without moving coverage --
+which is every change measured so far -- is a change in grounding, not in
+findings. Round 60's conclusion survives this and is sharpened: the rewrite's
+extra citations are real support (full-text-backed, resolved) for the **same**
+biology, not extra biology.
+
+### An instrument error found here, again
+
+`rubric_score` returns `(coverage, fabricated_items)`. The first pass through
+this analysis treated the return as a dict, got `n = 0` scored reports, and only
+an obviously-null result made it visible. The ranking published before that
+printed `"(0.57608"` -- a truncated tuple repr read as a score -- so the
+fabrication count was silently discarded. It is zero everywhere, so nothing
+downstream was wrong, but the check that established it had not been run.

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -5582,3 +5582,43 @@ cancelled. That is a pre-registration for the next round, not a claim here.
 n = 1 report, and it is round 57's BEST replicate. Whether the guard's rejection
 rate is 0% or 40% across a full round is unknown, and a stage that falls back to
 the dossier half the time is a different proposition from one that does not.
+
+## Round 66 pre-registration — measuring the Results section
+
+`AI_AGENT_RESULTS_SECTION=1`, agent arm, 8 replicates, against round 57's 8.
+
+### The falsifier is rubric coverage, not citations
+
+The citation guard makes the usual falsifier **structurally unfailable**: a
+rejected rewrite ships the dossier, which carries every citation. Citations
+cannot fall. Writing the falsifier on them would therefore be theatre.
+
+Round 64 measured citation count and rubric coverage as **independent**
+(r = 0.05). So a rewrite can keep all 22 markers and still lose findings --
+compressing 8 184 words to ~3 000 is exactly the operation that would do it, and
+**nothing in the stage guards against it.** That is the risk this round exists
+to price.
+
+### Predictions
+
+1. **Rubric coverage does not fall more than 0.05** against round 57's mean of
+   **0.570**. *(FALSIFIER. A larger fall means the compression is discarding
+   findings, and the stage is reverted regardless of how much better it reads.)*
+2. Accepted rather than rejected in **>= 6 of 8** runs. A stage that falls back
+   to the dossier half the time is a different proposition from one that works.
+3. Median span stays **under 600 s**. Measured cost is 84 s on one report against
+   a 450 s median, so this should hold with ~66 s to spare -- and round 57 showed
+   that a stage spending budget before the gate is how corrections get cancelled,
+   so `correction_failed` is watched too.
+4. Words fall **>= 40%**.
+
+### Power, stated before the fact
+
+n = 8. Round 57's coverage spread was 0.489-0.641, sd ~0.045, so a 0.05
+difference is right at the resolution limit and will be reported as a
+**direction** unless it is larger. Prediction 2 is a proportion on 8 trials and
+cannot resolve anything finer than "usually" versus "rarely". Only predictions 3
+and 4 are expected to resolve cleanly at this n.
+
+This is written before the round runs, as every pre-registration in this
+document is, and rounds 56, 59 and 61 record what happens when it is not.

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -5486,6 +5486,75 @@ The whole-report rewrite stays the correction mechanism, and `VERIFY_ITERATIONS
 cancelled mid-flight -- is real but is not fixed by repair, because repair's
 price is a third of the citations.
 
+## Round 60 — the rewrite's extra citations are real, and the cancellations have one cause
+
+### Testing my own suspicion about round 59, and being wrong
+
+Round 59 killed repair because citations fell 33%. Before accepting that at face
+value it was worth asking whether the rewrite's extra citations are PADDING --
+it covers the same pathways (15.38 vs 15.50) with 7 more citations.
+
+| | rewrite | repair | |
+|---|---|---|---|
+| citations_in_body | 21.38 | 14.25 | RESOLVED |
+| **full_text_cited** | **12.88** | **9.12** | **RESOLVED** |
+| papers_retrieved | 56.62 | 58.50 | not resolved |
+| prose_pathways_covered | 15.38 | 15.50 | not resolved |
+
+**They are not padding.** 3.75 of the 7.12 extra citations are full-text-backed
+-- the higher-quality kind, since a specific mechanistic claim rarely has a
+quotable sentence in an abstract. Both arms retrieve the SAME literature
+(56.6 vs 58.5 papers); the rewrite converts more of it into grounded citations.
+Round 59's verdict stands and is better supported than when it was accepted.
+
+### The cancelled corrections have a single visible cause
+
+Round 57's eight runs, from the archived stats:
+
+| topup_s | waves | correction cancelled |
+|---------|-------|----------------------|
+| --      | 3 | -- |
+| **102** | **2** | **YES** |
+| **108** | **2** | **YES** |
+| --      | 3 | -- |
+| 59      | 3 | -- |
+| 95      | 3 | -- |
+| --      | 2 | -- |
+| 38      | 3 | -- |
+
+**Both cancelled runs are the two slowest top-ups.** Every run with a top-up at
+or under 95 s completed three waves; both runs over 100 s lost the third. They
+draw on one 600 s budget, so this is a mechanism rather than a coincidence --
+though with n=8 and two events, the separation is suggestive, not settled.
+
+`TOPUP_MIN_SECONDS = 200` decides whether top-up STARTS, from remaining
+headroom, and was calibrated when two waves were the default. A third wave costs
+~60-80 s of verification plus a ~117 s rewrite, about 200 s. So a run can clear
+the guard with 200 s, spend ~95 s on top-up, and leave the wave 105 s -- which
+is how a correction gets cancelled at 46 s.
+
+### Pre-registration (round 61, NOT yet run)
+
+`AI_AGENT_TOPUP_MIN=320` -- top-up starts only if the third wave can still
+afford to finish after it. No code change; the knob exists.
+
+**The trade this makes is exactly the one that killed repair, so it is guarded
+the same way.** Top-up adds ~20 citations when it runs. Raising the threshold
+skips it in tight runs, which costs citations in precisely those runs.
+
+**Predictions**
+1. Corrections cancelled falls from 2/8 to **0/8**.
+2. `citations_in_body` does **not** fall more than 5% versus round 57's 21.38.
+3. Median span stays under 600 s.
+
+**Falsifier:** if citations fall more than 5%, this is repair's trade in another
+costume -- buying grounding with citations -- and is reverted. Round 59 killed a
+change for a 33% citation loss; a change cannot be exempt from that bar because
+its mechanism is more appealing.
+
+**Power note:** cancellation is 2 events in 8 runs. Prediction 1 cannot be
+resolved at n=8 -- going 2/8 to 0/8 is consistent with chance. It will be
+reported as a direction, not a result, unless the round is enlarged.
 ## Round 63 — a rejected top-up now says which condition rejected it
 
 Round 62 identified the only lever in this pipeline with no citation cost: a

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -5603,6 +5603,62 @@ Direction 2 is the better candidate: it costs no citations in runs where both
 fit, and in tight runs it prefers grounding over addition, which is the standard
 this document is written to. It needs its own pre-registration and is not
 claimed here.
+
+## Round 62 — no budget-side fix exists, and top-up's real problem is compliance
+
+### Reordering is impossible
+
+Top-up is traced at line 2883; the verify loop starts at 2927. **Top-up already
+runs before ALL verification.** There is no third wave to move ahead of it. It
+consumes budget first and the waves get the remainder, which is exactly why a
+slow top-up starves them.
+
+### The deadline is dead too, priced without spending a round
+
+Thirteen runs across rounds 57 and 59 where top-up ran:
+
+| deadline | cut | worthless | citations lost | cancellations saved |
+|----------|-----|-----------|----------------|---------------------|
+| 90 s  | 9/13 | 2 | **7 runs: 22, 18, 12, 3, 2, 2, 1** | 2 |
+| 110 s | 3/13 | 0 | 3 runs: 18, 3, 2 | **0** |
+
+A deadline low enough to save both cancellations costs ~60 citations over 13
+runs -- **4.6 per run against a mean of 21.4, a 21% loss**, four times the 5%
+falsifier round 60 set. The least damaging deadline that cuts anything saves
+**zero** cancellations. Dead on the same grounds as repair.
+
+**So no budget-side intervention works.** Threshold and deadline both fail the
+citation bar. The cancellations are structural: a variable-cost ADDITION stage
+runs before a variable-cost GROUNDING stage inside a fixed budget, and the
+ten-minute requirement means the budget cannot be raised -- median span is
+already 450 s against a 600 s cap.
+
+The honest position is that the ~25% cancellation rate is the current price of
+that design, and it is not worth paying citations to remove.
+
+### The one lever with no citation cost
+
+Top-up is bimodal -- it adds 12-22 citations, or it adds 0-3 -- and **5 of 13
+runs (38%) were rejected outright**, contributing nothing for 32-130 s:
+
+```
+102 s  rejected      95 s  rejected      40 s  rejected
+ 38 s  rejected      32 s  rejected
+```
+
+A rejected top-up delivers zero **by definition**, so removing it costs no
+citations. At 38% x ~85 s that is ~32 s per run, free.
+
+The guard rejects a candidate that drops existing citations, is too short, or
+adds nothing. `topup_dropped_existing` is recorded for some. The top-up prompt
+already says "Return the SAME report with citations added ... Change nothing
+else" -- so this is a **prompt-compliance failure at 38%**, not a design flaw,
+and it is the first tool-building problem in this document whose fix cannot cost
+citations.
+
+Not pre-registered yet: the rejection reasons need counting across more runs
+before a prompt change is worth testing, and `topup_rejected` has only been
+archived since round 56.
 ## Round 63 — a rejected top-up now says which condition rejected it
 
 Round 62 identified the only lever in this pipeline with no citation cost: a

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -5485,3 +5485,75 @@ The whole-report rewrite stays the correction mechanism, and `VERIFY_ITERATIONS
 = 3` stays the default. The known cost of the rewrite -- 2 of 8 corrections
 cancelled mid-flight -- is real but is not fixed by repair, because repair's
 price is a third of the citations.
+
+## Round 65 — a Results section, and the citation guard that had to exist
+
+Requested directly: the interpretation is too long and does not read like a
+paper's Results. No bullet key-findings, subsections that tell different
+stories, clusters described rather than tabulated. And, added mid-implementation
+and decisively: **citations must be kept.**
+
+### What the arm produces today
+
+Measured on round 57's best replicate: **8 184 words over 497 lines**, opening
+with a "Key Findings" bullet block, then fifteen numbered pathway sections each
+carrying the same three sub-headings, then a 37-row table -- 50 bullets and 67
+bold run-ins in all. It also reads as stitched: a second H1 mid-document and
+"Cross-Pathway Synthesis" appearing twice, because it is the concatenation of
+delegated chunks.
+
+### The stage
+
+`_write_results_section`, behind `AI_AGENT_RESULTS_SECTION` (default off).
+
+**It runs before the exit gate, and the order is the safety property.** Its
+prose then goes through top-up, the Claim Verifier and the programmatic net, so
+it is grounded by the same machinery as any other draft. Running it after the
+gate would let a rewrite move a verified marker onto a claim nobody checked --
+reintroducing exactly the overshoot the gate exists to remove.
+
+### The guard was not paranoia
+
+First live attempt, prompt only: **it lost 5 of 22 citations.** The instruction
+"every marker must survive" was in the prompt and was not followed. Asking a
+model to reorganise 8 000 words and carry two dozen markers is two tasks, and
+the second fails quietly.
+
+So the rule is a guard, mirroring how merge and top-up already reject candidates:
+a rewrite that drops a marker, invents one, loses the References or truncates is
+**discarded and the dossier ships instead**. Then one retry that names the
+missing markers rather than repeating "be careful".
+
+One detail found by its own test: the guard first compared markers across the
+WHOLE document, and the reference list repeats every marker as its own line
+(`[2] Smith et al.`), so prose could drop a citation while its entry survived
+and the guard would see no change. That is marker-stripping -- the behaviour
+that makes `failed_citations` read 0.0 on a report whose prose lost its support.
+It now compares **body** markers only.
+
+### Result
+
+| | dossier | Results section |
+|---|---|---|
+| words | 8 184 | **2 957** (-64%) |
+| body citations | 22 | **22 -- all kept** |
+| bullets | 50 | **0** |
+| table rows | 37 | **0** |
+
+Section titles are findings, not accessions: "Chromatin Accessibility Remodeling
+Precedes Transcriptional Activation", "A Coordinated 12-Hour Checkpoint Marks
+the Differentiation Commitment Window". Numbers sit inside sentences with the
+measure named. The cluster table is suppressed when a section is written, since
+the section describes the clustering in prose; the enriched pathway summary
+stays, being data the job already holds rather than a model assertion.
+
+### Not yet measured, and the reason it matters
+
+**84 s** for the two attempts on this report. Median span is 450 s against a
+600 s bar, so this fits -- but with ~66 s of the remaining headroom, and round
+57 showed that a stage consuming budget before the gate is how corrections get
+cancelled. That is a pre-registration for the next round, not a claim here.
+
+n = 1 report, and it is round 57's BEST replicate. Whether the guard's rejection
+rate is 0% or 40% across a full round is unknown, and a stage that falls back to
+the dossier half the time is a different proposition from one that does not.

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -5962,3 +5962,61 @@ round that began at `1787149061`), so it read one trace instead of eight. The
 same stale-filter error had already been caught once this session, in a different
 script, an hour earlier. The corrected count is 7 accepted, 1 rejected, and
 prediction 2 HELD.
+
+## Round 67 pre-registration — CLUSTER_SCOPE, and a correction
+
+### The correction first
+
+Reported earlier in this session: "switching production to the agent arm
+silently disabled cluster mode, because `AI_CLUSTER_MODE` has zero references in
+`agent_loop.py`". **That was wrong.** `CLUSTER_MODE` is read in `clusters.py`
+but `build_partition` never checks it; its only consumer is `agent.py:1206`, the
+workflow arm's own gate. The agent arm calls `build_partition` unconditionally
+from the `cluster_pathways` tool, which fires in **24 of 24** archived runs.
+Clustering has been on the entire time.
+
+### What the coverage gap actually is
+
+Measured across 24 runs:
+
+```
+significant pathways available (clustering widens to this)   90
+distinct pathways the agent looks up                          8
+pathways named in the prose                                  15.4
+delegate_interpretation calls per run                      1.00
+pathways sent per delegation                              ~15  (capacity 60)
+```
+
+**The agent has 90 pathways of territory and walks 17% of it.** Not because the
+universe is narrow -- clustering already widened it -- but because the Lead
+selects ~15. Cluster-mode base reaches 52-102 because the workflow arm
+mechanically batches every cluster; the agent chooses, and chooses narrowly.
+
+This is already diagnosed in the source: the Lead's prompt says "top-ranked"
+five times, and in a 102-pathway context that reads as the top fifteen. Every
+constant suspected of binding was measured NOT to: `DELEGATE_MAX_PATHWAYS` is 60
+and never reached, `SEARCH_BUDGET` is 40 with ~15 used. Rewriting the delegation
+tool's stated capacity to 60 was measured **inert** -- the pathway set came back
+identical.
+
+### The experiment
+
+`AI_AGENT_CLUSTER_SCOPE=1`. The flag exists, rewrites the five "top-ranked"
+instructions to "every cluster", and has never been measured.
+
+**Predictions**
+1. `prose_pathways_covered` rises from **15.4** toward cluster-base's 74.
+   Anything under 25 means the rewrite did not bind and the limiter is elsewhere
+   again.
+2. **Rubric coverage rises** above round 57's **0.571**. *(The point of the
+   change; AgentEvolve measured this shape at +0.210 for base.)*
+3. **FALSIFIER: median span stays under 600 s.** Twenty clusters instead of
+   fifteen pathways is more delegation, more searches and more prose. If it
+   crosses the bar it is reverted regardless of what it does to coverage --
+   the ten-minute requirement is not tradeable.
+4. Citations do not fall more than 10% from 21.4.
+
+**Power.** n = 8. Round 57's coverage sd was ~0.045, so prediction 2 resolves
+only if the gain is around 0.05 or more; a smaller rise is a direction. Span sd
+was ~69 s, so prediction 3 resolves cleanly. Prediction 1 is a large expected
+effect (15 -> 25+) and should resolve.


### PR DESCRIPTION
Three changes. Gate: **225 suites, 220 pass, 5 inherited from master, 0 INTRODUCED**, and a full suite run leaves the trace corpus byte-identical (188 traces, 0 stubs).

## 1. A rejected top-up now says *which* condition rejected it

38% of top-ups (5 of 13 archived runs) are rejected outright, burning 32–130 s and delivering nothing. That is the only lever in this pipeline with **no citation cost** — a rejected top-up adds zero *by definition* — unlike the deadline (21% citation loss) and the headroom threshold (blocks runs that didn't need it), both priced and rejected in rounds 61–62.

It couldn't be aimed at anything: the guard has three conditions and only one left a trace, so **3 of 5 rejections recorded no reason at all**. Now records `topup_rejected_why` (`short` / `no_gain` / `dropped`) and `topup_candidate_ratio`, each label the exact negation of its condition.

The split matters: `short` and `dropped` are prompt-compliance failures worth fixing, but `no_gain` means the model complied and found nothing to add — correct behaviour that must *not* be "fixed". Without separating them a prompt change would be scored on the wrong population.

## 2. Results-section stage — **measured, failed its falsifier, ships OFF**

Rewrites the dossier as a paper Results section: continuous prose, subsections titled by finding, clusters described rather than tabulated, no tables.

| | dossier | Results section | |
|---|---|---|---|
| **rubric coverage** | **0.571** | **0.446** | **−0.125 RESOLVED** |
| citations | 21.38 | 21.12 | not resolved |
| words | 7,537 | 4,543 | −40% |
| wall | 422 s | 373 s | faster |

Accepted 7 times in 8, **faster** than what it replaces, keeps **every citation** — and discards **22% of the findings**. Kept behind `AI_AGENT_RESULTS_SECTION` (default off) with the negative result recorded beside it, following sentence repair's precedent.

This is the failure round 64 predicted: citation count and rubric coverage are independent (r = 0.05). Had the falsifier stayed on citations — as every previous one was — this would have passed at −0.25 citations and shipped.

**The citation guard is load-bearing, not ceremony.** The first pass drops citations in most runs; one dropped **nine**. A candidate that drops, invents, truncates or loses the References is discarded and the dossier ships. Its own test caught the guard comparing markers across the *whole* document, where the reference list repeats every marker and would mask a dropped inline citation — it now compares body markers only. Ordering is pinned too: the rewrite scrambles first-appearance order, and `renumber_citations` running downstream is what restores `[1..22]`.

## 3. Stop the AI status poll retrying a session that cannot come back

PR #36 fixed the opposite bug — one dropped request killed the chain forever — by making *every* failure retry, including failures that can never clear.

Measured live: after a restart invalidated one user's session, their browser polled `/ai_interpret_status` every 31 s for **over four hours**, ~460 requests, each answered `400 CredentialException: User not valid … please log-in again`, with nothing shown to them.

401/403 now end the chain. A 400 ends it **only when the body names a session problem**, because the servlet also returns 400 for handled errors a retry may clear — treating every 400 as permanent would reintroduce PR #36's bug somewhere new. Transport failures keep their backoff. The user is told the session expired, that **the job is safe on the server**, and to sign in again; the existing Retry button is the right affordance once they have.

## Also

`test_no_stage_measures_into_the_void` flagged 11 new stats keys classified nowhere — the suite doing its job. All are now in the bench's `STAGE_TIMES`/`COUNTS`/`NOTES`. Both word counts are kept rather than a delta because the stage exists to compress and the ratio is the measurement — that is what caught a 984-word interpretation coming back at 1,408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)