### PR TITLE
Results section: drop the dossier furniture it was leaving behind

### DIFF
--- a/PaintomicsServer/src/classes/AIInterpret/agent_loop.py
+++ b/PaintomicsServer/src/classes/AIInterpret/agent_loop.py
@@ -2410,7 +2410,11 @@ research paper's Results.
   do not add markers.
 - Report numbers inside the sentence with the measure named ("accessibility
   rose at 83 of 130 autophagy loci, p = 0.0029").
-- No preamble, no closing summary. Return only the section.
+- No preamble, no closing summary, and NO "Limitations" or "Caveats" section --
+  the report's own caveats are appended once after all sections, and one written
+  here becomes a duplicate.
+- No bullet lists. Any list in the source becomes prose.
+- Return only the section.
 
 HEADINGS ALREADY USED BY EARLIER SECTIONS -- yours must be clearly different,
 and must not restate the same claim in other words:
@@ -2435,13 +2439,19 @@ def _split_pathway_sections(report):
     """
     ref = report.split("### References")
     body, tail = ref[0], ("### References" + ref[1] if len(ref) > 1 else "")
-    parts = re.split(r"(?m)^(##\s+[^\n]+)$", body)
+    # Split on H1 as well as H2. Measured on a live job: that report opened
+    # with "# Key Findings" as an H1, so an H2-only split swept it into the
+    # preamble and carried the bullet block through verbatim -- the one thing
+    # the rewrite exists to remove.
+    parts = re.split(r"(?m)^(#{1,2}\s+[^\n]+)$", body)
     preamble = parts[0]
     secs = [(parts[i].strip(), parts[i + 1]) for i in range(1, len(parts) - 1, 2)]
     return preamble, secs, tail
 
 
 RESULTS_CHUNK = int(os.getenv("AI_AGENT_RESULTS_CHUNK", "4"))
+# How many subsections a Results section should aim for.
+RESULTS_TARGET_SECTIONS = int(os.getenv("AI_AGENT_RESULTS_SECTIONS", "5"))
 
 
 async def _results_by_chunk(agent, ctx, report, pw_names, job_id, stats, timeout):
@@ -2476,8 +2486,16 @@ async def _results_by_chunk(agent, ctx, report, pw_names, job_id, stats, timeout
             pathway_secs.append((h, b))
     if not pathway_secs:
         return None
-    groups = [pathway_secs[i:i + RESULTS_CHUNK]
-              for i in range(0, len(pathway_secs), RESULTS_CHUNK)]
+    # Chunk size is derived from the report, not fixed. A flat 4 gives a
+    # 4-section dossier exactly ONE subsection -- measured on a live job, whose
+    # Results section came back as a single wall under one heading. A Results
+    # section wants several subsections each telling a different story, so aim
+    # for about RESULTS_TARGET_SECTIONS of them and never fewer than two
+    # sections per chunk (a chunk of one cannot find a theme, only restate the
+    # pathway).
+    size = max(2, -(-len(pathway_secs) // RESULTS_TARGET_SECTIONS))
+    groups = [pathway_secs[i:i + size]
+              for i in range(0, len(pathway_secs), size)]
     async def one(group, taken):
         chunk = "\n\n".join(h + b for h, b in group)
         owned = [n for n in pw_names
@@ -2532,7 +2550,18 @@ async def _results_by_chunk(agent, ctx, report, pw_names, job_id, stats, timeout
     stats["results_chunks"] = len(groups)
     body = "\n\n".join(t for t, _ in out if t)
     if closing:
-        body = body.rstrip() + "\n\n" + "\n\n".join(c.strip() for c in closing)
+        # Deduplicated on the HEADING, keeping the longest body. A stitched
+        # dossier carries the caveats block once per stitched part, and those
+        # copies differ in wording -- so a body-text key keeps them all, which
+        # is how one live report ended with three "Limitations and Caveats".
+        by_head = {}
+        for c in closing:
+            m = re.match(r"\s*(#+\s*[^\n]+)", c)
+            key = " ".join((m.group(1) if m else c[:60]).lower().split())
+            if key not in by_head or len(c) > len(by_head[key]):
+                by_head[key] = c.strip()
+        uniq = list(by_head.values())
+        body = body.rstrip() + "\n\n" + "\n\n".join(uniq)
     return (preamble.rstrip() + "\n\n" + body + "\n\n" + tail).strip()
 
 
@@ -3154,7 +3183,11 @@ async def _run_loop_async(job_instance, job_id, experiment_design, budgets,
     # summary stays: it is the quantitative backbone, it is data the job already
     # holds rather than anything the model asserted, and dropping it would lose
     # numbers the reader may want to check.
-    if "## Enriched Pathway Summary" not in report:
+    # The enriched-pathway table is appended only when the dossier ships. A
+    # Results section carries its numbers in the sentences, and a 17-row table
+    # under it is the dossier furniture the rewrite was asked to remove -- the
+    # first live job with the stage on came back with prose AND the table.
+    if not results_written and "## Enriched Pathway Summary" not in report:
         report = report.rstrip() + "\n\n" + render_pathway_table(pathways)
     if ctx.partition is not None:
         if not results_written:

--- a/PaintomicsServer/src/tests/test_the_results_section_keeps_its_citations.py
+++ b/PaintomicsServer/src/tests/test_the_results_section_keeps_its_citations.py
@@ -252,6 +252,62 @@ class ResultsSectionKeepsItsFindings(unittest.TestCase):
         self.assertIn("closing", block)
 
 
+class ResultsSectionDropsTheDossierFurniture(unittest.TestCase):
+    """Found by running a LIVE job, not by testing one report.
+
+    Job Z2x664211R came back with prose AND a "# Key Findings" bullet block, a
+    17-row table, and "Limitations and Caveats" three times. Every one of these
+    passed on the report this stage was developed against, because that report
+    happened to use `## Key Findings` under an H1 title while the live one used
+    `# Key Findings` directly. One report is not a sample.
+    """
+
+    def setUp(self):
+        with open(SRC) as fh:
+            self.src = fh.read()
+
+    def test_the_splitter_sees_h1_headings_too(self):
+        """An H2-only split sweeps a "# Key Findings" section into the preamble,
+        which is carried verbatim -- so the one block the rewrite exists to
+        remove survives untouched."""
+        block = self.src.split("def _split_pathway_sections")[1][:1400]
+        self.assertIn("#{1,2}", block,
+                      "the section split must match H1 as well as H2")
+
+    def test_the_pathway_table_is_dropped_when_a_section_is_written(self):
+        """A Results section carries its numbers in sentences. A 17-row table
+        under it is exactly the dossier furniture being removed."""
+        block = self.src.split("The enriched-pathway table is appended only")[1][:500]
+        self.assertIn("not results_written", block)
+
+    def test_caveats_are_deduplicated_by_heading(self):
+        """A stitched dossier carries one caveats block per stitched part, and
+        the copies differ in wording -- so a body-text key keeps them all. One
+        live report ended with three."""
+        block = self.src.split("async def _results_by_chunk")[1]
+        block = block.split("\nasync def ")[0].split("\ndef ")[0]
+        self.assertIn("by_head", block)
+        self.assertNotIn('[:200]', block,
+                         "keying the dedup on body text is what let three "
+                         "differently-worded copies through")
+
+    def test_a_chunk_is_told_not_to_write_its_own_caveats(self):
+        """Two carried copies plus one the model wrote = three."""
+        prompt = " ".join(self.src.split("RESULTS_CHUNK_PROMPT")[1][:1600].lower().split())
+        self.assertIn("limitations", prompt)
+        self.assertIn("caveats", prompt)
+
+    def test_the_chunk_size_is_derived_not_fixed(self):
+        """A flat 4 gives a 4-section report exactly ONE subsection -- one wall
+        of text under one heading, which is not a Results section."""
+        block = self.src.split("async def _results_by_chunk")[1]
+        block = block.split("\nasync def ")[0].split("\ndef ")[0]
+        self.assertIn("RESULTS_TARGET_SECTIONS", block)
+        self.assertIn("max(2,", block,
+                      "a chunk of one cannot find a theme, only restate the "
+                      "pathway it was given")
+
+
 if __name__ == "__main__":
     # Load from the MODULE, not a named class. A second TestCase was added to
     # this file and silently never ran -- the runner reported 13/13 green while

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -80,7 +80,7 @@ INDEX_HTML = os.path.join(CLIENT_ROOT, "index.html")
 # year, and recording a digest for a 300KB minified bundle only creates churn.
 PUBLISHED = {
     "app/view/common/Util.js": (
-        "2.0", "284b8be3fd6f8e746730408b7bacc37c9385e4ce6e76743885c3a11dae6c3ecd"),
+        "2.1", "12359b8bf746394f63a7e0a15513a4f9ac82de1a25bbaa0e91e6b2fdd7e0050e"),
     "app/view/common/ExtJS_extensions.js": (
         "0.7", "f1e68f670cc56064fc15649d259004ccbd96f49181ced049cffbe62c29bf1d80"),
     "app/view/common/CookieConsent.js": (
@@ -118,7 +118,7 @@ PUBLISHED = {
     # upstream number is both the more informative marker and the one that
     # cannot drift from what is on disk.
     "js/libs/cytoscape/cytoscape.min.js": ("3.34.0", None),
-    "app.js": ("0.2", None),
+    "app.js": ("0.3", None),
 }
 
 _SRC = re.compile(r'src="([^"]+?)\?v=([0-9.]+)"')


### PR DESCRIPTION
Gate: **223 suites, 218 pass, 5 inherited, 0 INTRODUCED**, corpus byte-identical (199 traces, 0 stubs).

## Found by running a live job, not by testing one report

Job `Z2x664211R` came back with prose **and** a `# Key Findings` bullet block, a 17-row table, and `Limitations and Caveats` three times.

The conservation guard held throughout — **21 citations and 14/14 pathways kept** — so nothing was lost. It simply did not produce what was asked for. Guarding against data loss and producing the requested format are different properties, and only the first had been tested.

## Four bugs, each a SHAPE difference the development report did not have

| bug | cause | fix |
|---|---|---|
| `# Key Findings` survived | splitter matched `^## ` only; the dev report used `## Key Findings` under an H1 title, the live one used `# Key Findings` directly, so the block fell into the preamble and was carried verbatim | splits on H1 **and** H2 |
| 17-row table remained | the enriched-pathway table was appended even when a Results section was written | suppressed — a Results section carries its numbers in the sentences |
| `Limitations` ×3 | dedup keyed on the first 200 chars of the body; a stitched dossier carries one copy per part and they differ in wording, so all survived — plus the chunk wrote its own | dedup on the **heading**, keeping the longest body; chunk prompt told not to write one |
| one giant section | flat chunk size of 4 on a 4-section report = exactly ONE subsection | size derived from the report, aiming for ~5 subsections, never fewer than 2 sections per chunk (a chunk of one cannot find a theme, only restate the pathway) |

## Verified against that job's own report

```
5,124 words | 21 citations, sequential | 0 bullets | 0 tables
2 distinct subsections + 1 caveats block + References
```

## Also: two stale asset records that fail on master too

`index.html` serves `Util.js` at v=2.1 and `app.js` at v=0.3 while `test_versioned_assets_are_bumped` still recorded 2.0 and 0.2. The assets were bumped correctly by an earlier merge; the record was not updated with them. Fixed rather than baselined — a stale record makes that guard useless, and the guard exists because `getClusterColor` and `truncatableTextRenderer` both broke this way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)