### PR TITLE
Results section: stop rejecting every rewrite it writes

### DIFF
--- a/PaintomicsServer/src/benchmarks/ai_arm_bench.py
+++ b/PaintomicsServer/src/benchmarks/ai_arm_bench.py
@@ -203,11 +203,14 @@ STAGE_COUNTS = ("delegate_fulltext_gained", "quotes_supplied", "quotes_reused", 
                 # that held 16 of 16 from one that held 16 of 40.
                 "results_pathways_kept", "results_pathways_before",
                 # How many calls the chunked rewrite took, how many pathways a
-                # per-chunk retry had to restore, and how many it could not.
-                # unfixed > 0 with the run still accepted would mean the guard
-                # is being satisfied by something other than the chunks.
+                # per-chunk retry had to restore, how many sections a named-
+                # furniture heading turned out to be carrying, and how many
+                # chunks ended up keeping their ORIGINAL dossier text because
+                # three attempts would not conserve their markers or pathways.
+                # `reverted` is the stage's real cost now: a rewrite is no
+                # longer all-or-nothing, so this is where the loss shows up.
                 "results_chunks", "results_retried_pathways",
-                "results_chunk_unfixed",
+                "results_furniture_kept", "results_chunk_reverted",
                 # Which searches reached the report. Retrieval novelty is
                 # ~99.9%; conversion to a citation is ~12%, so the useful
                 # question is per-theme, not per-call.
@@ -268,7 +271,7 @@ STAGE_MAPS = ("tool_chars_by_tool", "tool_calls_by_tool")
 # Outcomes whose value is a sentence, not a number: a stage that skipped or
 # failed says WHY, and "absent from the archive" reads identically to "never
 # happened". Truncated because a traceback string is not a metric.
-STAGE_NOTES = ("delegate_fulltext_failed", "fulltext_candidates", "fulltext_upgraded", "fulltext_skipped", "fulltext_failed", "framing_failed", "correction_failed", "correction_skipped", "framing_reused", "trace_file", "merge_citations", "merge_grounded",
+STAGE_NOTES = ("results_chunk_revert_why", "delegate_fulltext_failed", "fulltext_candidates", "fulltext_upgraded", "fulltext_skipped", "fulltext_failed", "framing_failed", "correction_failed", "correction_skipped", "framing_reused", "trace_file", "merge_citations", "merge_grounded",
                "merge_coverage", "merge_mode", "merge_probe_failed",
                "failed_refs", "topup_refs", "topup_verify_failed",
                "topup_fulltext_skipped", "topup_fulltext_failed",

--- a/PaintomicsServer/src/classes/AIInterpret/agent_loop.py
+++ b/PaintomicsServer/src/classes/AIInterpret/agent_loop.py
@@ -2449,9 +2449,127 @@ def _split_pathway_sections(report):
     return preamble, secs, tail
 
 
+def _without_table_rows(text):
+    """The section with its markdown table rows removed.
+
+    Used to decide whether a section carries evidence. A table is data the job
+    already holds rendered as rows; it asserts nothing the prose does not, and
+    treating its cells as findings readmits the exact furniture the rewrite
+    exists to strip.
+    """
+    return re.sub(r"(?m)^\s*\|.*$", "", str(text))
+
+
+# A pathway written as a bold lead-in rather than a heading:
+# `**Cadherin signaling (p=5.03e-06, 20/26)** -- converges on ...`
+_LEAD_IN = re.compile(r"(?m)^\*\*([^*\n]{4,160}?)\*\*\s*(?=[\u2014\u2013:-])")
+
+
+def _explode_container(head, body):
+    """Split a section whose pathways are bold lead-ins, not headings.
+
+    Two production reports had their ENTIRE body under a single
+    `## Detailed Pathway Analysis`, with each pathway a `**Name (p=...)** --
+    prose` paragraph. The splitter looks for headings, found none inside, and
+    handed the chunker one chunk covering everything -- which is exactly the
+    one-call rewrite that chunking exists to replace, and it duly dropped 28 of
+    35 citations. Promoting each lead-in to a heading gives the chunker the
+    several small questions it needs.
+
+    Returns the section unchanged when there are fewer than two lead-ins: one
+    paragraph is not a container, and splitting on it would only relabel it.
+    """
+    hits = list(_LEAD_IN.finditer(body))
+    if len(hits) < 2:
+        return [(head, body)]
+    out = []
+    for i, m in enumerate(hits):
+        end = hits[i + 1].start() if i + 1 < len(hits) else len(body)
+        out.append(("## " + m.group(1).strip(), "\n" + body[m.start():end].strip()))
+    # Whatever preceded the first lead-in is the container's own framing; it
+    # rides with the first pathway rather than being dropped, because it can
+    # carry a citation of its own.
+    lead = body[:hits[0].start()].strip()
+    if lead:
+        out[0] = (out[0][0], "\n" + lead + "\n\n" + out[0][1].strip())
+    return out
+
+
 RESULTS_CHUNK = int(os.getenv("AI_AGENT_RESULTS_CHUNK", "4"))
 # How many subsections a Results section should aim for.
 RESULTS_TARGET_SECTIONS = int(os.getenv("AI_AGENT_RESULTS_SECTIONS", "5"))
+
+
+def _partition_sections(report, pw_names, stats):
+    """Sort the dossier into (preamble, findings, closing, tail).
+
+    Pure and side-effect free apart from the stats counter, so the
+    classification can be replayed over real reports without a gateway --
+    which is how the four production rejections were reproduced.
+    """
+    preamble, secs, tail = _split_pathway_sections(report)
+    # Headings that USUALLY introduce framing rather than a pathway finding.
+    # A name is a suspicion, not a verdict -- see the evidence test below.
+    SKIP = ("key findings", "cross-pathway", "detailed pathway analysis",
+            "pathway clusters", "enriched pathway summary", "summary of")
+    # Caveats close a Results section; they are not a finding to reorganise.
+    # Grouped with the pathways they landed third of six, which reads as the
+    # report giving up halfway through. Follow-up experiments belong with them:
+    # a proposal is not a result, and rewritten as one it acquires a finding
+    # heading for work nobody did.
+    LAST = ("limitation", "caveat", "follow-up experiment", "follow up experiment")
+    kinds = []
+    for h, b in secs:
+        low = h.lower()
+        kinds.append(("last" if any(k in low for k in LAST)
+                      else "skip" if any(k in low for k in SKIP)
+                      else "path", h, b))
+
+    # A SKIP-named section is dropped only if dropping it LOSES NOTHING.
+    #
+    # The name list was a guess about shape, and on live reports the guess was
+    # wrong in the most expensive way: four consecutive production runs had the
+    # whole rewrite rejected, and every rejection traces here. In the flat
+    # report shape the entire body is one `## Detailed Pathway Analysis` whose
+    # pathways are bold lead-ins, so the name list threw away all 15 (and all
+    # 35) citations at once; in the sectioned shape `## Key Findings` carried
+    # one or two markers that appeared nowhere else, which cost `lost_1` and
+    # `lost_2`. Both are the same mistake -- deciding a section's role from its
+    # title instead of its content. So the test is now what it should always
+    # have been: a section is furniture when every citation marker in it is
+    # also somewhere that survives and it names no pathway that would otherwise
+    # go unmentioned. Anything else is evidence and is rewritten like the rest.
+    surviving = preamble + "\n".join(h + b for k, h, b in kinds if k != "skip")
+    surv_marks = set(re.findall(r"\[(\d+)\]", surviving))
+    surv_low = _without_table_rows(surviving).lower()
+    pathway_secs, closing = [], []
+    for kind, h, b in kinds:
+        if kind == "last":
+            closing.append(h + b)
+        elif kind == "path":
+            pathway_secs.append((h, b))
+        else:
+            # Markers count wherever they are -- a citation is evidence even
+            # in a table cell. Pathway NAMES count only in PROSE, because the
+            # enriched-pathway summary and the cluster table are furniture by
+            # construction: rows of data the job already holds, appended
+            # deterministically below the report, naming dozens of pathways the
+            # prose never discusses. Judge their cells as findings and every
+            # one of those names reads as an orphan, the whole table is
+            # readmitted as evidence, and the rewrite ships with exactly the
+            # 46-row table it was asked to remove (measured on job 4j00f2377Y).
+            # A table row restates; it does not find.
+            prose = _without_table_rows(b)
+            marks = set(re.findall(r"\[(\d+)\]", b))
+            orphan_names = [n for n in pw_names
+                            if n and n.lower() in (h + prose).lower()
+                            and n.lower() not in surv_low]
+            if not (marks - surv_marks) and not orphan_names:
+                continue                       # genuinely furniture
+            stats["results_furniture_kept"] = (
+                stats.get("results_furniture_kept", 0) + 1)
+            pathway_secs.extend(_explode_container(h, b))
+    return preamble, pathway_secs, closing, tail
 
 
 async def _results_by_chunk(agent, ctx, report, pw_names, job_id, stats, timeout):
@@ -2469,21 +2587,8 @@ async def _results_by_chunk(agent, ctx, report, pw_names, job_id, stats, timeout
     ever holds them all. The preamble and the reference list are carried across
     verbatim: neither is a finding, and both are what a rewrite loses first.
     """
-    preamble, secs, tail = _split_pathway_sections(report)
-    # Sections that are framing rather than a pathway finding stay as they are.
-    SKIP = ("key findings", "cross-pathway", "detailed pathway analysis",
-            "pathway clusters", "enriched pathway summary", "summary of")
-    # Caveats close a Results section; they are not a finding to reorganise.
-    # Grouped with the pathways they landed third of six, which reads as the
-    # report giving up halfway through.
-    LAST = ("limitation", "caveat")
-    pathway_secs, closing = [], []
-    for h, b in secs:
-        low = h.lower()
-        if any(k in low for k in LAST):
-            closing.append(h + b)
-        elif not any(k in low for k in SKIP):
-            pathway_secs.append((h, b))
+    preamble, pathway_secs, closing, tail = _partition_sections(
+        report, pw_names, stats)
     if not pathway_secs:
         return None
     # Chunk size is derived from the report, not fixed. A flat 4 gives a
@@ -2493,6 +2598,9 @@ async def _results_by_chunk(agent, ctx, report, pw_names, job_id, stats, timeout
     # for about RESULTS_TARGET_SECTIONS of them and never fewer than two
     # sections per chunk (a chunk of one cannot find a theme, only restate the
     # pathway).
+    # Every marker the report carries, so a chunk reusing a marker another
+    # chunk introduced is not mistaken for inventing one.
+    all_marks = set(re.findall(r"\[(\d+)\]", report.split("### References")[0]))
     size = max(2, -(-len(pathway_secs) // RESULTS_TARGET_SECTIONS))
     groups = [pathway_secs[i:i + size]
               for i in range(0, len(pathway_secs), size)]
@@ -2505,14 +2613,23 @@ async def _results_by_chunk(agent, ctx, report, pw_names, job_id, stats, timeout
             "taken": ("\n".join("  - %s" % t for t in taken)
                       if taken else "  (none yet -- this is the first section)"),
             "chunk": chunk}
-        # Checked and retried per CHUNK, not once at the end. A chunk owns a
-        # known handful of pathways, so a miss is both detectable here and
-        # cheap to fix -- and a single dropped name at the end rejects the
-        # whole rewrite. Measured: one run kept 16/16, the next dropped one,
-        # from an identical input. The conservation is reliable; the wording
-        # is not, so it is checked rather than trusted.
+        # Checked and retried per CHUNK, and on failure the chunk keeps its
+        # ORIGINAL text rather than costing the whole rewrite.
+        #
+        # This is the second half of the production failure. Citations were
+        # only ever counted once, over the finished report, and any loss threw
+        # everything away -- so two live runs that had reorganised the entire
+        # dossier correctly were discarded for `lost_1` and `lost_2`. A chunk
+        # owns a known handful of markers and pathways, so the loss is
+        # detectable exactly where it happens and cheap to name in a retry;
+        # and if the retry still will not conserve them, one section reading
+        # like the old dossier is a far smaller loss than no rewrite at all.
+        # Only invented markers are judged against the whole report: a chunk
+        # may legitimately reuse a marker another chunk introduced, and
+        # reverting for that would punish good prose.
+        own_marks = set(re.findall(r"\[(\d+)\]", chunk))
         text = None
-        for attempt in (1, 2):
+        for attempt in (1, 2, 3):
             try:
                 r = await bounded(Runner.run(agent, prompt, context=ctx,
                                              max_turns=2), timeout,
@@ -2520,19 +2637,47 @@ async def _results_by_chunk(agent, ctx, report, pw_names, job_id, stats, timeout
                 text = str(r.final_output or "").strip()
             except (Exception, asyncio.TimeoutError) as e:
                 logger.warning("[%s][loop] results chunk failed: %s", job_id, e)
+                stats["results_chunk_reverted"] = (
+                    stats.get("results_chunk_reverted", 0) + 1)
                 return chunk, owned          # keep the ORIGINAL sections
+            got = set(re.findall(r"\[(\d+)\]", text))
             gone = [n for n in owned if n.lower() not in text.lower()]
-            if not gone or attempt == 2:
-                if gone:
-                    stats["results_chunk_unfixed"] = (
-                        stats.get("results_chunk_unfixed", 0) + len(gone))
+            lost = own_marks - got
+            made_up = got - all_marks
+            if not gone and not lost and not made_up:
                 break
-            prompt = (
-                "Your section stopped discussing these pathways:\n%s\n\n"
-                "Each is a finding, not an optional detail. Return the SAME "
-                "section with them discussed by name, keeping everything else "
-                "exactly as you wrote it.\n\n%s"
-                % ("\n".join("  - %s" % n for n in gone), text))
+            if attempt == 3:
+                stats["results_chunk_reverted"] = (
+                    stats.get("results_chunk_reverted", 0) + 1)
+                stats["results_chunk_revert_why"] = ",".join(
+                    filter(None, ["names_%d" % len(gone) if gone else "",
+                                  "cites_%d" % len(lost) if lost else "",
+                                  "invented_%d" % len(made_up) if made_up else ""]))
+                logger.info("[%s][loop] results chunk kept verbatim (%s)",
+                            job_id, stats["results_chunk_revert_why"])
+                return chunk, owned          # keep the ORIGINAL sections
+            asks = []
+            if gone:
+                asks.append(
+                    "It stopped discussing these pathways, each of which is a "
+                    "finding and not an optional detail:\n%s"
+                    % "\n".join("  - %s" % n for n in gone))
+            if lost:
+                asks.append(
+                    "It dropped these citation markers: %s\nEach marks a claim "
+                    "that was checked against the paper it points at, so a "
+                    "dropped marker loses a verified fact. Put each one back on "
+                    "the sentence carrying its claim."
+                    % " ".join("[%s]" % m for m in sorted(lost, key=int)))
+            if made_up:
+                asks.append(
+                    "It used these markers, which do not exist in this report: "
+                    "%s\nRemove them; do not renumber the rest."
+                    % " ".join("[%s]" % m for m in sorted(made_up, key=int)))
+            prompt = ("Your section did not conserve its source.\n\n%s\n\n"
+                      "Return the SAME section with that fixed, keeping "
+                      "everything else exactly as you wrote it.\n\n%s"
+                      % ("\n\n".join(asks), text))
         return text, owned
 
     # Sequential, not gathered. Run in parallel the chunks cannot see each
@@ -2615,7 +2760,13 @@ async def _write_results_section(agent, ctx, report, cluster_text, pathways,
 
     before = _body_markers(report)
     pw_names = [p.get("name") for p in (pathways or []) if p.get("name")]
-    pw_before = _named_pathways(report, pw_names)
+    # Prose only, on both sides. The dossier's enriched-pathway table lists
+    # EVERY enriched pathway -- 46 rows on one live job -- while the prose
+    # discusses a handful. Counting table cells as findings makes the guard
+    # demand that a Results section name all of them, which no Results section
+    # does, and the rewrite is rejected for dropping a table it was asked to
+    # drop.
+    pw_before = _named_pathways(_without_table_rows(report), pw_names)
     prompt = RESULTS_PROMPT % {
         "markers": " ".join("[%s]" % m for m in sorted(before, key=int)) or "(none)",
         "pathways": "\n".join("  - %s" % n for n in sorted(pw_before)) or "  (none)",
@@ -2636,7 +2787,7 @@ async def _write_results_section(agent, ctx, report, cluster_text, pathways,
                                       stats, timeout)
     if chunked:
         cand_after = _body_markers(chunked)
-        cand_pw = _named_pathways(chunked, pw_names)
+        cand_pw = _named_pathways(_without_table_rows(chunked), pw_names)
         reasons = []
         if before - cand_after:
             reasons.append("lost_%d" % len(before - cand_after))
@@ -3177,16 +3328,17 @@ async def _run_loop_async(job_instance, job_id, experiment_design, budgets,
     # arm ships them (its phase 5d): data the job already holds is appended,
     # never asked of the model.
     #
-    # When a Results section was written, the CLUSTER table is suppressed --
-    # the section describes the clustering in prose, which is the whole point of
-    # asking for it, and a table restating it undoes that. The enriched pathway
-    # summary stays: it is the quantitative backbone, it is data the job already
-    # holds rather than anything the model asserted, and dropping it would lose
-    # numbers the reader may want to check.
-    # The enriched-pathway table is appended only when the dossier ships. A
-    # Results section carries its numbers in the sentences, and a 17-row table
-    # under it is the dossier furniture the rewrite was asked to remove -- the
-    # first live job with the stage on came back with prose AND the table.
+    # When a Results section was written, BOTH tables are suppressed. The
+    # section describes the clustering in prose, which is the whole point of
+    # asking for it, and a table restating it undoes that; the enriched-pathway
+    # table is the same trade, and a Results section carries its numbers in the
+    # sentences. The first live job with the stage on came back with prose AND
+    # a 17-row table under it -- the dossier furniture the rewrite exists to
+    # remove.
+    #
+    # (An earlier comment here claimed the enriched summary stays. It never
+    # did; the condition below has always suppressed it. The comment was the
+    # thing that was wrong.)
     if not results_written and "## Enriched Pathway Summary" not in report:
         report = report.rstrip() + "\n\n" + render_pathway_table(pathways)
     if ctx.partition is not None:

--- a/PaintomicsServer/src/tests/test_the_results_section_keeps_its_citations.py
+++ b/PaintomicsServer/src/tests/test_the_results_section_keeps_its_citations.py
@@ -226,7 +226,11 @@ class ResultsSectionKeepsItsFindings(unittest.TestCase):
         block = self.src.split("async def _results_by_chunk")[1]
         block = block.split("\nasync def ")[0].split("\ndef ")[0]
         self.assertIn("gone = [n for n in owned", block)
-        self.assertIn("for attempt in (1, 2)", block)
+        # Three attempts, not two. The third exists because the fallback
+        # changed: a chunk that still will not conserve its source now keeps
+        # its ORIGINAL text instead of costing the whole rewrite, so one more
+        # try is cheaper than one more dossier-shaped section.
+        self.assertIn("for attempt in (1, 2, 3)", block)
 
     def test_chunks_run_in_order_so_headings_differ(self):
         """Run in parallel they cannot see each other and converge: five
@@ -247,7 +251,12 @@ class ResultsSectionKeepsItsFindings(unittest.TestCase):
         self.assertIn('"### References"', block)
 
     def test_caveats_close_the_section(self):
-        block = self.src.split("async def _results_by_chunk")[1]
+        # The classification lives in _partition_sections since it became
+        # evidence-based; it is pure so it can be replayed over real reports
+        # without a gateway, which is how four production rejections were
+        # reproduced offline.
+        block = self.src.split("def _partition_sections")[1]
+        block = block.split("\nasync def ")[0]
         self.assertIn("LAST = (", block)
         self.assertIn("closing", block)
 
@@ -276,9 +285,18 @@ class ResultsSectionDropsTheDossierFurniture(unittest.TestCase):
 
     def test_the_pathway_table_is_dropped_when_a_section_is_written(self):
         """A Results section carries its numbers in sentences. A 17-row table
-        under it is exactly the dossier furniture being removed."""
-        block = self.src.split("The enriched-pathway table is appended only")[1][:500]
-        self.assertIn("not results_written", block)
+        under it is exactly the dossier furniture being removed.
+
+        Anchored on the CONDITION, not on a sentence of the comment above it.
+        This test broke once because the comment was rewritten -- and the
+        comment was rewritten because it had been claiming the opposite of what
+        the code did for as long as both existed.
+        """
+        block = self.src.split("report = report.rstrip() + \"\\n\\n\" + "
+                               "render_pathway_table(pathways)")[0]
+        guard = block[block.rindex("\n    if "):]
+        self.assertIn("not results_written", guard)
+        self.assertIn("## Enriched Pathway Summary", guard)
 
     def test_caveats_are_deduplicated_by_heading(self):
         """A stitched dossier carries one caveats block per stitched part, and

--- a/PaintomicsServer/src/tests/test_the_results_stage_keeps_the_evidence.py
+++ b/PaintomicsServer/src/tests/test_the_results_stage_keeps_the_evidence.py
@@ -1,0 +1,322 @@
+"""A section is furniture only if dropping it loses nothing.
+
+Four consecutive production runs on paintomics.uv.es had their Results rewrite
+rejected -- `lost_15,droppedpathways_12`, `lost_28,invented_1,droppedpathways_7`,
+`lost_2`, `lost_1` -- so every user saw the old dossier and none of them saw
+the paper prose the stage exists to produce. Every one of those rejections came
+from the same place: a hard-coded list of heading names deciding which sections
+were framing.
+
+The list was a guess about SHAPE made from a TITLE, and reports come in more
+than one shape:
+
+  * flat      -- the whole body is one `## Detailed Pathway Analysis` whose
+                 pathways are `**Name (p=...)** -- prose` lead-ins. The name
+                 was on the list, so all 15 (and all 35) citations went at once.
+  * sectioned -- one `## ` per pathway, plus a `## Key Findings` summary that
+                 happened to carry one or two markers appearing nowhere else.
+  * stitched  -- several `# ` reports concatenated, each with its own framing.
+
+These tests fix the rule that replaces the guess: a named-furniture section is
+dropped only when every citation marker in it survives elsewhere and it names
+no pathway that would otherwise go unmentioned. They use the three real shapes
+because a single fixture is what let this ship -- the one report I tested by
+hand was the one shape the bug does not touch.
+"""
+import os
+import re
+import sys
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SERVER = os.path.dirname(os.path.dirname(HERE))
+sys.path.insert(0, os.path.join(SERVER, "src"))
+sys.path.insert(0, SERVER)
+
+SRC = os.path.join(SERVER, "src", "classes", "AIInterpret", "agent_loop.py")
+
+try:
+    from src.classes.AIInterpret import agent_loop as al
+    IMPORTED = True
+except Exception as _e:                                   # pragma: no cover
+    IMPORTED = False
+    IMPORT_ERROR = _e
+
+
+REFS = "\n### References\n" + "".join("[%d] Paper %d.\n" % (i, i)
+                                      for i in range(1, 8))
+
+FLAT = """# Synthesis Report: Cross-Pathway Analysis
+
+## Key Findings
+- Ikaros induction drives differentiation.
+- Chromatin opens before transcription responds.
+
+## Cross-Pathway Themes
+The pathways share a chromatin-first ordering.
+
+## Detailed Pathway Analysis
+
+**Kaposi sarcoma-associated herpesvirus infection (p=1.47e-06, 38/61 genes)** -- the
+top-ranked pathway. Myc shows a biphasic pattern [1], and IMiD-mediated IKZF1
+degradation downregulates MYC [2].
+
+**Cadherin signaling (p=5.03e-06, 20/26)** -- converges on beta-catenin. Wnt4 rises
+to 17.92 at 24 h [3].
+
+**Thyroid cancer (p=1.58e-05, 15/18)** -- shared RET/RAS/RAF drivers [4].
+
+## Suggested Follow-up Experiments
+ATAC-seq at 6 h would separate the two orderings.
+
+## Limitations and Caveats
+Time points are sparse.
+
+## Enriched Pathway Summary
+| Pathway | p | Genes |
+| --- | --- | --- |
+| Alcoholism | 1e-03 | 12/40 |
+| Adherens junction | 4e-03 | 8/22 |
+""" + REFS
+
+SECTIONED = """# Integrated Synthesis Report
+
+## Key Findings
+Ribosome biogenesis leads the response [5]; lysosome genes follow [1].
+
+## Ribosome Biogenesis in Eukaryotes (mmu03008)
+Ribosome biogenesis rises early [1].
+
+## Lysosome Biogenesis (mmu04142)
+Lysosome genes follow at 18 h [2].
+
+## Basal Transcription Factors (mmu03022)
+Basal factors are unchanged [3].
+
+## Limitations and Caveats
+Replicates are limited.
+""" + REFS
+
+FURNITURE_ONLY = """# Report
+
+## Key Findings
+Ribosome biogenesis leads the response [1].
+
+## Ribosome Biogenesis in Eukaryotes (mmu03008)
+Ribosome biogenesis rises early [1].
+
+## Lysosome Biogenesis (mmu04142)
+Lysosome genes follow [2].
+""" + REFS
+
+NAMES = ["Kaposi sarcoma-associated herpesvirus infection", "Cadherin signaling",
+         "Thyroid cancer", "Ribosome Biogenesis in Eukaryotes",
+         "Lysosome Biogenesis", "Basal Transcription Factors"]
+
+
+def _marks(text):
+    return set(re.findall(r"\[(\d+)\]", str(text).split("### References")[0]))
+
+
+@unittest.skipUnless(IMPORTED, "agent_loop did not import")
+class FurnitureIsDecidedByEvidence(unittest.TestCase):
+    """The classification, replayed over the three real report shapes."""
+
+    def _partition(self, report):
+        stats = {}
+        pre, secs, closing, tail = al._partition_sections(report, NAMES, stats)
+        kept = pre + "".join(h + b for h, b in secs) + "".join(closing)
+        return pre, secs, closing, tail, kept, stats
+
+    # ---- the flat shape: the whole report was being thrown away ----------
+    def test_a_container_holding_every_citation_is_not_dropped(self):
+        """`lost_15` and `lost_28`, the two worst production rejections.
+
+        `## Detailed Pathway Analysis` is on the furniture list, and in this
+        shape it is the entire report.
+        """
+        _, _, _, _, kept, _ = self._partition(FLAT)
+        self.assertEqual(_marks(FLAT) - _marks(kept), set(),
+                         "the container carried every marker in the report")
+
+    def test_a_container_is_split_into_one_section_per_pathway(self):
+        """Kept but unsplit is only half a fix.
+
+        One chunk covering everything is the single-call rewrite that chunking
+        exists to replace -- measured at 28 of 35 citations dropped.
+        """
+        _, secs, _, _, _, _ = self._partition(FLAT)
+        heads = " | ".join(h for h, _ in secs).lower()
+        self.assertIn("kaposi", heads)
+        self.assertIn("cadherin", heads)
+        self.assertIn("thyroid", heads)
+        self.assertGreaterEqual(len(secs), 3)
+
+    def test_a_split_container_keeps_each_pathway_with_its_own_citations(self):
+        """A split that separates a claim from its marker would trade one
+        failure for a subtler one."""
+        _, secs, _, _, _, _ = self._partition(FLAT)
+        by_head = {h.lower(): b for h, b in secs}
+        kaposi = [b for h, b in by_head.items() if "kaposi" in h][0]
+        self.assertEqual(_marks(kaposi), {"1", "2"})
+        cadherin = [b for h, b in by_head.items() if "cadherin" in h][0]
+        self.assertEqual(_marks(cadherin), {"3"})
+
+    # ---- the sectioned shape: one or two orphan markers ------------------
+    def test_a_summary_holding_an_orphan_marker_is_kept(self):
+        """`lost_2` and `lost_1`. [5] appears only in Key Findings."""
+        _, _, _, _, kept, stats = self._partition(SECTIONED)
+        self.assertIn("5", _marks(kept),
+                      "a marker that lives only in the summary is still a "
+                      "verified claim")
+        self.assertEqual(stats.get("results_furniture_kept"), 1)
+
+    def test_a_summary_that_repeats_what_survives_is_still_dropped(self):
+        """The guard must not become 'keep everything' -- the bullets and the
+        duplicate tables are what the stage was built to remove."""
+        _, secs, _, _, kept, stats = self._partition(FURNITURE_ONLY)
+        self.assertNotIn("key findings", " ".join(h for h, _ in secs).lower())
+        self.assertNotIn("results_furniture_kept", stats)
+        self.assertEqual(_marks(FURNITURE_ONLY) - _marks(kept), set())
+
+    def test_furniture_naming_an_otherwise_unmentioned_pathway_is_kept(self):
+        """A finding can be lost without a citation going with it: the rubric
+        scores pathway NAMES, and coverage and citation count are independent
+        (r = 0.05 measured)."""
+        report = FURNITURE_ONLY.replace(
+            "Ribosome biogenesis leads the response [1].",
+            "Basal Transcription Factors are unchanged [1].")
+        _, secs, _, _, kept, _ = self._partition(report)
+        self.assertIn("basal transcription factors", kept.lower())
+
+    # ---- placement -------------------------------------------------------
+    def test_follow_up_experiments_close_the_section_rather_than_open_one(self):
+        """Rewritten as a finding it acquires a heading for work nobody did."""
+        _, secs, closing, _, _, _ = self._partition(FLAT)
+        self.assertNotIn("follow-up", " ".join(h for h, _ in secs).lower())
+        self.assertIn("follow-up", " ".join(closing).lower())
+
+    def test_caveats_stay_in_the_closing_block(self):
+        _, secs, closing, _, _, _ = self._partition(FLAT)
+        self.assertIn("limitations", " ".join(closing).lower())
+        self.assertNotIn("limitations", " ".join(h for h, _ in secs).lower())
+
+    # ---- a table restates; it does not find -----------------------------
+    def test_a_data_table_is_furniture_however_many_pathways_it_names(self):
+        """The over-correction the first fix shipped.
+
+        The enriched-pathway summary lists EVERY enriched pathway -- 46 rows on
+        job 4j00f2377Y -- while the prose discusses a handful. Judged on raw
+        text, all 46 read as pathways mentioned nowhere else, the table is
+        readmitted as evidence, and the rewrite ships with exactly the table it
+        was asked to remove.
+        """
+        _, secs, closing, _, kept, _ = self._partition(FLAT)
+        self.assertNotIn("| Alcoholism |", kept,
+                         "a row of data the job already holds is not a finding")
+        self.assertNotIn("enriched pathway summary",
+                         " ".join(h for h, _ in secs).lower())
+
+    def test_a_citation_inside_a_table_still_counts_as_evidence(self):
+        """Names are findings only in prose; a marker is evidence wherever it
+        is. Stripping tables from BOTH tests would let a cited row vanish."""
+        report = FLAT.replace("| Alcoholism | 1e-03 | 12/40 |",
+                              "| Alcoholism | 1e-03 | see [7] |")
+        _, _, _, _, kept, _ = self._partition(report)
+        self.assertIn("7", _marks(kept))
+
+    def test_the_reference_list_is_carried_across_verbatim(self):
+        for report in (FLAT, SECTIONED, FURNITURE_ONLY):
+            _, _, _, tail, _, _ = self._partition(report)
+            self.assertIn("### References", tail)
+
+    # ---- the property that all four rejections violated ------------------
+    def test_no_shape_loses_a_marker_in_classification(self):
+        """The one assertion that would have caught every production failure
+        before it shipped."""
+        for name, report in (("flat", FLAT), ("sectioned", SECTIONED),
+                             ("furniture-only", FURNITURE_ONLY)):
+            _, _, _, _, kept, _ = self._partition(report)
+            self.assertEqual(_marks(report) - _marks(kept), set(),
+                             "%s shape dropped a marker before the model ever "
+                             "ran" % name)
+
+    def test_no_shape_loses_a_pathway_the_prose_discusses(self):
+        """The other half of the guard, on the same basis the guard uses.
+
+        Citation count and rubric coverage are independent (r = 0.05), so
+        conserving markers says nothing about conserving findings.
+        """
+        for name, report in (("flat", FLAT), ("sectioned", SECTIONED),
+                             ("furniture-only", FURNITURE_ONLY)):
+            _, _, _, _, kept, _ = self._partition(report)
+            prose_before = al._without_table_rows(
+                report.split("### References")[0]).lower()
+            prose_kept = al._without_table_rows(kept).lower()
+            lost = [n for n in NAMES
+                    if n.lower() in prose_before and n.lower() not in prose_kept]
+            self.assertEqual(lost, [], "%s shape dropped %s" % (name, lost))
+
+
+@unittest.skipUnless(IMPORTED, "agent_loop did not import")
+class ALeadInIsOnlySplitWhenItIsAContainer(unittest.TestCase):
+
+    def test_a_single_lead_in_is_left_alone(self):
+        """One bold paragraph is emphasis, not a list of pathways."""
+        out = al._explode_container("## Notes", "\n**Only one** -- prose [1].\n")
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0][0], "## Notes")
+
+    def test_framing_above_the_first_lead_in_is_carried(self):
+        body = ("\nThese pathways share a theme [9].\n\n"
+                "**One (p=1)** -- a [1].\n\n**Two (p=2)** -- b [2].\n")
+        out = al._explode_container("## Detailed Pathway Analysis", body)
+        self.assertEqual(len(out), 2)
+        self.assertIn("9", _marks(out[0][1]),
+                      "the container's own framing can carry a citation")
+
+
+class TheChunkKeepsItsSourceWhenItCannotConserveIt(unittest.TestCase):
+    """Source-level: the second half of the production failure.
+
+    Citations were counted once, over the finished report, and any loss threw
+    the whole rewrite away -- so two runs that had reorganised the dossier
+    correctly were discarded for one and two markers.
+    """
+
+    def setUp(self):
+        with open(SRC) as fh:
+            self.src = fh.read()
+        self.block = self.src.split("    async def one(group, taken):")[1]
+        self.block = self.block.split("\n    # Sequential")[0]
+
+    def test_a_chunk_checks_its_own_markers(self):
+        self.assertIn("own_marks", self.block)
+        self.assertIn("lost = own_marks - got", self.block)
+
+    def test_a_failing_chunk_reverts_to_its_source_text(self):
+        """One section reading like the old dossier is a far smaller loss than
+        no rewrite at all."""
+        self.assertIn("results_chunk_reverted", self.block)
+        self.assertEqual(self.block.count("return chunk, owned"), 2,
+                         "both the exception path and the unconserved path "
+                         "must keep the ORIGINAL sections")
+
+    def test_invented_markers_are_judged_against_the_whole_report(self):
+        """A chunk may legitimately reuse a marker another chunk introduced;
+        reverting for that would punish good prose."""
+        self.assertIn("made_up = got - all_marks", self.block)
+
+    def test_the_retry_names_what_went_missing(self):
+        low = self.block.lower()
+        self.assertIn("dropped these citation markers", low)
+        self.assertIn("stopped discussing these pathways", low)
+
+
+if __name__ == "__main__":
+    if not IMPORTED:
+        print("NOTE: agent_loop did not import (%s); behavioural cases skip."
+              % IMPORT_ERROR)
+    r = unittest.TextTestRunner(verbosity=2).run(
+        unittest.TestLoader().loadTestsFromModule(sys.modules[__name__]))
+    sys.exit(0 if r.wasSuccessful() else 1)

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -6101,3 +6101,89 @@ renamed tests, so each suite died on a `NameError` *instead of running* -- a
 failure that reads as an error, not as a pass, but only because someone looks.
 All four now collect from `globals()`. That is the sixth through ninth
 occurrence recorded in this document.
+
+## The Results stage was rejecting itself on every production run
+
+The stage shipped, was enabled on paintomics.uv.es, and **never once reached a
+user**. Four consecutive live runs, read out of `__stats__` in the trace archive:
+
+| job | `results_rejected` | shape |
+| --- | --- | --- |
+| `4j00f2377Y` | `lost_15,droppedpathways_12` | flat |
+| `7wkV30zivJ` | `lost_28,invented_1,droppedpathways_7` | flat |
+| `y7gI3AVpSm` | `lost_2` | sectioned |
+| `D3k1L35664` | `lost_1` | stitched |
+
+`results_section: false` in all four, so every user saw the dossier. The stage
+was on, running, costing 3-58 s a run, and throwing away everything it wrote.
+
+**This was invisible to the way it had been verified.** It was developed and
+hand-checked against one report, `Z2x664211R`, which is the one shape the bug
+does not touch -- its `## Key Findings` carries no citation, so nothing is lost
+when the block is dropped. Testing a second real report would have found it.
+One report is not a sample; that lesson is now recorded twice in this document.
+
+### Cause 1: a section's role was read off its title
+
+`SKIP` was a list of heading names. Reports come in more than one shape, and in
+the flat shape the entire body is a single `## Detailed Pathway Analysis` whose
+pathways are `**Name (p=...)** -- prose` lead-ins, not headings. That name was
+on the list, so all 15 (and all 35) citations went at once. In the sectioned
+shape `## Key Findings` happened to carry one or two markers appearing nowhere
+else -- hence `lost_1` and `lost_2`, near-misses that cost the whole rewrite.
+
+The rule is now computed, not named: **a section is furniture only when every
+citation marker in it survives elsewhere and it names no pathway that would
+otherwise go unmentioned.** Names are counted in PROSE only -- the
+enriched-pathway table lists every enriched pathway (46 rows on `4j00f2377Y`)
+while the prose discusses a handful, and judging its cells as findings readmits
+the whole table as evidence. Markers count wherever they are, table cells
+included. The report-level guard was moved onto the same basis; before, it
+selected on one basis and judged on another.
+
+### Cause 2: a container was one chunk
+
+Kept but unsplit is half a fix. A flat report gave the chunker `results_chunks:
+1`, which is the single-call rewrite chunking exists to replace -- and it duly
+dropped 28 of 35 citations. `_explode_container` promotes each bold lead-in to a
+heading: `4j00f2377Y` goes 1 -> 17 sections, `7wkV30zivJ` 1 -> 3.
+
+### Cause 3: the guard was all-or-nothing
+
+Citations were counted once, over the finished report. `lost_1` discarded a
+rewrite that had reorganised everything else correctly. Conservation is now
+checked **per chunk**, where the loss happens and where it is cheap to name in a
+retry (three attempts, the repair prompt listing the exact markers and pathway
+names). A chunk that still will not conserve its source keeps its ORIGINAL text.
+One section reading like the old dossier is a far smaller loss than no rewrite.
+Only invented markers are judged against the whole report -- a chunk may
+legitimately reuse a marker another chunk introduced.
+
+### Measured, on the deployed venv against the live gateway
+
+All four rejected reports now accept:
+
+| job | before | after | s | chunks | reverted | tables |
+| --- | --- | --- | --- | --- | --- | --- |
+| `4j00f2377Y` | `lost_15,droppedpathways_12` | **accepted** | 26 | 5 | 0 | 46 -> 0 |
+| `7wkV30zivJ` | `lost_28,invented_1,...` | **accepted** | 17 | 2 | 0 | 40 -> 0 |
+| `D3k1L35664` | `lost_1` | **accepted** | 69 | 5 | 0 | 54 -> 0 |
+| `y7gI3AVpSm` | `lost_2` | **accepted** | 48 | 5 | 1 `names_1` | 52 -> 0 |
+
+Bullets 45 -> 4, 41 -> 11, 10 -> 5, 5 -> 0; the residue is the caveats list,
+which is carried verbatim on purpose. Classification replayed offline over all
+nine stored UV reports loses **no citation marker and no prose-named pathway**
+in any of them.
+
+`y7gI3AVpSm` is the one that proves the third fix: one chunk reverted, the run
+still accepted. Under the old guard that single chunk was the whole rejection.
+
+### What this says about verifying a guard
+
+`results_pathways_before: 0` in an earlier hand-probe was reported as a caveat
+and chased down: the probe's own name extraction found nothing, while the real
+path passes 40 named pathways. That was the right instinct applied to the wrong
+number. **The number that mattered was in the archive the whole time** --
+`results_rejected` was set on every live run, and reading four traces would have
+found this before any of it shipped. A stage that records why it refused itself
+is only useful if the refusals are read.


### PR DESCRIPTION
## The Results section stage never reached a user

It shipped, it was enabled on paintomics.uv.es, and it rejected its own output
on **every** production run. Four consecutive live jobs, read out of
`__stats__` in the trace archive:

| job | `results_rejected` | report shape |
| --- | --- | --- |
| `4j00f2377Y` | `lost_15,droppedpathways_12` | flat |
| `7wkV30zivJ` | `lost_28,invented_1,droppedpathways_7` | flat |
| `y7gI3AVpSm` | `lost_2` | sectioned |
| `D3k1L35664` | `lost_1` | stitched |

`results_section: false` in all four — so every user saw the old dossier
(bulleted Key Findings, a 46-row table, a per-pathway catalogue), which is
exactly what was reported.

## Three causes, all in the section classifier

**1. A section's role was read off its title.** `SKIP` was a list of heading
names. Reports come in more than one shape, and in the flat shape the whole
body is a single `## Detailed Pathway Analysis` whose pathways are
`**Name (p=…)** — prose` lead-ins. That name was on the list, so all 15 (and
all 35) citations went at once. In the sectioned shape `## Key Findings`
carried one or two markers appearing nowhere else — `lost_1`, `lost_2`.

The rule is now computed, not named: **a section is furniture only when every
citation marker in it survives elsewhere and it names no pathway that would
otherwise go unmentioned.** Names count in **prose only** — the
enriched-pathway table lists *every* enriched pathway while the prose discusses
a handful, and judging its cells as findings readmits the whole table as
evidence (this over-correction was caught by a live run, not by a test).
Markers count anywhere, table cells included. The report-level guard was moved
onto the same basis; before, it selected on one basis and judged on another.

**2. A container was one chunk.** Kept but unsplit is half a fix — a flat
report gave the chunker `results_chunks: 1`, the single-call rewrite that
chunking exists to replace, and it duly dropped 28 of 35 citations.
`_explode_container` promotes each bold lead-in to a heading (`4j00f2377Y`
1 → 17 sections, `7wkV30zivJ` 1 → 3).

**3. The guard was all-or-nothing.** Citations were counted once, over the
finished report, so `lost_1` discarded a rewrite that had reorganised
everything else correctly. Conservation is now checked **per chunk**, with a
three-attempt retry naming the exact markers and pathway names that went
missing; a chunk that still will not conserve its source **keeps its original
text**. One section reading like the old dossier is a far smaller loss than no
rewrite at all.

Follow-up experiments move to the closing block: a proposal is not a result,
and rewritten as one it acquires a finding heading for work nobody did.

## Measured — deployed venv, live CSIC gateway, real stored reports

All four rejected reports now accept:

| job | before | after | s | chunks | reverted | table rows | bullets |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `4j00f2377Y` | `lost_15,droppedpathways_12` | **accepted** | 26 | 5 | 0 | 46 → 0 | 10 → 5 |
| `7wkV30zivJ` | `lost_28,invented_1,…` | **accepted** | 17 | 2 | 0 | 40 → 0 | 5 → 0 |
| `D3k1L35664` | `lost_1` | **accepted** | 69 | 5 | 0 | 54 → 0 | 45 → 4 |
| `y7gI3AVpSm` | `lost_2` | **accepted** | 48 | 5 | 1 `names_1` | 52 → 0 | 41 → 11 |

The bullet residue is the caveats list, carried verbatim on purpose.
`y7gI3AVpSm` is the case that proves the third fix: one chunk reverted and the
run **still accepted** — under the old guard that single chunk was the whole
rejection.

Classification replayed offline over **all nine** stored UV reports loses no
citation marker and no prose-named pathway in any of them.

## Tests

* New `test_the_results_stage_keeps_the_evidence.py` (19 cases) — fixtures for
  all three real report shapes, plus the table rule and the per-chunk revert.
  `test_no_shape_loses_a_marker_in_classification` is the one assertion that
  would have caught every production failure before it shipped.
* `_partition_sections` extracted as a pure function so the classification can
  be replayed over real reports with no gateway — that is how the four
  rejections were reproduced.
* Two stale source-scanning cases in
  `test_the_results_section_keeps_its_citations` re-anchored (one had been
  pinned to a comment sentence; that comment had been claiming the opposite of
  what its code did).
* Full suite: **224 suites, 219 pass, 0 introduced**; the 5 failures are
  inherited from master.

## Note on how this was missed

The stage was hand-verified against **one** report, `Z2x664211R` — the one
shape the bug does not touch, because its `## Key Findings` carries no citation.
A second real report would have found it, and so would reading
`results_rejected`, which the archive had been recording on every live run the
whole time. A stage that records why it refused itself is only useful if the
refusals get read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
