### PR TITLE
Results section: a container is not a finding at any heading level

### DIFF
--- a/PaintomicsServer/src/classes/AIInterpret/agent_loop.py
+++ b/PaintomicsServer/src/classes/AIInterpret/agent_loop.py
@@ -2465,31 +2465,64 @@ def _without_table_rows(text):
 _LEAD_IN = re.compile(r"(?m)^\*\*([^*\n]{4,160}?)\*\*\s*(?=[\u2014\u2013:-])")
 
 
-def _explode_container(head, body):
-    """Split a section whose pathways are bold lead-ins, not headings.
+# A `###` subsection: the other way a report nests several findings under one
+# `##`. Three is the threshold, not two -- a single pathway's own write-up can
+# reasonably carry a couple of subsections, but not a list of them.
+_SUBHEAD = re.compile(r"(?m)^#{3,4}\s+([^\n]+)$")
+CONTAINER_MIN_SUBHEADS = 3
 
-    Two production reports had their ENTIRE body under a single
-    `## Detailed Pathway Analysis`, with each pathway a `**Name (p=...)** --
-    prose` paragraph. The splitter looks for headings, found none inside, and
-    handed the chunker one chunk covering everything -- which is exactly the
-    one-call rewrite that chunking exists to replace, and it duly dropped 28 of
-    35 citations. Promoting each lead-in to a heading gives the chunker the
-    several small questions it needs.
 
-    Returns the section unchanged when there are fewer than two lead-ins: one
-    paragraph is not a container, and splitting on it would only relabel it.
+def _explode_container(head, body, pw_names=()):
+    """Split a section that holds several findings under one heading.
+
+    A container is not one finding, and handing the chunker one is handing it
+    the whole report again -- the single-call rewrite that chunking exists to
+    replace. Both nesting styles seen in production are handled:
+
+    * **`###` subsections.** Job `Yj5oty03Uf`, run through the UI: 12 pathways
+      under `## Pathway-Specific Findings`, 7 themes under `## Cross-Pathway
+      Themes`, 6 under `## Most Biologically Significant Findings`. The splitter
+      only descends to `##`, so each of those arrived as ONE section; the stage
+      accepted its own output and the user got the dossier back nearly verbatim,
+      because a chunk that IS a report has nothing to reorganise it into.
+    * **Bold lead-ins.** Two other production reports had their entire body
+      under `## Detailed Pathway Analysis` with each pathway a
+      `**Name (p=...)** -- prose` paragraph. That one chunk dropped 28 of 35
+      citations.
+
+    Children are promoted to `##` so the rewritten section keeps the one-heading
+    convention the chunk prompt asks for. Returns the section unchanged when it
+    is not a container: relabelling a single finding buys nothing.
+
+    **A section whose own heading names a pathway is never a container.** One
+    report writes `## 2. ATP-Dependent Chromatin Remodeling (mmu03082)` with
+    three `###` subsections inside it; splitting that fragments one finding into
+    three chunks that each own nothing, and it took a live report from 18
+    sections to 40 while dropping six pathway names. A container's heading is
+    generic precisely because it holds things that are not it.
     """
-    hits = list(_LEAD_IN.finditer(body))
-    if len(hits) < 2:
+    if any(n and n.lower() in head.lower() for n in pw_names):
         return [(head, body)]
+    subs = list(_SUBHEAD.finditer(body))
+    if len(subs) >= CONTAINER_MIN_SUBHEADS:
+        return _split_on(head, body, subs, lambda m: m.group(1))
+    hits = list(_LEAD_IN.finditer(body))
+    if len(hits) >= 2:
+        return _split_on(head, body, hits, lambda m: m.group(1))
+    return [(head, body)]
+
+
+def _split_on(head, body, hits, title_of):
+    """One section per match, with the framing above the first carried along."""
     out = []
     for i, m in enumerate(hits):
         end = hits[i + 1].start() if i + 1 < len(hits) else len(body)
-        out.append(("## " + m.group(1).strip(), "\n" + body[m.start():end].strip()))
-    # Whatever preceded the first lead-in is the container's own framing; it
-    # rides with the first pathway rather than being dropped, because it can
-    # carry a citation of its own.
-    lead = body[:hits[0].start()].strip()
+        out.append(("## " + title_of(m).strip(),
+                    "\n" + body[m.start():end].strip()))
+    # The container's own heading and whatever preceded the first match ride
+    # with the first child rather than being dropped -- either can carry a
+    # citation, and the heading can carry a pathway name.
+    lead = (head + "\n" + body[:hits[0].start()]).strip()
     if lead:
         out[0] = (out[0][0], "\n" + lead + "\n\n" + out[0][1].strip())
     return out
@@ -2547,7 +2580,10 @@ def _partition_sections(report, pw_names, stats):
         if kind == "last":
             closing.append(h + b)
         elif kind == "path":
-            pathway_secs.append((h, b))
+            # Exploded too, not only the furniture. `## Pathway-Specific
+            # Findings` is on no name list and held all 12 pathways of job
+            # Yj5oty03Uf under `###`.
+            pathway_secs.extend(_explode_container(h, b, pw_names))
         else:
             # Markers count wherever they are -- a citation is evidence even
             # in a table cell. Pathway NAMES count only in PROSE, because the
@@ -2568,7 +2604,7 @@ def _partition_sections(report, pw_names, stats):
                 continue                       # genuinely furniture
             stats["results_furniture_kept"] = (
                 stats.get("results_furniture_kept", 0) + 1)
-            pathway_secs.extend(_explode_container(h, b))
+            pathway_secs.extend(_explode_container(h, b, pw_names))
     return preamble, pathway_secs, closing, tail
 
 

--- a/PaintomicsServer/src/tests/test_the_results_stage_keeps_the_evidence.py
+++ b/PaintomicsServer/src/tests/test_the_results_stage_keeps_the_evidence.py
@@ -109,6 +109,57 @@ Ribosome biogenesis rises early [1].
 Lysosome genes follow [2].
 """ + REFS
 
+# The fourth shape, found by running a job through the UI: findings nested one
+# level deeper, under `###`, inside generically-titled `##` containers.
+NESTED = """# Synthesis Report: Multi-Omic Analysis
+
+## Key Findings
+1. **Chromatin remodeling precedes transcription** across several pathways.
+
+## Cross-Pathway Themes and Shared Mechanisms
+
+### 1. Chromatin-First Regulation
+Accessibility leads mRNA by 6-12 h [1].
+
+### 2. Post-Translational Signaling
+Protein spikes precede transcript change [2].
+
+### 3. miRNA-Mediated Buffering
+Derepression follows [3].
+
+## Pathway-Specific Findings
+
+### Ribosome Biogenesis in Eukaryotes (mmu03008)
+Repressed throughout [4].
+
+### Lysosome Biogenesis (mmu04142)
+Induced hydrolases [5].
+
+### Basal Transcription Factors (mmu03022)
+Subunit exchange [6].
+
+## Limitations and Caveats
+Time points are sparse.
+""" + REFS
+
+# A pathway's OWN section, which happens to carry subsections. Not a container.
+PATHWAY_WITH_SUBSECTIONS = """# Report
+
+## 2. Basal Transcription Factors (mmu03022)
+
+### Gene-level observations
+Taf8 up, Taf12 down [1].
+
+### Chromatin context
+Accessibility rises early [2].
+
+### Timing
+The switch completes by 18 h [3].
+
+## Lysosome Biogenesis (mmu04142)
+Induced hydrolases [4].
+""" + REFS
+
 NAMES = ["Kaposi sarcoma-associated herpesvirus infection", "Cadherin signaling",
          "Thyroid cancer", "Ribosome Biogenesis in Eukaryotes",
          "Lysosome Biogenesis", "Basal Transcription Factors"]
@@ -189,6 +240,53 @@ class FurnitureIsDecidedByEvidence(unittest.TestCase):
         _, secs, _, _, kept, _ = self._partition(report)
         self.assertIn("basal transcription factors", kept.lower())
 
+    # ---- the fourth shape: findings nested under `###` ------------------
+    def test_a_generically_titled_section_of_subsections_is_split(self):
+        """Job `Yj5oty03Uf`, run through the UI after the first fix shipped.
+
+        12 pathways under `## Pathway-Specific Findings`, 7 themes under
+        `## Cross-Pathway Themes`. The splitter descends only to `##`, so each
+        arrived as ONE section -- the stage accepted its own output and handed
+        the user back the dossier, because a chunk that IS a report has nothing
+        to reorganise it into.
+        """
+        _, secs, _, _, _, _ = self._partition(NESTED)
+        heads = [h.lower() for h, _ in secs]
+        self.assertNotIn("## pathway-specific findings", heads)
+        self.assertTrue(any("ribosome biogenesis" in h for h in heads))
+        self.assertTrue(any("lysosome biogenesis" in h for h in heads))
+        self.assertTrue(any("chromatin-first" in h for h in heads))
+        self.assertGreaterEqual(len(secs), 6)
+
+    def test_a_section_whose_heading_names_a_pathway_is_never_split(self):
+        """The over-correction the `###` rule shipped with.
+
+        `## 2. ATP-Dependent Chromatin Remodeling (mmu03082)` with three
+        subsections is ONE finding. Splitting it took a live report from 18
+        sections to 40 and dropped six pathway names, because the parent
+        heading -- the only place the pathway was named -- went with it.
+        """
+        _, secs, _, _, kept, _ = self._partition(PATHWAY_WITH_SUBSECTIONS)
+        heads = " | ".join(h.lower() for h, _ in secs)
+        self.assertIn("basal transcription factors", heads)
+        self.assertNotIn("gene-level observations", heads)
+        self.assertIn("basal transcription factors", kept.lower())
+
+    def test_two_subsections_are_not_a_container(self):
+        """Three is the threshold: a single finding can reasonably carry a
+        couple of subsections, but not a list of them."""
+        out = al._explode_container(
+            "## Themes", "\n### One\na [1].\n\n### Two\nb [2].\n")
+        self.assertEqual(len(out), 1)
+
+    def test_the_container_heading_rides_with_the_first_child(self):
+        """It can carry a citation, and it can carry a pathway name."""
+        out = al._explode_container(
+            "## Themes [9]",
+            "\n### One\na [1].\n\n### Two\nb [2].\n\n### Three\nc [3].\n")
+        self.assertEqual(len(out), 3)
+        self.assertIn("9", _marks(out[0][1]))
+
     # ---- placement -------------------------------------------------------
     def test_follow_up_experiments_close_the_section_rather_than_open_one(self):
         """Rewritten as a finding it acquires a heading for work nobody did."""
@@ -235,7 +333,9 @@ class FurnitureIsDecidedByEvidence(unittest.TestCase):
         """The one assertion that would have caught every production failure
         before it shipped."""
         for name, report in (("flat", FLAT), ("sectioned", SECTIONED),
-                             ("furniture-only", FURNITURE_ONLY)):
+                             ("furniture-only", FURNITURE_ONLY),
+                             ("nested", NESTED),
+                             ("subsectioned", PATHWAY_WITH_SUBSECTIONS)):
             _, _, _, _, kept, _ = self._partition(report)
             self.assertEqual(_marks(report) - _marks(kept), set(),
                              "%s shape dropped a marker before the model ever "
@@ -248,7 +348,9 @@ class FurnitureIsDecidedByEvidence(unittest.TestCase):
         conserving markers says nothing about conserving findings.
         """
         for name, report in (("flat", FLAT), ("sectioned", SECTIONED),
-                             ("furniture-only", FURNITURE_ONLY)):
+                             ("furniture-only", FURNITURE_ONLY),
+                             ("nested", NESTED),
+                             ("subsectioned", PATHWAY_WITH_SUBSECTIONS)):
             _, _, _, _, kept, _ = self._partition(report)
             prose_before = al._without_table_rows(
                 report.split("### References")[0]).lower()

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -6187,3 +6187,42 @@ number. **The number that mattered was in the archive the whole time** --
 `results_rejected` was set on every live run, and reading four traces would have
 found this before any of it shipped. A stage that records why it refused itself
 is only useful if the refusals are read.
+
+### A fourth shape, found by running the fixed code through the UI
+
+The fix above was verified by re-running the four rejected reports. All four
+accepted, so I ran a real job through the browser -- `Yj5oty03Uf`, STATegra
+5-omics, mmu, KEGG + Reactome + OmniPath -- and the report came back looking
+like the dossier again, with `## Key Findings`, 55 bullets and a per-pathway
+catalogue.
+
+The archive said the stage had **succeeded**: `results_section: true`,
+`results_pathways_kept: 13` of 13, `results_citations_kept: 19`, 5 chunks, 62 s.
+It accepted its own output, and its own output was the dossier.
+
+That report nests one level deeper: 12 pathways as `###` under
+`## Pathway-Specific Findings`, 7 themes as `###` under `## Cross-Pathway
+Themes`, 6 more under `## Most Biologically Significant Findings`.
+`_split_pathway_sections` descends only to `##`, so each container arrived as
+ONE section -- and a chunk that IS a report has nothing to reorganise it into,
+so the model returned the structure it was handed. Same failure as the bold
+lead-in container, one heading level down.
+
+`_explode_container` now handles both nesting styles, with a veto: **a section
+whose own heading names a pathway is never a container.** Without it the `###`
+rule split `## 2. ATP-Dependent Chromatin Remodeling (mmu03082)` into its three
+subsections, took a live report from 18 sections to 40, and dropped six pathway
+names -- the parent heading was the only place they were written.
+
+Re-measured live: `Yj5oty03Uf` 26 sections / 5 chunks, accepted in 34 s,
+bullets **55 -> 7**, five finding-titled subsections and no `## Key Findings`.
+`y7gI3AVpSm` and `4j00f2377Y` still accept. Classification over all **ten**
+stored UV reports loses no marker and no prose-named pathway.
+
+**The lesson is the same one, one level down, and it is about the verification
+rather than the code.** Re-running the reports that had failed confirmed the
+failures were fixed; it could not find a shape none of them had. Only driving
+the actual UI produced the fourth. `results_section: true` on a report that
+still reads like a dossier is also the sharper warning: a stage that grades
+itself on conservation will pass whenever it conserves everything by changing
+nothing.


### PR DESCRIPTION
## Found by running a job through the UI, after PR #59 shipped

PR #59 fixed the four rejections and I verified it by re-running those four
reports. So I ran a real job on paintomics.uv.es — `Yj5oty03Uf`, STATegra
5-omics, mmu, KEGG + Reactome + OmniPath — and **it came back looking like the
dossier**: `## Key Findings`, 55 bullets, a per-pathway catalogue.

The archive said the stage had **succeeded**:

```
results_section: true      results_chunks: 5        results_s: 62.4
results_pathways_kept: 13  results_pathways_before: 13
results_citations_kept: 19
```

It accepted its own output, and its own output was the dossier.

## Cause: the same container bug, one heading level down

That report nests deeper than any shape PR #59 saw — 12 pathways as `###`
under `## Pathway-Specific Findings`, 7 themes as `###` under
`## Cross-Pathway Themes`, 6 more under `## Most Biologically Significant
Findings`. `_split_pathway_sections` descends only to `##`, so each container
arrived as **one section**, and a chunk that IS a report has nothing to
reorganise it into — the model returned the structure it was handed.

`_explode_container` now splits on `###` subsections as well as bold lead-ins
(threshold **three**: one finding can carry a couple of subsections, not a list
of them), and it is applied to ordinary sections too, not only kept furniture —
`## Pathway-Specific Findings` is on no name list.

**With a veto: a section whose own heading names a pathway is never a
container.** Without it the rule split
`## 2. ATP-Dependent Chromatin Remodeling (mmu03082)` into its three
subsections, took a live report from 18 sections to 40, and dropped six pathway
names — the parent heading was the only place they were written. The container
heading now also rides with the first child, so nothing in it is lost either
way.

## Measured — deployed venv, live gateway

| job | sections | chunks | accepted | s | bullets | citations |
| --- | --- | --- | --- | --- | --- | --- |
| `Yj5oty03Uf` (the UI run) | 26 | 5 | **yes** | 34 | **55 → 7** | 15 |
| `y7gI3AVpSm` | 20 | 5 | yes | 46 | 41 → 4 | 23 |
| `4j00f2377Y` | 17 | 5 | yes | 29 | 10 → 5 | 15 |

`Yj5oty03Uf` now produces five finding-titled subsections and no
`## Key Findings`. Classification over all **ten** stored UV reports loses no
citation marker and no prose-named pathway.

Full suite: **224 suites, 219 pass, 0 introduced.** Four new cases cover the
nested shape, the pathway-heading veto, the three-subsection threshold, and the
carried container heading.

## Why re-running the failures could not have found this

None of those four reports had this shape. Only driving the actual UI produced
it. And `results_section: true` on a report that still reads like a dossier is
the sharper warning: **a stage that grades itself on conservation passes
whenever it conserves everything by changing nothing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
