### PR TITLE
Fix the broken logo and stale contact address in report emails

### DIFF
--- a/PaintomicsServer/src/resources/example_serverconf.py
+++ b/PaintomicsServer/src/resources/example_serverconf.py
@@ -135,7 +135,10 @@ smpt_sender_name = EMAIL_FROM_DISPLAY
 # PAINTOMICS_BASE_URL must be the externally reachable URL; it is embedded in
 # activation links sent by email, so localhost breaks registration in production.
 PAINTOMICS_BASE_URL     = os.getenv("PAINTOMICS_BASE_URL", "http://localhost:8000").rstrip("/")
-PAINTOMICS_LOGO_PATH    = os.getenv("PAINTOMICS_LOGO_PATH", "/resources/images/paintomics_white_300x66")
+# The extension is part of the path. Without it the URL 404s and every email
+# renders a broken-image icon where the logo should be; the file on disk is
+# public_html/resources/images/paintomics_white_300x66.png
+PAINTOMICS_LOGO_PATH    = os.getenv("PAINTOMICS_LOGO_PATH", "/resources/images/paintomics_white_300x66.png")
 PAINTOMICS_LOGO_URL     = f"{PAINTOMICS_BASE_URL}{PAINTOMICS_LOGO_PATH}"
 PAINTOMICS_LOGIN_URL    = os.getenv("PAINTOMICS_LOGIN_URL", f"{PAINTOMICS_BASE_URL}/")
 PAINTOMICS_DOCS_URL     = os.getenv("PAINTOMICS_DOCS_URL", "https://paintomics.readthedocs.io/en/latest/")

--- a/PaintomicsServer/src/servlets/AdminServlet.py
+++ b/PaintomicsServer/src/servlets/AdminServlet.py
@@ -819,7 +819,11 @@ def adminServletSendReport(request, response, ROOT_DIRECTORY):
         message += "<p>Best regards,</p>"
         message += "<p>The Paintomics developers team.</p>"
         message += "<div style='width:100%; height:10px; border-top: 1px dotted #333; margin-top:20px; margin-bottom:30px;'></div>"
-        message += "<p>Problems? E-mail <a href='mailto:" + "paintomics4@gmail.com" + "'>" + "paintomics4@gmail.com" + "</a></p>"
+        # The contact address follows EMAIL_FROM_ADDRESS rather than being
+        # hardcoded, so changing the project mailbox in config changes it here
+        # too. Pinned to a literal in two places, this footer kept naming a
+        # mailbox the deployment no longer used.
+        message += "<p>Problems? E-mail <a href='mailto:" + smpt_sender + "'>" + smpt_sender + "</a></p>"
         message += '</body></html>'
 
         #****************************************************************

--- a/PaintomicsServer/src/tests/test_report_survives_mail_outage.py
+++ b/PaintomicsServer/src/tests/test_report_survives_mail_outage.py
@@ -286,6 +286,66 @@ class ReportRoutesTest(unittest.TestCase):
         self.assertIn("adminServletDeleteReport", source)
 
 
+class EmailTemplateTest(unittest.TestCase):
+    """The report email rendered a broken logo and named the wrong mailbox.
+
+    Both were config-shaped bugs that no test could see:
+      * PAINTOMICS_LOGO_PATH had no file extension, so the <img> URL 404'd and
+        every recipient saw a broken-image icon.
+      * The "Problems? E-mail ..." footer hardcoded one address in two places,
+        so it kept naming a mailbox the deployment had moved off.
+    """
+
+    def _templateLogoPath(self):
+        """The default in the tracked template, which is what fresh deploys get.
+
+        serverconf.py itself is gitignored and per-machine, so asserting on it
+        would pass or fail by accident of the local box.
+        """
+        path = os.path.join(HERE, "..", "resources", "example_serverconf.py")
+        with open(path, encoding="utf-8") as handle:
+            for line in handle:
+                if line.strip().startswith("PAINTOMICS_LOGO_PATH"):
+                    return line.split('"')[-2]
+        self.fail("example_serverconf.py defines no PAINTOMICS_LOGO_PATH")
+
+    def test_the_logo_path_names_a_file_that_exists(self):
+        PAINTOMICS_LOGO_PATH = self._templateLogoPath()
+
+        extension = os.path.splitext(PAINTOMICS_LOGO_PATH)[1].lower()
+        self.assertIn(extension, (".png", ".jpg", ".jpeg", ".gif", ".svg"),
+                      "PAINTOMICS_LOGO_PATH (%s) has no image file extension, so "
+                      "the email <img> URL 404s and renders as a broken image"
+                      % PAINTOMICS_LOGO_PATH)
+
+        served = os.path.join(REPO, "PaintomicsClient", "public_html",
+                              PAINTOMICS_LOGO_PATH.lstrip("/"))
+        if os.path.isdir(os.path.join(REPO, "PaintomicsClient", "public_html")):
+            self.assertTrue(os.path.isfile(served),
+                            "PAINTOMICS_LOGO_PATH points at %s, which is not in "
+                            "public_html" % PAINTOMICS_LOGO_PATH)
+
+    def test_the_contact_footer_is_not_a_hardcoded_address(self):
+        """It must follow config, or it drifts from the live mailbox."""
+        path = os.path.join(REPO, "PaintomicsServer", "src", "servlets",
+                            "AdminServlet.py")
+        with open(path, encoding="utf-8") as handle:
+            lines = handle.readlines()
+
+        offenders = []
+        for number, line in enumerate(lines, 1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                continue                      # the licence header names a contact
+            if "message +=" in line and "@" in line and "mailto:" in line:
+                if '"' in line and "@gmail" in line:
+                    offenders.append("%d: %s" % (number, stripped[:90]))
+        self.assertEqual(
+            offenders, [],
+            "the email footer hardcodes an address instead of using the "
+            "configured sender: " + "; ".join(offenders))
+
+
 class UwsgiIniTest(unittest.TestCase):
     def test_ini_does_not_use_the_nonexistent_env_file_option(self):
         path = os.path.join(REPO, "paintomics4.ini")


### PR DESCRIPTION
Now that report mail sends again, the template it sends was visibly wrong in two ways.

### 1. The logo rendered as a broken-image icon

`PAINTOMICS_LOGO_PATH` had **no file extension** — `/resources/images/paintomics_white_300x66` — while the file on disk is `paintomics_white_300x66.png`. Checked against production:

| URL | Result |
|---|---|
| `/resources/images/paintomics_white_300x66` | **404** text/html |
| `/resources/images/paintomics_white_300x66.png` | **200** image/png, 11,499 bytes |

Separately, and not fixable in the repo: `PAINTOMICS_BASE_URL` was unset on the deployment, so the same URL was built against its `http://localhost:8000` default. A recipient can no more load `localhost` than a 404 — so the logo was broken twice over. That variable is now set in the server environment file.

### 2. The footer named a mailbox the deployment had moved off

`Problems? E-mail ...` hardcoded one address, twice. It now follows `EMAIL_FROM_ADDRESS`, so changing the project mailbox in config changes the footer with it.

### Tests

Two cases in `test_report_survives_mail_outage.py`: the template's logo path must carry an image extension **and** name a file that exists under `public_html`, and the footer must not hardcode an address. Both fail against the pre-fix code and pass after.

The logo assertion deliberately reads the **tracked template** rather than `serverconf.py` — that file is gitignored and per-machine, so asserting on it would pass or fail by accident of whichever box runs the suite.

### Verified

Real send, viewed in Gmail: logo renders, and both the sender and the `Username:` line read `paintomicsai@gmail.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)