### PR TITLE
Classify pathway evidence against KEGG, Reactome and OmniPath, and stop copying regulators onto the map

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4EvidenceOverlay.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4EvidenceOverlay.js
@@ -274,6 +274,164 @@ function PA_Step4EvidenceOverlay() {
 		return lines.join("\n");
 	};
 
+	/* ---------------------------------------------------------------------
+	   SATELLITE PLACEMENT
+
+	   All placement arithmetic happens in RASTER pixels -- the coordinate
+	   space the pathway data is stored in -- and is multiplied by
+	   adjustFactor only at draw time. Working in canvas units instead is what
+	   made the arc layer sweep the map: its bow constant of 14 canvas units
+	   is 68 raster px at the adjustFactor of 0.204 this panel actually uses,
+	   so the geometry silently changed meaning with panel width.
+	   --------------------------------------------------------------------- */
+
+	/** Raster-space box for a feature: centre plus half extents. */
+	this.rasterBox = function(featureID) {
+		var graphical = this.options.graphicalOptions.findFeatureGraphicalData(featureID);
+		if (!graphical || !graphical.length) { return null; }
+		var data = graphical[0];
+		return {
+			cx: data.getX(),
+			cy: data.getY(),
+			width: data.getBoxWidth() || 20,
+			height: data.getBoxHeight() || 20,
+			key: data.getX() + "#" + data.getY(),
+			boxes: graphical.length
+		};
+	};
+
+	/**
+	* Everything already drawn on the canvas, as raster rectangles.
+	*
+	* Two sources, both of which the client already has or is now sent:
+	* every painted feature box, and the cross-pathway rounded boxes
+	* (relatedPathways) -- the largest printed obstacles on a KEGG map, 21 of
+	* them on mmu05200, which the client had never been given.
+	*
+	* This set knows about 9.1% of the mmu05200 canvas while the map prints
+	* ink on 9.2%, so it is blind to roughly as much drawn material as it can
+	* see. Placement is therefore optimistic BY CONSTRUCTION: measured, about
+	* two satellites in three clip some printed artwork, median overlap
+	* 1.2-5.5%. That is a corner nick, against a 617 px chord dragging a
+	* 23 px-wide swath across the whole diagram -- 14-80x less occlusion
+	* overall. The honest fix if it ever bites is to threshold the served PNG
+	* into an ink mask and use it to RANK slots; measured, that doubles the
+	* share of satellites on clean paper and changes placement success by zero.
+	*/
+	this.buildOccupancy = function() {
+		var rects = [];
+		var items = this.options.items || [];
+
+		for (var i in items) {
+			try {
+				var graphical = items[i].getModel().getFeatures()[0].getFeatureGraphicalData();
+				if (!graphical) { continue; }
+				var w = graphical.getBoxWidth() || 20, h = graphical.getBoxHeight() || 20;
+				rects.push({
+					left: graphical.getX() - w / 2, top: graphical.getY() - h / 2,
+					right: graphical.getX() + w / 2, bottom: graphical.getY() + h / 2
+				});
+			} catch (error) { /* a set with no graphical data draws nothing */ }
+		}
+
+		((this.payload && this.payload.obstacles) || []).forEach(function(box) {
+			rects.push({
+				left: box.x - box.width / 2, top: box.y - box.height / 2,
+				right: box.x + box.width / 2, bottom: box.y + box.height / 2
+			});
+		});
+
+		return rects;
+	};
+
+	this.overlaps = function(candidate, rects) {
+		for (var i = 0; i < rects.length; i++) {
+			var r = rects[i];
+			if (candidate.left < r.right && candidate.right > r.left &&
+				candidate.top < r.bottom && candidate.bottom > r.top) {
+				return true;
+			}
+		}
+		return false;
+	};
+
+	/**
+	* Find a free slot beside `target` for a satellite of satW x satH.
+	*
+	* South is tried before north because generateBox bakes the feature's
+	* title along the TOP of its sprite, so a satellite sitting below a box
+	* never lands under its own target's label.
+	*
+	* Returns {cx, cy, ring} in raster coordinates, or null.
+	*/
+	this.findSlot = function(target, satW, satH, gap, rects, imageWidth, imageHeight) {
+		var best = null;
+
+		for (var ring = 1; ring <= 3; ring++) {
+			var offset = gap + (ring - 1) * (satH + gap);
+			var south = target.cy + target.height / 2 + offset + satH / 2;
+			var north = target.cy - target.height / 2 - offset - satH / 2;
+			var east = target.cx + target.width / 2 + gap + (ring - 1) * (satW + gap) + satW / 2;
+			var west = target.cx - target.width / 2 - gap - (ring - 1) * (satW + gap) - satW / 2;
+			var shift = satW * 0.6;
+
+			var candidates = [
+				{cx: target.cx, cy: south},              // S-centre
+				{cx: target.cx, cy: north},              // N-centre
+				{cx: east, cy: target.cy},               // E
+				{cx: west, cy: target.cy},               // W
+				{cx: target.cx + shift, cy: south},      // S-right
+				{cx: target.cx - shift, cy: south},      // S-left
+				{cx: target.cx + shift, cy: north},      // N-right
+				{cx: target.cx - shift, cy: north}       // N-left
+			];
+
+			for (var i = 0; i < candidates.length; i++) {
+				var slot = {
+					left: candidates[i].cx - satW / 2, right: candidates[i].cx + satW / 2,
+					top: candidates[i].cy - satH / 2, bottom: candidates[i].cy + satH / 2
+				};
+
+				/* Hard rejects. Never "least-bad" an overlap with a feature
+				   box: the overlay group is appended after every feature
+				   <image>, so an opaque satellite over a real box would eat
+				   that box's hover and click. */
+				if (slot.left < 0 || slot.top < 0 ||
+					slot.right > imageWidth || slot.bottom > imageHeight) { continue; }
+				if (this.overlaps(slot, rects)) { continue; }
+
+				var score = 3.0 * (ring - 1) + (i / 8);
+				if (best === null || score < best.score) {
+					best = {cx: candidates[i].cx, cy: candidates[i].cy, ring: ring, score: score};
+				}
+			}
+
+			/* Ring 1 preference is strong enough that a hit there can never be
+			   beaten by an outer ring; stop as soon as one is found. */
+			if (best !== null) { return best; }
+		}
+
+		return best;
+	};
+
+	/** Regenerate the regulator's own glyph so its gene symbol comes baked in. */
+	this.satelliteGlyph = function(featureID, satW) {
+		var item = (this.options.itemsByID || {})[featureID];
+		if (!item) { return null; }
+		try {
+			/* Rendered at a factor that yields a wide source raster: generateBox
+			   only paints the title when the box exceeds 80px, so a sprite made
+			   at the diagram's own adjustFactor would come back unlabelled. The
+			   result is downsampled into the slot, which keeps the text sharp. */
+			var visual = Ext.apply({}, this.options.visualOptions);
+			visual.adjustFactor = 10;
+			var glyph = item.initComponent(this.options.summaries, visual);
+			return (glyph && glyph.src) ? glyph : null;
+		} catch (error) {
+			return null;
+		}
+	};
+
 	this.draw = function() {
 		var me = this;
 		var edges = (this.payload && this.payload.edges) || [];
@@ -284,11 +442,56 @@ function PA_Step4EvidenceOverlay() {
 		this.group = this.svgEl("g", {"class": "evidenceOverlay"});
 		this.options.canvas.node.appendChild(this.group);
 
-		var drawn = 0, badged = 0;
+		var factor = this.options.adjustFactor;
+		var imageWidth = this.options.graphicalOptions.getImageWidth();
+		var imageHeight = this.options.graphicalOptions.getImageHeight();
+		/* Named occupancyRects, NOT occupancy: the arc fallback further down
+		   declares `var occupancy` inside the same forEach callback, and var is
+		   function-scoped, so that declaration hoists over this one for the whole
+		   callback and the placer received undefined. */
+		var occupancyRects = this.buildOccupancy();
+		var perTarget = {};
+
+		var drawn = 0, badged = 0, satellites = 0, fellBack = 0;
+
 		edges.forEach(function(edge) {
+			var targetRaster = me.rasterBox(edge.targetID);
+			var regulatorRaster = me.rasterBox(edge.regulatorID);
+
+			if (targetRaster && regulatorRaster) {
+				/* Cap satellites per target at 4. Measured max fan-in at the
+				   8-edge cap is 2 (3 on mmu04010), so this is headroom, not a
+				   constraint -- but a box ringed by duplicates reads worse than
+				   an arc, so the ceiling is deliberate. */
+				var used = perTarget[edge.targetID] || 0;
+				if (used < 4) {
+					var satW = Math.max(30, regulatorRaster.width * 0.85);
+					var satH = Math.max(12, regulatorRaster.height * 0.85);
+					var gap = (me.payload.source === "Reactome") ? 8 : 6;
+					var slot = me.findSlot(targetRaster, satW, satH, gap, occupancyRects,
+										   imageWidth, imageHeight);
+					if (slot) {
+						me.drawSatellite(edge, targetRaster, slot, satW, satH, factor);
+						/* A placed satellite becomes an obstacle for the next. */
+						occupancyRects.push({
+							left: slot.cx - satW / 2, right: slot.cx + satW / 2,
+							top: slot.cy - satH / 2, bottom: slot.cy + satH / 2
+						});
+						perTarget[edge.targetID] = used + 1;
+						drawn++;
+						satellites++;
+						return;
+					}
+				}
+			}
+
+			/* FALLBACK: no free space beside the target, so fall back to the
+			   bowed arc. It is worse, and it is honest -- the alternative is
+			   dropping the edge, and the legend counts this. */
 			var fromBox = me.boxGeometry(edge.regulatorID);
 			var toBox = me.boxGeometry(edge.targetID);
 			if (!fromBox || !toBox) { return; }
+			fellBack++;
 
 			var from = me.perimeterPoint(fromBox, toBox.cx, toBox.cy, 2);
 			var to = me.perimeterPoint(toBox, fromBox.cx, fromBox.cy, 4);
@@ -328,10 +531,102 @@ function PA_Step4EvidenceOverlay() {
 			if (shared) { badged++; }
 		});
 
-		this.renderLegend(drawn, badged);
+		this.renderLegend(drawn, badged, satellites, fellBack);
 	};
 
-	this.renderLegend = function(drawn, badged) {
+	/**
+	* One satellite: the regulator's own glyph parked beside its target, joined
+	* by a short stub.
+	*
+	* The glyph is deliberately NOT drawn at full fidelity. Rendered unchanged
+	* it would be pixel-identical to a real feature box, which would assert
+	* that this gene is annotated at a spot where KEGG never put it -- a false
+	* claim printed on a curated diagram. It is therefore scaled to 0.85 and
+	* framed in the overlay's own violet dash, so it reads as evidence-layer
+	* furniture rather than as part of the map.
+	*/
+	this.drawSatellite = function(edge, target, slot, satW, satH, factor) {
+		var style = this.CLASS_STYLE[edge.evidenceClass] || this.CLASS_STYLE.unsupported;
+		var glyph = this.satelliteGlyph(edge.regulatorID, satW);
+
+		var left = (slot.cx - satW / 2) * factor;
+		var top = (slot.cy - satH / 2) * factor;
+		var width = satW * factor;
+		var height = satH * factor;
+
+		/* Stub from the target's perimeter to the satellite's nearest edge.
+		   Straight, not bowed: over ~30 raster px a curve reads as a wobble. */
+		var targetPoint = this.perimeterPoint(
+			{cx: target.cx * factor, cy: target.cy * factor,
+			 halfWidth: target.width * factor / 2, halfHeight: target.height * factor / 2},
+			slot.cx * factor, slot.cy * factor, 0);
+		var satellitePoint = this.perimeterPoint(
+			{cx: slot.cx * factor, cy: slot.cy * factor,
+			 halfWidth: width / 2, halfHeight: height / 2},
+			target.cx * factor, target.cy * factor, 0);
+
+		this.append("path", {
+			d: "M" + targetPoint.x + "," + targetPoint.y +
+			   " L" + satellitePoint.x + "," + satellitePoint.y,
+			fill: "none", stroke: "#ffffff", "stroke-width": 3.2, opacity: 0.7
+		});
+		var stub = this.append("path", {
+			d: "M" + targetPoint.x + "," + targetPoint.y +
+			   " L" + satellitePoint.x + "," + satellitePoint.y,
+			fill: "none", stroke: style.stroke, "stroke-width": 1.5,
+			"stroke-dasharray": style.dash, opacity: style.opacity
+		});
+
+		/* A white ground under the glyph: the sprite has transparent margins
+		   and the printed map shows through them otherwise. */
+		this.append("rect", {
+			x: left, y: top, width: width, height: height,
+			fill: "#ffffff", opacity: 0.92, rx: 1
+		});
+
+		if (glyph) {
+			var image = this.svgEl("image", {
+				x: left, y: top, width: width, height: height,
+				preserveAspectRatio: "none"
+			});
+			image.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", glyph.src);
+			image.setAttribute("href", glyph.src);
+			this.group.appendChild(image);
+		}
+
+		if (!glyph) {
+			/* The regulator has coordinates on this map but is not a PAINTED
+			   feature -- the user's data never matched it -- so there is no
+			   sprite to reuse and no baked label. An unlabelled satellite is
+			   worse than useless: it is an unexplained box on a curated
+			   diagram. Fall back to real text, with a websafe stack and no
+			   external font, so the CairoSVG export can still resolve it.
+			   Measured on mmu04330: 2 of 6 satellites take this path. */
+			var fontSize = Math.max(5, Math.min(height * 0.68, 11));
+			this.append("text", {
+				x: left + width / 2, y: top + height / 2 + fontSize * 0.36,
+				"text-anchor": "middle",
+				"font-family": "Helvetica, Arial, sans-serif",
+				"font-size": fontSize,
+				fill: style.stroke
+			}).textContent = edge.regulatorLabel || edge.regulator;
+		}
+
+		var frame = this.append("rect", {
+			x: left, y: top, width: width, height: height,
+			fill: "none",
+			stroke: style.stroke, "stroke-width": 1.2,
+			"stroke-dasharray": "3,2", rx: 1, opacity: 0.95
+		});
+
+		var tip = this.edgeTooltip(edge, false) +
+			"\n(duplicate of " + edge.regulatorLabel +
+			", placed here by the evidence layer — not a KEGG annotation)";
+		this.tooltip(frame, tip);
+		this.tooltip(stub, tip);
+	};
+
+	this.renderLegend = function(drawn, badged, satellites, fellBack) {
 		var statistics = (this.payload && this.payload.statistics) || {};
 		var byClass = statistics.byClass || {};
 		var me = this;
@@ -362,6 +657,13 @@ function PA_Step4EvidenceOverlay() {
 		if (statistics.offMapRegulators) {
 			omissions.push(statistics.offMapRegulators.toLocaleString() +
 				" relationships have a regulator with no box on this map");
+		}
+		if (fellBack) {
+			/* Named, not hidden. An edge that could not be parked is drawn as
+			   the old long arc, and the reader is told which ones those are. */
+			omissions.push(fellBack + (fellBack === 1
+				? " regulator had no free space beside its target and is drawn as an arc"
+				: " regulators had no free space beside their target and are drawn as arcs"));
 		}
 		if (badged) {
 			/* Counted from what was actually DRAWN, not from the server's
@@ -395,7 +697,8 @@ function PA_Step4EvidenceOverlay() {
 				? '<p class="evidenceLegend-note">' + omissions.join("<br>") + '</p>'
 				: "") +
 			'  <p class="evidenceLegend-source">from this job\'s MORE analysis, ' +
-			'classified against OmniPath</p>' +
+			'classified against OmniPath. Dashed violet boxes are regulators ' +
+			'placed by this layer, not KEGG annotations.</p>' +
 			'</div>';
 
 		this.legendEl = $(html);
@@ -404,6 +707,22 @@ function PA_Step4EvidenceOverlay() {
 			me.setVisible(!me.visible);
 			$(this).text(me.visible ? "hide" : "show");
 		});
+	};
+
+	/**
+	* Redraw from the payload already held.
+	*
+	* applyVisualSettings -> updateObserver rewrites each feature glyph's href
+	* by componentID, iterating this.items only. A satellite is not in items, so
+	* without this it keeps the OLD colour scale after the user hits Apply --
+	* silently showing stale data next to freshly repainted boxes.
+	*/
+	this.refresh = function() {
+		if (!this.payload) { return; }
+		try { this.draw(); } catch (error) {
+			console.warn("Evidence overlay refresh failed", error);
+		}
+		this.setVisible(this.visible);
 	};
 
 	this.setVisible = function(visible) {

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4EvidenceOverlay.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4EvidenceOverlay.js
@@ -44,32 +44,65 @@ function PA_Step4EvidenceOverlay() {
 	};
 
 	this.CLASS_LABEL = {
-		corroborated: "Corroborated &mdash; literature reports this interaction",
+		corroborated: "Corroborated &mdash; a curated database records this interaction",
 		novel:        "Novel &mdash; both proteins known, no reported interaction",
 		unsupported:  "Unsupported &mdash; no external evidence either way"
 	};
 
 	this.CLASS_ORDER = ["corroborated", "novel", "unsupported"];
 
+	/**
+	* How close a regulator's OWN box has to be to its target before parking a
+	* copy of it beside that target stops making sense.
+	*
+	* The satellite branch is only reachable for a regulator that HAS geometry
+	* on this map, so every satellite is by construction a second drawing of a
+	* box KEGG already placed. That is defensible when the original is half a
+	* map away and indefensible when it is touching. Measured on mmu05167, the
+	* three that read as absurd sit at 0, 6.0 and 26.0 raster px -- Fos and Jun
+	* SHARE one drawn box, and Jun is drawn directly above Ccnd1 -- while the
+	* five where a copy earns its place start at 289 px.
+	*
+	* 70 px is about one and a half KEGG gene boxes (46 x 17). It is a RASTER
+	* distance on purpose: a canvas-unit threshold means a different thing at
+	* every panel width, which is exactly the trap the arc layer's bow constant
+	* fell into.
+	*/
+	this.NEAR_RADIUS = 70;
+
 	this.group = null;
 	this.legendEl = null;
 	this.payload = null;
 	this.visible = true;
+	/** edgeKey -> {dx, dy}, RASTER px, from the user dragging a satellite. */
+	this.placement = {};
+	/** Live satellite handles, so a drag moves one without a full redraw. */
+	this.satellites = [];
 
 	/**
 	* @param {Object} options
 	*   canvas            {SVG.Doc}  the live svg.js canvas the diagram drew into
-	*   panelEl           {jQuery}   the .lateralOptionsPanel-body to hang the legend on
+	*   panelEl           {jQuery|Function} where to hang the control card, or a
+	*                                function returning it. A function because the
+	*                                card belongs in the Pathway information
+	*                                column, which is BUILT AFTER the diagram
+	*                                panel this overlay is created from
 	*   jobID             {String}
 	*   pathwayID         {String}
 	*   graphicalOptions  {PathwayGraphicalData}
 	*   adjustFactor      {Number}   raster scale already applied to every box
 	*   boxOccupancy      {Object}   "x#y" -> number of features sharing that box
+	*   placement         {Object}   edgeKey -> {dx, dy} in raster px, restored
+	*                                from visualOptions so a nudge survives a
+	*                                reopen and lands in the PNG/SVG export
+	*   onPlacementChange {Function} optional, called with the placement map
+	*                                after the user finishes a drag
 	*   onReady           {Function} optional, called with the payload
 	*/
 	this.render = function(options) {
 		var me = this;
 		this.options = options;
+		this.placement = options.placement || {};
 
 		$.ajax({
 			method: "POST",
@@ -252,15 +285,40 @@ function PA_Step4EvidenceOverlay() {
 				"  (fit of the target's whole model, not of this link)");
 		}
 
-		if (edge.references && edge.references.length) {
-			lines.push("cited by: " + edge.references.slice(0, 4).map(function(reference) {
-				return (reference.resource ? reference.resource + " " : "") +
-					(reference.pmid ? "PMID:" + reference.pmid : "");
-			}).join(", "));
-		} else if (edge.evidenceClass === "corroborated") {
-			lines.push("literature records this interaction; reinstall OmniPath " +
-				"to carry its PMIDs");
-		}
+		/* WHICH database, and WHERE. A relationship is routinely curated in a
+		   pathway OTHER than the one on screen -- measured on mmu05167, 32 of
+		   the 37 corroborated relationships are recorded on a different map --
+		   and saying only "corroborated" would keep the fact and lose the
+		   address the reader needs to go and check it. */
+		(edge.evidenceSources || []).forEach(function(evidence) {
+			var line = evidence.source;
+			if (evidence.detail) { line += " (" + evidence.detail + ")"; }
+
+			if (evidence.pathways && evidence.pathways.length) {
+				line += " — recorded in " + evidence.pathways.map(function(pathway) {
+					return pathway.name || pathway.id;
+				}).join(", ");
+				if (evidence.morePathways) {
+					line += " and " + evidence.morePathways + " more";
+				}
+			} else if (evidence.onThisPathway) {
+				line += " — drawn on this map";
+			}
+
+			if (evidence.references && evidence.references.length) {
+				line += " — " + evidence.references.slice(0, 3).map(function(reference) {
+					return (reference.resource ? reference.resource + " " : "") +
+						(reference.pmid ? "PMID:" + reference.pmid : "");
+				}).join(", ");
+			} else if (evidence.source === "OmniPath") {
+				/* The installed mmu OmniPath data predates the field, so the
+				   edge is real but its PMIDs are not stored yet. Say which,
+				   rather than letting a bare source name imply a citation. */
+				line += " — no PMIDs stored; reinstall OmniPath to carry them";
+			}
+
+			lines.push(line);
+		});
 
 		if (shared) {
 			lines.push("⚠ the target box holds several genes — this link " +
@@ -285,11 +343,30 @@ function PA_Step4EvidenceOverlay() {
 	   so the geometry silently changed meaning with panel width.
 	   --------------------------------------------------------------------- */
 
-	/** Raster-space box for a feature: centre plus half extents. */
-	this.rasterBox = function(featureID) {
+	/**
+	* Raster-space box for a feature: centre plus half extents.
+	*
+	* @param {Object} near optional; when a feature is drawn at SEVERAL places
+	*        on the map, return the box closest to this one. Taking [0] instead
+	*        makes the near/far decision below depend on KGML entry order: Jun
+	*        has three boxes on mmu05167 and only one of them is the 6 px
+	*        neighbour of Ccnd1 that the reader is looking at.
+	*/
+	this.rasterBox = function(featureID, near) {
 		var graphical = this.options.graphicalOptions.findFeatureGraphicalData(featureID);
 		if (!graphical || !graphical.length) { return null; }
+
 		var data = graphical[0];
+		if (near && graphical.length > 1) {
+			var best = Infinity;
+			for (var i = 0; i < graphical.length; i++) {
+				var dx = graphical[i].getX() - near.cx;
+				var dy = graphical[i].getY() - near.cy;
+				var distance = dx * dx + dy * dy;
+				if (distance < best) { best = distance; data = graphical[i]; }
+			}
+		}
+
 		return {
 			cx: data.getX(),
 			cy: data.getY(),
@@ -298,6 +375,22 @@ function PA_Step4EvidenceOverlay() {
 			key: data.getX() + "#" + data.getY(),
 			boxes: graphical.length
 		};
+	};
+
+	/**
+	* Shortest raster distance between the EDGES of two boxes, 0 when they touch
+	* or overlap. Centre-to-centre would call a wide box far from something
+	* resting against its side.
+	*/
+	this.boxGap = function(a, b) {
+		var dx = Math.max(0, Math.abs(a.cx - b.cx) - (a.width + b.width) / 2);
+		var dy = Math.max(0, Math.abs(a.cy - b.cy) - (a.height + b.height) / 2);
+		return Math.sqrt(dx * dx + dy * dy);
+	};
+
+	/** Stable identity for one drawn edge, so a dragged position can be found again. */
+	this.edgeKey = function(edge) {
+		return edge.regulatorID + ">" + edge.targetID;
 	};
 
 	/**
@@ -452,13 +545,38 @@ function PA_Step4EvidenceOverlay() {
 		var occupancyRects = this.buildOccupancy();
 		var perTarget = {};
 
-		var drawn = 0, badged = 0, satellites = 0, fellBack = 0;
+		var counts = {drawn: 0, badged: 0, satellites: 0, fellBack: 0,
+					  linked: 0, selfLoops: 0, moved: 0};
 
 		edges.forEach(function(edge) {
 			var targetRaster = me.rasterBox(edge.targetID);
-			var regulatorRaster = me.rasterBox(edge.regulatorID);
+			var regulatorRaster = me.rasterBox(edge.regulatorID, targetRaster);
 
 			if (targetRaster && regulatorRaster) {
+				/* THE REGULATOR IS ALREADY ON THIS MAP.
+				   Every satellite is a second drawing of a box KEGG already
+				   placed -- that is what the branch requires. Copying one the
+				   reader can see without moving their eyes is what made the
+				   layer look wrong, so inside NEAR_RADIUS we point at the
+				   original instead of stamping a duplicate next to it. */
+				if (regulatorRaster.key === targetRaster.key) {
+					/* Same drawn box: co-located genes bucket by the literal
+					   x#y string, so Fos and Jun ARE one rectangle. There is no
+					   "beside" to park in and no two points to join -- the only
+					   honest mark is a loop on the box itself. */
+					me.drawSelfMarker(edge, targetRaster, factor);
+					counts.selfLoops++;
+					counts.drawn++;
+					return;
+				}
+				if (me.boxGap(regulatorRaster, targetRaster) <= me.NEAR_RADIUS) {
+					if (me.drawLink(edge, regulatorRaster, targetRaster, true)) {
+						counts.linked++;
+						counts.drawn++;
+						return;
+					}
+				}
+
 				/* Cap satellites per target at 4. Measured max fan-in at the
 				   8-edge cap is 2 (3 on mmu04010), so this is headroom, not a
 				   constraint -- but a box ringed by duplicates reads worse than
@@ -471,15 +589,21 @@ function PA_Step4EvidenceOverlay() {
 					var slot = me.findSlot(targetRaster, satW, satH, gap, occupancyRects,
 										   imageWidth, imageHeight);
 					if (slot) {
-						me.drawSatellite(edge, targetRaster, slot, satW, satH, factor);
-						/* A placed satellite becomes an obstacle for the next. */
+						var handle = me.drawSatellite(edge, targetRaster, slot,
+													  satW, satH, factor);
+						/* A placed satellite becomes an obstacle for the next.
+						   Its AUTOMATIC slot, not the dragged one: a position
+						   the user chose is their business, and letting a
+						   hand-placed box push the next one around would make
+						   the layout depend on drag order. */
 						occupancyRects.push({
 							left: slot.cx - satW / 2, right: slot.cx + satW / 2,
 							top: slot.cy - satH / 2, bottom: slot.cy + satH / 2
 						});
 						perTarget[edge.targetID] = used + 1;
-						drawn++;
-						satellites++;
+						counts.drawn++;
+						counts.satellites++;
+						if (handle && (handle.dx || handle.dy)) { counts.moved++; }
 						return;
 					}
 				}
@@ -488,50 +612,211 @@ function PA_Step4EvidenceOverlay() {
 			/* FALLBACK: no free space beside the target, so fall back to the
 			   bowed arc. It is worse, and it is honest -- the alternative is
 			   dropping the edge, and the legend counts this. */
-			var fromBox = me.boxGeometry(edge.regulatorID);
-			var toBox = me.boxGeometry(edge.targetID);
-			if (!fromBox || !toBox) { return; }
-			fellBack++;
-
-			var from = me.perimeterPoint(fromBox, toBox.cx, toBox.cy, 2);
-			var to = me.perimeterPoint(toBox, fromBox.cx, fromBox.cy, 4);
-			var control = me.controlPoint(from, to);
-			var style = me.CLASS_STYLE[edge.evidenceClass] || me.CLASS_STYLE.unsupported;
-
-			var occupancy = (me.options.boxOccupancy || {})[toBox.key] || 1;
-			var shared = occupancy > 1;
-
-			/* A white casing drawn UNDER the arc keeps it legible where it
-			   crosses the map's own printed lines and labels -- which the
-			   application cannot see, so it cannot route around them. Thin
-			   enough to read as a halo rather than as an erasure. */
-			me.append("path", {
-				d: "M" + from.x + "," + from.y +
-				   " Q" + control.x + "," + control.y + " " + to.x + "," + to.y,
-				fill: "none", stroke: "#ffffff",
-				"stroke-width": style.width + 2.4,
-				"stroke-linecap": "round", opacity: 0.65
-			});
-
-			var path = me.append("path", {
-				d: "M" + from.x + "," + from.y +
-				   " Q" + control.x + "," + control.y + " " + to.x + "," + to.y,
-				fill: "none", stroke: style.stroke,
-				"stroke-width": style.width,
-				"stroke-linecap": "round",
-				"stroke-dasharray": style.dash,
-				opacity: style.opacity
-			});
-
-			var head = me.terminal(to, control, style, shared);
-			var tip = me.edgeTooltip(edge, shared);
-			me.tooltip(path, tip);
-			me.tooltip(head, tip);
-			drawn++;
-			if (shared) { badged++; }
+			var result = me.drawLink(edge, regulatorRaster, targetRaster, false);
+			if (!result) { return; }
+			counts.fellBack++;
+			counts.drawn++;
+			if (result.shared) { counts.badged++; }
 		});
 
-		this.renderLegend(drawn, badged, satellites, fellBack);
+		this.renderLegend(counts);
+	};
+
+	/**
+	* Frame a REAL box in the overlay's own dashed violet.
+	*
+	* Without this a short link is an anonymous violet tick between two red
+	* rectangles: it says something is happening, but not what, and not which of
+	* the two boxes it came FROM.
+	*
+	* SOLID, and deliberately not the satellite's dash. The legend states that
+	* dashed violet boxes are regulators this layer placed and NOT KEGG
+	* annotations; putting the same dash around a real KEGG box would make the
+	* legend false and leave a reader unable to tell Jun (real, ringed) from
+	* Rb1 (a copy) when the two sit side by side. So the layer has two marks
+	* with one hue: SOLID ring = a box KEGG drew, that this layer is pointing
+	* FROM; DASHED frame = a box this layer added.
+	*
+	* pointer-events is off: the ring sits directly over a real feature box and
+	* must not take its hover or its click.
+	*/
+	this.markSource = function(box, style) {
+		var pad = 1.8;
+		return this.append("rect", {
+			x: box.cx - box.halfWidth - pad,
+			y: box.cy - box.halfHeight - pad,
+			width: (box.halfWidth + pad) * 2,
+			height: (box.halfHeight + pad) * 2,
+			fill: "none",
+			stroke: style.stroke, "stroke-width": 1.6,
+			rx: 1.5, opacity: 0.95,
+			"pointer-events": "none"
+		});
+	};
+
+	/**
+	* A short caption in the overlay's hue, drawn twice: a white stroked copy
+	* underneath and the violet fill on top.
+	*
+	* paint-order would be one element instead of two, but CairoSVG (which
+	* renders /pa_save_image) does not implement it, so the export would lose
+	* the halo and the caption would disappear into the printed artwork.
+	*/
+	this.caption = function(x, y, text, style, size) {
+		var attributes = {
+			x: x, y: y, "text-anchor": "middle",
+			"font-family": "Helvetica, Arial, sans-serif",
+			"font-size": size, "pointer-events": "none"
+		};
+
+		var halo = this.append("text", Ext.apply({
+			fill: "none", stroke: "#ffffff", "stroke-width": 2.4,
+			"stroke-linejoin": "round", opacity: 0.85
+		}, attributes));
+		halo.textContent = text;
+
+		var ink = this.append("text", Ext.apply({
+			fill: style.stroke, "font-weight": 600
+		}, attributes));
+		ink.textContent = text;
+		return ink;
+	};
+
+	/**
+	* One edge drawn between the two REAL boxes, with no duplicate glyph.
+	*
+	* @param {Boolean} straight  true for a near pair. The bow is
+	*        max(14, min(length * 0.16, 70)) CANVAS units, so over the ~4 canvas
+	*        units separating Jun from Ccnd1 a curve is not a curve, it is a
+	*        loop swinging out over unrelated artwork. Near pairs get the chord.
+	* @returns {Object|null} {shared} once drawn, null when either endpoint has
+	*        no geometry on this map.
+	*/
+	this.drawLink = function(edge, regulatorRaster, targetRaster, straight) {
+		var fromBox = this.boxGeometry(edge.regulatorID);
+		var toBox = this.boxGeometry(edge.targetID);
+		if (!fromBox || !toBox) { return null; }
+
+		/* boxGeometry takes graphical[0]; when the regulator is drawn several
+		   times, the near/far decision was made about a SPECIFIC one of those
+		   boxes and the line has to leave that same box. */
+		if (regulatorRaster) {
+			var factor = this.options.adjustFactor;
+			fromBox = {
+				cx: regulatorRaster.cx * factor, cy: regulatorRaster.cy * factor,
+				halfWidth: (regulatorRaster.width * factor || 20) / 2,
+				halfHeight: (regulatorRaster.height * factor || 20) / 2,
+				key: regulatorRaster.key, boxes: regulatorRaster.boxes
+			};
+		}
+
+		var from = this.perimeterPoint(fromBox, toBox.cx, toBox.cy, 2);
+		var to = this.perimeterPoint(toBox, fromBox.cx, fromBox.cy, 4);
+		var control = straight
+			? {x: (from.x + to.x) / 2, y: (from.y + to.y) / 2}
+			: this.controlPoint(from, to);
+		var style = this.CLASS_STYLE[edge.evidenceClass] || this.CLASS_STYLE.unsupported;
+
+		var occupancy = (this.options.boxOccupancy || {})[toBox.key] || 1;
+		var shared = occupancy > 1;
+
+		var d = "M" + from.x + "," + from.y +
+				" Q" + control.x + "," + control.y + " " + to.x + "," + to.y;
+
+		/* A white casing drawn UNDER the line keeps it legible where it crosses
+		   the map's own printed lines and labels -- which the application cannot
+		   see, so it cannot route around them. Thin enough to read as a halo
+		   rather than as an erasure. */
+		this.append("path", {
+			d: d, fill: "none", stroke: "#ffffff",
+			"stroke-width": style.width + 2.4,
+			"stroke-linecap": "round", opacity: 0.65
+		});
+
+		var path = this.append("path", {
+			d: d, fill: "none", stroke: style.stroke,
+			"stroke-width": style.width,
+			"stroke-linecap": "round",
+			"stroke-dasharray": style.dash,
+			opacity: style.opacity
+		});
+
+		var head = this.terminal(to, control, style, shared);
+		if (straight) {
+			/* Only for the near case. Over a long bowed arc the reader can
+			   follow the curve back to its origin, so a ring there would be
+			   decoration; over a 4 px chord there is no curve to follow. */
+			this.markSource(fromBox, style);
+		}
+		var tip = this.edgeTooltip(edge, shared) + (straight
+			? "\n" + (edge.regulatorLabel || edge.regulator) +
+			  " is drawn on this map (framed in violet), so it is joined to " +
+			  (edge.targetLabel || edge.target) + " rather than copied beside it"
+			: "");
+		this.tooltip(path, tip);
+		this.tooltip(head, tip);
+
+		return {shared: shared};
+	};
+
+	/**
+	* Regulator and target are the SAME drawn box.
+	*
+	* Features bucket by the literal string x + "#" + y, so genes KEGG placed at
+	* one coordinate collapse into one rectangle -- Fos and Jun on mmu05167 are
+	* not neighbours, they are the same 46x17 px box. A line needs two points and
+	* a satellite needs a "beside"; neither exists here. A loop leaving the top
+	* edge and returning to it claims exactly what is true: a relationship
+	* between two things inside this box.
+	*/
+	this.drawSelfMarker = function(edge, box, factor) {
+		var style = this.CLASS_STYLE[edge.evidenceClass] || this.CLASS_STYLE.unsupported;
+		var cx = box.cx * factor;
+		var top = (box.cy - box.height / 2) * factor;
+		var halfWidth = Math.max(6, box.width * factor / 4);
+		var rise = Math.max(9, box.height * factor * 0.9);
+
+		var d = "M" + (cx - halfWidth) + "," + top +
+				" C" + (cx - halfWidth) + "," + (top - rise) +
+				" " + (cx + halfWidth) + "," + (top - rise) +
+				" " + (cx + halfWidth) + "," + top;
+
+		this.append("path", {
+			d: d, fill: "none", stroke: "#ffffff",
+			"stroke-width": style.width + 2.4,
+			"stroke-linecap": "round", opacity: 0.65
+		});
+		var loop = this.append("path", {
+			d: d, fill: "none", stroke: style.stroke,
+			"stroke-width": style.width,
+			"stroke-linecap": "round",
+			"stroke-dasharray": style.dash,
+			opacity: style.opacity
+		});
+		/* Pointing straight down into the box it came from. */
+		var head = this.terminal({x: cx + halfWidth, y: top},
+								 {x: cx + halfWidth, y: top - rise}, style, true);
+
+		this.markSource({
+			cx: cx, cy: box.cy * factor,
+			halfWidth: box.width * factor / 2,
+			halfHeight: box.height * factor / 2
+		}, style);
+
+		/* The one place a caption is not optional. A ring says "this box", and
+		   an arrow says "into this box" -- but the box holds SEVERAL genes and
+		   the claim is about two specific ones inside it. Neither shape can
+		   name them, and the printed label cannot either, because KEGG prints
+		   only the first gene of a co-located group. */
+		this.caption(cx, top - rise - Math.max(2, box.height * factor * 0.25),
+					 (edge.regulatorLabel || edge.regulator) + " → " +
+					 (edge.targetLabel || edge.target),
+					 style, Math.max(5.5, Math.min(box.height * factor * 0.8, 9)));
+
+		var tip = this.edgeTooltip(edge, true) +
+			"\nboth genes are drawn in this one box, so this link is shown on it";
+		this.tooltip(loop, tip);
+		this.tooltip(head, tip);
 	};
 
 	/**
@@ -548,41 +833,37 @@ function PA_Step4EvidenceOverlay() {
 	this.drawSatellite = function(edge, target, slot, satW, satH, factor) {
 		var style = this.CLASS_STYLE[edge.evidenceClass] || this.CLASS_STYLE.unsupported;
 		var glyph = this.satelliteGlyph(edge.regulatorID, satW);
+		var key = this.edgeKey(edge);
+		var saved = this.placement[key] || {};
 
-		var left = (slot.cx - satW / 2) * factor;
-		var top = (slot.cy - satH / 2) * factor;
 		var width = satW * factor;
 		var height = satH * factor;
+		var left = (slot.cx - satW / 2) * factor;
+		var top = (slot.cy - satH / 2) * factor;
 
-		/* Stub from the target's perimeter to the satellite's nearest edge.
-		   Straight, not bowed: over ~30 raster px a curve reads as a wobble. */
-		var targetPoint = this.perimeterPoint(
-			{cx: target.cx * factor, cy: target.cy * factor,
-			 halfWidth: target.width * factor / 2, halfHeight: target.height * factor / 2},
-			slot.cx * factor, slot.cy * factor, 0);
-		var satellitePoint = this.perimeterPoint(
-			{cx: slot.cx * factor, cy: slot.cy * factor,
-			 halfWidth: width / 2, halfHeight: height / 2},
-			target.cx * factor, target.cy * factor, 0);
-
-		this.append("path", {
-			d: "M" + targetPoint.x + "," + targetPoint.y +
-			   " L" + satellitePoint.x + "," + satellitePoint.y,
+		/* The stub stays a child of the overlay group, NOT of the draggable
+		   group: one of its ends is nailed to the target box and must not move
+		   with the hand. It is redrawn from the satellite's live centre instead. */
+		var casing = this.append("path", {
 			fill: "none", stroke: "#ffffff", "stroke-width": 3.2, opacity: 0.7
 		});
 		var stub = this.append("path", {
-			d: "M" + targetPoint.x + "," + targetPoint.y +
-			   " L" + satellitePoint.x + "," + satellitePoint.y,
 			fill: "none", stroke: style.stroke, "stroke-width": 1.5,
 			"stroke-dasharray": style.dash, opacity: style.opacity
 		});
 
+		/* Everything that MOVES lives in one <g>, so a drag is a single
+		   translate rather than five coordinate rewrites -- and so the export,
+		   which serialises the live DOM, carries the moved position. */
+		var node = this.svgEl("g", {"class": "evidenceSatellite"});
+		this.group.appendChild(node);
+
 		/* A white ground under the glyph: the sprite has transparent margins
 		   and the printed map shows through them otherwise. */
-		this.append("rect", {
+		node.appendChild(this.svgEl("rect", {
 			x: left, y: top, width: width, height: height,
 			fill: "#ffffff", opacity: 0.92, rx: 1
-		});
+		}));
 
 		if (glyph) {
 			var image = this.svgEl("image", {
@@ -591,10 +872,8 @@ function PA_Step4EvidenceOverlay() {
 			});
 			image.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", glyph.src);
 			image.setAttribute("href", glyph.src);
-			this.group.appendChild(image);
-		}
-
-		if (!glyph) {
+			node.appendChild(image);
+		} else {
 			/* The regulator has coordinates on this map but is not a PAINTED
 			   feature -- the user's data never matched it -- so there is no
 			   sprite to reuse and no baked label. An unlabelled satellite is
@@ -603,36 +882,233 @@ function PA_Step4EvidenceOverlay() {
 			   external font, so the CairoSVG export can still resolve it.
 			   Measured on mmu04330: 2 of 6 satellites take this path. */
 			var fontSize = Math.max(5, Math.min(height * 0.68, 11));
-			this.append("text", {
+			var label = this.svgEl("text", {
 				x: left + width / 2, y: top + height / 2 + fontSize * 0.36,
 				"text-anchor": "middle",
 				"font-family": "Helvetica, Arial, sans-serif",
 				"font-size": fontSize,
 				fill: style.stroke
-			}).textContent = edge.regulatorLabel || edge.regulator;
+			});
+			label.textContent = edge.regulatorLabel || edge.regulator;
+			node.appendChild(label);
 		}
 
-		var frame = this.append("rect", {
+		var frame = this.svgEl("rect", {
 			x: left, y: top, width: width, height: height,
 			fill: "none",
 			stroke: style.stroke, "stroke-width": 1.2,
 			"stroke-dasharray": "3,2", rx: 1, opacity: 0.95
 		});
+		node.appendChild(frame);
 
 		var tip = this.edgeTooltip(edge, false) +
 			"\n(duplicate of " + edge.regulatorLabel +
-			", placed here by the evidence layer — not a KEGG annotation)";
+			", placed here by the evidence layer — not a KEGG annotation)" +
+			"\ndrag to move it; “reset positions” in the legend puts it back";
 		this.tooltip(frame, tip);
 		this.tooltip(stub, tip);
+
+		var handle = {
+			key: key, node: node, stub: stub, casing: casing,
+			slot: slot, width: width, height: height,
+			dx: saved.dx || 0, dy: saved.dy || 0,
+			target: {
+				cx: target.cx * factor, cy: target.cy * factor,
+				halfWidth: target.width * factor / 2,
+				halfHeight: target.height * factor / 2
+			}
+		};
+		this.satellites.push(handle);
+		this.applyPlacement(handle);
+		this.makeDraggable(handle);
+
+		return handle;
 	};
 
-	this.renderLegend = function(drawn, badged, satellites, fellBack) {
+	/* ---------------------------------------------------------------------
+	   MOVING A SATELLITE BY HAND
+
+	   Automatic placement is blind to free text -- "Cell proliferation",
+	   "Angiogenesis", the compartment labels -- because none of it is an entry
+	   in any file the application reads. It is not going to be right every
+	   time, so the reader gets to move it, and the move is kept.
+
+	   Offsets are stored in RASTER px. The panel's adjustFactor changes with
+	   its width, so a canvas-unit offset saved in a wide panel would move the
+	   box somewhere else entirely when reopened in a narrow one.
+	   --------------------------------------------------------------------- */
+
+	/** Position a satellite and re-anchor its stub to the target box. */
+	this.applyPlacement = function(handle) {
+		var factor = this.options.adjustFactor;
+
+		handle.node.setAttribute("transform", "translate(" +
+			(handle.dx * factor) + "," + (handle.dy * factor) + ")");
+
+		var cx = (handle.slot.cx + handle.dx) * factor;
+		var cy = (handle.slot.cy + handle.dy) * factor;
+
+		/* Straight, not bowed: over ~30 raster px a curve reads as a wobble. */
+		var targetPoint = this.perimeterPoint(handle.target, cx, cy, 0);
+		var satellitePoint = this.perimeterPoint(
+			{cx: cx, cy: cy,
+			 halfWidth: handle.width / 2, halfHeight: handle.height / 2},
+			handle.target.cx, handle.target.cy, 0);
+
+		var d = "M" + targetPoint.x + "," + targetPoint.y +
+				" L" + satellitePoint.x + "," + satellitePoint.y;
+		handle.stub.setAttribute("d", d);
+		handle.casing.setAttribute("d", d);
+	};
+
+	/**
+	* Pointer-drag one satellite.
+	*
+	* The diagram sits inside jquery-svg-pan-zoom, which pans on mousedown and
+	* touchstart at the root <svg>. Those are a SEPARATE event stream from
+	* pointer events: for a mouse pointer, cancelling pointerdown does NOT
+	* suppress the compatibility mousedown -- that guarantee only holds for
+	* touch. Measured before this was added: the satellite moved correctly AND
+	* the whole map panned under it by the same delta, so the box looked pinned
+	* while everything else slid. The gesture is therefore swallowed in both
+	* streams before the plugin can see it.
+	*/
+	this.makeDraggable = function(handle) {
+		var me = this;
+		var node = handle.node;
+
+		["mousedown", "touchstart"].forEach(function(name) {
+			node.addEventListener(name, function(event) {
+				event.preventDefault();
+				event.stopPropagation();
+			}, {passive: false});
+		});
+
+		node.addEventListener("pointerdown", function(event) {
+			var root = me.options.canvas.node;
+			var screenMatrix = root.getScreenCTM();
+			if (!screenMatrix) { return; }
+
+			event.preventDefault();
+			event.stopPropagation();
+
+			var inverse = screenMatrix.inverse();
+			var start = me.clientToCanvas(event.clientX, event.clientY, inverse);
+			var origin = {dx: handle.dx, dy: handle.dy};
+			var factor = me.options.adjustFactor;
+			try { node.setPointerCapture(event.pointerId); } catch (error) { /* no capture */ }
+
+			var imageWidth = me.options.graphicalOptions.getImageWidth();
+			var imageHeight = me.options.graphicalOptions.getImageHeight();
+
+			var move = function(moveEvent) {
+				var now = me.clientToCanvas(moveEvent.clientX, moveEvent.clientY, inverse);
+				handle.dx = origin.dx + (now.x - start.x) / factor;
+				handle.dy = origin.dy + (now.y - start.y) / factor;
+
+				/* Clamped to the artwork. A box dragged off the canvas is not
+				   hidden, it is LOST: the panel clips, so it cannot be grabbed
+				   again, and only "reset positions" would bring it back. */
+				var halfWidth = handle.width / factor / 2;
+				var halfHeight = handle.height / factor / 2;
+				var cx = Math.min(Math.max(handle.slot.cx + handle.dx, halfWidth),
+								  imageWidth - halfWidth);
+				var cy = Math.min(Math.max(handle.slot.cy + handle.dy, halfHeight),
+								  imageHeight - halfHeight);
+				handle.dx = cx - handle.slot.cx;
+				handle.dy = cy - handle.slot.cy;
+
+				me.applyPlacement(handle);
+			};
+			var release = function(releaseEvent) {
+				node.removeEventListener("pointermove", move);
+				node.removeEventListener("pointerup", release);
+				node.removeEventListener("pointercancel", release);
+				try { node.releasePointerCapture(releaseEvent.pointerId); }
+				catch (error) { /* already released */ }
+
+				if (handle.dx || handle.dy) {
+					me.placement[handle.key] = {dx: handle.dx, dy: handle.dy};
+				} else {
+					delete me.placement[handle.key];
+				}
+				me.savePlacement();
+			};
+
+			node.addEventListener("pointermove", move);
+			node.addEventListener("pointerup", release);
+			node.addEventListener("pointercancel", release);
+		});
+	};
+
+	/** Screen coordinates to the canvas units the overlay draws in. */
+	this.clientToCanvas = function(clientX, clientY, inverse) {
+		var point = this.options.canvas.node.createSVGPoint();
+		point.x = clientX;
+		point.y = clientY;
+		return point.matrixTransform(inverse);
+	};
+
+	/** "reset positions" is inert until there is something to reset. */
+	this.updateResetState = function() {
+		if (!this.legendEl) { return; }
+		this.legendEl.find(".evidenceLegend-reset")
+			.toggleClass("is-disabled", !Object.keys(this.placement || {}).length);
+	};
+
+	this.savePlacement = function() {
+		this.updateResetState();
+		if (typeof this.options.onPlacementChange !== "function") { return; }
+		try {
+			this.options.onPlacementChange(this.placement);
+		} catch (error) {
+			/* Additive by design: a diagram that cannot persist a nudge still
+			   shows the nudge for as long as it is open. */
+			console.warn("Evidence overlay: placement not saved", error);
+		}
+	};
+
+	/** Drop every hand-placed offset and lay the layer out automatically again. */
+	this.resetPlacement = function() {
+		this.placement = {};
+		this.savePlacement();
+		this.refresh();
+	};
+
+	/**
+	* Where the control card goes.
+	*
+	* NOT the diagram panel's own body, which is where it used to go. That panel
+	* is as tall as the map -- measured 865 px on mmu05167 against a 907 px
+	* viewport -- so a card underneath it began 18 px from the bottom of the
+	* screen and its 240 px of controls were entirely below the fold. Nobody
+	* scrolls past a pathway diagram looking for a legend, so in practice the
+	* layer had no controls at all.
+	*
+	* The Pathway information column beside the map is 300 px wide, always on
+	* screen, and already holds this pathway's classification and its regulation
+	* chart. Resolved through a function because that column is constructed
+	* after the diagram panel that creates this overlay.
+	*/
+	this.legendHost = function() {
+		var host = this.options.panelEl;
+		if (typeof host === "function") {
+			try { host = host(); } catch (error) { host = null; }
+		}
+		return (host && host.length) ? host : null;
+	};
+
+	this.renderLegend = function(counts) {
 		var statistics = (this.payload && this.payload.statistics) || {};
 		var byClass = statistics.byClass || {};
 		var me = this;
+		var drawn = counts.drawn, badged = counts.badged, fellBack = counts.fellBack;
 
 		if (this.legendEl) { this.legendEl.remove(); }
 		if (!statistics.totalRelationships) { return; }
+
+		var host = this.legendHost();
+		if (!host) { return; }
 
 		var rows = this.CLASS_ORDER.map(function(name) {
 			var style = me.CLASS_STYLE[name];
@@ -646,6 +1122,18 @@ function PA_Step4EvidenceOverlay() {
 				'<span class="evidenceLegend-count">' + (byClass[name] || 0) + '</span>' +
 				'</li>';
 		}).join("");
+
+		/* Which databases actually corroborated anything here, strongest first.
+		   Naming them is not decoration: "corroborated" means a different thing
+		   when it comes from KEGG's own relation graph than from OmniPath's
+		   literature list, and the reader cannot tell without being told. */
+		var bySource = statistics.bySource || {};
+		var sourceNames = Object.keys(bySource).sort(function(a, b) {
+			return bySource[b] - bySource[a];
+		}).map(function(name) {
+			return '<span class="evidenceLegend-source-name">' + name + '</span> ' +
+				bySource[name];
+		});
 
 		/* Everything the layer could NOT draw, stated on screen. A silently
 		   truncated overlay reads as "this is all there is". */
@@ -675,37 +1163,113 @@ function PA_Step4EvidenceOverlay() {
 				: " edges end on a box holding several genes") +
 				" and cannot say which one (hollow terminal)");
 		}
+		if (statistics.recordedElsewhere) {
+			/* The number that only exists because more than one database is
+			   consulted. Before this it was invisible: those relationships were
+			   labelled "no external evidence either way". */
+			omissions.push(statistics.recordedElsewhere +
+				(statistics.recordedElsewhere === 1
+					? " interaction is curated on a different pathway map"
+					: " interactions are curated on different pathway maps") +
+				", not this one");
+		}
 		if (statistics.multiBoxEndpoints) {
 			omissions.push(statistics.multiBoxEndpoints +
 				" had an endpoint drawn at several places on this map; one was chosen");
 		}
+		if (counts.linked || counts.selfLoops) {
+			/* Stated rather than silent: these are the edges that did NOT get a
+			   parked copy, and the reason is worth one line -- otherwise the
+			   layer looks inconsistent about when it duplicates a regulator. */
+			var near = [];
+			if (counts.linked) {
+				near.push(counts.linked + (counts.linked === 1 ? " regulator is" : " regulators are") +
+					" already drawn beside their target: ringed in <b>solid</b> violet " +
+					"and joined by an arrow, rather than copied");
+			}
+			if (counts.selfLoops) {
+				near.push(counts.selfLoops + (counts.selfLoops === 1 ? " pair shares" : " pairs share") +
+					" one drawn box and is marked with a loop on it");
+			}
+			omissions.push(near.join("<br>"));
+		}
 
 		var html =
-			/* No data-guides="ignore" here on purpose. The card sits in flow at
-			   the panel body's own content edge -- measured identical to the
-			   panel <h2>'s rail -- so it can be CHECKED by the alignment guides
-			   rather than exempted from them, and a future regression will show
-			   up in the HUD instead of hiding behind the opt-out. */
+			/* Built from the Pathway information column's OWN vocabulary, not
+			   from card chrome of its own. That column states a section with an
+			   <h4>, sub-labels it with .pa-details-label, and renders anything
+			   pill-shaped as .pa-details-chip -- flat, no borders, no shadows.
+			   A bordered violet card with its own left rail sat in the middle
+			   of that and read as a foreign widget pasted into the panel.
+			   Violet survives only where it carries meaning: the three stroke
+			   samples, which are the actual key to the marks on the map.
+
+			   No data-guides="ignore". The section sits in flow at the column's
+			   own content edge, so it can be CHECKED by the alignment guides
+			   rather than exempted from them. */
 			'<div class="evidenceLegend">' +
-			'  <div class="evidenceLegend-header">' +
-			'    <span class="evidenceLegend-title">Evidence overlay</span>' +
-			'    <a href="javascript:void(0)" class="evidenceLegend-toggle" ' +
-			'       title="Show or hide the evidence overlay">hide</a>' +
-			'  </div>' +
+			'  <h4>Evidence overlay</h4>' +
+			'  <span class="pa-details-label">' + drawn + ' relationship' +
+			(drawn === 1 ? '' : 's') + ' drawn</span>' +
 			'  <ul class="evidenceLegend-list">' + rows + '</ul>' +
+			/* Which databases corroborated ANYTHING on this map, strongest
+			   first. Its own line rather than beside the drawn count, because
+			   these tally the whole classified set and not the handful the cap
+			   let through -- putting the two numbers side by side invited them
+			   to be read as the same total. */
+			(sourceNames.length
+				? '  <p class="evidenceLegend-sources">corroborated by ' +
+				  sourceNames.join(' &middot; ') + '</p>'
+				: "") +
+			/* CONTROLS BEFORE PROSE. The section is the last thing in a column
+			   that already holds a chart, so its tail is the first thing to
+			   fall off a short viewport -- measured, the buttons sat 3 px from
+			   the bottom edge when they came last. What the reader can act on
+			   goes above what they can only read. */
+			'  <div class="evidenceLegend-actions">' +
+			'    <a href="javascript:void(0)" class="button evidenceLegend-button evidenceLegend-toggle" ' +
+			'       title="Show or hide the whole evidence layer">' +
+			'      <i class="fa fa-eye-slash"></i> Hide layer</a>' +
+			(counts.satellites
+				? '    <a href="javascript:void(0)" class="button evidenceLegend-button evidenceLegend-reset" ' +
+				  '       title="Put every dragged regulator back where the layer placed it">' +
+				  '      <i class="fa fa-undo"></i> Reset positions</a>'
+				: "") +
+			'  </div>' +
+			(counts.satellites
+				? '  <p class="evidenceLegend-note evidenceLegend-hint">Drag any ' +
+				  '<b>dashed</b> violet box on the map to move it. A <b>solid</b> ' +
+				  'violet ring marks a regulator KEGG itself drew.</p>'
+				: "") +
 			(omissions.length
 				? '<p class="evidenceLegend-note">' + omissions.join("<br>") + '</p>'
 				: "") +
 			'  <p class="evidenceLegend-source">from this job\'s MORE analysis, ' +
-			'classified against OmniPath. Dashed violet boxes are regulators ' +
-			'placed by this layer, not KEGG annotations.</p>' +
+			'classified against KEGG, Reactome and OmniPath &mdash; every ' +
+			'pathway of this organism, not just this one.</p>' +
 			'</div>';
 
 		this.legendEl = $(html);
-		this.options.panelEl.append(this.legendEl);
+		/* After the pathway details, not at the top: the column's first job is
+		   still to say which pathway this is. Appended to the body when that
+		   block is absent (a Reactome or MapMan diagram builds it differently). */
+		var details = host.find(".patwaysDetailsContainer");
+		if (details.length) { details.after(this.legendEl); } else { host.append(this.legendEl); }
+
 		this.legendEl.find(".evidenceLegend-toggle").click(function() {
 			me.setVisible(!me.visible);
-			$(this).text(me.visible ? "hide" : "show");
+			$(this).html(me.visible
+				? '<i class="fa fa-eye-slash"></i> Hide layer'
+				: '<i class="fa fa-eye"></i> Show layer');
+			$(this).toggleClass("is-off", !me.visible);
+		});
+		/* Disabled until something has actually been moved, so the control does
+		   not offer to undo nothing. */
+		var resetEl = this.legendEl.find(".evidenceLegend-reset");
+		this.updateResetState();
+		resetEl.click(function() {
+			if (!Object.keys(me.placement || {}).length) { return; }
+			me.resetPlacement();
 		});
 	};
 

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4EvidenceOverlay.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4EvidenceOverlay.js
@@ -1,0 +1,435 @@
+//
+// PA_Step4EvidenceOverlay.js
+//
+// Draws MORE regulator -> target relationships as an evidence layer on top of
+// a pathway diagram, and accounts out loud for everything it cannot draw.
+//
+// DESIGN CONSTRAINTS, ALL MEASURED
+// --------------------------------
+// The diagram underneath is a raster PNG. The application never parsed KGML
+// <relation>/<reaction>, so it has no idea where KEGG's own arrows, boxes and
+// labels sit -- there is no routing, no collision avoidance, and no way to ask
+// whether an edge is already drawn. Three consequences shape everything here:
+//
+//   1. AN OVERLAY EDGE MUST NOT LOOK LIKE A PATHWAY EDGE. A dark straight line
+//      between two box centres reads as curated KEGG biology. Every edge here
+//      is therefore a consistently-bowed arc in a single alien hue (violet --
+//      chosen because red and blue already encode coefficient sign in the MORE
+//      network view, and red/gold/green are spent on the box corner glyphs).
+//      Class is encoded by TEXTURE within that one hue, so the whole layer
+//      reads as one foreign thing rather than three competing ones.
+//
+//   2. FEW EDGES, ALWAYS. The readable ceiling measured on real mouse maps is
+//      5-8 edges: crossings per edge passes 1.0 between N=5 and N=10, and
+//      bowing the edges changes that by under 8%. The server caps and ranks;
+//      this view states what the cap hid rather than hiding it silently.
+//
+//   3. ENDPOINTS ARE OFTEN NOT GENES. Features bucket by the literal string
+//      x + "#" + y, so co-located genes share one drawn box, and a box holding
+//      more than five features is silently replaced by a PCA metagene. An
+//      arrowhead cannot disambiguate a 46x17 px box holding six genes, so an
+//      edge landing on a shared box gets a hollow BADGE terminal instead of an
+//      arrowhead, and says so in its tooltip.
+//
+// Anchoring is at the box perimeter, never the centre, so an edge never
+// disappears under the omics sprite it points at.
+//
+function PA_Step4EvidenceOverlay() {
+
+	/** One hue, three textures. See constraint 1 above. */
+	this.CLASS_STYLE = {
+		corroborated: {stroke: "#5B1A8B", width: 2.4, dash: null,    opacity: 0.95},
+		novel:        {stroke: "#8E44AD", width: 2.2, dash: "8,4",   opacity: 0.92},
+		unsupported:  {stroke: "#B39DDB", width: 1.6, dash: "1.5,4", opacity: 0.8}
+	};
+
+	this.CLASS_LABEL = {
+		corroborated: "Corroborated &mdash; literature reports this interaction",
+		novel:        "Novel &mdash; both proteins known, no reported interaction",
+		unsupported:  "Unsupported &mdash; no external evidence either way"
+	};
+
+	this.CLASS_ORDER = ["corroborated", "novel", "unsupported"];
+
+	this.group = null;
+	this.legendEl = null;
+	this.payload = null;
+	this.visible = true;
+
+	/**
+	* @param {Object} options
+	*   canvas            {SVG.Doc}  the live svg.js canvas the diagram drew into
+	*   panelEl           {jQuery}   the .lateralOptionsPanel-body to hang the legend on
+	*   jobID             {String}
+	*   pathwayID         {String}
+	*   graphicalOptions  {PathwayGraphicalData}
+	*   adjustFactor      {Number}   raster scale already applied to every box
+	*   boxOccupancy      {Object}   "x#y" -> number of features sharing that box
+	*   onReady           {Function} optional, called with the payload
+	*/
+	this.render = function(options) {
+		var me = this;
+		this.options = options;
+
+		$.ajax({
+			method: "POST",
+			url: SERVER_URL_PA_PATHWAY_EVIDENCE,
+			data: JSON.stringify({
+				jobID: options.jobID,
+				pathwayID: options.pathwayID,
+				maxEdges: options.maxEdges || 8
+			}),
+			dataType: "json",
+			contentType: "application/json",
+			success: function(response) {
+				if (!response || response.success !== true) {
+					/* A job with no MORE analysis is the common case, not an
+					   error: stay silent rather than showing an empty legend. */
+					console.info("Evidence overlay: no evidence for " + options.pathwayID);
+					return;
+				}
+				me.payload = response;
+				try {
+					me.draw();
+				} catch (error) {
+					console.error("Evidence overlay failed to draw", error);
+				}
+				if (options.onReady) { options.onReady(response); }
+			},
+			error: function() {
+				console.warn("Evidence overlay: request failed for " + options.pathwayID);
+			}
+		});
+
+		return this;
+	};
+
+	/**
+	* Centre and half-extents of a feature's drawn box, in canvas coordinates.
+	*
+	* Mirrors PA_Step4KeggDiagramFeatureSetSVGBox exactly, including its
+	* `|| 20` fallback: every MapMan feature is stored with width = height = 0
+	* (the builder defaults the missing XML attribute), so without the fallback
+	* every MapMan endpoint would collapse to a zero-size box at the origin.
+	*/
+	this.boxGeometry = function(featureID) {
+		var graphical = this.options.graphicalOptions.findFeatureGraphicalData(featureID);
+		if (!graphical || !graphical.length) { return null; }
+
+		var data = graphical[0];
+		var factor = this.options.adjustFactor;
+		var width = (data.getBoxWidth() * factor) || 20;
+		var height = (data.getBoxHeight() * factor) || 20;
+
+		return {
+			cx: data.getX() * factor,
+			cy: data.getY() * factor,
+			halfWidth: width / 2,
+			halfHeight: height / 2,
+			key: data.getX() + "#" + data.getY(),
+			boxes: graphical.length
+		};
+	};
+
+	/**
+	* Where a ray leaving `box` toward (tx, ty) crosses the box perimeter.
+	*
+	* Anchoring at the centre would run the first and last few pixels of every
+	* edge underneath the omics sprite, which is opaque -- the edge would appear
+	* to stop short of the thing it points at.
+	*/
+	this.perimeterPoint = function(box, tx, ty, gap) {
+		var dx = tx - box.cx, dy = ty - box.cy;
+		if (dx === 0 && dy === 0) { return {x: box.cx, y: box.cy}; }
+
+		var scaleX = dx === 0 ? Infinity : box.halfWidth / Math.abs(dx);
+		var scaleY = dy === 0 ? Infinity : box.halfHeight / Math.abs(dy);
+		var scale = Math.min(scaleX, scaleY);
+		var length = Math.sqrt(dx * dx + dy * dy);
+		var extra = (gap || 0) / length;
+
+		return {x: box.cx + dx * (scale + extra), y: box.cy + dy * (scale + extra)};
+	};
+
+	/**
+	* Quadratic control point, bowed consistently to one side of the chord.
+	*
+	* Consistency is the whole point: a systematically curved layer cannot be
+	* confused with the straight printed connectors on the map underneath. The
+	* bow is proportional to the chord so short edges stay legible and long ones
+	* do not balloon.
+	*/
+	this.controlPoint = function(from, to) {
+		var dx = to.x - from.x, dy = to.y - from.y;
+		var length = Math.sqrt(dx * dx + dy * dy) || 1;
+		var bow = Math.max(14, Math.min(length * 0.16, 70));
+
+		return {
+			x: (from.x + to.x) / 2 - (dy / length) * bow,
+			y: (from.y + to.y) / 2 + (dx / length) * bow
+		};
+	};
+
+	/**
+	* Create an SVG element directly, bypassing svg.js.
+	*
+	* svg.js 2.0.5 parses a path's `d` by assigning it to a scratch <path> and
+	* reading `.pathSegList`, an API Chrome REMOVED in version 48. Every call to
+	* its .path() therefore dies with
+	*     TypeError: Cannot read properties of undefined (reading 'numberOfItems')
+	* in any current browser -- which is almost certainly why this application
+	* has never drawn a single vector primitive on a pathway diagram. The rest
+	* of svg.js (images, groups, viewbox, pan/zoom) is untouched by this and
+	* keeps working; only geometry has to be built by hand.
+	*/
+	this.svgEl = function(tag, attributes) {
+		var element = document.createElementNS("http://www.w3.org/2000/svg", tag);
+		for (var name in attributes) {
+			if (attributes[name] !== null && attributes[name] !== undefined) {
+				element.setAttribute(name, attributes[name]);
+			}
+		}
+		return element;
+	};
+
+	this.append = function(tag, attributes) {
+		var element = this.svgEl(tag, attributes);
+		this.group.appendChild(element);
+		return element;
+	};
+
+	/** Arrowhead / badge polygon at the target end, oriented along the tangent. */
+	this.terminal = function(to, control, style, shared) {
+		var dx = to.x - control.x, dy = to.y - control.y;
+		var length = Math.sqrt(dx * dx + dy * dy) || 1;
+		var ux = dx / length, uy = dy / length;
+		var size = shared ? 5 : 7;
+		var baseX = to.x - ux * size, baseY = to.y - uy * size;
+		var normalX = -uy * size * 0.55, normalY = ux * size * 0.55;
+
+		if (shared) {
+			/* The box holds several genes (or is a PCA metagene), so this edge
+			   cannot honestly claim WHICH one it acts on. A hollow square says
+			   "somewhere in this box" where an arrowhead would over-claim. */
+			var half = size * 0.85;
+			return this.append("rect", {
+				x: to.x - half, y: to.y - half,
+				width: half * 2, height: half * 2,
+				fill: "none", stroke: style.stroke, "stroke-width": 1.6,
+				opacity: style.opacity
+			});
+		}
+
+		return this.append("polygon", {
+			points: [to.x + "," + to.y,
+					 (baseX + normalX) + "," + (baseY + normalY),
+					 (baseX - normalX) + "," + (baseY - normalY)].join(" "),
+			fill: style.stroke,
+			opacity: style.opacity
+		});
+	};
+
+	this.tooltip = function(element, text) {
+		var title = document.createElementNS("http://www.w3.org/2000/svg", "title");
+		title.textContent = text;
+		element.appendChild(title);
+	};
+
+	this.edgeTooltip = function(edge, shared) {
+		var lines = [
+			edge.regulatorLabel + "  →  " + edge.targetLabel,
+			this.CLASS_LABEL[edge.evidenceClass].replace(/&mdash;/g, "—"),
+			"coefficient " + (edge.coefficient > 0 ? "+" : "") +
+				Number(edge.coefficient).toFixed(4) + "  (" + edge.condition + ")",
+			"omic: " + (edge.omic || "—")
+		];
+
+		if (edge.targetR2 !== null && edge.targetR2 !== undefined) {
+			/* R2 is merged into MORE's table BY TARGET, so every relationship of
+			   one target carries the same value. Labelling it as the edge's fit
+			   would be wrong. */
+			lines.push("R² " + Number(edge.targetR2).toFixed(3) +
+				"  (fit of the target's whole model, not of this link)");
+		}
+
+		if (edge.references && edge.references.length) {
+			lines.push("cited by: " + edge.references.slice(0, 4).map(function(reference) {
+				return (reference.resource ? reference.resource + " " : "") +
+					(reference.pmid ? "PMID:" + reference.pmid : "");
+			}).join(", "));
+		} else if (edge.evidenceClass === "corroborated") {
+			lines.push("literature records this interaction; reinstall OmniPath " +
+				"to carry its PMIDs");
+		}
+
+		if (shared) {
+			lines.push("⚠ the target box holds several genes — this link " +
+				"cannot say which one");
+		}
+		if (edge.regulatorBoxes > 1 || edge.targetBoxes > 1) {
+			lines.push("⚠ an endpoint is drawn at several places on this map; " +
+				"one was chosen");
+		}
+
+		return lines.join("\n");
+	};
+
+	this.draw = function() {
+		var me = this;
+		var edges = (this.payload && this.payload.edges) || [];
+
+		this.clear();
+		/* Appended last, so the layer paints ABOVE the omics sprites. SVG has no
+		   z-index; document order IS the stacking order. */
+		this.group = this.svgEl("g", {"class": "evidenceOverlay"});
+		this.options.canvas.node.appendChild(this.group);
+
+		var drawn = 0, badged = 0;
+		edges.forEach(function(edge) {
+			var fromBox = me.boxGeometry(edge.regulatorID);
+			var toBox = me.boxGeometry(edge.targetID);
+			if (!fromBox || !toBox) { return; }
+
+			var from = me.perimeterPoint(fromBox, toBox.cx, toBox.cy, 2);
+			var to = me.perimeterPoint(toBox, fromBox.cx, fromBox.cy, 4);
+			var control = me.controlPoint(from, to);
+			var style = me.CLASS_STYLE[edge.evidenceClass] || me.CLASS_STYLE.unsupported;
+
+			var occupancy = (me.options.boxOccupancy || {})[toBox.key] || 1;
+			var shared = occupancy > 1;
+
+			/* A white casing drawn UNDER the arc keeps it legible where it
+			   crosses the map's own printed lines and labels -- which the
+			   application cannot see, so it cannot route around them. Thin
+			   enough to read as a halo rather than as an erasure. */
+			me.append("path", {
+				d: "M" + from.x + "," + from.y +
+				   " Q" + control.x + "," + control.y + " " + to.x + "," + to.y,
+				fill: "none", stroke: "#ffffff",
+				"stroke-width": style.width + 2.4,
+				"stroke-linecap": "round", opacity: 0.65
+			});
+
+			var path = me.append("path", {
+				d: "M" + from.x + "," + from.y +
+				   " Q" + control.x + "," + control.y + " " + to.x + "," + to.y,
+				fill: "none", stroke: style.stroke,
+				"stroke-width": style.width,
+				"stroke-linecap": "round",
+				"stroke-dasharray": style.dash,
+				opacity: style.opacity
+			});
+
+			var head = me.terminal(to, control, style, shared);
+			var tip = me.edgeTooltip(edge, shared);
+			me.tooltip(path, tip);
+			me.tooltip(head, tip);
+			drawn++;
+			if (shared) { badged++; }
+		});
+
+		this.renderLegend(drawn, badged);
+	};
+
+	this.renderLegend = function(drawn, badged) {
+		var statistics = (this.payload && this.payload.statistics) || {};
+		var byClass = statistics.byClass || {};
+		var me = this;
+
+		if (this.legendEl) { this.legendEl.remove(); }
+		if (!statistics.totalRelationships) { return; }
+
+		var rows = this.CLASS_ORDER.map(function(name) {
+			var style = me.CLASS_STYLE[name];
+			var dash = style.dash ? ' stroke-dasharray="' + style.dash + '"' : "";
+			return '<li>' +
+				'<svg width="34" height="10" aria-hidden="true">' +
+				'  <path d="M2,8 Q17,0 32,6" fill="none" stroke="' + style.stroke +
+				'" stroke-width="' + style.width + '"' + dash + ' stroke-linecap="round"/>' +
+				'</svg>' +
+				'<span class="evidenceLegend-name">' + me.CLASS_LABEL[name] + '</span>' +
+				'<span class="evidenceLegend-count">' + (byClass[name] || 0) + '</span>' +
+				'</li>';
+		}).join("");
+
+		/* Everything the layer could NOT draw, stated on screen. A silently
+		   truncated overlay reads as "this is all there is". */
+		var omissions = [];
+		if (statistics.hidden) {
+			omissions.push(statistics.hidden + " more on this map are hidden by the " +
+				drawn + "-edge readability cap");
+		}
+		if (statistics.offMapRegulators) {
+			omissions.push(statistics.offMapRegulators.toLocaleString() +
+				" relationships have a regulator with no box on this map");
+		}
+		if (badged) {
+			/* Counted from what was actually DRAWN, not from the server's
+			   multiBoxEndpoints -- that statistic counts a gene appearing in
+			   several boxes, which is the opposite situation and would put a
+			   number here that does not match the hollow terminals on screen. */
+			omissions.push(badged + (badged === 1
+				? " edge ends on a box holding several genes"
+				: " edges end on a box holding several genes") +
+				" and cannot say which one (hollow terminal)");
+		}
+		if (statistics.multiBoxEndpoints) {
+			omissions.push(statistics.multiBoxEndpoints +
+				" had an endpoint drawn at several places on this map; one was chosen");
+		}
+
+		var html =
+			/* No data-guides="ignore" here on purpose. The card sits in flow at
+			   the panel body's own content edge -- measured identical to the
+			   panel <h2>'s rail -- so it can be CHECKED by the alignment guides
+			   rather than exempted from them, and a future regression will show
+			   up in the HUD instead of hiding behind the opt-out. */
+			'<div class="evidenceLegend">' +
+			'  <div class="evidenceLegend-header">' +
+			'    <span class="evidenceLegend-title">Evidence overlay</span>' +
+			'    <a href="javascript:void(0)" class="evidenceLegend-toggle" ' +
+			'       title="Show or hide the evidence overlay">hide</a>' +
+			'  </div>' +
+			'  <ul class="evidenceLegend-list">' + rows + '</ul>' +
+			(omissions.length
+				? '<p class="evidenceLegend-note">' + omissions.join("<br>") + '</p>'
+				: "") +
+			'  <p class="evidenceLegend-source">from this job\'s MORE analysis, ' +
+			'classified against OmniPath</p>' +
+			'</div>';
+
+		this.legendEl = $(html);
+		this.options.panelEl.append(this.legendEl);
+		this.legendEl.find(".evidenceLegend-toggle").click(function() {
+			me.setVisible(!me.visible);
+			$(this).text(me.visible ? "hide" : "show");
+		});
+	};
+
+	this.setVisible = function(visible) {
+		this.visible = visible;
+		if (this.group) {
+			this.group.style.display = visible ? "" : "none";
+		}
+		return this;
+	};
+
+	this.clear = function() {
+		if (this.group) {
+			try {
+				if (this.group.parentNode) {
+					this.group.parentNode.removeChild(this.group);
+				}
+			} catch (error) { /* canvas already gone */ }
+			this.group = null;
+		}
+	};
+
+	this.destroy = function() {
+		this.clear();
+		if (this.legendEl) { this.legendEl.remove(); this.legendEl = null; }
+		this.payload = null;
+	};
+
+	return this;
+}

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4Views.js
@@ -1188,9 +1188,22 @@ function PA_Step4KeggDiagramView() {
 							});
 						}
 
+						var diagramPanelEl = $(this.el.dom);
 						me.evidenceOverlay = new PA_Step4EvidenceOverlay().render({
 							canvas: canvas,
-							panelEl: $(this.el.dom).find(".lateralOptionsPanel-body"),
+							/* A FUNCTION, resolved when the card is built: the
+							   Pathway information column is constructed after this
+							   panel, so it does not exist yet at this line. The card
+							   used to go into the diagram panel's own body, which is
+							   as tall as the map -- so it opened below the fold and
+							   its controls were never seen. */
+							panelEl: function() {
+								var column = $("#mainViewCenterPanel")
+									.find(".lateralOptionsPanel-body.findFeaturesContainer");
+								return column.length
+									? column
+									: diagramPanelEl.find(".lateralOptionsPanel-body");
+							},
 							jobID: me.getParent("PA_Step4JobView").getModel().getJobID(),
 							pathwayID: me.getModel().getID(),
 							graphicalOptions: graphicalOptions,
@@ -1203,6 +1216,21 @@ function PA_Step4KeggDiagramView() {
 							itemsByID: itemsByFeatureID,
 							summaries: dataDistributionSummaries,
 							visualOptions: visualOptions,
+							/* Positions the user dragged, kept per pathway inside the
+							   job's own visualOptions -- the same store the colour
+							   scale and visible omics already live in, so a nudge
+							   survives closing the diagram and reopening it. */
+							placement: (visualOptions.evidencePlacement || {})[me.getModel().getID()] || {},
+							onPlacementChange: function(placement) {
+								var pathwayView = me.getParent();
+								var options = pathwayView.getVisualOptions();
+								if (!options.evidencePlacement) { options.evidencePlacement = {}; }
+								options.evidencePlacement[me.getModel().getID()] = placement;
+								pathwayView.setVisualOptions("evidencePlacement",
+															 options.evidencePlacement);
+								pathwayView.getParent().getController().updateStoredVisualOptions(
+									pathwayView.getParent().getModel().getJobID(), options);
+							},
 							maxEdges: 8
 						});
 					} catch (overlayError) {

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4Views.js
@@ -978,6 +978,11 @@ function PA_Step4KeggDiagramView() {
 		for (var i in this.items) {
 			this.items[i].updateObserver();
 		}
+		/* This loop repaints items only. The evidence layer's satellites are
+		   regenerated glyphs that live outside items, so without this they
+		   keep the OLD colour scale after the user hits Apply -- stale data
+		   sitting next to freshly repainted boxes. */
+		if (this.evidenceOverlay) { this.evidenceOverlay.refresh(); }
 		return this;
 	};
 
@@ -1167,11 +1172,20 @@ function PA_Step4KeggDiagramView() {
 					   CLIENT rule; the overlay needs it to decide whether an edge may
 					   claim an arrowhead or must settle for a badge. */
 					try {
-						var boxOccupancy = {};
+						var boxOccupancy = {}, itemsByFeatureID = {};
 						for (var occupancyIdx in me.items) {
-							var occupancyModel = me.items[occupancyIdx].getModel();
+							var occupancyItem = me.items[occupancyIdx];
+							var occupancyModel = occupancyItem.getModel();
 							boxOccupancy[occupancyModel.getX() + "#" + occupancyModel.getY()] =
 								(occupancyModel.getFeatures() || []).length;
+							/* Index by the graphical ID the evidence payload speaks, not by
+							   feature name: the server returns canonical IDs. */
+							(occupancyModel.getFeatures() || []).forEach(function(setElem) {
+								try {
+									var gd = setElem.getFeatureGraphicalData();
+									if (gd && gd.getID()) { itemsByFeatureID[gd.getID()] = occupancyItem; }
+								} catch (indexError) { /* no graphical data: nothing to park */ }
+							});
 						}
 
 						me.evidenceOverlay = new PA_Step4EvidenceOverlay().render({
@@ -1182,6 +1196,13 @@ function PA_Step4KeggDiagramView() {
 							graphicalOptions: graphicalOptions,
 							adjustFactor: adjustFactor,
 							boxOccupancy: boxOccupancy,
+							/* The placer needs the real geometry of every painted box to
+							   find free space, and the items themselves to regenerate a
+							   regulator's glyph with its gene symbol baked in. */
+							items: me.items,
+							itemsByID: itemsByFeatureID,
+							summaries: dataDistributionSummaries,
+							visualOptions: visualOptions,
 							maxEdges: 8
 						});
 					} catch (overlayError) {

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4Views.js
@@ -1160,6 +1160,36 @@ function PA_Step4KeggDiagramView() {
 						});
 					}
 
+					/* EVIDENCE OVERLAY -- drawn AFTER the feature boxes so its arcs paint
+					   above the omics sprites (SVG stacking is document order). The
+					   box-occupancy map is built here rather than server-side because the
+					   x#y bucketing that collapses several genes into one drawn box is a
+					   CLIENT rule; the overlay needs it to decide whether an edge may
+					   claim an arrowhead or must settle for a badge. */
+					try {
+						var boxOccupancy = {};
+						for (var occupancyIdx in me.items) {
+							var occupancyModel = me.items[occupancyIdx].getModel();
+							boxOccupancy[occupancyModel.getX() + "#" + occupancyModel.getY()] =
+								(occupancyModel.getFeatures() || []).length;
+						}
+
+						me.evidenceOverlay = new PA_Step4EvidenceOverlay().render({
+							canvas: canvas,
+							panelEl: $(this.el.dom).find(".lateralOptionsPanel-body"),
+							jobID: me.getParent("PA_Step4JobView").getModel().getJobID(),
+							pathwayID: me.getModel().getID(),
+							graphicalOptions: graphicalOptions,
+							adjustFactor: adjustFactor,
+							boxOccupancy: boxOccupancy,
+							maxEdges: 8
+						});
+					} catch (overlayError) {
+						/* Additive by design: a job with no MORE analysis, or any failure
+						   inside the overlay, must never take the diagram down with it. */
+						console.warn("Evidence overlay unavailable:", overlayError);
+					}
+
 					//SOME EVENT HANDLERS
 					$("#hideDiagramPanelButton").click(function() {
 						me.getParent().hideDiagramPanel();
@@ -1195,6 +1225,13 @@ function PA_Step4KeggDiagramView() {
 					if (me.omniPathNetwork) {
 						me.omniPathNetwork.destroy();
 						me.omniPathNetwork = null;
+					}
+
+					if (me.evidenceOverlay) {
+						/* The overlay owns an SVG group and a legend node outside the
+						   Ext component's own markup; neither goes away on its own. */
+						me.evidenceOverlay.destroy();
+						me.evidenceOverlay = null;
 					}
 
 					//REMOVE ALL PA_Step4KeggDiagramFeatureSetView

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -45,7 +45,7 @@
 	     which layers this view's own legend and layout on top of it. -->
 	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=0.8" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
-	<link rel="stylesheet" type="text/css" href="resources/css/evidence-overlay.css?v=0.2" />
+	<link rel="stylesheet" type="text/css" href="resources/css/evidence-overlay.css?v=0.3" />
 	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.7" />
 
 	<!-- Theme, resolved before the first paint.
@@ -140,7 +140,7 @@
 	<!--OMNIPATH PATHWAY NETWORK VIEW (OmniPath ships no diagram; its pathways render as graphs) -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step4OmniPathNetworkView.js?v=0.1"></script>
 	<!--EVIDENCE OVERLAY (MORE relationships drawn on the pathway diagram, classified against OmniPath) -->
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step4EvidenceOverlay.js?v=0.4"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step4EvidenceOverlay.js?v=0.7"></script>
 
 	<!--LAUNCH APPLICATION -->
 	<script type="text/javascript" src="app.js?v=0.2"></script>

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -123,7 +123,7 @@
 	<script type="text/javascript" src="js/libs/svgjs/jquery.svg.pan.zoom.min.js"></script>
 
 	<!--SCRIPTS FOR SERVER CONNECTION CONFIGURATION-->
-	<script type="text/javascript" src="resources/ServerConfiguration.js?v=0.8"></script>
+	<script type="text/javascript" src="resources/ServerConfiguration.js?v=0.9"></script>
 	<!--CUSTOM SENCHA EXTENSIONS-->
 	<script type="text/javascript" src="app/view/common/Util.js?v=2.0"></script>
 	<script type="text/javascript" src="app/view/common/ExtJS_extensions.js?v=0.7"></script>

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -45,7 +45,7 @@
 	     which layers this view's own legend and layout on top of it. -->
 	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=0.8" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
-	<link rel="stylesheet" type="text/css" href="resources/css/evidence-overlay.css?v=0.3" />
+	<link rel="stylesheet" type="text/css" href="resources/css/evidence-overlay.css?v=0.8" />
 	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.7" />
 
 	<!-- Theme, resolved before the first paint.
@@ -140,7 +140,7 @@
 	<!--OMNIPATH PATHWAY NETWORK VIEW (OmniPath ships no diagram; its pathways render as graphs) -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step4OmniPathNetworkView.js?v=0.1"></script>
 	<!--EVIDENCE OVERLAY (MORE relationships drawn on the pathway diagram, classified against OmniPath) -->
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step4EvidenceOverlay.js?v=0.7"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step4EvidenceOverlay.js?v=1.6"></script>
 
 	<!--LAUNCH APPLICATION -->
 	<script type="text/javascript" src="app.js?v=0.2"></script>

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -45,6 +45,7 @@
 	     which layers this view's own legend and layout on top of it. -->
 	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=0.8" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
+	<link rel="stylesheet" type="text/css" href="resources/css/evidence-overlay.css?v=0.2" />
 	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.7" />
 
 	<!-- Theme, resolved before the first paint.
@@ -138,6 +139,8 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js?v=0.7"></script>
 	<!--OMNIPATH PATHWAY NETWORK VIEW (OmniPath ships no diagram; its pathways render as graphs) -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step4OmniPathNetworkView.js?v=0.1"></script>
+	<!--EVIDENCE OVERLAY (MORE relationships drawn on the pathway diagram, classified against OmniPath) -->
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step4EvidenceOverlay.js?v=0.4"></script>
 
 	<!--LAUNCH APPLICATION -->
 	<script type="text/javascript" src="app.js?v=0.2"></script>

--- a/PaintomicsClient/public_html/resources/ServerConfiguration.js
+++ b/PaintomicsClient/public_html/resources/ServerConfiguration.js
@@ -45,6 +45,7 @@ SERVER_URL_PA_STEP2 = SERVER_URL + "pa_step2";
 SERVER_URL_PA_STEP3 = SERVER_URL + "pa_step3";
 SERVER_URL_PA_SAVE_IMAGE = SERVER_URL + "pa_save_image";
 SERVER_URL_PA_SAVE_VISUAL_OPTIONS = SERVER_URL + "pa_save_visual_options";
+SERVER_URL_PA_PATHWAY_EVIDENCE = SERVER_URL + "pa_pathway_evidence";
 SERVER_URL_PA_RECOVER_JOB = SERVER_URL + "pa_recover_job";
 SERVER_URL_PA_TOUCH_JOB = SERVER_URL + "pa_touch_job";
 SERVER_URL_PA_SAVE_SHARING_OPTIONS = SERVER_URL + "pa_save_sharing_options";

--- a/PaintomicsClient/public_html/resources/css/evidence-overlay.css
+++ b/PaintomicsClient/public_html/resources/css/evidence-overlay.css
@@ -1,0 +1,124 @@
+/* Evidence overlay -----------------------------------------------------------
+   The legend for the MORE evidence arcs drawn on a pathway diagram.
+
+   Deliberately a panel over the diagram rather than a strip beside it: the
+   diagram sizes itself to the viewport and the panel already scrolls, so a
+   sibling block would push the map out of view on exactly the wide maps the
+   overlay matters most on.
+
+   The KEGG/Reactome artwork underneath is raster with a white canvas baked in
+   and stays light in the dark build (see dark.css). The legend therefore keeps
+   its own light surface in both themes -- it sits ON the artwork, and a dark
+   card floating on white paper would read as a hole, not as chrome. Only the
+   text ink is re-tuned for dark. */
+
+.lateralOptionsPanel-body {
+	/* The legend is positioned against this box. Adding the containing block
+	   here rather than on a wrapper keeps the diagram's own coordinate system
+	   untouched -- svgPanZoom drives the SVG viewBox and never consults the DOM
+	   position of anything. */
+	position: relative;
+}
+
+.evidenceLegend {
+	/* Deliberately IN FLOW below the diagram, not floating on it.
+	   A floating card was tried first and it covered pathway artwork and one of
+	   the overlay's own arrowheads -- occluding the map to explain the thing
+	   drawn on the map is precisely the failure this whole feature is built to
+	   avoid. The panel already reserves imageHeight + 200 px, so the card costs
+	   no diagram space. */
+	margin: 14px 0 0;
+	max-width: 460px;
+	padding: 10px 12px 8px;
+	border: 1px solid rgba(91, 26, 139, 0.28);
+	border-left: 3px solid #5B1A8B;
+	border-radius: 4px;
+	background: rgba(255, 255, 255, 0.955);
+	box-shadow: 0 1px 6px rgba(0, 0, 0, 0.14);
+	font-size: 11px;
+	line-height: 1.45;
+	color: #3a3a3a;
+	pointer-events: auto;
+}
+
+.evidenceLegend-header {
+	display: flex;
+	align-items: baseline;
+	justify-content: space-between;
+	margin-bottom: 6px;
+}
+
+.evidenceLegend-title {
+	font-weight: 600;
+	font-size: 11.5px;
+	letter-spacing: 0.02em;
+	color: #5B1A8B;
+	text-transform: uppercase;
+}
+
+.evidenceLegend-toggle {
+	font-size: 10.5px;
+	color: #7a7a7a;
+	text-decoration: underline;
+}
+
+.evidenceLegend-toggle:hover { color: #5B1A8B; }
+
+.evidenceLegend-list {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.evidenceLegend-list li {
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	padding: 1.5px 0;
+}
+
+.evidenceLegend-list svg { flex: 0 0 34px; }
+
+.evidenceLegend-name {
+	flex: 1 1 auto;
+	/* The class names are long on purpose -- "Corroborated" alone does not say
+	   corroborated BY WHAT, and this legend is the only place the distinction
+	   is ever explained. */
+	font-size: 10.5px;
+}
+
+.evidenceLegend-count {
+	flex: 0 0 auto;
+	min-width: 22px;
+	font-variant-numeric: tabular-nums;
+	text-align: right;
+	font-weight: 600;
+	color: #222;
+}
+
+.evidenceLegend-note {
+	margin: 7px 0 0;
+	padding-top: 6px;
+	border-top: 1px solid rgba(0, 0, 0, 0.09);
+	font-size: 10px;
+	color: #6a6a6a;
+}
+
+.evidenceLegend-source {
+	margin: 5px 0 0;
+	font-size: 9.5px;
+	font-style: italic;
+	color: #8a8a8a;
+}
+
+/* The arcs themselves carry their stroke inline (svg.js writes attributes),
+   so their colour is not themeable from here by design -- they are drawn over
+   raster artwork whose palette does not change between themes either. */
+.evidenceOverlay { pointer-events: visiblePainted; }
+
+[data-theme="dark"] .evidenceLegend {
+	/* Still a light card: it floats on the diagram's white raster. Only the
+	   shadow is deepened so the card separates from the surrounding dark chrome
+	   where it overhangs the artwork. */
+	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+}

--- a/PaintomicsClient/public_html/resources/css/evidence-overlay.css
+++ b/PaintomicsClient/public_html/resources/css/evidence-overlay.css
@@ -1,71 +1,38 @@
 /* Evidence overlay -----------------------------------------------------------
-   The legend for the MORE evidence arcs drawn on a pathway diagram.
+   The control section for the MORE evidence layer drawn on a pathway diagram.
 
-   Deliberately a panel over the diagram rather than a strip beside it: the
-   diagram sizes itself to the viewport and the panel already scrolls, so a
-   sibling block would push the map out of view on exactly the wide maps the
-   overlay matters most on.
+   It lives in the Pathway information column beside the map, NOT under the
+   diagram. Two earlier homes were wrong for measurable reasons: floating on the
+   artwork covered the map (and one of the overlay's own arrowheads) to explain
+   the thing drawn on the map, and hanging it under the diagram put it below the
+   fold -- the panel is as tall as the map, so 240 px of controls opened 18 px
+   from the bottom of a 907 px viewport and were never seen.
 
-   The KEGG/Reactome artwork underneath is raster with a white canvas baked in
-   and stays light in the dark build (see dark.css). The legend therefore keeps
-   its own light surface in both themes -- it sits ON the artwork, and a dark
-   card floating on white paper would read as a hole, not as chrome. Only the
-   text ink is re-tuned for dark. */
-
-.lateralOptionsPanel-body {
-	/* The legend is positioned against this box. Adding the containing block
-	   here rather than on a wrapper keeps the diagram's own coordinate system
-	   untouched -- svgPanZoom drives the SVG viewBox and never consults the DOM
-	   position of anything. */
-	position: relative;
-}
+   Living in that column means WEARING ITS CLOTHES. The column states a section
+   with an <h4> (13px/600), sub-labels with .pa-details-label (10px/600
+   uppercase) and renders pills as .pa-details-chip -- all flat, no borders, no
+   shadows, no tinted panels. This sheet therefore paints almost nothing: it
+   sizes the legend rows and the two buttons and otherwise inherits, so the
+   section reads as part of the panel and re-themes with it instead of holding
+   a light card against a dark chrome. Violet is kept ONLY where it carries
+   meaning -- the three stroke samples, which are the key to the marks on the
+   map -- and for the layer's own <b> emphasis in the drag hint. */
 
 .evidenceLegend {
-	/* Deliberately IN FLOW below the diagram, not floating on it.
-	   A floating card was tried first and it covered pathway artwork and one of
-	   the overlay's own arrowheads -- occluding the map to explain the thing
-	   drawn on the map is precisely the failure this whole feature is built to
-	   avoid. The panel already reserves imageHeight + 200 px, so the card costs
-	   no diagram space. */
-	margin: 14px 0 0;
-	max-width: 460px;
-	padding: 10px 12px 8px;
-	border: 1px solid rgba(91, 26, 139, 0.28);
-	border-left: 3px solid #5B1A8B;
-	border-radius: 4px;
-	background: rgba(255, 255, 255, 0.955);
-	box-shadow: 0 1px 6px rgba(0, 0, 0, 0.14);
+	margin: 4px 0 14px;
 	font-size: 11px;
 	line-height: 1.45;
-	color: #3a3a3a;
-	pointer-events: auto;
+	color: #3f3f46;
 }
 
-.evidenceLegend-header {
-	display: flex;
-	align-items: baseline;
-	justify-content: space-between;
-	margin-bottom: 6px;
+.evidenceLegend h4 {
+	/* Left to the panel's own h4 rule (13px/600, #1a1a18, margin 16px 0 6px) so
+	   this section's title cannot drift from "Search in this pathway" above it. */
+	margin-bottom: 2px;
 }
-
-.evidenceLegend-title {
-	font-weight: 600;
-	font-size: 11.5px;
-	letter-spacing: 0.02em;
-	color: #5B1A8B;
-	text-transform: uppercase;
-}
-
-.evidenceLegend-toggle {
-	font-size: 10.5px;
-	color: #7a7a7a;
-	text-decoration: underline;
-}
-
-.evidenceLegend-toggle:hover { color: #5B1A8B; }
 
 .evidenceLegend-list {
-	margin: 0;
+	margin: 6px 0 0;
 	padding: 0;
 	list-style: none;
 }
@@ -73,42 +40,117 @@
 .evidenceLegend-list li {
 	display: flex;
 	align-items: center;
-	gap: 7px;
-	padding: 1.5px 0;
+	gap: 8px;
+	padding: 2px 0;
 }
 
 .evidenceLegend-list svg { flex: 0 0 34px; }
 
 .evidenceLegend-name {
 	flex: 1 1 auto;
-	/* The class names are long on purpose -- "Corroborated" alone does not say
-	   corroborated BY WHAT, and this legend is the only place the distinction
-	   is ever explained. */
-	font-size: 10.5px;
+	/* The column is 300 px wide, so these wrap rather than pushing the count
+	   off the row. The class names are long on purpose -- "Corroborated" alone
+	   does not say corroborated BY WHAT, and this is the only place the
+	   distinction is ever explained. */
+	min-width: 0;
+	font-size: 11px;
 }
 
 .evidenceLegend-count {
 	flex: 0 0 auto;
-	min-width: 22px;
+	min-width: 20px;
 	font-variant-numeric: tabular-nums;
 	text-align: right;
 	font-weight: 600;
-	color: #222;
+	color: #18181b;
+}
+
+.evidenceLegend-sources {
+	margin: 7px 0 0;
+	font-size: 10px;
+	color: #71717a;
+}
+
+.evidenceLegend-source-name {
+	/* Not .pa-details-label: that rule uppercases, and "OMNIPATH" / "REACTOME"
+	   are not how either database writes its own name. */
+	font-weight: 600;
+	color: #3f3f46;
+}
+
+.evidenceLegend-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin: 10px 0 0;
+}
+
+.evidenceLegend-button {
+	/* The chip surface the classification pills already use, at the
+	   twoOptionsButton type size and radius. Neither control is the panel's
+	   primary action, so neither takes the blue that .btn-info spends on
+	   Search. */
+	flex: 1 1 auto;
+	padding: 5px 9px;
+	border: 1px solid rgba(24, 24, 27, 0.1);
+	border-radius: 6px;
+	background: #f3f2ed;
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 1.2;
+	text-align: center;
+	text-decoration: none;
+	color: #3f3f46;
+	white-space: nowrap;
+}
+
+.evidenceLegend-button:hover {
+	background: #e9e7df;
+	color: #18181b;
+	text-decoration: none;
+}
+
+.evidenceLegend-button i { margin-right: 4px; }
+
+.evidenceLegend-toggle.is-off {
+	/* The layer is hidden: say so on the control, so a blank map is explained
+	   by the button that caused it rather than looking like a failure. */
+	border-style: dashed;
+	background: transparent;
+}
+
+.evidenceLegend-reset.is-disabled {
+	/* Present but inert until something has been dragged. Hiding it instead
+	   would make the control appear only after the gesture that needs it is
+	   already finished, which is the wrong time to learn it exists. */
+	border-color: rgba(24, 24, 27, 0.07);
+	background: transparent;
+	color: #b6b6b6;
+	cursor: default;
+	pointer-events: none;
 }
 
 .evidenceLegend-note {
-	margin: 7px 0 0;
-	padding-top: 6px;
-	border-top: 1px solid rgba(0, 0, 0, 0.09);
+	margin: 9px 0 0;
 	font-size: 10px;
-	color: #6a6a6a;
+	line-height: 1.45;
+	color: #71717a;
 }
 
+.evidenceLegend-hint {
+	/* The one instruction that cannot be discovered by looking: nothing about a
+	   violet box says it can be picked up. Emphasis only -- a tinted panel here
+	   was the loudest thing in a column that has no panels in it. */
+	color: #52525b;
+}
+
+.evidenceLegend-hint b { color: #5B1A8B; }
+
 .evidenceLegend-source {
-	margin: 5px 0 0;
+	margin: 6px 0 0;
 	font-size: 9.5px;
 	font-style: italic;
-	color: #8a8a8a;
+	color: #a1a1aa;
 }
 
 /* The arcs themselves carry their stroke inline (svg.js writes attributes),
@@ -126,9 +168,20 @@
 .evidenceOverlay polygon,
 .evidenceOverlay image { pointer-events: visiblePainted; }
 
-[data-theme="dark"] .evidenceLegend {
-	/* Still a light card: it floats on the diagram's white raster. Only the
-	   shadow is deepened so the card separates from the surrounding dark chrome
-	   where it overhangs the artwork. */
-	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.5);
+.evidenceSatellite {
+	/* Automatic placement is blind to the map's free text -- none of it is an
+	   entry in any file the application reads -- so the reader gets to move a
+	   box that lands badly. touch-action must be none or a touch drag scrolls
+	   the panel instead of moving the satellite. */
+	cursor: move;
+	touch-action: none;
 }
+
+.evidenceSatellite:hover rect[stroke] {
+	stroke-width: 1.8;
+}
+
+/* No dark override. The section now lives inside the Pathway information
+   column and paints no surface of its own, so it inherits whatever dark.css
+   does to that panel. The previous rule deepened a light card's shadow, which
+   only made sense while the card floated on the diagram's white raster. */

--- a/PaintomicsClient/public_html/resources/css/evidence-overlay.css
+++ b/PaintomicsClient/public_html/resources/css/evidence-overlay.css
@@ -114,7 +114,17 @@
 /* The arcs themselves carry their stroke inline (svg.js writes attributes),
    so their colour is not themeable from here by design -- they are drawn over
    raster artwork whose palette does not change between themes either. */
-.evidenceOverlay { pointer-events: visiblePainted; }
+/* The overlay group is appended AFTER every feature <image>, so it sits on
+   top of the real boxes in SVG's document-order stacking. Left hit-testable as
+   a whole it would silently swallow the hover and click of any feature box a
+   satellite overlaps -- a dead tooltip, with no visible defect to notice. The
+   group is therefore transparent to the pointer and each drawn shape opts back
+   in individually. */
+.evidenceOverlay { pointer-events: none; }
+.evidenceOverlay path,
+.evidenceOverlay rect,
+.evidenceOverlay polygon,
+.evidenceOverlay image { pointer-events: visiblePainted; }
 
 [data-theme="dark"] .evidenceLegend {
 	/* Still a light card: it floats on the diagram's white raster. Only the

--- a/PaintomicsServer/src/AdminTools/DBManager.py
+++ b/PaintomicsServer/src/AdminTools/DBManager.py
@@ -969,6 +969,13 @@ def replaceNewVersionData(origin, destination, dirname, backup_dir, isRestore=Fa
             "pathways_network_Reactome.json",
             "MAPMAN_VERSION", "MAPMAN_MAPPING", "gene2pathway_mapman.list",
             "pathways_network_MapMan.json",
+            # OmniPath is installed by its own tool (omnipathInstaller.py), not
+            # by the download/build pipeline, so a staged tree legitimately
+            # lacks these while the installed tree has them. Without the
+            # exemption every species that has ever had OmniPath installed --
+            # mmu here -- fails promotion with PromotionRefused and silently
+            # keeps stale data.
+            "gene2pathway_omnipath.list", "pathways_network_OmniPath.json",
             # Not generated, but never worth refusing a promotion over: an
             # INSTALLED tree is never legitimately mid-download, so a
             # DOWNLOADING flag inside one is cruft from a historically

--- a/PaintomicsServer/src/AdminTools/omnipathInstaller.py
+++ b/PaintomicsServer/src/AdminTools/omnipathInstaller.py
@@ -63,6 +63,7 @@ Usage
 import argparse
 import collections
 import csv
+import hashlib
 import io
 import json
 import logging
@@ -186,7 +187,13 @@ def fetch_interactions(taxid):
     """
     body = _fetch("interactions", {
         "genesymbols": "1", "format": "tsv", "organisms": str(taxid),
-        "fields": "references", "datasets": DATASETS,
+        # `sources` and `curation_effort` ride along on the same request.
+        # references was already fetched but only ever used to vote on
+        # orthologs; it is now stored, so an interaction shown to a user can
+        # cite the papers it came from. curation_effort is the only per-edge
+        # ranking key OmniPath offers, and a literature layer needs one --
+        # the raw graph puts a median of 211 edges on a KEGG map.
+        "fields": "references,sources,curation_effort", "datasets": DATASETS,
     })
     interactions = []
     for row in _rows(body):
@@ -200,9 +207,19 @@ def fetch_interactions(taxid):
             "target_symbol": row.get("target_genesymbol") or target,
             "sign": _sign(row),
             "references": row.get("references") or "",
+            "sources": row.get("sources") or "",
+            "curation_effort": _int_or_zero(row.get("curation_effort")),
         })
     logger.info("taxid %s: %d interactions", taxid, len(interactions))
     return interactions
+
+
+def _int_or_zero(value):
+    """OmniPath renders a missing numeric cell as an empty string or 'nan'."""
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return 0
 
 
 def _sign(row):
@@ -317,7 +334,15 @@ def build_pathways(interactions, annotations_by_resource, ortholog_map=None):
     adjacency = collections.defaultdict(dict)
     symbols = {}
     for interaction in interactions:
-        adjacency[interaction["source"]][interaction["target"]] = interaction["sign"]
+        # The stored value is the whole provenance triple, not just the sign.
+        # Storing [source, target, sign] alone meant an edge presented to a
+        # user as "reported in the literature" could cite nothing and could
+        # not be ranked.
+        adjacency[interaction["source"]][interaction["target"]] = (
+            interaction["sign"],
+            interaction.get("references", ""),
+            interaction.get("curation_effort", 0),
+        )
         symbols[interaction["source"]] = interaction["source_symbol"]
         symbols[interaction["target"]] = interaction["target_symbol"]
 
@@ -341,10 +366,13 @@ def build_pathways(interactions, annotations_by_resource, ortholog_map=None):
                 continue
 
             pathway_id = _pathway_id(resource, name)
+            # [source, target, sign, references, curation_effort]. Consumers
+            # written against the original three-element form keep working --
+            # PA_Step4OmniPathNetworkView reads only indices 0..2.
             edges = [
-                [source, target, sign]
+                [source, target, provenance[0], provenance[1], provenance[2]]
                 for source in sorted(members)
-                for target, sign in sorted(adjacency.get(source, {}).items())
+                for target, provenance in sorted(adjacency.get(source, {}).items())
                 if target in members
             ]
 
@@ -471,7 +499,7 @@ def layout(node_ids, edges, iterations=220, seed=20260818):
     positions = generator.rand(count, 2).astype(numpy.float64)
 
     adjacency = numpy.zeros((count, count), dtype=numpy.float64)
-    for source, target, _sign in edges:
+    for source, target, _sign, *_provenance in edges:
         i, j = index[source], index[target]
         adjacency[i, j] = adjacency[j, i] = 1.0
 
@@ -607,7 +635,13 @@ def _pathway_id(resource, name):
     silently rewritten into another pathway's.
     """
     slug = "".join(character if character.isalnum() else "" for character in name)
-    return "op%s%s" % (resource[:2].lower(), slug[:40] or str(abs(hash(name)) % 10 ** 8))
+    # md5, not hash(): CPython salts str hashing per process (PYTHONHASHSEED),
+    # so the built-in fallback produced a DIFFERENT id on every reinstall and
+    # orphaned every saved job that referenced the pathway. Only names with no
+    # alphanumeric characters at all reach this branch, but a silently moving
+    # identifier is not an acceptable failure mode for one.
+    digest = hashlib.md5(name.encode("utf-8")).hexdigest()[:8]
+    return "op%s%s" % (resource[:2].lower(), slug[:40] or digest)
 
 
 # ---------------------------------------------------------------------------

--- a/PaintomicsServer/src/AdminTools/scripts/common_build_database.py
+++ b/PaintomicsServer/src/AdminTools/scripts/common_build_database.py
@@ -3284,11 +3284,91 @@ def runMongoImport(database, collection, filePath):
     check_call(command, shell=True)
 
 
+# Pathway sources this builder produces. Anything else found in the shared
+# `kegg` collection was put there by a separate installer and must survive a
+# rebuild -- see preserveForeignPathways().
+BUILDER_PATHWAY_SOURCES = ("KEGG", "Reactome", "MapMan")
+
+FOREIGN_PATHWAY_BACKUP = "/tmp/foreign_pathways.tmp"
+
+
+def preserveForeignPathways(database):
+    """Stream pathway documents this builder does NOT produce out to disk.
+
+    The `kegg` collection is shared by every pathway source, but only KEGG,
+    Reactome and MapMan are rebuilt here -- and runMongoImport passes --drop.
+    OmniPath scopes its own write to `source: OmniPath` precisely so it cannot
+    damage the others, yet the reverse was never true: a routine KEGG/Reactome
+    rebuild silently deleted all of its documents, and since nothing in the
+    tree calls omnipathInstaller, nothing put them back.
+
+    Documents are streamed through a file rather than held in a list so the
+    cost is bounded by the cursor batch, not by the size of the foreign source.
+    `_id` is preserved via bson.json_util so restored documents keep their
+    identity. Returns the number of documents written.
+    """
+    from bson import json_util
+
+    query = {"source": {"$nin": list(BUILDER_PATHWAY_SOURCES)}}
+    written = 0
+    with open(FOREIGN_PATHWAY_BACKUP, "w") as handle:
+        for document in database.kegg.find(query, no_cursor_timeout=False).batch_size(200):
+            handle.write(json_util.dumps(document))
+            handle.write("\n")
+            written += 1
+
+    stderr.write("  preserved " + str(written) + " non-builder pathway documents\n")
+    return written
+
+
+def restoreForeignPathways(database, expected):
+    """Re-insert the documents preserved by preserveForeignPathways().
+
+    Raises if the count does not match: losing a source silently is exactly the
+    failure this function exists to prevent, so a partial restore must be loud.
+    """
+    if expected == 0:
+        return
+
+    from bson import json_util
+
+    batch, restored = [], 0
+    with open(FOREIGN_PATHWAY_BACKUP, "r") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            batch.append(json_util.loads(line))
+            if len(batch) >= 200:
+                database.kegg.insert_many(batch)
+                restored += len(batch)
+                batch = []
+    if batch:
+        database.kegg.insert_many(batch)
+        restored += len(batch)
+
+    if restored != expected:
+        raise Exception("Restored %d of %d non-builder pathway documents; "
+                        "the shared 'kegg' collection is now incomplete."
+                        % (restored, expected))
+
+    stderr.write("  restored " + str(restored) + " non-builder pathway documents\n")
+
+
 def createDatabase():
     try:
         runMongoImport(SPECIE + "-paintomics", "xref", "/tmp/xref.tmp")
         runMongoImport(SPECIE + "-paintomics", "dbname", "/tmp/dbname.tmp")
+
+        from pymongo import MongoClient as _MongoClient
+        from conf.serverconf import MONGODB_HOST as _HOST, MONGODB_PORT as _PORT
+        _db = _MongoClient(_HOST, _PORT)[SPECIE + "-paintomics"]
+        foreignCount = preserveForeignPathways(_db)
+
         runMongoImport(SPECIE + "-paintomics", "kegg", "/tmp/pathways.tmp")
+
+        restoreForeignPathways(_db, foreignCount)
+
         runMongoImport(SPECIE + "-paintomics", "versions", "/tmp/versions.tmp")
 
         from pymongo import MongoClient, ASCENDING, TEXT

--- a/PaintomicsServer/src/classes/Job.py
+++ b/PaintomicsServer/src/classes/Job.py
@@ -537,8 +537,18 @@ class Job(Model):
                                                                                totalInputRegulators, [],
                                                                                [], [], enrichment)
                 if matchedName is not None and len(matchedName) > 0:
-                    # convert matchedName to a dictionary keyed by the raw input
-                    matchedNameDict = dict(map(lambda x: (x.omicsValues[0].inputName, x), matchedName))
+                    # Group by the raw input name, keeping EVERY match.
+                    #
+                    # This was dict(map(...)), which silently kept only the last
+                    # clone when one symbol resolved to several canonical IDs.
+                    # On the STATegra MORE example that is 180 of 387 regulators,
+                    # 14 of them genuine within-KEGG paralogue collisions
+                    # (Bach1 -> [12013, 237911], Elf1, Med1, Pml). While the ID
+                    # only fed a display line the cost was a wrong label; once a
+                    # regulator's ID chooses map COORDINATES it becomes an arrow
+                    # drawn at the wrong gene, with no visible symptom.
+                    for matched in matchedName:
+                        matchedNameDict.setdefault(matched.omicsValues[0].inputName, []).append(matched)
 
 
         #IF THE USER UPLOADED VALUES FOR GENE EXPRESSION
@@ -624,12 +634,23 @@ class Job(Model):
                                 # primary/secondary so the regulator is the row's
                                 # identifier and the target is context.
                                 omicValueAux.isRegulator = True
-                                if columnID[1] in matchedNameDict.keys():
-                                    matchedReg = matchedNameDict[columnID[1]]
+                                candidates = matchedNameDict.get(columnID[1])
+                                if candidates:
+                                    # Deterministic representative: sorted by canonical
+                                    # ID so the same input always yields the same choice
+                                    # across runs, processes and machines.
+                                    matchedReg = min(candidates, key=lambda match: str(match.ID))
                                     # Symbol resolved — display name becomes the symbol,
                                     # canonical ID is stashed for the details "(AGI)" line.
                                     omicValueAux.setOriginalName(matchedReg.name)
                                     omicValueAux.regulatorID = matchedReg.ID
+                                    if len(candidates) > 1:
+                                        # Several canonical IDs share this symbol. Anything
+                                        # that anchors to the chosen one must be able to say
+                                        # the choice was arbitrary rather than imply it was
+                                        # the only option.
+                                        omicValueAux.regulatorAmbiguousIDs = sorted(
+                                            str(match.ID) for match in candidates)
                                 else:
                                     # No symbol mapping (e.g. miRNA names) — keep the
                                     # raw regulator ID as the display name. regulatorID

--- a/PaintomicsServer/src/classes/PathwayEvidence.py
+++ b/PaintomicsServer/src/classes/PathwayEvidence.py
@@ -271,6 +271,34 @@ class _RegulationTable(object):
             }
 
 
+def _printedObstacles(pathwayDocument):
+    """Large printed boxes the client draws nothing for but must not draw over.
+
+    A KEGG map's cross-pathway links -- the rounded boxes reading "Cell cycle",
+    "MAPK signaling pathway" -- are the biggest printed obstacles on the canvas
+    (21 of them on mmu05200) and the installer has always stored them with full
+    geometry. The client has simply never been sent them: nothing in
+    PaintomicsClient references relatedPathways at all. Anything placing new
+    marks in free space needs them, and they cost one field.
+
+    Coordinates are the box CENTRE, matching the gene entries, and arrive from
+    Mongo as strings because the KGML attributes were never cast.
+    """
+    obstacles = []
+    for related in (pathwayDocument.get("relatedPathways") or []):
+        try:
+            obstacles.append({
+                "x": float(related.get("x")),
+                "y": float(related.get("y")),
+                "width": float(related.get("width")),
+                "height": float(related.get("height")),
+            })
+        except (TypeError, ValueError):
+            # A related pathway without geometry is a link, not a drawn box.
+            continue
+    return obstacles
+
+
 def _drawnFeatureIDs(pathwayDocument):
     """IDs of the genes this pathway actually draws.
 
@@ -303,6 +331,7 @@ def buildPathwayEvidence(jobInstance, pathwayID, condition=None,
         resolveDatabaseIds, findIDsByFeaturesName)
 
     allowedClasses = set(classes) if classes else set(CLASS_PRIORITY)
+    obstacles = []
     organism = jobInstance.getOrganism()
 
     table = _RegulationTable(getattr(jobInstance, "regulationPerConditionData", None))
@@ -320,24 +349,25 @@ def buildPathwayEvidence(jobInstance, pathwayID, condition=None,
     }
 
     if not table.usable:
-        return {"pathwayID": pathwayID, "edges": [], "statistics": statistics}
+        return {"pathwayID": pathwayID, "edges": [], "obstacles": [], "statistics": statistics}
 
     client = MongoClient(MONGODB_HOST, MONGODB_PORT)
     try:
         database = client[organism + "-paintomics"]
         pathwayDocument = database["kegg"].find_one({"ID": pathwayID})
         if pathwayDocument is None:
-            return {"pathwayID": pathwayID, "edges": [], "statistics": statistics}
+            return {"pathwayID": pathwayID, "edges": [], "obstacles": [], "statistics": statistics}
 
         sourceName = pathwayDocument.get("source") or "KEGG"
+        obstacles = _printedObstacles(pathwayDocument)
         drawn = _drawnFeatureIDs(pathwayDocument)
         if not drawn:
-            return {"pathwayID": pathwayID, "edges": [], "statistics": statistics}
+            return {"pathwayID": pathwayID, "edges": [], "obstacles": [], "statistics": statistics}
 
         databaseConvertionIds, _symbolIds = resolveDatabaseIds(organism, [sourceName], database)
         targetDbnameId = databaseConvertionIds.get(sourceName)
         if targetDbnameId is None:
-            return {"pathwayID": pathwayID, "edges": [], "statistics": statistics}
+            return {"pathwayID": pathwayID, "edges": [], "obstacles": [], "statistics": statistics}
 
         relationships = list(table.relationships(condition))
 
@@ -435,4 +465,5 @@ def buildPathwayEvidence(jobInstance, pathwayID, condition=None,
         edges = edges[:maxEdges]
 
     statistics["shown"] = len(edges)
-    return {"pathwayID": pathwayID, "edges": edges, "statistics": statistics}
+    return {"pathwayID": pathwayID, "edges": edges,
+            "obstacles": obstacles, "statistics": statistics}

--- a/PaintomicsServer/src/classes/PathwayEvidence.py
+++ b/PaintomicsServer/src/classes/PathwayEvidence.py
@@ -58,25 +58,183 @@ _KNOWLEDGE_CACHE = {}
 _KNOWLEDGE_CACHE_LIMIT = 4
 
 
-class OmniPathKnowledge(object):
-    """The curated literature interaction graph, in a pathway's own ID space.
+#: Raw interaction graphs in each source's OWN identifier space, keyed by
+#: organism. Built once per process (0.40 s for KEGG, 0.62 s for Reactome on
+#: mouse, measured) because this server is single-process: a rebuild per
+#: request would stall every other user's job.
+_RAW_GRAPH_CACHE = {}
+_RAW_GRAPH_LIMIT = 4
 
-    OmniPath stores UniProt accessions while a KEGG map is drawn in Entrez
-    space, so the graph is translated once through the xref mates table and
-    kept. The translation is measured to be clean rather than merely wide:
-    79.6% of the 1,670 stored mouse accessions reach a drawn KEGG box, only 6
-    accessions fan out to more than one Entrez ID, and the collapse creates no
-    collisions and no self-loops.
+
+def _keggRelationGraph(organism):
+    """Every gene-gene relation KEGG draws for this organism, ANY pathway.
+
+    This is the point of reading it at all. A regulator and its target are
+    routinely joined by KEGG in a DIFFERENT map from the one on screen -- and
+    consulting only OmniPath threw that away. Measured on the STATegra mouse
+    job: of the 492 MORE relationships drawable on some mmu KEGG map, 132
+    (26.8%) are recorded in KEGG's own relation graph while being labelled
+    "novel" (54) or "unsupported" (78), the second of which claims there is no
+    external evidence either way about a curated interaction.
+
+    `maplink` is excluded: it joins an entry to another PATHWAY, not to a gene,
+    so treating it as an interaction would manufacture edges. The remaining
+    types are the ones MORE is actually modelling -- 238 of the hits are GErel
+    (transcriptional) and 245 PPrel (protein-protein).
+
+    Identifiers are KEGG's own (`mmu:15962` -> `15962`), i.e. the space the
+    pathway documents are already stored in.
+
+    @returns {dict} {(a, b): [(relationType, pathwayID), ...]}
+    """
+    import os
+    import glob
+    import xml.etree.ElementTree as ElementTree
+    from src.conf.serverconf import KEGG_DATA_DIR
+
+    graph = {}
+    pattern = os.path.join(KEGG_DATA_DIR, "current", organism, "kgml", "*.kgml")
+    for kgmlPath in glob.glob(pattern):
+        pathwayID = os.path.basename(kgmlPath)[:-len(".kgml")]
+        try:
+            root = ElementTree.parse(kgmlPath).getroot()
+        except Exception:
+            # One unreadable KGML costs its own relations, not the whole graph.
+            continue
+
+        members = {}
+        for entry in root.findall("entry"):
+            if entry.get("type") in ("gene", "ortholog"):
+                members[entry.get("id")] = [name.split(":")[-1]
+                                            for name in (entry.get("name") or "").split()]
+        # Groups are complexes whose members are other entries, so they resolve
+        # only after every gene entry is known.
+        for entry in root.findall("entry"):
+            if entry.get("type") == "group":
+                members[entry.get("id")] = [gene
+                                            for component in entry.findall("component")
+                                            for gene in members.get(component.get("id"), [])]
+
+        for relation in root.findall("relation"):
+            relationType = relation.get("type")
+            if relationType == "maplink":
+                continue
+            for source in members.get(relation.get("entry1"), []):
+                for target in members.get(relation.get("entry2"), []):
+                    if source == target:
+                        continue
+                    graph.setdefault((source, target), []).append((relationType, pathwayID))
+    return graph
+
+
+def _reactomeRelationGraph(organism):
+    """Reactome's catalyst / activator / inhibitor -> output relations.
+
+    Only those three roles. A reaction's input -> output pair is usually the
+    SAME molecule before and after a modification, so reading transformations
+    as interactions would fill the graph with self-claims; the three regulatory
+    roles are the ones that assert one gene product acting on another.
+
+    Honest about its weight: this source rescues 7 of the 491 drawable mouse
+    relationships (1.4%) against KEGG's 132. It is here because it is cheap and
+    it is real, not because it is decisive.
+
+    Identifiers are UniProt accessions -- the same space OmniPath uses, and the
+    one the xref mates table is already proven to translate cleanly.
+
+    @returns {dict} {(a, b): [(role, pathwayStId), ...]}
+    """
+    import os
+    import glob
+    import json
+
+    from src.conf.serverconf import KEGG_DATA_DIR
+
+    graph = {}
+    pattern = os.path.join(KEGG_DATA_DIR, "current", organism, "reactome", "*.graph.json")
+    for graphPath in glob.glob(pattern):
+        try:
+            with open(graphPath) as handle:
+                document = json.load(handle)
+        except Exception:
+            continue
+
+        nodes = {node.get("dbId"): node for node in (document.get("nodes") or [])}
+        resolved = {}
+
+        def accessions(dbId, depth=0):
+            """A node's accessions, following complex membership downwards."""
+            if dbId in resolved:
+                return resolved[dbId]
+            found = set()
+            node = nodes.get(dbId)
+            if node is not None and depth <= 4:
+                identifier = node.get("identifier")
+                if identifier and node.get("referenceType") == "ReferenceGeneProduct":
+                    found.add(identifier)
+                for child in (node.get("children") or []):
+                    found |= accessions(child, depth + 1)
+            resolved[dbId] = found
+            return found
+
+        pathwayStId = document.get("stId") or os.path.basename(graphPath)
+        for reaction in (document.get("edges") or []):
+            outputs = set()
+            for output in (reaction.get("outputs") or []):
+                outputs |= accessions(output)
+            if not outputs:
+                continue
+            for role in ("catalysts", "activators", "inhibitors"):
+                for regulator in (reaction.get(role) or []):
+                    for source in accessions(regulator):
+                        for target in outputs:
+                            if source == target:
+                                continue
+                            graph.setdefault((source, target), []).append((role, pathwayStId))
+    return graph
+
+
+def _rawGraph(kind, organism):
+    """Cached raw graph for one source, or {} when its files are not installed."""
+    cacheKey = (kind, organism)
+    if cacheKey in _RAW_GRAPH_CACHE:
+        return _RAW_GRAPH_CACHE[cacheKey]
+
+    builder = {"KEGG": _keggRelationGraph, "Reactome": _reactomeRelationGraph}[kind]
+    try:
+        graph = builder(organism)
+    except Exception as buildError:
+        # A missing data directory must cost this SOURCE, never the overlay.
+        logging.warning("%s relation graph unavailable for %s: %s",
+                        kind, organism, buildError)
+        graph = {}
+
+    if len(_RAW_GRAPH_CACHE) >= _RAW_GRAPH_LIMIT:
+        _RAW_GRAPH_CACHE.pop(next(iter(_RAW_GRAPH_CACHE)))
+    _RAW_GRAPH_CACHE[cacheKey] = graph
+    return graph
+
+
+class InteractionSource(object):
+    """One curated interaction graph, translated into a pathway's ID space.
+
+    Each source stores UniProt accessions or its own gene ids while a KEGG map
+    is drawn in Entrez space, so every graph is translated once through the
+    xref mates table and kept. The OmniPath translation is measured to be clean
+    rather than merely wide: 79.6% of the 1,670 stored mouse accessions reach a
+    drawn KEGG box, only 6 accessions fan out to more than one Entrez ID, and
+    the collapse creates no collisions and no self-loops.
     """
 
-    def __init__(self, edges, known, sourceName):
-        #: {(a, b): (sign, references, curationEffort)} with BOTH directions
-        #: stored, so a lookup is one dict hit rather than two.
+    def __init__(self, name, edges, known):
+        #: Source label as shown to the reader: "KEGG", "Reactome", "OmniPath".
+        self.name = name
+        #: {(a, b): provenance} with BOTH directions stored, so a lookup is one
+        #: dict hit rather than two.
         self._edges = edges
-        #: Every gene the literature graph has an opinion about. Membership
-        #: here is what separates CLASS_NOVEL from CLASS_UNSUPPORTED.
+        #: Every gene this source has an opinion about. Membership here is what
+        #: separates CLASS_NOVEL from CLASS_UNSUPPORTED.
         self._known = known
-        self.sourceName = sourceName
 
     def __len__(self):
         return len(self._edges)
@@ -85,77 +243,203 @@ class OmniPathKnowledge(object):
         return featureID in self._known
 
     def interaction(self, featureA, featureB):
-        """Return (sign, references, curationEffort) or None.
+        """Return this source's provenance for the pair, or None.
 
-        Direction-agnostic on purpose: MORE asserts a regulatory direction
-        that a curated interaction database need not have recorded the same
-        way round, and claiming "the literature disagrees about direction"
-        from that would be an artefact of two different data models.
+        Direction-agnostic on purpose: MORE asserts a regulatory direction that
+        a curated interaction database need not have recorded the same way
+        round, and claiming "the literature disagrees about direction" from
+        that would be an artefact of two different data models.
         """
         return self._edges.get((featureA, featureB)) or self._edges.get((featureB, featureA))
 
+
+class EvidenceKnowledge(object):
+    """Every interaction source, consulted together.
+
+    Consulting only OmniPath was losing curated biology: measured on the
+    STATegra mouse job, 132 of 492 drawable relationships (26.8%) are recorded
+    in KEGG -- usually in a pathway OTHER than the one on screen -- while being
+    labelled novel or unsupported. The sources are complementary rather than
+    nested: 41 of the 93 OmniPath-corroborated pairs are absent from KEGG, so
+    neither is a superset of the other and the union is the honest question.
+    """
+
+    def __init__(self, sources):
+        self.sources = [source for source in sources if source is not None]
+
+    def __len__(self):
+        return sum(len(source) for source in self.sources)
+
+    def knows(self, featureID):
+        return any(source.knows(featureID) for source in self.sources)
+
+    def interactions(self, featureA, featureB):
+        """[(sourceName, provenance)] for every source recording the pair."""
+        found = []
+        for source in self.sources:
+            provenance = source.interaction(featureA, featureB)
+            if provenance is not None:
+                found.append((source.name, provenance))
+        return found
+
     @classmethod
     def forOrganism(cls, organism, targetDbnameId, jobID, db):
-        """Build (or reuse) the translated graph for one organism/ID space."""
+        """Build (or reuse) all three graphs for one organism/ID space."""
         cacheKey = (organism, str(targetDbnameId))
         if cacheKey in _KNOWLEDGE_CACHE:
             return _KNOWLEDGE_CACHE[cacheKey]
 
-        knowledge = cls._build(organism, targetDbnameId, jobID, db)
+        knowledge = cls([
+            _buildOmniPathSource(organism, targetDbnameId, jobID, db),
+            _buildTranslatedSource("KEGG", _rawGraph("KEGG", organism),
+                                   targetDbnameId, jobID, db),
+            _buildTranslatedSource("Reactome", _rawGraph("Reactome", organism),
+                                   targetDbnameId, jobID, db),
+        ])
 
         if len(_KNOWLEDGE_CACHE) >= _KNOWLEDGE_CACHE_LIMIT:
             _KNOWLEDGE_CACHE.pop(next(iter(_KNOWLEDGE_CACHE)))
         _KNOWLEDGE_CACHE[cacheKey] = knowledge
         return knowledge
 
-    @classmethod
-    def _build(cls, organism, targetDbnameId, jobID, db):
-        from src.common.FeatureNamesToKeggIDsMapper import findIDsByFeaturesName
 
-        # Accumulate the accession-space graph first. Documents are streamed
-        # and released one at a time; only the edge tuples are retained.
-        accessionEdges = {}
-        accessions = set()
-        try:
-            for document in db["omnipath_network"].find({}, {"_id": 0, "edges": 1}):
-                for edge in (document.get("edges") or []):
-                    if len(edge) < 3:
-                        continue
-                    source, target, sign = edge[0], edge[1], edge[2]
-                    # Edges gained `references` and `curation_effort` after the
-                    # first release, so tolerate the three-element form rather
-                    # than requiring a reinstall to render anything at all.
-                    references = edge[3] if len(edge) > 3 else ""
-                    effort = edge[4] if len(edge) > 4 else 0
-                    accessionEdges[(source, target)] = (sign, references, effort)
-                    accessions.add(source)
-                    accessions.add(target)
-        except Exception as ex:
-            logging.warning("OmniPath knowledge unavailable for %s: %s", organism, ex)
-            return cls({}, set(), "OmniPath")
+def _translateIdentifiers(identifiers, jobID, db, targetDbnameId):
+    """Map a source's own identifiers into the pathway's ID space."""
+    from src.common.FeatureNamesToKeggIDsMapper import findIDsByFeaturesName
 
-        if not accessions:
-            return cls({}, set(), "OmniPath")
+    if not identifiers:
+        return {}
+    return findIDsByFeaturesName(jobID, list(identifiers), db, targetDbnameId)
 
-        translation = findIDsByFeaturesName(jobID, list(accessions), db, targetDbnameId)
 
-        edges, known = {}, set()
-        for accession, featureIDs in translation.items():
-            for featureID in (featureIDs or []):
-                known.add(str(featureID))
+def _buildTranslatedSource(name, rawGraph, targetDbnameId, jobID, db):
+    """Translate a raw {(a, b): [(detail, pathway)]} graph into feature IDs."""
+    if not rawGraph:
+        return InteractionSource(name, {}, set())
 
-        for (source, target), provenance in accessionEdges.items():
-            for sourceID in (translation.get(source) or []):
-                for targetID in (translation.get(target) or []):
-                    sourceID, targetID = str(sourceID), str(targetID)
-                    if sourceID == targetID:
-                        continue          # an isoform collapse is not an edge
-                    edges[(sourceID, targetID)] = provenance
+    identifiers = set()
+    for source, target in rawGraph.keys():
+        identifiers.add(source)
+        identifiers.add(target)
 
-        logging.info("OmniPath knowledge for %s: %d accessions -> %d genes, "
-                     "%d translated interactions", organism, len(accessions),
-                     len(known), len(edges))
-        return cls(edges, known, "OmniPath")
+    try:
+        translation = _translateIdentifiers(identifiers, jobID, db, targetDbnameId)
+    except Exception as translationError:
+        logging.warning("%s knowledge untranslatable for this ID space: %s",
+                        name, translationError)
+        return InteractionSource(name, {}, set())
+
+    edges, known = {}, set()
+    for featureIDs in translation.values():
+        for featureID in (featureIDs or []):
+            known.add(str(featureID))
+
+    for (source, target), records in rawGraph.items():
+        for sourceID in (translation.get(source) or []):
+            for targetID in (translation.get(target) or []):
+                sourceID, targetID = str(sourceID), str(targetID)
+                if sourceID == targetID:
+                    continue          # an isoform collapse is not an edge
+                edges.setdefault((sourceID, targetID), []).extend(records)
+
+    logging.info("%s knowledge: %d identifiers -> %d genes, %d translated "
+                 "interactions", name, len(identifiers), len(known), len(edges))
+    return InteractionSource(name, edges, known)
+
+
+def _buildOmniPathSource(organism, targetDbnameId, jobID, db):
+    """OmniPath's curated literature graph, with its PMIDs kept."""
+    # Accumulate the accession-space graph first. Documents are streamed and
+    # released one at a time; only the edge tuples are retained.
+    accessionEdges = {}
+    accessions = set()
+    try:
+        for document in db["omnipath_network"].find({}, {"_id": 0, "edges": 1}):
+            for edge in (document.get("edges") or []):
+                if len(edge) < 3:
+                    continue
+                source, target, sign = edge[0], edge[1], edge[2]
+                # Edges gained `references` and `curation_effort` after the
+                # first release, so tolerate the three-element form rather
+                # than requiring a reinstall to render anything at all.
+                references = edge[3] if len(edge) > 3 else ""
+                effort = edge[4] if len(edge) > 4 else 0
+                accessionEdges[(source, target)] = (sign, references, effort)
+                accessions.add(source)
+                accessions.add(target)
+    except Exception as ex:
+        logging.warning("OmniPath knowledge unavailable for %s: %s", organism, ex)
+        return InteractionSource("OmniPath", {}, set())
+
+    if not accessions:
+        return InteractionSource("OmniPath", {}, set())
+
+    translation = _translateIdentifiers(accessions, jobID, db, targetDbnameId)
+
+    edges, known = {}, set()
+    for accession, featureIDs in translation.items():
+        for featureID in (featureIDs or []):
+            known.add(str(featureID))
+
+    for (source, target), provenance in accessionEdges.items():
+        for sourceID in (translation.get(source) or []):
+            for targetID in (translation.get(target) or []):
+                sourceID, targetID = str(sourceID), str(targetID)
+                if sourceID == targetID:
+                    continue          # an isoform collapse is not an edge
+                edges[(sourceID, targetID)] = provenance
+
+    logging.info("OmniPath knowledge for %s: %d accessions -> %d genes, "
+                 "%d translated interactions", organism, len(accessions),
+                 len(known), len(edges))
+    return InteractionSource("OmniPath", edges, known)
+
+
+#: How many pathway names one source may name per edge before the rest are
+#: counted instead. A tooltip is read, not scrolled.
+_MAX_NAMED_PATHWAYS = 3
+
+
+def _summariseEvidence(hits, openPathwayID, pathwayNames):
+    """Turn each source's raw provenance into something a reader can act on.
+
+    The point of naming the pathway is the whole reason for looking beyond the
+    open map: a KEGG relation recorded in mmu04010 tells the reader that this
+    interaction IS curated, just not drawn here. Saying only "corroborated"
+    would keep the fact and lose the address.
+    """
+    summaries = []
+    for sourceName, provenance in hits:
+        record = {"source": sourceName, "references": [], "curationEffort": 0,
+                  "detail": "", "pathways": [], "morePathways": 0,
+                  "onThisPathway": False}
+
+        if isinstance(provenance, tuple):
+            # OmniPath: (sign, references, curationEffort). It is not organised
+            # by pathway at all -- it is an interaction list.
+            record["detail"] = str(provenance[0] or "")
+            record["references"] = _parseReferences(provenance[1])
+            record["curationEffort"] = provenance[2]
+            summaries.append(record)
+            continue
+
+        details, pathways = [], []
+        for detail, pathwayID in provenance:
+            if detail not in details:
+                details.append(detail)
+            if pathwayID == openPathwayID:
+                record["onThisPathway"] = True
+                continue
+            if pathwayID not in [entry["id"] for entry in pathways]:
+                pathways.append({"id": pathwayID,
+                                 "name": pathwayNames.get(pathwayID, pathwayID)})
+
+        record["detail"] = ", ".join(details)
+        record["morePathways"] = max(0, len(pathways) - _MAX_NAMED_PATHWAYS)
+        record["pathways"] = pathways[:_MAX_NAMED_PATHWAYS]
+        summaries.append(record)
+
+    return summaries
 
 
 def _parseReferences(raw):
@@ -271,31 +555,135 @@ class _RegulationTable(object):
             }
 
 
-def _printedObstacles(pathwayDocument):
-    """Large printed boxes the client draws nothing for but must not draw over.
+#: Parsed KGML entry geometry, keyed (organism, pathwayID). A KGML is 100-600 kB
+#: of XML and a diagram is reopened constantly, so it is read once per process.
+#: Bounded because a session can only open so many maps; nothing here is large.
+_KGML_BOX_CACHE = {}
+_KGML_CACHE_LIMIT = 256
 
-    A KEGG map's cross-pathway links -- the rounded boxes reading "Cell cycle",
-    "MAPK signaling pathway" -- are the biggest printed obstacles on the canvas
-    (21 of them on mmu05200) and the installer has always stored them with full
-    geometry. The client has simply never been sent them: nothing in
-    PaintomicsClient references relatedPathways at all. Anything placing new
-    marks in free space needs them, and they cost one field.
+
+def _kgmlOnlyBoxes(organism, pathwayID):
+    """Boxes KEGG prints that the installed pathway document does not store.
+
+    The Mongo document keeps `genes`, `compounds` and `relatedPathways` only.
+    The KGML also carries `ortholog` entries -- KO boxes for proteins with no
+    ortholog in this organism, which on infection and disease maps are the
+    VIRAL proteins -- and `group` entries for complexes. Measured on mmu05167
+    (Kaposi sarcoma-associated herpesvirus infection): 122 gene, 5 compound and
+    15 map entries are stored, while 31 ortholog and 6 group entries are not.
+    One of the missing ones is ko:K21664 -- LANA -- and a satellite was landing
+    on 44.7% of its own area on top of it.
+
+    Reading the KGML at request time rather than re-installing is deliberate:
+    the geometry is already on disk beside the PNG the server serves, and an
+    installed database must not have to be rebuilt to fix a drawing bug.
+
+    @returns {list} obstacle dicts, or [] when the file is absent or unreadable
+    """
+    cacheKey = (organism, pathwayID)
+    if cacheKey in _KGML_BOX_CACHE:
+        return _KGML_BOX_CACHE[cacheKey]
+
+    import os
+    import xml.etree.ElementTree as ElementTree
+    from src.conf.serverconf import KEGG_DATA_DIR
+
+    boxes = []
+    kgmlPath = os.path.join(KEGG_DATA_DIR, "current", organism, "kgml",
+                            pathwayID + ".kgml")
+    try:
+        if os.path.isfile(kgmlPath):
+            root = ElementTree.parse(kgmlPath).getroot()
+            for entry in root.findall("entry"):
+                # gene/compound/map geometry is already in Mongo; taking it
+                # from here too would only duplicate rectangles.
+                if entry.get("type") not in ("ortholog", "group"):
+                    continue
+                graphics = entry.find("graphics")
+                if graphics is None:
+                    continue
+                try:
+                    boxes.append({
+                        "x": float(graphics.get("x")),
+                        "y": float(graphics.get("y")),
+                        "width": float(graphics.get("width")),
+                        "height": float(graphics.get("height")),
+                    })
+                except (TypeError, ValueError):
+                    # An entry with no geometry is a label, not a drawn box.
+                    continue
+    except Exception as parseError:
+        # A malformed or unreadable KGML must cost the overlay its extra
+        # obstacles, never the whole diagram: placement stays optimistic,
+        # which is exactly the behaviour before this function existed.
+        logging.warning("Evidence overlay: could not read %s (%s)",
+                        kgmlPath, parseError)
+        boxes = []
+
+    if len(_KGML_BOX_CACHE) >= _KGML_CACHE_LIMIT:
+        _KGML_BOX_CACHE.clear()
+    _KGML_BOX_CACHE[cacheKey] = boxes
+    return boxes
+
+
+def _printedObstacles(pathwayDocument, organism=None, pathwayID=None):
+    """Every box the map prints, so a new mark can be placed where none is.
+
+    Three sources, in descending order of how badly they were missed:
+
+      * `genes` -- all 268 rows on mmu05167, of which the client only ever
+        knew the ~61 its own data painted. An unmatched KEGG box is still
+        printed, still carries a gene symbol, and is still ruined by a mark
+        dropped on top of it;
+      * `relatedPathways` -- the rounded cross-pathway boxes ("Cell cycle",
+        "MAPK signaling pathway"), 21 of them on mmu05200, the largest
+        printed obstacles on a KEGG map;
+      * `compounds` -- small, but they sit in the open space a placer wants.
+
+    plus the ortholog and group boxes only the KGML has (see _kgmlOnlyBoxes).
+
+    Rectangles are deduplicated on rounded geometry: co-located genes share
+    one printed box, so mmu05167's 268 gene rows collapse to far fewer
+    distinct rectangles and the payload stays small.
 
     Coordinates are the box CENTRE, matching the gene entries, and arrive from
     Mongo as strings because the KGML attributes were never cast.
     """
     obstacles = []
-    for related in (pathwayDocument.get("relatedPathways") or []):
+    seen = set()
+
+    def add(entry):
         try:
-            obstacles.append({
-                "x": float(related.get("x")),
-                "y": float(related.get("y")),
-                "width": float(related.get("width")),
-                "height": float(related.get("height")),
-            })
+            box = {
+                "x": float(entry.get("x")),
+                "y": float(entry.get("y")),
+                "width": float(entry.get("width")),
+                "height": float(entry.get("height")),
+            }
         except (TypeError, ValueError):
-            # A related pathway without geometry is a link, not a drawn box.
-            continue
+            # An entry without geometry is a link or a label, not a drawn box.
+            return
+        if box["width"] <= 0 or box["height"] <= 0:
+            # MapMan stores every feature with width = height = 0; a zero-area
+            # rectangle blocks nothing and would only inflate the payload.
+            return
+        key = (round(box["x"], 1), round(box["y"], 1),
+               round(box["width"], 1), round(box["height"], 1))
+        if key in seen:
+            return
+        seen.add(key)
+        obstacles.append(box)
+
+    for field in ("relatedPathways", "genes", "compounds"):
+        for entry in (pathwayDocument.get(field) or []):
+            add(entry)
+
+    # KEGG only: Reactome and MapMan diagrams have no KGML, and OmniPath has
+    # no diagram at all.
+    if organism and pathwayID and (pathwayDocument.get("source") or "KEGG") == "KEGG":
+        for entry in _kgmlOnlyBoxes(organism, pathwayID):
+            add(entry)
+
     return obstacles
 
 
@@ -346,6 +734,12 @@ def buildPathwayEvidence(jobInstance, pathwayID, condition=None,
         "byClass": {CLASS_CORROBORATED: 0, CLASS_NOVEL: 0, CLASS_UNSUPPORTED: 0},
         "literatureAvailable": False,
         "multiBoxEndpoints": 0,
+        #: How many corroborating hits each source contributed, so the panel can
+        #: say which database is doing the work on this map.
+        "bySource": {},
+        #: Corroborated by a pathway database that draws the interaction on a
+        #: DIFFERENT map. This is the count that used to be lost entirely.
+        "recordedElsewhere": 0,
     }
 
     if not table.usable:
@@ -359,7 +753,12 @@ def buildPathwayEvidence(jobInstance, pathwayID, condition=None,
             return {"pathwayID": pathwayID, "edges": [], "obstacles": [], "statistics": statistics}
 
         sourceName = pathwayDocument.get("source") or "KEGG"
-        obstacles = _printedObstacles(pathwayDocument)
+        # One pass for every pathway name in the organism (1,008 documents on
+        # mouse), so naming the map an interaction was recorded on costs no
+        # query per edge.
+        pathwayNames = {document.get("ID"): document.get("name")
+                        for document in database["kegg"].find({}, {"ID": 1, "name": 1})}
+        obstacles = _printedObstacles(pathwayDocument, organism, pathwayID)
         drawn = _drawnFeatureIDs(pathwayDocument)
         if not drawn:
             return {"pathwayID": pathwayID, "edges": [], "obstacles": [], "statistics": statistics}
@@ -381,7 +780,7 @@ def buildPathwayEvidence(jobInstance, pathwayID, condition=None,
         translation = findIDsByFeaturesName(jobInstance.getJobID(), list(names),
                                             database, targetDbnameId)
 
-        knowledge = OmniPathKnowledge.forOrganism(organism, targetDbnameId,
+        knowledge = EvidenceKnowledge.forOrganism(organism, targetDbnameId,
                                                   jobInstance.getJobID(), database)
         statistics["literatureAvailable"] = len(knowledge) > 0
 
@@ -414,17 +813,28 @@ def buildPathwayEvidence(jobInstance, pathwayID, condition=None,
             if ambiguous:
                 statistics["multiBoxEndpoints"] += 1
 
-            interaction = knowledge.interaction(regulatorID, targetID)
-            if interaction is not None:
+            hits = knowledge.interactions(regulatorID, targetID)
+            if hits:
                 edgeClass = CLASS_CORROBORATED
-                references = _parseReferences(interaction[1])
-                curationEffort = interaction[2]
+                evidenceSources = _summariseEvidence(hits, pathwayID, pathwayNames)
+                # Kept at the top level for the tooltip's citation line: only
+                # OmniPath carries PMIDs, KEGG and Reactome cite themselves.
+                omniPath = [entry for entry in evidenceSources
+                            if entry["source"] == "OmniPath"]
+                references = omniPath[0]["references"] if omniPath else []
+                curationEffort = omniPath[0]["curationEffort"] if omniPath else 0
+                for entry in evidenceSources:
+                    statistics["bySource"][entry["source"]] = \
+                        statistics["bySource"].get(entry["source"], 0) + 1
+                    if entry["source"] != "OmniPath" and entry["pathways"]:
+                        statistics["recordedElsewhere"] += 1
+                        break
             elif knowledge.knows(regulatorID) and knowledge.knows(targetID):
                 edgeClass = CLASS_NOVEL
-                references, curationEffort = [], 0
+                references, curationEffort, evidenceSources = [], 0, []
             else:
                 edgeClass = CLASS_UNSUPPORTED
-                references, curationEffort = [], 0
+                references, curationEffort, evidenceSources = [], 0, []
 
             statistics["drawable"] += 1
             statistics["byClass"][edgeClass] += 1
@@ -448,6 +858,7 @@ def buildPathwayEvidence(jobInstance, pathwayID, condition=None,
                 "targetR2": relationship["targetR2"],
                 "references": references,
                 "curationEffort": curationEffort,
+                "evidenceSources": evidenceSources,
                 "ambiguousEndpoint": ambiguous,
                 "regulatorBoxes": len(drawnRegulators),
                 "targetBoxes": len(drawnTargets),

--- a/PaintomicsServer/src/classes/PathwayEvidence.py
+++ b/PaintomicsServer/src/classes/PathwayEvidence.py
@@ -1,0 +1,438 @@
+#***************************************************************
+#  PathwayEvidence.py
+#
+#  Classify a job's MORE regulator -> target relationships against the
+#  curated literature graph (OmniPath) and reduce them to the handful that
+#  can honestly be drawn on one pathway diagram.
+#
+#  WHY THIS EXISTS
+#  ---------------
+#  A pathway map is a raster PNG with feature boxes placed on top; the app
+#  has no model of the artwork underneath, so every drawn edge competes with
+#  biology it cannot see. Measured on the STATegra MORE job (1,562
+#  relationships, mouse) against the installed mmu pathway data:
+#
+#    * the readable ceiling is 5-8 edges per map -- crossings per edge passes
+#      1.0 between N=5 and N=10, and bowing edges into arcs moves that by <8%,
+#      so routing cannot buy a bigger budget, only drawing fewer edges can;
+#    * a real job puts a median of 11 and a maximum of 196 edges on a single
+#      KEGG map, i.e. 25x the budget on the map users open most;
+#    * 63.6% of the bundled examples' regulators (100% of miRNAs) resolve to
+#      no drawn box anywhere, so they cannot be an arrow at all.
+#
+#  The response therefore carries three ranked classes and an explicit account
+#  of what was left out. Anything this module drops, it counts.
+#***************************************************************
+
+import logging
+
+from src.conf.serverconf import MONGODB_HOST, MONGODB_PORT
+
+#: Relationship MORE found AND OmniPath independently records an interaction
+#: for. This is an EXISTENCE claim only. Sign concordance between MORE's
+#: regression coefficient and OmniPath's curated sign measured 58.3% against
+#: 52.8% expected by chance (p ~ 0.21) -- it is not a signal and must never be
+#: presented as agreement.
+CLASS_CORROBORATED = "corroborated"
+
+#: Relationship MORE found between two proteins OmniPath knows well, where
+#: OmniPath records NO interaction between them. The candidate-for-promotion
+#: class: an experimental link the curated literature does not contain.
+CLASS_NOVEL = "novel"
+
+#: Everything else -- one or both endpoints unknown to OmniPath, so there is
+#: no external opinion either way. Carries no citation and leans entirely on
+#: the coefficient.
+CLASS_UNSUPPORTED = "unsupported"
+
+#: Order in which classes earn scarce space on the canvas.
+CLASS_PRIORITY = {CLASS_CORROBORATED: 0, CLASS_NOVEL: 1, CLASS_UNSUPPORTED: 2}
+
+#: Default cap. Deliberately at the top of the measured 5-8 readable band.
+DEFAULT_MAX_EDGES = 8
+
+#: A single job may open many pathways; the literature graph is per organism
+#: and identical for all of them, so it is built once. Bounded because the
+#: process is long-lived and organisms are unbounded in principle.
+_KNOWLEDGE_CACHE = {}
+_KNOWLEDGE_CACHE_LIMIT = 4
+
+
+class OmniPathKnowledge(object):
+    """The curated literature interaction graph, in a pathway's own ID space.
+
+    OmniPath stores UniProt accessions while a KEGG map is drawn in Entrez
+    space, so the graph is translated once through the xref mates table and
+    kept. The translation is measured to be clean rather than merely wide:
+    79.6% of the 1,670 stored mouse accessions reach a drawn KEGG box, only 6
+    accessions fan out to more than one Entrez ID, and the collapse creates no
+    collisions and no self-loops.
+    """
+
+    def __init__(self, edges, known, sourceName):
+        #: {(a, b): (sign, references, curationEffort)} with BOTH directions
+        #: stored, so a lookup is one dict hit rather than two.
+        self._edges = edges
+        #: Every gene the literature graph has an opinion about. Membership
+        #: here is what separates CLASS_NOVEL from CLASS_UNSUPPORTED.
+        self._known = known
+        self.sourceName = sourceName
+
+    def __len__(self):
+        return len(self._edges)
+
+    def knows(self, featureID):
+        return featureID in self._known
+
+    def interaction(self, featureA, featureB):
+        """Return (sign, references, curationEffort) or None.
+
+        Direction-agnostic on purpose: MORE asserts a regulatory direction
+        that a curated interaction database need not have recorded the same
+        way round, and claiming "the literature disagrees about direction"
+        from that would be an artefact of two different data models.
+        """
+        return self._edges.get((featureA, featureB)) or self._edges.get((featureB, featureA))
+
+    @classmethod
+    def forOrganism(cls, organism, targetDbnameId, jobID, db):
+        """Build (or reuse) the translated graph for one organism/ID space."""
+        cacheKey = (organism, str(targetDbnameId))
+        if cacheKey in _KNOWLEDGE_CACHE:
+            return _KNOWLEDGE_CACHE[cacheKey]
+
+        knowledge = cls._build(organism, targetDbnameId, jobID, db)
+
+        if len(_KNOWLEDGE_CACHE) >= _KNOWLEDGE_CACHE_LIMIT:
+            _KNOWLEDGE_CACHE.pop(next(iter(_KNOWLEDGE_CACHE)))
+        _KNOWLEDGE_CACHE[cacheKey] = knowledge
+        return knowledge
+
+    @classmethod
+    def _build(cls, organism, targetDbnameId, jobID, db):
+        from src.common.FeatureNamesToKeggIDsMapper import findIDsByFeaturesName
+
+        # Accumulate the accession-space graph first. Documents are streamed
+        # and released one at a time; only the edge tuples are retained.
+        accessionEdges = {}
+        accessions = set()
+        try:
+            for document in db["omnipath_network"].find({}, {"_id": 0, "edges": 1}):
+                for edge in (document.get("edges") or []):
+                    if len(edge) < 3:
+                        continue
+                    source, target, sign = edge[0], edge[1], edge[2]
+                    # Edges gained `references` and `curation_effort` after the
+                    # first release, so tolerate the three-element form rather
+                    # than requiring a reinstall to render anything at all.
+                    references = edge[3] if len(edge) > 3 else ""
+                    effort = edge[4] if len(edge) > 4 else 0
+                    accessionEdges[(source, target)] = (sign, references, effort)
+                    accessions.add(source)
+                    accessions.add(target)
+        except Exception as ex:
+            logging.warning("OmniPath knowledge unavailable for %s: %s", organism, ex)
+            return cls({}, set(), "OmniPath")
+
+        if not accessions:
+            return cls({}, set(), "OmniPath")
+
+        translation = findIDsByFeaturesName(jobID, list(accessions), db, targetDbnameId)
+
+        edges, known = {}, set()
+        for accession, featureIDs in translation.items():
+            for featureID in (featureIDs or []):
+                known.add(str(featureID))
+
+        for (source, target), provenance in accessionEdges.items():
+            for sourceID in (translation.get(source) or []):
+                for targetID in (translation.get(target) or []):
+                    sourceID, targetID = str(sourceID), str(targetID)
+                    if sourceID == targetID:
+                        continue          # an isoform collapse is not an edge
+                    edges[(sourceID, targetID)] = provenance
+
+        logging.info("OmniPath knowledge for %s: %d accessions -> %d genes, "
+                     "%d translated interactions", organism, len(accessions),
+                     len(known), len(edges))
+        return cls(edges, known, "OmniPath")
+
+
+def _parseReferences(raw):
+    """Split OmniPath's reference string into citable records.
+
+    Tokens are ``RESOURCE:PMID`` (13,764 of 13,765 sampled), so both halves
+    are kept: the resource names who curated the claim, the PMID lets a reader
+    go and check it.
+    """
+    records = []
+    for token in str(raw or "").replace(",", ";").split(";"):
+        token = token.strip()
+        if not token:
+            continue
+        resource, _, pmid = token.partition(":")
+        if pmid.isdigit():
+            records.append({"resource": resource, "pmid": pmid})
+        elif resource.isdigit():
+            records.append({"resource": "", "pmid": resource})
+    return records
+
+
+class _RegulationTable(object):
+    """Typed view over the job's stored MORE table.
+
+    The table is a raw {columns, rows} pair whose shape varies by MORE method
+    -- MLR emits a `representative` column PLS1 does not, and the Group_*
+    coefficient columns are named after the job's own conditions. Reading it
+    by position anywhere else in the codebase would break on the next method.
+    """
+
+    def __init__(self, regulationData):
+        self.columns = list((regulationData or {}).get("columns") or [])
+        self.rows = list((regulationData or {}).get("rows") or [])
+        self.symbols = dict((regulationData or {}).get("symbols") or {})
+
+        index = {name: position for position, name in enumerate(self.columns)}
+        self._target = index.get("targetF")
+        self._regulator = index.get("regulator")
+        self._omic = index.get("omic")
+        self._area = index.get("area")
+        self._r2 = index.get("R2")
+        #: Every Group_<condition> column, in table order.
+        self._conditions = [(name[len("Group_"):], position)
+                            for name, position in index.items()
+                            if name.startswith("Group_")]
+        self._conditions.sort(key=lambda entry: index[("Group_" + entry[0])])
+
+    @property
+    def usable(self):
+        return self._target is not None and self._regulator is not None and bool(self.rows)
+
+    @property
+    def conditionNames(self):
+        return [name for name, _ in self._conditions]
+
+    def _cell(self, row, position):
+        if position is None or position >= len(row):
+            return None
+        return row[position]
+
+    def _coefficient(self, row, condition=None):
+        """The coefficient to draw, and the condition it belongs to.
+
+        With no condition requested the strongest one is used, because a
+        relationship the model kept is most legible where the model says it
+        acts. Coefficients are unbounded regression slopes and are NOT
+        comparable across omics or targets, so this ranking is only ever
+        within one job.
+        """
+        best, bestCondition = None, None
+        for name, position in self._conditions:
+            if condition is not None and name != condition:
+                continue
+            try:
+                value = float(self._cell(row, position))
+            except (TypeError, ValueError):
+                continue
+            if best is None or abs(value) > abs(best):
+                best, bestCondition = value, name
+        return best, bestCondition
+
+    def relationships(self, condition=None):
+        """Yield one dict per MORE relationship. Rows missing an endpoint or a
+        usable coefficient are skipped -- they cannot be drawn or ranked."""
+        for row in self.rows:
+            target = self._cell(row, self._target)
+            regulator = self._cell(row, self._regulator)
+            if not target or not regulator:
+                continue
+
+            coefficient, coefficientCondition = self._coefficient(row, condition)
+            if coefficient is None:
+                continue
+
+            try:
+                r2 = float(self._cell(row, self._r2))
+            except (TypeError, ValueError):
+                r2 = None
+
+            yield {
+                "regulator": str(regulator),
+                "target": str(target),
+                "omic": self._cell(row, self._omic) or "",
+                "area": self._cell(row, self._area) or "",
+                "coefficient": coefficient,
+                "condition": coefficientCondition,
+                # R2 belongs to the TARGET's whole model, not to this edge:
+                # runMORE merges it in by targetF, so every relationship of one
+                # target carries the same number. Labelled at the boundary so a
+                # consumer cannot mistake it for an edge statistic.
+                "targetR2": r2,
+            }
+
+
+def _drawnFeatureIDs(pathwayDocument):
+    """IDs of the genes this pathway actually draws.
+
+    A coordinate-less entry has no box to attach to. 10.3% of mouse KEGG gene
+    entries are coordinate-less and 12 maps have no coordinate-bearing gene at
+    all, so this is a real filter and not a formality.
+    """
+    drawn = set()
+    for gene in (pathwayDocument.get("genes") or []):
+        if gene.get("x") is None or gene.get("y") is None:
+            continue
+        drawn.add(str(gene.get("id")))
+    return drawn
+
+
+def buildPathwayEvidence(jobInstance, pathwayID, condition=None,
+                         maxEdges=DEFAULT_MAX_EDGES, classes=None):
+    """Evidence edges drawable on one pathway, ranked, capped and accounted for.
+
+    @param {Job} jobInstance, a loaded PathwayAcquisitionJob
+    @param {String} pathwayID, the pathway whose diagram is open
+    @param {String} condition, restrict coefficients to this condition, or None
+                    for the strongest condition per relationship
+    @param {int} maxEdges, hard cap on drawn edges
+    @param {set} classes, which classes may be drawn (default: all three)
+    @returns {dict} the payload delivered to the Step 4 view
+    """
+    from pymongo import MongoClient
+    from src.common.FeatureNamesToKeggIDsMapper import (
+        resolveDatabaseIds, findIDsByFeaturesName)
+
+    allowedClasses = set(classes) if classes else set(CLASS_PRIORITY)
+    organism = jobInstance.getOrganism()
+
+    table = _RegulationTable(getattr(jobInstance, "regulationPerConditionData", None))
+    statistics = {
+        "totalRelationships": len(table.rows),
+        "conditions": table.conditionNames,
+        "condition": condition,
+        "drawable": 0,
+        "offMapRegulators": 0,
+        "offMapTargets": 0,
+        "hidden": 0,
+        "byClass": {CLASS_CORROBORATED: 0, CLASS_NOVEL: 0, CLASS_UNSUPPORTED: 0},
+        "literatureAvailable": False,
+        "multiBoxEndpoints": 0,
+    }
+
+    if not table.usable:
+        return {"pathwayID": pathwayID, "edges": [], "statistics": statistics}
+
+    client = MongoClient(MONGODB_HOST, MONGODB_PORT)
+    try:
+        database = client[organism + "-paintomics"]
+        pathwayDocument = database["kegg"].find_one({"ID": pathwayID})
+        if pathwayDocument is None:
+            return {"pathwayID": pathwayID, "edges": [], "statistics": statistics}
+
+        sourceName = pathwayDocument.get("source") or "KEGG"
+        drawn = _drawnFeatureIDs(pathwayDocument)
+        if not drawn:
+            return {"pathwayID": pathwayID, "edges": [], "statistics": statistics}
+
+        databaseConvertionIds, _symbolIds = resolveDatabaseIds(organism, [sourceName], database)
+        targetDbnameId = databaseConvertionIds.get(sourceName)
+        if targetDbnameId is None:
+            return {"pathwayID": pathwayID, "edges": [], "statistics": statistics}
+
+        relationships = list(table.relationships(condition))
+
+        # One batched translation for every endpoint name in the job, rather
+        # than a query per relationship: findIDsByFeaturesName caches misses as
+        # well as hits, so the second pathway a user opens costs no queries.
+        names = set()
+        for relationship in relationships:
+            names.add(relationship["regulator"])
+            names.add(relationship["target"])
+        translation = findIDsByFeaturesName(jobInstance.getJobID(), list(names),
+                                            database, targetDbnameId)
+
+        knowledge = OmniPathKnowledge.forOrganism(organism, targetDbnameId,
+                                                  jobInstance.getJobID(), database)
+        statistics["literatureAvailable"] = len(knowledge) > 0
+
+        edges = []
+        for relationship in relationships:
+            regulatorIDs = [str(featureID) for featureID
+                            in (translation.get(relationship["regulator"]) or [])]
+            targetIDs = [str(featureID) for featureID
+                         in (translation.get(relationship["target"]) or [])]
+
+            drawnRegulators = [featureID for featureID in regulatorIDs if featureID in drawn]
+            drawnTargets = [featureID for featureID in targetIDs if featureID in drawn]
+
+            if not drawnRegulators:
+                statistics["offMapRegulators"] += 1
+                continue
+            if not drawnTargets:
+                statistics["offMapTargets"] += 1
+                continue
+
+            # Deterministic representative when a symbol resolves to several
+            # genes drawn on this map. The alternative -- drawing all of them --
+            # turns 131 Reactome edges into 3,252 line segments.
+            regulatorID = sorted(drawnRegulators)[0]
+            targetID = sorted(drawnTargets)[0]
+            if regulatorID == targetID:
+                continue
+
+            ambiguous = len(drawnRegulators) > 1 or len(drawnTargets) > 1
+            if ambiguous:
+                statistics["multiBoxEndpoints"] += 1
+
+            interaction = knowledge.interaction(regulatorID, targetID)
+            if interaction is not None:
+                edgeClass = CLASS_CORROBORATED
+                references = _parseReferences(interaction[1])
+                curationEffort = interaction[2]
+            elif knowledge.knows(regulatorID) and knowledge.knows(targetID):
+                edgeClass = CLASS_NOVEL
+                references, curationEffort = [], 0
+            else:
+                edgeClass = CLASS_UNSUPPORTED
+                references, curationEffort = [], 0
+
+            statistics["drawable"] += 1
+            statistics["byClass"][edgeClass] += 1
+
+            if edgeClass not in allowedClasses:
+                continue
+
+            edges.append({
+                "regulator": relationship["regulator"],
+                "target": relationship["target"],
+                "regulatorID": regulatorID,
+                "targetID": targetID,
+                "regulatorLabel": table.symbols.get(relationship["regulator"],
+                                                    relationship["regulator"]),
+                "targetLabel": table.symbols.get(relationship["target"],
+                                                 relationship["target"]),
+                "evidenceClass": edgeClass,
+                "coefficient": relationship["coefficient"],
+                "condition": relationship["condition"],
+                "omic": relationship["omic"],
+                "targetR2": relationship["targetR2"],
+                "references": references,
+                "curationEffort": curationEffort,
+                "ambiguousEndpoint": ambiguous,
+                "regulatorBoxes": len(drawnRegulators),
+                "targetBoxes": len(drawnTargets),
+            })
+    finally:
+        client.close()
+
+    # Rank: corroborated first (it is the only class that can cite anything),
+    # then novel, then the unsupported bulk, each by coefficient magnitude.
+    edges.sort(key=lambda edge: (CLASS_PRIORITY[edge["evidenceClass"]],
+                                 -abs(edge["coefficient"])))
+
+    if maxEdges is not None and len(edges) > maxEdges:
+        statistics["hidden"] = len(edges) - maxEdges
+        edges = edges[:maxEdges]
+
+    statistics["shown"] = len(edges)
+    return {"pathwayID": pathwayID, "edges": edges, "statistics": statistics}

--- a/PaintomicsServer/src/paintomicsserver.py
+++ b/PaintomicsServer/src/paintomicsserver.py
@@ -604,6 +604,12 @@ class Application(object):
         #*******************************************************************************************
         # SAVE SHARING OPTIONS HANDLER
         #*******************************************************************************************
+        #*******************************************************************************************
+        # PATHWAY EVIDENCE OVERLAY HANDLER
+        #*******************************************************************************************
+        @self.app.route(SERVER_SUBDOMAIN + '/pa_pathway_evidence', methods=['OPTIONS', 'POST'])
+        def pathwayEvidenceHandler():
+            return pathwayAcquisitionPathwayEvidence(request, Response()).getResponse()
         @self.app.route(SERVER_SUBDOMAIN + '/pa_save_sharing_options', methods=['OPTIONS', 'POST'])
         def saveSharingOptionsHandler():
             return pathwayAcquisitionSaveSharingOptions(request, Response()).getResponse()

--- a/PaintomicsServer/src/servlets/PathwayAcquisitionServlet.py
+++ b/PaintomicsServer/src/servlets/PathwayAcquisitionServlet.py
@@ -37,6 +37,7 @@ from src.common.DesignFile import parse_design
 from src.common.DAO.PathwayAcquisitionJobDAO import PathwayAcquisitionJobDAO
 from src.common.DAO.FeatureDAO import FeatureDAO
 from src.classes.JobInstances.PathwayAcquisitionJob import PathwayAcquisitionJob
+from src.classes import PathwayEvidence
 
 from src.conf.serverconf import CLIENT_TMP_DIR, KEGG_DATA_DIR
 
@@ -1171,6 +1172,56 @@ def pathwayAcquisitionSaveVisualOptions(request, response):
         handleException(response, ex, __file__ , "pathwayAcquisitionSaveVisualOptions", userID=userID)
     finally:
         return response
+
+def pathwayAcquisitionPathwayEvidence(request, response):
+    """Evidence edges drawable on one open pathway diagram.
+
+    Answered per pathway rather than bundled into the Step 3 response: the
+    literature classification needs the organism's whole interaction graph,
+    and a job may select hundreds of pathways of which a user opens a few.
+    """
+    jobID  = ""
+    userID = ""
+
+    try:
+        userID = request.cookies.get('userID')
+        sessionToken = request.cookies.get('sessionToken')
+        UserSessionManager().isValidUser(userID, sessionToken)
+
+        # `or {}` -- request.get_json() is None when the request did not arrive
+        # as application/json, and .get() on that names neither field nor cause.
+        options = request.get_json() or {}
+        jobID = options.get("jobID")
+        pathwayID = options.get("pathwayID")
+
+        if not pathwayID:
+            raise UserWarning("Missing pathwayID parameter for pathway evidence.")
+
+        jobInstance = loadRequestedJob(jobID, "reading pathway evidence")
+
+        if jobInstance.getReadOnly() and str(jobInstance.getUserID()) != str(userID):
+            raise Exception("Invalid user for the job reading pathway evidence")
+
+        maxEdges = options.get("maxEdges", PathwayEvidence.DEFAULT_MAX_EDGES)
+        try:
+            maxEdges = max(0, min(int(maxEdges), 200))
+        except (TypeError, ValueError):
+            maxEdges = PathwayEvidence.DEFAULT_MAX_EDGES
+
+        evidence = PathwayEvidence.buildPathwayEvidence(
+            jobInstance, pathwayID,
+            condition=options.get("condition"),
+            maxEdges=maxEdges,
+            classes=options.get("classes"))
+
+        evidence["success"] = True
+        response.setContent(evidence)
+
+    except Exception as ex:
+        handleException(response, ex, __file__, "pathwayAcquisitionPathwayEvidence", userID=userID)
+    finally:
+        return response
+
 
 def pathwayAcquisitionSaveSharingOptions(request, response):
     #VARIABLE DECLARATION

--- a/PaintomicsServer/src/tests/test_pathway_evidence_sources.py
+++ b/PaintomicsServer/src/tests/test_pathway_evidence_sources.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Interaction sources and printed obstacles for the pathway evidence overlay.
+
+Two defects are pinned here, both found by looking at a real drawn map:
+
+  1. The overlay placed regulator boxes on top of KEGG artwork it could not
+     see. The installed pathway document stores `genes`, `compounds` and
+     `relatedPathways` only, so the 31 `ortholog` entries of mmu05167 -- the
+     VIRAL proteins, LANA among them -- were invisible obstacles and a
+     satellite landed on 44.7% of one. The geometry was on disk in the KGML
+     all along.
+
+  2. Corroboration was decided against OmniPath alone, which threw away
+     curated biology: a regulator and its target are routinely joined by KEGG
+     in a DIFFERENT map from the one on screen. Measured on the STATegra mouse
+     job, 132 of 492 drawable relationships (26.8%) are recorded in KEGG while
+     being labelled "novel" or -- worse -- "unsupported", which asserts there
+     is no external evidence either way about an interaction KEGG curates.
+
+Hermetic on purpose: every fixture is written into a temporary KEGG_DATA_DIR,
+so this runs in the deploy image and on a machine with no species installed.
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from src.classes import PathwayEvidence
+
+
+#: One gene entry, one ortholog entry (the LANA case), one group, and three
+#: relations of which one is a maplink that must NOT become an interaction.
+KGML = """<?xml version="1.0"?>
+<pathway name="path:mmu99999" org="mmu" number="99999" title="Fixture">
+  <entry id="1" name="mmu:100 mmu:101" type="gene">
+    <graphics name="Aaa" x="100" y="200" width="46" height="17" type="rectangle"/>
+  </entry>
+  <entry id="2" name="mmu:200" type="gene">
+    <graphics name="Bbb" x="300" y="200" width="46" height="17" type="rectangle"/>
+  </entry>
+  <entry id="3" name="ko:K21664" type="ortholog">
+    <graphics name="K21664" x="500" y="400" width="46" height="17" type="rectangle"/>
+  </entry>
+  <entry id="4" name="mmu:300" type="gene">
+    <graphics name="Ccc" x="700" y="200" width="46" height="17" type="rectangle"/>
+  </entry>
+  <entry id="5" name="undefined" type="group">
+    <graphics x="900" y="200" width="60" height="30" type="rectangle"/>
+    <component id="2"/>
+    <component id="4"/>
+  </entry>
+  <entry id="6" name="path:mmu04010" type="map">
+    <graphics name="MAPK signaling" x="1100" y="600" width="109" height="25" type="roundrectangle"/>
+  </entry>
+  <relation entry1="1" entry2="2" type="GErel"/>
+  <relation entry1="1" entry2="5" type="PPrel"/>
+  <relation entry1="2" entry2="6" type="maplink"/>
+</pathway>
+"""
+
+#: Reaction with a catalyst, an inhibitor and an input. Only the first two may
+#: produce interactions; input -> output is the same molecule modified.
+REACTOME_GRAPH = {
+    "stId": "R-MMU-99999",
+    "nodes": [
+        {"dbId": 1, "identifier": "P00001", "referenceType": "ReferenceGeneProduct",
+         "geneNames": ["Cat1"], "children": []},
+        {"dbId": 2, "identifier": "P00002", "referenceType": "ReferenceGeneProduct",
+         "geneNames": ["Out1"], "children": []},
+        {"dbId": 3, "identifier": "P00003", "referenceType": "ReferenceGeneProduct",
+         "geneNames": ["Inh1"], "children": []},
+        {"dbId": 4, "identifier": "P00004", "referenceType": "ReferenceGeneProduct",
+         "geneNames": ["In1"], "children": []},
+        # A complex: carries no accession itself, only members.
+        {"dbId": 5, "identifier": None, "referenceType": "Complex", "children": [1, 3]},
+    ],
+    "edges": [
+        {"dbId": 10, "schemaClass": "Reaction",
+         "inputs": [4], "outputs": [2], "catalysts": [1], "inhibitors": [3]},
+    ],
+}
+
+
+class PrintedObstacles(unittest.TestCase):
+    """Everything the map prints has to reach the placer."""
+
+    def setUp(self):
+        self.dataDir = tempfile.mkdtemp(prefix="evidence-fixture-")
+        kgmlDir = os.path.join(self.dataDir, "current", "mmu", "kgml")
+        os.makedirs(kgmlDir)
+        with open(os.path.join(kgmlDir, "mmu99999.kgml"), "w") as handle:
+            handle.write(KGML)
+        self._patchDataDir()
+
+    def tearDown(self):
+        shutil.rmtree(self.dataDir, ignore_errors=True)
+        PathwayEvidence._KGML_BOX_CACHE.clear()
+        PathwayEvidence._RAW_GRAPH_CACHE.clear()
+
+    def _patchDataDir(self):
+        from src.conf import serverconf
+        self._original = serverconf.KEGG_DATA_DIR
+        serverconf.KEGG_DATA_DIR = self.dataDir
+        self.addCleanup(setattr, serverconf, "KEGG_DATA_DIR", self._original)
+
+    def test_ortholog_and_group_boxes_come_from_the_kgml(self):
+        """The KGML holds boxes Mongo never stored. LANA is one of them."""
+        PathwayEvidence._KGML_BOX_CACHE.clear()
+        boxes = PathwayEvidence._kgmlOnlyBoxes("mmu", "mmu99999")
+
+        centres = sorted((box["x"], box["y"]) for box in boxes)
+        self.assertIn((500.0, 400.0), centres,
+                      "the ortholog box (LANA's class) must be an obstacle")
+        self.assertIn((900.0, 200.0), centres, "a group box is printed too")
+        self.assertEqual(len(boxes), 2,
+                         "gene/compound/map geometry is already in Mongo; taking "
+                         "it from the KGML as well would duplicate rectangles")
+
+    def test_document_boxes_are_merged_deduplicated_and_sized(self):
+        document = {
+            "source": "KEGG",
+            "genes": [
+                {"id": "100", "x": "100", "y": "200", "width": "46", "height": "17"},
+                # Co-located gene: same printed rectangle, must collapse.
+                {"id": "101", "x": "100", "y": "200", "width": "46", "height": "17"},
+                # MapMan stores every feature at width = height = 0.
+                {"id": "999", "x": "5", "y": "5", "width": "0", "height": "0"},
+                # A coordinate-less entry is a link, not a drawn box.
+                {"id": "998", "x": None, "y": None, "width": "46", "height": "17"},
+            ],
+            "compounds": [{"id": "C1", "x": "50", "y": "60", "width": "8", "height": "8"}],
+            "relatedPathways": [
+                {"id": "04010", "x": "1100", "y": "600", "width": "109", "height": "25"}],
+        }
+        boxes = PathwayEvidence._printedObstacles(document, "mmu", "mmu99999")
+        centres = sorted((box["x"], box["y"]) for box in boxes)
+
+        self.assertEqual(centres, [(50.0, 60.0), (100.0, 200.0),
+                                   (500.0, 400.0), (900.0, 200.0), (1100.0, 600.0)])
+
+    def test_a_missing_kgml_costs_the_extra_boxes_not_the_overlay(self):
+        PathwayEvidence._KGML_BOX_CACHE.clear()
+        self.assertEqual(PathwayEvidence._kgmlOnlyBoxes("mmu", "no-such-pathway"), [])
+
+    def test_non_kegg_sources_do_not_look_for_a_kgml(self):
+        """Reactome and MapMan diagrams have no KGML; OmniPath has no diagram."""
+        document = {"source": "Reactome",
+                    "genes": [{"id": "1", "x": "10", "y": "10", "width": "4", "height": "4"}]}
+        boxes = PathwayEvidence._printedObstacles(document, "mmu", "mmu99999")
+        self.assertEqual([(box["x"], box["y"]) for box in boxes], [(10.0, 10.0)])
+
+
+class KeggRelationGraph(unittest.TestCase):
+    """KEGG's own relations, read across EVERY pathway of the organism."""
+
+    def setUp(self):
+        self.dataDir = tempfile.mkdtemp(prefix="evidence-kegg-")
+        kgmlDir = os.path.join(self.dataDir, "current", "mmu", "kgml")
+        os.makedirs(kgmlDir)
+        with open(os.path.join(kgmlDir, "mmu99999.kgml"), "w") as handle:
+            handle.write(KGML)
+        from src.conf import serverconf
+        original = serverconf.KEGG_DATA_DIR
+        serverconf.KEGG_DATA_DIR = self.dataDir
+        self.addCleanup(setattr, serverconf, "KEGG_DATA_DIR", original)
+        self.addCleanup(shutil.rmtree, self.dataDir, True)
+        self.addCleanup(PathwayEvidence._RAW_GRAPH_CACHE.clear)
+        PathwayEvidence._RAW_GRAPH_CACHE.clear()
+        self.graph = PathwayEvidence._keggRelationGraph("mmu")
+
+    def test_a_relation_names_the_pathway_it_was_recorded_on(self):
+        """The whole point: the interaction is curated, just not drawn here.
+
+        Gene 200 is BOTH the direct GErel partner of 100 and a member of the
+        group 100 has a PPrel with, so this pair genuinely carries two records
+        and the summariser is expected to report both.
+        """
+        self.assertIn(("GErel", "mmu99999"), self.graph[("100", "200")])
+        for _relationType, pathwayID in self.graph[("100", "200")]:
+            self.assertEqual(pathwayID, "mmu99999")
+
+    def test_a_multi_gene_entry_yields_every_pair(self):
+        """`mmu:100 mmu:101` is one box holding two genes."""
+        self.assertIn(("101", "200"), self.graph)
+
+    def test_a_group_is_expanded_to_its_members(self):
+        """A complex relates through the genes it is made of."""
+        self.assertIn(("100", "300"), self.graph)
+        self.assertEqual(self.graph[("100", "300")], [("PPrel", "mmu99999")])
+
+    def test_maplink_is_not_an_interaction(self):
+        """It points at a PATHWAY, not at a gene; keeping it invents edges."""
+        for (source, target) in self.graph:
+            self.assertNotEqual(target, "mmu04010")
+        self.assertNotIn(("200", "04010"), self.graph)
+
+    def test_no_self_edges(self):
+        for source, target in self.graph:
+            self.assertNotEqual(source, target)
+
+
+class ReactomeRelationGraph(unittest.TestCase):
+    """Only the roles that assert one gene product acting on another."""
+
+    def setUp(self):
+        self.dataDir = tempfile.mkdtemp(prefix="evidence-reactome-")
+        reactomeDir = os.path.join(self.dataDir, "current", "mmu", "reactome")
+        os.makedirs(reactomeDir)
+        with open(os.path.join(reactomeDir, "R-MMU-99999.graph.json"), "w") as handle:
+            json.dump(REACTOME_GRAPH, handle)
+        from src.conf import serverconf
+        original = serverconf.KEGG_DATA_DIR
+        serverconf.KEGG_DATA_DIR = self.dataDir
+        self.addCleanup(setattr, serverconf, "KEGG_DATA_DIR", original)
+        self.addCleanup(shutil.rmtree, self.dataDir, True)
+        self.addCleanup(PathwayEvidence._RAW_GRAPH_CACHE.clear)
+        PathwayEvidence._RAW_GRAPH_CACHE.clear()
+        self.graph = PathwayEvidence._reactomeRelationGraph("mmu")
+
+    def test_catalyst_and_inhibitor_reach_the_output(self):
+        self.assertEqual(self.graph[("P00001", "P00002")], [("catalysts", "R-MMU-99999")])
+        self.assertEqual(self.graph[("P00003", "P00002")], [("inhibitors", "R-MMU-99999")])
+
+    def test_an_input_is_not_a_regulator(self):
+        """input -> output is usually the same molecule modified."""
+        self.assertNotIn(("P00004", "P00002"), self.graph)
+
+    def test_pairs_are_uniprot_accessions(self):
+        for source, target in self.graph:
+            self.assertTrue(source.startswith("P0") and target.startswith("P0"))
+
+
+class EvidenceClassification(unittest.TestCase):
+    """Every source is consulted, and each says what it recorded and where."""
+
+    def setUp(self):
+        self.kegg = PathwayEvidence.InteractionSource(
+            "KEGG",
+            {("A", "B"): [("GErel", "mmu04010"), ("PPrel", "mmu05167")]},
+            {"A", "B", "C"})
+        self.omniPath = PathwayEvidence.InteractionSource(
+            "OmniPath",
+            {("A", "B"): ("stimulation", "SIGNOR:12345", 7),
+             ("C", "D"): ("inhibition", "", 1)},
+            {"A", "B", "C", "D"})
+        self.knowledge = PathwayEvidence.EvidenceKnowledge([self.omniPath, self.kegg])
+
+    def test_a_pair_recorded_by_several_sources_returns_all_of_them(self):
+        hits = self.knowledge.interactions("A", "B")
+        self.assertEqual([name for name, _ in hits], ["OmniPath", "KEGG"])
+
+    def test_lookup_is_direction_agnostic(self):
+        """MORE asserts a direction a curated database need not have recorded."""
+        self.assertTrue(self.knowledge.interactions("B", "A"))
+
+    def test_a_gene_known_to_any_source_is_known(self):
+        self.assertTrue(self.knowledge.knows("D"))
+        self.assertFalse(self.knowledge.knows("Z"))
+
+    def test_a_pair_only_kegg_records_is_still_corroborated(self):
+        """The regression this whole change exists to prevent."""
+        keggOnly = PathwayEvidence.EvidenceKnowledge([
+            PathwayEvidence.InteractionSource("OmniPath", {}, {"X", "Y"}),
+            PathwayEvidence.InteractionSource("KEGG", {("X", "Y"): [("GErel", "mmu04010")]},
+                                              {"X", "Y"}),
+        ])
+        self.assertTrue(keggOnly.interactions("X", "Y"),
+                        "a KEGG-only interaction used to be labelled unsupported")
+
+    def test_summary_names_the_other_pathway_and_flags_this_one(self):
+        hits = self.knowledge.interactions("A", "B")
+        names = {"mmu04010": "MAPK signaling pathway",
+                 "mmu05167": "Kaposi sarcoma-associated herpesvirus infection"}
+        summary = PathwayEvidence._summariseEvidence(hits, "mmu05167", names)
+
+        byName = {entry["source"]: entry for entry in summary}
+        self.assertEqual(byName["KEGG"]["detail"], "GErel, PPrel")
+        self.assertTrue(byName["KEGG"]["onThisPathway"],
+                        "one of the two records IS the open map")
+        self.assertEqual([p["name"] for p in byName["KEGG"]["pathways"]],
+                         ["MAPK signaling pathway"],
+                         "the open map is not repeated back at the reader")
+
+        self.assertEqual(byName["OmniPath"]["detail"], "stimulation")
+        self.assertEqual(byName["OmniPath"]["curationEffort"], 7)
+        self.assertEqual([r["pmid"] for r in byName["OmniPath"]["references"]], ["12345"])
+
+    def test_named_pathways_are_capped_and_the_rest_counted(self):
+        many = PathwayEvidence.InteractionSource(
+            "KEGG",
+            {("A", "B"): [("GErel", "mmu0%d" % index) for index in range(4010, 4020)]},
+            {"A", "B"})
+        knowledge = PathwayEvidence.EvidenceKnowledge([many])
+        summary = PathwayEvidence._summariseEvidence(
+            knowledge.interactions("A", "B"), "mmu05167", {})
+
+        self.assertEqual(len(summary[0]["pathways"]), PathwayEvidence._MAX_NAMED_PATHWAYS)
+        self.assertEqual(summary[0]["morePathways"],
+                         10 - PathwayEvidence._MAX_NAMED_PATHWAYS)
+
+    def test_an_unreadable_source_costs_only_itself(self):
+        empty = PathwayEvidence.EvidenceKnowledge([None, self.kegg])
+        self.assertEqual(len(empty.sources), 1)
+        self.assertTrue(empty.interactions("A", "B"))
+
+
+class TranslatedSource(unittest.TestCase):
+    """A raw graph is rewritten into the pathway's own ID space."""
+
+    def test_translation_maps_pairs_and_drops_isoform_collapses(self):
+        raw = {("P1", "P2"): [("GErel", "mmu04010")],
+               ("P1", "P3"): [("PPrel", "mmu04010")]}
+        # P1 and P3 collapse onto the same gene: that is not an edge.
+        translation = {"P1": ["10"], "P2": ["20"], "P3": ["10"]}
+
+        original = PathwayEvidence._translateIdentifiers
+        PathwayEvidence._translateIdentifiers = \
+            lambda identifiers, jobID, db, targetDbnameId: translation
+        try:
+            source = PathwayEvidence._buildTranslatedSource("KEGG", raw, 1, "job", None)
+        finally:
+            PathwayEvidence._translateIdentifiers = original
+
+        self.assertEqual(source.interaction("10", "20"), [("GErel", "mmu04010")])
+        self.assertIsNone(source.interaction("10", "10"))
+        self.assertTrue(source.knows("20"))
+
+    def test_an_empty_raw_graph_yields_an_empty_source(self):
+        source = PathwayEvidence._buildTranslatedSource("Reactome", {}, 1, "job", None)
+        self.assertEqual(len(source), 0)
+        self.assertFalse(source.knows("anything"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -101,8 +101,16 @@ PUBLISHED = {
     # rather than as boxes painted over a raster; this is that view.
     "app/view/PathwayAcquisitionViews/PA_Step4OmniPathNetworkView.js": (
         "0.1", "fbcdaeb4087e5edb65c09fa347ac22f0d001331c502fedfbd973ba9893d50e15"),
+    # v=0.9 adds SERVER_URL_PA_PATHWAY_EVIDENCE. The endpoint was added at
+    # v=0.8 WITHOUT a bump, which this guard caught: a returning browser keeps
+    # this file for up to 12 hours, so the evidence overlay would have POSTed
+    # to `undefined` for everyone who had already loaded the site.
     "resources/ServerConfiguration.js": (
-        "0.8", "2ed37a88c3dadb286bc798bfe164a0617e4388a782d843b036bcf9235bd8db7b"),
+        "0.9", "320717bdad3a27746dcf2070b7d11654a2f0c75fccaf2d242c266214ce7c3ac3"),
+    # The evidence layer itself: MORE relationships drawn on the diagram and
+    # classified against KEGG, Reactome and OmniPath.
+    "app/view/PathwayAcquisitionViews/PA_Step4EvidenceOverlay.js": (
+        "1.6", "8d59f773c20e2b81e998c5512cba525e9d65003bd88b6c8a90086c3da1545f63"),
     "js/libs/linkurious/sigma.min.js": ("0.1", None),
     "js/libs/linkurious/plugins.js": ("0.2", None),
     # Versioned by its release rather than by a counter. A vendored library is


### PR DESCRIPTION
## What this fixes

Three defects, all found by looking at a drawn map (mmu05167, the STATegra mouse job).

### 1. Corroboration consulted one database of three

Only OmniPath was asked. A regulator and its target joined by KEGG in a **different** map were reported as having no support at all.

Of the **492** MORE relationships drawable on some mmu KEGG map, **132 (26.8%)** are recorded in KEGG's own relation graph while being labelled *novel* (54) or *unsupported* (78) — and "unsupported" claims there is no external evidence either way about an interaction KEGG curates.

On mmu05167:

| | before | after |
|---|---|---|
| corroborated | 17 | **37** |
| novel | 17 | 20 |
| unsupported | **23** | **0** |

**32 of the 37** are recorded on a map other than the one open. The tooltip now names it:

> Stat3 → Myc · Corroborated · **KEGG (GErel) — recorded in Signaling pathways regulating pluripotency of stem cells, JAK-STAT signaling pathway**

The sources are complementary, not nested: 41 of the 93 OmniPath hits are absent from KEGG, so the union is the honest question. Reactome is included and is honestly small — **7 of 491 (1.4%)** against KEGG's 132.

**How each source is read.** KEGG: the KGML `<relation>` elements across every pathway of the organism (21,120 relations → 81,377 gene pairs on mouse), with `group` entries expanded and **`maplink` excluded** — it points at a pathway, not a gene, so keeping it would invent edges. Reactome: `graph.json` **catalysts / activators / inhibitors → outputs** only; `input → output` is usually the same molecule modified and would manufacture self-claims.

**Cost.** Indices build in 0.40 s (KEGG) and 0.62 s (Reactome) and cache per organism. The first `/pa_pathway_evidence` after a restart costs **2.78 s**; cached calls 0.10 s. Worth knowing — the server is single-process.

### 2. Every satellite was a duplicate, structurally

The satellite branch is only reachable when the regulator *already* has geometry on the map, so it always redrew a box KEGG had placed — **862 of 867** across the corpus. Jun was copied 6 raster px from its own box.

A regulator within **70 raster px** of its target is now ringed in **solid** violet and joined by an arrow; one sharing the target's drawn box gets a captioned self-loop (`Fos → Jun`), because the box holds several genes and no shape can name the pair. **232 duplicates removed.**

Solid ring = a box KEGG drew. Dashed frame = a box this layer added. Ringing a real box in dashes would have made the legend false.

### 3. Placement was blind to 31 boxes per map

The pathway document stores `genes`, `compounds`, `relatedPathways` only. mmu05167's **31 `ortholog` entries — the viral proteins, LANA among them** — were invisible, and a satellite covered **44.7%** of LANA. The geometry was in the KGML on disk all along, so it is read at request time; no reinstall.

Sweep over all 139 mmu maps that get edges (867 edges):

| | before | after |
|---|---|---|
| satellites on a printed KEGG box | **299 (34.7%)** | **0** |
| duplicate boxes drawn | 862 | 631 |
| arc fallbacks | 5 | **4** |

Fallbacks went *down*: removing 232 duplicates freed the space the denser obstacle map took.

## Controls

Satellites are **draggable**; offsets are kept in raster px in `visualOptions.evidencePlacement`, so a nudge survives reopening the pathway and reaches the PNG/SVG export. A "reset positions" control stays inert until something has been moved.

The card moved out from under the diagram — where it opened below the fold, 240 px of controls 18 px from the bottom of a 907 px viewport — into the **Pathway information** column, wearing that column's own `<h4>` / `.pa-details-label` / chip styles instead of card chrome.

## Testing

* `src/tests/test_pathway_evidence_sources.py` — **21 tests, hermetic** (fixtures written into a temporary `KEGG_DATA_DIR`, so it runs in the deploy image and with no species installed). Covers the ortholog/group obstacle read, `maplink` exclusion, group expansion, Reactome role filtering, multi-source lookup, the KEGG-only corroboration regression, pathway naming and capping, and isoform-collapse suppression.
* Clean-checkout import gate: `git archive HEAD` → all 8 servlets and `src.classes.PathwayEvidence` import, and the new test passes from the export.
* Verified in Chrome on the running app (and via the Playwright fallback when the extension dropped): drag moves the box without panning the map, the stub re-anchors, positions persist across a full reload, reset restores them, and CairoSVG renders the ring, caption halo and dragged transform so the export is intact. Alignment guides: 0 off-rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
