### PR TITLE
Point the contact address at paintomicsai@gmail.com

### DIFF
--- a/PaintomicsClient/public_html/app.js
+++ b/PaintomicsClient/public_html/app.js
@@ -132,7 +132,7 @@ function showBootFailureMessage(error) {
         message: "</br>Paintomics could not start with the analysis stored in this browser." +
             "</br><a href='#' onclick='resetPaintomicsSession(); return false;'>Discard the stored analysis and reload</a>" +
             " - your jobs are kept on the server, so you can reopen them from [b]My Jobs[/b]." +
-            "</br>If the error persists, please contact your web <a href='mailto:paintomics4@gmail.com' target='_blank'>administrator</a>.",
+            "</br>If the error persists, please contact your web <a href='mailto:paintomicsai@gmail.com' target='_blank'>administrator</a>.",
         showButton: true
     });
 }

--- a/PaintomicsClient/public_html/app/view/MainView.js
+++ b/PaintomicsClient/public_html/app/view/MainView.js
@@ -383,7 +383,7 @@ function MainView() {
 									return;
 								}
 								showInfoMessage("Welcome to PaintOmics AI!", {
-									message: "PaintOmics AI runs on <a href=\"https://aic.csic.es/supercomputador-drago/\" target=\"_blank\" rel=\"noopener\">Supercomputador Drago</a> (CSIC). For any inquiries, please contact us at <a href=\"mailto:paintomics4@gmail.com\">paintomics4@gmail.com</a>",
+									message: "PaintOmics AI runs on <a href=\"https://aic.csic.es/supercomputador-drago/\" target=\"_blank\" rel=\"noopener\">Supercomputador Drago</a> (CSIC). For any inquiries, please contact us at <a href=\"mailto:paintomicsai@gmail.com\">paintomicsai@gmail.com</a>",
 									showButton: true
 								})
 							},

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -1404,7 +1404,7 @@ function PA_Step1JobView() {
 									'<a href="javascript:void(0)" id="poHeroExampleButton" class="po-btn-primary">Load an example</a>' +
 									'<a href="https://paintomics.readthedocs.io/en/latest/" target="_blank" class="po-btn-outline">Documentation</a>' +
 									'<a href="https://github.com/ConesaLab/paintomics4/" target="_blank" class="po-btn-quiet">GitHub</a>' +
-									'<a href="mailto:paintomics4@gmail.com" class="po-btn-quiet">Contact</a>' +
+									'<a href="mailto:paintomicsai@gmail.com" class="po-btn-quiet">Contact</a>' +
 									/* The abstract keeps its id and handler; it is a text link
 									   beside the other three actions rather than a picture. */
 								'</div>' +

--- a/PaintomicsClient/public_html/app/view/common/Util.js
+++ b/PaintomicsClient/public_html/app/view/common/Util.js
@@ -779,7 +779,7 @@ function ajaxErrorHandler(responseObj) {
     // where a stale cached model genuinely can be the cause.
     var serverSide = !!(err.extra && (err.extra.file_name || err.extra.exc_type));
     var adminLink = "If the error persists, please contact the " +
-        "<a href='mailto:paintomics4@gmail.com' target='_blank'> administrator</a>.";
+        "<a href='mailto:paintomicsai@gmail.com' target='_blank'> administrator</a>.";
 
     showErrorMessage("Oops..Internal error!", {
         message: err.message + "</br>" + (serverSide
@@ -812,7 +812,7 @@ function extJSErrorHandler(form, responseObj) {
     }
 
     showErrorMessage("Oops..Internal error!", {
-        message: err.message + "</br>Please try again later.</br>If the error persists, please contact your web <a href='mailto:paintomics4@gmail.com' target='_blank'> administrator</a>.",
+        message: err.message + "</br>Please try again later.</br>If the error persists, please contact your web <a href='mailto:paintomicsai@gmail.com' target='_blank'> administrator</a>.",
         showButton: true
     });
 }

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -125,7 +125,7 @@
 	<!--SCRIPTS FOR SERVER CONNECTION CONFIGURATION-->
 	<script type="text/javascript" src="resources/ServerConfiguration.js?v=0.9"></script>
 	<!--CUSTOM SENCHA EXTENSIONS-->
-	<script type="text/javascript" src="app/view/common/Util.js?v=2.0"></script>
+	<script type="text/javascript" src="app/view/common/Util.js?v=2.1"></script>
 	<script type="text/javascript" src="app/view/common/ExtJS_extensions.js?v=0.7"></script>
 	<script type="text/javascript" src="app/view/common/upload/Panel.js?v=0.2"></script>
 	<!--LAYOUT DEBUG OVERLAY - inert until ctrl+alt+G or ?guides=1 -->
@@ -143,7 +143,7 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step4EvidenceOverlay.js?v=1.6"></script>
 
 	<!--LAUNCH APPLICATION -->
-	<script type="text/javascript" src="app.js?v=0.2"></script>
+	<script type="text/javascript" src="app.js?v=0.3"></script>
 
 	<script type="text/javascript">
 	window.onbeforeunload = function (e) {

--- a/PaintomicsServer/src/AdminTools/scripts/clean_databases.py
+++ b/PaintomicsServer/src/AdminTools/scripts/clean_databases.py
@@ -8,6 +8,7 @@ from pymongo import MongoClient
 from pymongo.errors import OperationFailure
 from conf.serverconf import (
     MONGODB_HOST,
+    smpt_sender,
     MONGODB_PORT,
     MONGODB_DATABASE,
     CLIENT_TMP_DIR,
@@ -228,7 +229,7 @@ def remindJobByJobID(connection, user_id, job_id, ROOT_DIRECTORY):
         reminder_link = PAINTOMICS_BASE_URL + "/?jobID=" + job_id
         message += "<p><a target='_blank' href='" + reminder_link + "'>" + reminder_link + "</a></p></br>"
         message += "<div style='width:100%; height:10px; border-top: 1px dotted #333; margin-top:20px; margin-bottom:30px;'></div>"
-        message += "<p>Problems? E-mail <a href='mailto:" + "paintomics4@gmail.com" + "'>" + "paintomics4@gmail.com" + "</a></p>"
+        message += "<p>Problems? E-mail <a href='mailto:" + smpt_sender + "'>" + smpt_sender + "</a></p>"
         message += "<p>Legal notice: you are receiving this e-mail because you accepted Paintomics conditions. Your data will be stored for the"
         message += "solely purpose of informing you about actions involving your jobs."
         message += '</body></html>'

--- a/PaintomicsServer/src/classes/Feature.py
+++ b/PaintomicsServer/src/classes/Feature.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 
 from src.common.Util import Model

--- a/PaintomicsServer/src/classes/FeatureGraphicalData.py
+++ b/PaintomicsServer/src/classes/FeatureGraphicalData.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 
 from src.common.Util import Model

--- a/PaintomicsServer/src/classes/File.py
+++ b/PaintomicsServer/src/classes/File.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 
 from src.common.Util import Model

--- a/PaintomicsServer/src/classes/FoundFeature.py
+++ b/PaintomicsServer/src/classes/FoundFeature.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 
 from src.common.Util import Model

--- a/PaintomicsServer/src/classes/Job.py
+++ b/PaintomicsServer/src/classes/Job.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 
 import logging

--- a/PaintomicsServer/src/classes/JobInstances/Bed2GeneJob.py
+++ b/PaintomicsServer/src/classes/JobInstances/Bed2GeneJob.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 
 import logging

--- a/PaintomicsServer/src/classes/JobInstances/MiRNA2GeneJob.py
+++ b/PaintomicsServer/src/classes/JobInstances/MiRNA2GeneJob.py
@@ -19,7 +19,7 @@
 #     and others
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #
 #**************************************************************
 

--- a/PaintomicsServer/src/classes/Message.py
+++ b/PaintomicsServer/src/classes/Message.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 
 from src.common.Util import Model

--- a/PaintomicsServer/src/classes/Pathway.py
+++ b/PaintomicsServer/src/classes/Pathway.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 
 from .PathwayGraphicalData import PathwayGraphicalData

--- a/PaintomicsServer/src/classes/PathwayGraphicalData.py
+++ b/PaintomicsServer/src/classes/PathwayGraphicalData.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 
 from .FeatureGraphicalData import FeatureGraphicalData

--- a/PaintomicsServer/src/classes/Report.py
+++ b/PaintomicsServer/src/classes/Report.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 
 from src.common.Util import Model

--- a/PaintomicsServer/src/classes/User.py
+++ b/PaintomicsServer/src/classes/User.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 
 from src.common.Util import Model

--- a/PaintomicsServer/src/common/DAO/Bed2GeneJobDAO.py
+++ b/PaintomicsServer/src/common/DAO/Bed2GeneJobDAO.py
@@ -19,7 +19,7 @@
 #     and others
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #
 #**************************************************************
 

--- a/PaintomicsServer/src/common/DAO/FileDAO.py
+++ b/PaintomicsServer/src/common/DAO/FileDAO.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 
 from .DAO import DAO

--- a/PaintomicsServer/src/common/DAO/MessageDAO.py
+++ b/PaintomicsServer/src/common/DAO/MessageDAO.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 
 from .DAO import DAO

--- a/PaintomicsServer/src/common/DAO/MiRNA2GeneJobDAO.py
+++ b/PaintomicsServer/src/common/DAO/MiRNA2GeneJobDAO.py
@@ -19,7 +19,7 @@
 #     and others
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #
 #**************************************************************
 

--- a/PaintomicsServer/src/common/DAO/ReportDAO.py
+++ b/PaintomicsServer/src/common/DAO/ReportDAO.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 
 from .DAO import DAO

--- a/PaintomicsServer/src/common/DAO/UserDAO.py
+++ b/PaintomicsServer/src/common/DAO/UserDAO.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 
 import logging

--- a/PaintomicsServer/src/common/PySiQ.py
+++ b/PaintomicsServer/src/common/PySiQ.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #
 # THIS FILE CONTAINS THE FOLLOWING COMPONENT DECLARATION
 #  - JobStatus

--- a/PaintomicsServer/src/common/ReplicateDetection.py
+++ b/PaintomicsServer/src/common/ReplicateDetection.py
@@ -7,7 +7,7 @@
 #  the License, or (at your option) any later version.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 """
 ReplicateDetection

--- a/PaintomicsServer/src/common/ServerErrorManager.py
+++ b/PaintomicsServer/src/common/ServerErrorManager.py
@@ -19,7 +19,7 @@
 #     and others
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #
 #**************************************************************
 

--- a/PaintomicsServer/src/common/UserSessionManager.py
+++ b/PaintomicsServer/src/common/UserSessionManager.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 from src.common.ServerErrorManager import CredentialException
 from src.conf.serverconf import ADMIN_ACCOUNTS

--- a/PaintomicsServer/src/common/Util.py
+++ b/PaintomicsServer/src/common/Util.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 import codecs
 import os

--- a/PaintomicsServer/src/common/bioscripts/miRNA2Target.py
+++ b/PaintomicsServer/src/common/bioscripts/miRNA2Target.py
@@ -19,7 +19,7 @@
 #     and others
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #
 #**************************************************************
 

--- a/PaintomicsServer/src/paintomicsserver.py
+++ b/PaintomicsServer/src/paintomicsserver.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 import logging.config
 

--- a/PaintomicsServer/src/servlets/AdminServlet.py
+++ b/PaintomicsServer/src/servlets/AdminServlet.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 import logging
 import logging.config

--- a/PaintomicsServer/src/servlets/Bed2GenesServlet.py
+++ b/PaintomicsServer/src/servlets/Bed2GenesServlet.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 import logging
 import logging.config

--- a/PaintomicsServer/src/servlets/DataManagementServlet.py
+++ b/PaintomicsServer/src/servlets/DataManagementServlet.py
@@ -15,7 +15,7 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 import os, shutil
 import logging

--- a/PaintomicsServer/src/servlets/MiRNA2GenesServlet.py
+++ b/PaintomicsServer/src/servlets/MiRNA2GenesServlet.py
@@ -19,7 +19,7 @@
 #     and others
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #
 #**************************************************************
 

--- a/PaintomicsServer/src/servlets/UserManagementServlet.py
+++ b/PaintomicsServer/src/servlets/UserManagementServlet.py
@@ -15,13 +15,14 @@
 #  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
 #
 #  More info http://bioinfo.cipf.es/paintomics
-#  Technical contact paintomics4@gmail.com
+#  Technical contact paintomicsai@gmail.com
 #**************************************************************
 import logging
 import logging.config
 
 from src.conf.serverconf import (
     CLIENT_TMP_DIR,
+    smpt_sender,
     PAINTOMICS_BASE_URL,
     PAINTOMICS_LOGO_URL,
     PAINTOMICS_LOGIN_URL,
@@ -200,7 +201,7 @@ def userManagementSignUp(request, response, ROOT_DIRECTORY):
             message += "<p><b>Username:</b> " + userInstance.getEmail() + "</p></br>"
             message += "<p>Login in to Paintomics 4 at </p><a href='" + PAINTOMICS_LOGIN_URL + "'>" + PAINTOMICS_LOGIN_URL + "</a>"
             message += "<div style='width:100%; height:10px; border-top: 1px dotted #333; margin-top:20px; margin-bottom:30px;'></div>"
-            message += "<p>Problems? E-mail <a href='mailto:" + "paintomics4@gmail.com" + "'>" + "paintomics4@gmail.com" + "</a></p>"
+            message += "<p>Problems? E-mail <a href='mailto:" + smpt_sender + "'>" + smpt_sender + "</a></p>"
             message += '</body></html>'
 
             sendEmail(ROOT_DIRECTORY, userInstance.getEmail(), userInstance.getUserName(), "Welcome to Paintomics 4", message, isHTML=True)
@@ -411,7 +412,7 @@ def userManagementResetPassword(request, response, ROOT_DIRECTORY):
                 message += "<p>After restore your account, please use follow password to login.</p>"
                 message += "<h4>PASSWORD: " + randomPassword + "</h4>"
                 message += "<div style='width:100%; height:10px; border-top: 1px dotted #333; margin-top:20px; margin-bottom:30px;'></div>"
-                message += "<p>Problems? E-mail <a href='mailto:" + "paintomics4@gmail.com" + "'>" + "paintomics4@gmail.com" + "</a></p>"
+                message += "<p>Problems? E-mail <a href='mailto:" + smpt_sender + "'>" + smpt_sender + "</a></p>"
                 message += '</body></html>'
 
                 sendEmail(ROOT_DIRECTORY, userEmail, userInstance.getUserName(), "Reset password for Paintomics 4 account", message, isHTML=True)

--- a/PaintomicsServer/src/tests/test_report_survives_mail_outage.py
+++ b/PaintomicsServer/src/tests/test_report_survives_mail_outage.py
@@ -24,6 +24,7 @@ Run:  PYTHONPATH=PaintomicsServer python3 PaintomicsServer/src/tests/test_report
 """
 import importlib.util
 import os
+import re
 import sys
 import unittest
 
@@ -325,25 +326,37 @@ class EmailTemplateTest(unittest.TestCase):
                             "PAINTOMICS_LOGO_PATH points at %s, which is not in "
                             "public_html" % PAINTOMICS_LOGO_PATH)
 
-    def test_the_contact_footer_is_not_a_hardcoded_address(self):
-        """It must follow config, or it drifts from the live mailbox."""
-        path = os.path.join(REPO, "PaintomicsServer", "src", "servlets",
-                            "AdminServlet.py")
-        with open(path, encoding="utf-8") as handle:
-            lines = handle.readlines()
+    def test_no_email_template_hardcodes_a_contact_address(self):
+        """Every mail footer must follow config, or it drifts from the mailbox.
+
+        Four templates hardcoded the same literal address -- the report mail,
+        both account mails, and the quota warning -- so moving the project
+        mailbox left all four naming the old one.
+        """
+        roots = [os.path.join(REPO, "PaintomicsServer", "src", "servlets"),
+                 os.path.join(REPO, "PaintomicsServer", "src", "AdminTools", "scripts")]
 
         offenders = []
-        for number, line in enumerate(lines, 1):
-            stripped = line.strip()
-            if stripped.startswith("#"):
-                continue                      # the licence header names a contact
-            if "message +=" in line and "@" in line and "mailto:" in line:
-                if '"' in line and "@gmail" in line:
-                    offenders.append("%d: %s" % (number, stripped[:90]))
+        for root in roots:
+            if not os.path.isdir(root):
+                continue
+            for name in sorted(os.listdir(root)):
+                if not name.endswith(".py"):
+                    continue
+                path = os.path.join(root, name)
+                with open(path, encoding="utf-8") as handle:
+                    lines = handle.readlines()
+                for number, line in enumerate(lines, 1):
+                    if line.strip().startswith("#"):
+                        continue              # licence header names a contact
+                    if "mailto:" in line and "@" in line and '"' in line:
+                        # a quoted literal address next to mailto: is the bug
+                        if re.search(r'"[^"]*@[^"]*\.[a-z]{2,}[^"]*"', line):
+                            offenders.append("%s:%d" % (name, number))
         self.assertEqual(
             offenders, [],
-            "the email footer hardcodes an address instead of using the "
-            "configured sender: " + "; ".join(offenders))
+            "these email templates hardcode a contact address instead of using "
+            "the configured sender: " + "; ".join(offenders))
 
 
 class UwsgiIniTest(unittest.TestCase):

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ application.
 
 ## Contact and contributing
 
-Questions, bug reports and organism requests: [paintomics4@gmail.com](mailto:paintomics4@gmail.com)
+Questions, bug reports and organism requests: [paintomicsai@gmail.com](mailto:paintomicsai@gmail.com)
 or an [issue](https://github.com/ConesaLab/paintomics4/issues) on this
 repository. Pull requests are welcome.
 

--- a/docs/0_install.md
+++ b/docs/0_install.md
@@ -53,7 +53,7 @@ If you don't have Git (and thus can't run the git command), you can download Pai
 
 ## Configure the server
 Copy the example configuration file to a new *serverconf.py* file and adapt the values for the settings.
-If you are not sure about the values for an option, leave the default value or contact us for more info ([paintomics4@gmail.com](mailto:paintomics4@gmail.com).).
+If you are not sure about the values for an option, leave the default value or contact us for more info ([paintomicsai@gmail.com](mailto:paintomicsai@gmail.com).).
 
 ```bash
 cp $PWD/paintomics4/PaintomicsServer/src/conf/example_serverconf.py $PWD/paintomics4/PaintomicsServer/src/conf/serverconf.py

--- a/docs/2_1_accepted_input.md
+++ b/docs/2_1_accepted_input.md
@@ -4,7 +4,7 @@
 
 # Accepted input data
 
-For any question on Paintomics, users can send a mail to [paintomics4@gmail.com](mailto:paintomics4@gmail.com).
+For any question on Paintomics, users can send a mail to [paintomicsai@gmail.com](mailto:paintomicsai@gmail.com).
 
 As mentioned previously, the usage of multiple complementary genome-wide measurements is becoming a powerful tool for a better understanding the complexity of biological systems. Within this scenario, any new tool for System Biology cannot ignore this emerging trend and should be able to support multi-omic experiments. Following this idea, Paintomics 4.0 has been developed to accept data from diverse nature, including common techniques such as Transcriptomics, Metabolomics and Proteomics, but also emerging approaches such as DNase-seq, ChIP-seq or Methyl-seq. Resulting, the accepted inputs for Paintomics 4.0 can be broadly classified into 3 categories, depending on the nature of the input data.
 

--- a/docs/5_2_detailed_views.md
+++ b/docs/5_2_detailed_views.md
@@ -4,5 +4,5 @@
 
 
 # Paintomics, integrative visualization of multiple *omic* data
-For any question on Paintomics, users can send a mail to [paintomics4@gmail.com](mailto:paintomics4@gmail.com).
+For any question on Paintomics, users can send a mail to [paintomicsai@gmail.com](mailto:paintomicsai@gmail.com).
 

--- a/docs/5_3_heatmaps.md
+++ b/docs/5_3_heatmaps.md
@@ -4,4 +4,4 @@
 
 
 # Paintomics, integrative visualization of multiple *omic* data
-For any question on Paintomics, users can send a mail to [paintomics4@gmail.com](mailto:paintomics4@gmail.com).
+For any question on Paintomics, users can send a mail to [paintomicsai@gmail.com](mailto:paintomicsai@gmail.com).

--- a/docs/7_license.md
+++ b/docs/7_license.md
@@ -26,4 +26,4 @@ You should have received a copy of the GNU General Public License along with thi
 
 ** Ana Conesa, PhD. **, Head Genomics of Gene Expression Lab.
 
-For any question on Paintomics, users can send a mail to [paintomics4@gmail.com](mailto:paintomics4@gmail.com).
+For any question on Paintomics, users can send a mail to [paintomicsai@gmail.com](mailto:paintomicsai@gmail.com).

--- a/docs/8_step_by_step.md
+++ b/docs/8_step_by_step.md
@@ -135,4 +135,4 @@ Placing the cursor over these boxes will open up a tooltip window expanding the 
 
 
 <br/>
-For any question on PaintOmics, users can send a mail to [paintomics4@gmail.com](mailto:paintomics4@gmail.com).
+For any question on PaintOmics, users can send a mail to [paintomicsai@gmail.com](mailto:paintomicsai@gmail.com).

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 **Integrative visualization of multiple *omic* data**
 
-For any question on PaintOmics, users can send a mail to paintomics4@gmail.com
+For any question on PaintOmics, users can send a mail to paintomicsai@gmail.com
 
 **Welcome to PaintOmics v4.0 documentation.**
 
@@ -20,4 +20,4 @@ PaintOmics  is easy to run because the application itself guides you through the
 * **Identifier and Name Matching and Metabolite assignment:** Paintomics requires Entrez IDs for working with KEGG pathways, so the tool will convert the names and identifiers from different sources and databases in user’s the input data. This screen give users information about the number of features successfully mapped to KEGG pathways. It also shows the data distribution that will be used for pathway colouring, which can be modified when visualizing a pathway. Additionally, the metabolite names assignments are displayed and users can choose their favourite option in case of ambiguity. Click NEXT STEP button when you are ready.
 * **Results:** Pathways summary, Pathways classification, Pathways network, Pathways enrichment, Pathways visualization (by clicking PAINT BUTTON for any of the displayed pathways in Pathways enrichment section). Read more about these analyses in our documentation.
 
-Please check the user guide for further information. For any question on Paintomics, you can send an e-mail to paintomics4@gmail.com.
+Please check the user guide for further information. For any question on Paintomics, you can send an e-mail to paintomicsai@gmail.com.


### PR DESCRIPTION
The project mailbox moved, but the old address was still shown to users in several places:

- the **welcome dialog** — *"PaintOmics AI runs on Supercomputador Drago (CSIC). For any inquiries, please contact us at …"*
- every **error dialog**'s "contact your web administrator" link
- the **Contact** button on Step 1
- the docs and README
- **four email templates**

## The interesting part

Four of these were hardcoded literals inside mail bodies — the report mail, the registration and password-reset mails, and the quota warning. They now use the configured sender (`smpt_sender` / `EMAIL_FROM_ADDRESS`).

That duplication is precisely why the report footer kept naming the old address in #55 *after* the sender had already been changed in config: the value lived in four places and config governed none of them. Now moving the mailbox in config moves all four.

## Deliberately not changed

- **`Rafael Hernandez de Diego <paintomics4@gmail.com>`** in six licence headers — that is authorship attribution for a person. Rewriting it would misattribute the contributor.
- **`docs/superpowers/` plans and specs** — a record of what was decided at the time, not live configuration.

## Cache markers

Bumped for the two edited client files that carry them (`Util.js` 2.0 → 2.1, `app.js` 0.2 → 0.3). `MainView.js` and `PA_Step1Views.js` are loaded by the ExtJS dynamic loader and have no `?v=` marker.

## Tests

The hardcoded-address check now scans **every servlet and admin script** rather than `AdminServlet` alone. Mutation-checked: reintroducing a single literal address fails it, naming the offending file and line.

Full sweep **215/223**, with the 8 failures identical to master's baseline (missing local CSIC key, local Mongo drift, env/path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)