### PR TITLE
Show user requests in the admin panel

### DIFF
--- a/PaintomicsClient/public_html/admin/admin_app.js
+++ b/PaintomicsClient/public_html/admin/admin_app.js
@@ -8,7 +8,8 @@
 		'admin.controllers.systeminfo-controllers',
 		'admin.controllers.user-controllers',
 		'admin.controllers.file-controllers',
-		'admin.controllers.message-controllers'
+		'admin.controllers.message-controllers',
+		'admin.controllers.report-controllers'
 	]);
 
 	app.constant('myAppConfig', {
@@ -51,11 +52,18 @@
 				url: '/databases-management',
 				templateUrl: "templates/databases-management.tpl.html",
 				data: {requireLogin: false}
+			},
+			reportsManagement = {
+				name: 'reports-management',
+				url: '/reports-management',
+				templateUrl: "templates/reports-management.tpl.html",
+				data: {requireLogin: false}
 			};
 			$stateProvider.state(controlPanel);
 			$stateProvider.state(usersManagement);
 			$stateProvider.state(filesManagement);
 			$stateProvider.state(databasesManagement);
+			$stateProvider.state(reportsManagement);
 		}]
 	);
 
@@ -94,6 +102,8 @@
 				return myAppConfig.SERVER_URL + "api/admin/messages/" + extra;
 				case "databases":
 				return myAppConfig.SERVER_URL + "api/admin/databases/" + extra;
+				case "reports":
+				return myAppConfig.SERVER_URL + "api/admin/reports/" + extra;
 				case "clean-databases":
 				return myAppConfig.SERVER_URL + "api/admin/clean-databases/";
 				default:
@@ -176,7 +186,8 @@
 			{name:"control-panel", title: 'Control panel', description: 'The main Paintomics admin page', icon : 'fa-tachometer'},
 			{name:"users-management", title: 'Users', description: 'Manage the users in the applications', icon : 'fa-users'},
 			{name:"databases-management", title: 'Organisms', description: 'Manage the installed organisms', icon : 'fa-database'},
-			{name:"files-management", title: 'Files', description: 'Manage available reference files', icon : 'fa-files-o'}
+			{name:"files-management", title: 'Files', description: 'Manage available reference files', icon : 'fa-files-o'},
+			{name:"reports-management", title: 'Requests', description: 'Organism requests and error reports sent by users', icon : 'fa-inbox'}
 		];
 
 		$scope.visible_services = [$scope.open_services[0]];

--- a/PaintomicsClient/public_html/admin/controllers/admin.dir.js
+++ b/PaintomicsClient/public_html/admin/controllers/admin.dir.js
@@ -47,6 +47,12 @@
 		};
 	});
 
+	app.directive("reportRow", function() {
+		return {
+			templateUrl: 'templates/report-row.tpl.html'
+		};
+	});
+
 	app.directive('fileModel', ['$parse', function ($parse) {
 		return {
 			restrict: 'A',

--- a/PaintomicsClient/public_html/admin/controllers/report-list-service.js
+++ b/PaintomicsClient/public_html/admin/controllers/report-list-service.js
@@ -1,0 +1,87 @@
+/*
+* (C) Copyright 2014 The Genomics of Gene Expression Lab, CIPF
+* (http://bioinfo.cipf.es/aconesawp) and others.
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the GNU Lesser General Public License
+* (LGPL) version 3 which accompanies this distribution, and is available at
+* http://www.gnu.org/licenses/lgpl.html
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* THIS FILE CONTAINS THE FOLLOWING MODULE DECLARATION
+* - reports.reports.report-list
+*
+*/
+(function(){
+	var app = angular.module('reports.reports.report-list', []);
+
+	app.factory("ReportList", ['$rootScope', function($rootScope) {
+		var reports = [];
+		var undelivered = 0;
+		var old = new Date(0);
+
+		var TYPE_LABELS = {
+			specie_request: "Organism request",
+			error: "Error report",
+			other: "Other"
+		};
+
+		return {
+			getReports: function() {
+				return reports;
+			},
+			setReports: function(reportList) {
+				reports = this.adaptReportsInformation(reportList || []);
+				old = new Date();
+				return this;
+			},
+			getUndelivered: function() {
+				return undelivered;
+			},
+			setUndelivered: function(_undelivered) {
+				undelivered = _undelivered || 0;
+				return this;
+			},
+			deleteReport: function(report_id) {
+				for(var i in reports){
+					if(reports[i].report_id === report_id){
+						reports.splice(i,1);
+						return reports;
+					}
+				}
+				return null;
+			},
+			adaptReportsInformation: function(reportList) {
+				for(var i in reportList){
+					this.adaptReportInformation(reportList[i]);
+				}
+				return reportList;
+			},
+			adaptReportInformation: function(report){
+				report.type_label = TYPE_LABELS[report.report_type] || report.report_type;
+				// The message is assembled as HTML by the request form. The panel
+				// shows it as text, so strip the tags rather than trusting them:
+				// this string is user input and must never be rendered as markup.
+				report.message_text = String(report.message || "")
+					.replace(/<br\s*\/?>/gi, "\n")
+					.replace(/<\/p>/gi, "\n")
+					.replace(/<[^>]*>/g, " ")
+					.replace(/&nbsp;/gi, " ")
+					.replace(/&amp;/gi, "&")
+					.replace(/&lt;/gi, "<")
+					.replace(/&gt;/gi, ">")
+					.replace(/[ \t]+/g, " ")
+					.replace(/\n\s*\n+/g, "\n")
+					.trim();
+				return report;
+			},
+			getOld: function(){
+				return (new Date() - old)/120000;
+			}
+		};
+	}]);
+})();

--- a/PaintomicsClient/public_html/admin/controllers/reports.controller.js
+++ b/PaintomicsClient/public_html/admin/controllers/reports.controller.js
@@ -1,0 +1,103 @@
+/*
+* (C) Copyright 2014 The Genomics of Gene Expression Lab, CIPF
+* (http://bioinfo.cipf.es/aconesawp) and others.
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the GNU Lesser General Public License
+* (LGPL) version 3 which accompanies this distribution, and is available at
+* http://www.gnu.org/licenses/lgpl.html
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* THIS FILE CONTAINS THE FOLLOWING MODULE DECLARATION
+* - ReportListController
+*
+*/
+(function(){
+	var app = angular.module('admin.controllers.report-controllers', [
+		'ui.bootstrap',
+		'ang-dialogs',
+		'reports.reports.report-list'
+	]);
+
+	app.controller('ReportListController', function($rootScope, $scope, $http, $dialogs, $state, APP_EVENTS, ReportList) {
+		//--------------------------------------------------------------------
+		// CONTROLLER FUNCTIONS
+		//--------------------------------------------------------------------
+		this.retrieveReportsListData = function(force){
+			$scope.isLoading = true;
+
+			if(ReportList.getOld() > 1 || force){ //Max age for data 2min.
+				$http($rootScope.getHttpRequestConfig("GET", "reports", {})).
+				then(
+					function successCallback(response){
+						$scope.isLoading = false;
+						$scope.reports = ReportList.setReports(response.data.reportList).getReports();
+						$scope.undelivered = ReportList.setUndelivered(response.data.undelivered).getUndelivered();
+					},
+					function errorCallback(response){
+						$scope.isLoading = false;
+						var message = "Failed while retrieving the reports list.";
+						$dialogs.showErrorDialog(message, {
+							logMessage : message + " at ReportListController:retrieveReportsListData."
+						});
+						console.error(response.data);
+					}
+				);
+			}else{
+				$scope.reports = ReportList.getReports();
+				$scope.isLoading = false;
+			}
+		};
+
+		$scope.formatDate = function(submitted_at){
+			// Stored as an ISO-8601 UTC stamp (2026-08-19T14:36:40Z).
+			if(!submitted_at){ return ""; }
+			return String(submitted_at).replace("T", " ").replace("Z", " UTC");
+		};
+
+		//--------------------------------------------------------------------
+		// EVENT HANDLERS
+		//--------------------------------------------------------------------
+		this.deleteReportHandler = function (report){
+			var sendRemoveRequest = function(option){
+				if(option === "ok"){
+					$http($rootScope.getHttpRequestConfig("DELETE", "reports", {
+						extra: report.report_id
+					})).then(
+						function successCallback(response){
+							if(response.data.success){
+								me.retrieveReportsListData(true);
+							}
+						},
+						function errorCallback(response){
+							$scope.isLoading = false;
+							var message = "Failed while dismissing the report.";
+							$dialogs.showErrorDialog(message, {
+								logMessage : message + " at ReportListController:deleteReportHandler."
+							});
+							console.error(response.data);
+						}
+					);
+				}
+			};
+			$dialogs.showConfirmationDialog("This cannot be undone.", {title: "Dismiss this report?", callback : sendRemoveRequest});
+		};
+
+		this.refreshHandler = function(){
+			me.retrieveReportsListData(true);
+		};
+
+		//--------------------------------------------------------------------
+		// INITIALIZATION
+		//--------------------------------------------------------------------
+		var me = this;
+		$scope.reports = ReportList.getReports();
+		$scope.undelivered = ReportList.getUndelivered();
+
+		this.retrieveReportsListData(true);
+	});
+})();

--- a/PaintomicsClient/public_html/admin/index.html
+++ b/PaintomicsClient/public_html/admin/index.html
@@ -92,6 +92,8 @@
 <script type="text/javascript" src="controllers/file-list-service.js"></script>
 <script type="text/javascript" src="controllers/messages.controller.js"></script>
 <script type="text/javascript" src="controllers/message-list-service.js"></script>
+<script type="text/javascript" src="controllers/reports.controller.js"></script>
+<script type="text/javascript" src="controllers/report-list-service.js"></script>
 <script type="text/javascript" src="controllers/admin.dir.js"></script>
 <script type="text/javascript" src="lib/angular-dialogs/angular-dialogs.min.js"></script>
 </html>

--- a/PaintomicsClient/public_html/admin/templates/report-row.tpl.html
+++ b/PaintomicsClient/public_html/admin/templates/report-row.tpl.html
@@ -1,0 +1,19 @@
+<tr>
+	<td width="160px;">{{ formatDate(report.submitted_at) }}</td>
+	<td width="140px;">{{ report.type_label }}</td>
+	<td width="200px;">{{ report.user_email }}</td>
+	<td style="white-space: pre-wrap; word-break: break-word;">{{ report.message_text }}</td>
+	<td width="130px;">
+		<span ng-show="report.delivered" class="text-success">
+			<i class="fa fa-check" aria-hidden="true"></i> Sent
+		</span>
+		<span ng-hide="report.delivered" class="text-danger" title="{{ report.delivery_error }}">
+			<i class="fa fa-times" aria-hidden="true"></i> Not sent
+		</span>
+	</td>
+	<td width="110px;">
+		<a class="clickable" style="margin-right: 10px;" ng-click="controller.deleteReportHandler(report)">
+			<i class="fa fa-trash text-danger"></i> Dismiss
+		</a>
+	</td>
+</tr>

--- a/PaintomicsClient/public_html/admin/templates/reports-management.tpl.html
+++ b/PaintomicsClient/public_html/admin/templates/reports-management.tpl.html
@@ -1,0 +1,55 @@
+<div ng-controller="ReportListController as controller">
+	<div class=" admin-section-title-div">
+		<div class="panel-body">
+			<div style="margin: -9px;"><h1>PaintOmics 3 Administration</h1></div>
+		</div>
+	</div>
+	<div class="panel panel-default">
+		<div class="panel-body">
+			<h1>User requests</h1>
+			<h3>Organism requests and error reports submitted from the application</h3>
+
+			<div class="well" ng-show="undelivered > 0">
+				<h4><i class="fa fa-exclamation-triangle text-warning" aria-hidden="true"></i> {{undelivered}} of these were not emailed</h4>
+				<p>
+					Reports are saved here the moment they are submitted, before any email is
+					attempted, so nothing is lost when the mail provider is unavailable.
+					The ones marked <b>Not sent</b> below never reached an inbox &mdash; this
+					page is the only place they appear.
+				</p>
+				<p>
+					To restore email delivery, set a working <code>SMTP_PASSWORD</code> in
+					<code>/etc/paintomics/paintomics.env</code> and restart the service.
+				</p>
+			</div>
+
+			<a class="clickable btn btn-sm btn-info" ng-click="controller.refreshHandler();">
+				<i class="fa fa-refresh" aria-hidden="true"></i> Refresh
+			</a>
+
+			<h2 ng-show="isLoading === true">
+				<i class="fa fa-circle-o-notch fa-spin fa-fw"></i> Loading...
+			</h2>
+
+			<h4 ng-show="isLoading !== true && reports.length === 0">
+				No requests have been submitted yet.
+			</h4>
+
+			<table class="table" style="margin: auto; " ng-show="reports.length > 0">
+				<thead>
+					<tr style="text-align:center;">
+						<th>Date</th>
+						<th>Type</th>
+						<th>From</th>
+						<th>Request</th>
+						<th>Emailed</th>
+						<th>Options</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr report-row ng-repeat="report in reports" ></tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+</div>

--- a/PaintomicsServer/src/classes/Report.py
+++ b/PaintomicsServer/src/classes/Report.py
@@ -31,6 +31,7 @@ class Report (Model):
     # CONSTRUCTORS
     #******************************************************************************************************************
     def __init__(self, report_type=""):
+        self.report_id = ""
         self.report_type = report_type or "other"
         self.user_email = ""
         self.user_name = ""
@@ -42,6 +43,12 @@ class Report (Model):
     #******************************************************************************************************************
     # GETTERS AND SETTER
     #******************************************************************************************************************
+    def getReportID(self):
+        return self.report_id
+
+    def setReportID(self, report_id):
+        self.report_id = str(report_id or "")
+
     def getReportType(self):
         return self.report_type
 

--- a/PaintomicsServer/src/common/DAO/ReportDAO.py
+++ b/PaintomicsServer/src/common/DAO/ReportDAO.py
@@ -46,11 +46,17 @@ class ReportDAO(DAO):
 
         collection = self.dbManager.getCollection(self.collectionName)
 
+        # Newest first: the admin panel reads this top-down, and a report only
+        # matters until it is acted on.
         matchedReports = []
-        for instance in collection.find(queryParams):
+        for instance in collection.find(queryParams).sort("_id", -1):
             instance = self.adaptBSON(instance)
+            # Model.parseBSON pops _id, but the panel needs it to dismiss a
+            # report, so keep it before it is discarded.
+            reportID = instance.get("_id", "")
             reportInstance = Report("")
             reportInstance.parseBSON(instance)
+            reportInstance.setReportID(reportID)
             matchedReports.append(reportInstance)
         return matchedReports
 
@@ -62,8 +68,19 @@ class ReportDAO(DAO):
         # copy). Insert a shallow copy so the caller's Report keeps the plain
         # scalar fields it was built with and stays safe to serialise.
         instanceBSON = dict(instanceBSON)
+        # report_id is a read-side convenience carrying Mongo's own _id back to
+        # the admin panel; storing an empty copy of it would be noise.
+        instanceBSON.pop("report_id", None)
         result = collection.insert_one(instanceBSON)
         return str(result.inserted_id)
+
+    def remove(self, reportID, otherParams=None):
+        """Dismiss one report once it has been acted on."""
+        from bson.objectid import ObjectId
+
+        collection = self.dbManager.getCollection(self.collectionName)
+        result = collection.delete_one({"_id": ObjectId(reportID)})
+        return result.deleted_count > 0
 
     def markDelivered(self, reportID, delivered, deliveryError="", otherParams=None):
         """Record the outcome of the delivery attempt for an already-stored report."""

--- a/PaintomicsServer/src/paintomicsserver.py
+++ b/PaintomicsServer/src/paintomicsserver.py
@@ -848,6 +848,18 @@ class Application(object):
         def sendReportHandler():
             return adminServletSendReport(request, Response(), self.ROOT_DIRECTORY).getResponse()
         ##*******************************************************************************************
+        ##* RETRIEVE THE SUBMITTED REPORTS (organism requests, error reports)
+        ##*******************************************************************************************
+        @self.app.route(SERVER_SUBDOMAIN + '/api/admin/reports/', methods=['OPTIONS', 'GET'])
+        def getReports():
+            return adminServletGetReports(request, Response()).getResponse()
+        ##*******************************************************************************************
+        ##* DISMISS A REPORT
+        ##*******************************************************************************************
+        @self.app.route(SERVER_SUBDOMAIN + '/api/admin/reports/<path:reportID>', methods=['OPTIONS', 'DELETE'])
+        def deleteReport(reportID):
+            return adminServletDeleteReport(request, Response(), reportID).getResponse()
+        ##*******************************************************************************************
         ##* ADMIN SERVLETS HANDLERS - END
         #############################################################################################
         #############################################################################################

--- a/PaintomicsServer/src/servlets/AdminServlet.py
+++ b/PaintomicsServer/src/servlets/AdminServlet.py
@@ -673,6 +673,92 @@ def adminServletSystemInformation(request, response):
     finally:
         return response
 
+def adminServletGetReports(request, response):
+    """
+    List the reports users have submitted (organism requests, error reports).
+
+    These are stored by adminServletSendReport before any delivery is attempted,
+    so they are the record of what users asked for even when outbound mail is
+    unavailable -- which it has been in production. Without this handler the
+    only way to read them is a Mongo shell on the server.
+
+    @param {Request} request, the request object
+    @param {Response} response, the response object
+    """
+    daoInstance = None
+    try:
+        #****************************************************************
+        # Step 0.CHECK IF VALID USER SESSION
+        #****************************************************************
+        logging.info("STEP0 - CHECK IF VALID USER....")
+        userID = request.cookies.get('userID')
+        sessionToken = request.cookies.get('sessionToken')
+        userName = request.cookies.get('userName')
+        UserSessionManager().isValidAdminUser(userID, userName, sessionToken)
+
+        #****************************************************************
+        # Step 1. GET THE LIST OF REPORTS
+        #****************************************************************
+        logging.info("STEP1 - GET THE LIST OF REPORTS...")
+        daoInstance = ReportDAO()
+        reportList = [reportInstance.toBSON() for reportInstance in daoInstance.findAll()]
+
+        # Surfaced so the panel can warn that mail is down rather than letting
+        # an operator assume these were also emailed to them.
+        undelivered = len([r for r in reportList if not r.get("delivered")])
+
+        response.setContent({
+            "success": True,
+            "reportList": reportList,
+            "undelivered": undelivered,
+        })
+
+    except Exception as ex:
+        handleException(response, ex, __file__, "adminServletGetReports")
+
+    finally:
+        if daoInstance is not None:
+            daoInstance.closeConnection()
+        return response
+
+
+def adminServletDeleteReport(request, response, reportID):
+    """
+    Dismiss one report once it has been acted on.
+
+    @param {Request} request, the request object
+    @param {Response} response, the response object
+    @param {String} reportID, the id of the report to remove
+    """
+    daoInstance = None
+    try:
+        #****************************************************************
+        # Step 0.CHECK IF VALID USER SESSION
+        #****************************************************************
+        logging.info("STEP0 - CHECK IF VALID USER....")
+        userID = request.cookies.get('userID')
+        sessionToken = request.cookies.get('sessionToken')
+        userName = request.cookies.get('userName')
+        UserSessionManager().isValidAdminUser(userID, userName, sessionToken)
+
+        #****************************************************************
+        # Step 1. REMOVE THE REPORT
+        #****************************************************************
+        logging.info("STEP1 - REMOVE THE REPORT...")
+        daoInstance = ReportDAO()
+        removed = daoInstance.remove(reportID)
+
+        response.setContent({"success": True, "removed": removed})
+
+    except Exception as ex:
+        handleException(response, ex, __file__, "adminServletDeleteReport")
+
+    finally:
+        if daoInstance is not None:
+            daoInstance.closeConnection()
+        return response
+
+
 def adminServletSendReport(request, response, ROOT_DIRECTORY):
     """
     This function...

--- a/PaintomicsServer/src/tests/test_report_survives_mail_outage.py
+++ b/PaintomicsServer/src/tests/test_report_survives_mail_outage.py
@@ -57,6 +57,7 @@ def _ensureServerConfig():
 _ensureServerConfig()
 
 import src.servlets.AdminServlet as AdminServlet
+from src.classes.Report import Report
 
 
 class _Cookies(object):
@@ -183,6 +184,106 @@ class MailOutageTest(unittest.TestCase):
             self.assertTrue(response.content.get("success"))
         finally:
             AdminServlet.ReportDAO, AdminServlet.sendEmail = originalDAO, originalMail
+
+
+class AdminReportsViewTest(unittest.TestCase):
+    """The panel that makes stored reports visible without a Mongo shell.
+
+    With outbound mail unavailable, this view is the ONLY place an organism
+    request appears, so 'it is stored' is only half the fix.
+    """
+
+    def _run(self, handler, calls, admin=True, extra=None):
+        class _StubSessionManager(object):
+            def isValidAdminUser(self, userID, userName, sessionToken):
+                calls.append(("adminCheck", userID))
+                if not admin:
+                    raise Exception("Invalid admin user")
+                return True
+
+        class _StubDAO(object):
+            def findAll(self, otherParams=None):
+                calls.append(("findAll",))
+                stored, undelivered = Report("specie_request"), Report("error")
+                stored.setMessage("Please add Fusarium oxysporum")
+                stored.setDelivered(True)
+                stored.setReportID("id-delivered")
+                undelivered.setMessage("boom")
+                undelivered.setDelivered(False)
+                undelivered.setReportID("id-undelivered")
+                return [stored, undelivered]
+
+            def remove(self, reportID, otherParams=None):
+                calls.append(("remove", reportID))
+                return True
+
+            def closeConnection(self):
+                calls.append(("close",))
+                return True
+
+        originalDAO = AdminServlet.ReportDAO
+        originalSession = AdminServlet.UserSessionManager
+        AdminServlet.ReportDAO = _StubDAO
+        AdminServlet.UserSessionManager = _StubSessionManager
+        try:
+            response = _Response()
+            if extra is None:
+                handler(_Request({}), response)
+            else:
+                handler(_Request({}), response, extra)
+            return response
+        finally:
+            AdminServlet.ReportDAO = originalDAO
+            AdminServlet.UserSessionManager = originalSession
+
+    def test_reports_are_listed_for_an_admin(self):
+        calls = []
+        response = self._run(AdminServlet.adminServletGetReports, calls)
+        self.assertTrue(response.content.get("success"), response.content)
+        reports = response.content.get("reportList")
+        self.assertEqual(len(reports), 2)
+        self.assertIn("Fusarium oxysporum", reports[0]["message"])
+
+    def test_the_undelivered_count_is_reported(self):
+        """So an operator is told these never reached an inbox."""
+        calls = []
+        response = self._run(AdminServlet.adminServletGetReports, calls)
+        self.assertEqual(response.content.get("undelivered"), 1)
+
+    def test_listing_requires_an_admin(self):
+        calls = []
+        response = self._run(AdminServlet.adminServletGetReports, calls, admin=False)
+        self.assertIn(("adminCheck", None), calls)
+        self.assertFalse((response.content or {}).get("success"),
+                         "a non-admin was served the report list: %r" % (response.content,))
+
+    def test_dismissing_requires_an_admin(self):
+        calls = []
+        self._run(AdminServlet.adminServletDeleteReport, calls, admin=False, extra="id-1")
+        self.assertNotIn(("remove", "id-1"), calls,
+                         "a non-admin deleted a report")
+
+    def test_an_admin_can_dismiss_a_report(self):
+        calls = []
+        response = self._run(AdminServlet.adminServletDeleteReport, calls, extra="id-1")
+        self.assertTrue(response.content.get("success"))
+        self.assertIn(("remove", "id-1"), calls)
+
+    def test_the_mongo_connection_is_closed(self):
+        """DBmanager builds a client per DAO; the panel polls this route."""
+        calls = []
+        self._run(AdminServlet.adminServletGetReports, calls)
+        self.assertIn(("close",), calls)
+
+
+class ReportRoutesTest(unittest.TestCase):
+    def test_the_admin_report_routes_are_registered(self):
+        path = os.path.join(REPO, "PaintomicsServer", "src", "paintomicsserver.py")
+        source = open(path, encoding="utf-8").read()
+        self.assertIn("'/api/admin/reports/'", source,
+                      "the reports listing route is not registered")
+        self.assertIn("adminServletGetReports", source)
+        self.assertIn("adminServletDeleteReport", source)
 
 
 class UwsgiIniTest(unittest.TestCase):


### PR DESCRIPTION
Organism requests and error reports are stored durably since #50, but there was nowhere to read them. With outbound mail down — the SendGrid account is out of credits and no working SMTP credential is configured — a submitted request reached nobody, and the only way to see one was a Mongo shell on the server.

This adds a **Requests** section to the admin panel.


It lists date, type, sender, the request text, and whether it was ever emailed. A banner counts the undelivered ones and states plainly that this page is the only place they appear — so an operator is never left assuming a copy also landed in an inbox. Handled requests can be dismissed.

### Server

- `adminServletGetReports` / `adminServletDeleteReport`, both behind `isValidAdminUser` — these carry user email addresses. **Mutation-checked:** deleting either guard fails `test_admin_and_readonly_guards` (3 failures) *and* the new tests (1), and both pass again when restored.
- `ReportDAO` gains `remove()`, sorts newest-first, and carries Mongo's `_id` out as `report_id`. `Model.parseBSON` pops `_id`, so the panel previously had no handle to delete by. `insert()` drops that read-side field rather than storing an empty copy.

### Client

Reports controller + list service, a management and a row template, wired into `admin_app.js` routing and navigation. The request body is assembled as HTML by the request form, so the panel **strips tags and renders it as text** rather than trusting user-supplied markup.

### Verified in Chrome

Against a local server, driving the real UI:

- both seeded reports listed, with the form's HTML stripped to clean text (`Specie: Fusarium oxysporum` / `Comments: …` on separate lines)
- banner counted **2 of these were not emailed**
- dismissing one removed the row and recounted the banner to **1**; MongoDB agreed
- no page console errors
- an unauthenticated `GET /api/admin/reports/` is refused with `CredentialException`

Incidentally found while testing: the local dev `admin` account stores `userID` as the string `"0"` while `UserDAO.findByID` queries `int(userID)`, so *every* admin route 401s locally. Pre-existing and local-data-only — not touched here.

### Tests

Full sweep: **215 passed, 8 failed of 223**. The 8 are identical to the master baseline (missing local CSIC key, local Mongo snapshot drift, env/path) and each was confirmed to fail on `origin/master` without this branch. Zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
