### PR TITLE
Results section: take the dossier furniture off after the gate too

### DIFF
--- a/PaintomicsServer/src/benchmarks/ai_arm_bench.py
+++ b/PaintomicsServer/src/benchmarks/ai_arm_bench.py
@@ -211,6 +211,12 @@ STAGE_COUNTS = ("delegate_fulltext_gained", "quotes_supplied", "quotes_reused", 
                 # longer all-or-nothing, so this is where the loss shows up.
                 "results_chunks", "results_retried_pathways",
                 "results_furniture_kept", "results_chunk_reverted",
+                # How many furniture sections a post-gate rewrite put BACK and
+                # the final strip had to remove. Non-zero means the correction
+                # or top-up pass is undoing the Results section, which is
+                # invisible in `results_section` -- that flag reports what the
+                # stage produced, not what was stored.
+                "results_furniture_restripped",
                 # Which searches reached the report. Retrieval novelty is
                 # ~99.9%; conversion to a citation is ~12%, so the useful
                 # question is per-theme, not per-call.

--- a/PaintomicsServer/src/classes/AIInterpret/agent_loop.py
+++ b/PaintomicsServer/src/classes/AIInterpret/agent_loop.py
@@ -2528,9 +2528,72 @@ def _split_on(head, body, hits, title_of):
     return out
 
 
+# Headings that USUALLY introduce framing rather than a pathway finding.
+# A name is a suspicion, not a verdict -- see _loses_nothing.
+RESULTS_FURNITURE = ("key findings", "cross-pathway", "detailed pathway analysis",
+                     "pathway clusters", "enriched pathway summary", "summary of")
+
 RESULTS_CHUNK = int(os.getenv("AI_AGENT_RESULTS_CHUNK", "4"))
 # How many subsections a Results section should aim for.
 RESULTS_TARGET_SECTIONS = int(os.getenv("AI_AGENT_RESULTS_SECTIONS", "5"))
+
+
+def _loses_nothing(head, body, surv_marks, surv_low, pw_names):
+    """Is this section safe to drop -- does everything in it survive elsewhere?
+
+    Markers count wherever they are: a citation is evidence even in a table
+    cell. Pathway NAMES count only in PROSE, because the enriched-pathway
+    summary and the cluster table are furniture by construction -- rows of data
+    the job already holds, appended deterministically below the report, naming
+    dozens of pathways the prose never discusses. Judge their cells as findings
+    and every one of those names reads as an orphan, the whole table is
+    readmitted as evidence, and the rewrite ships with exactly the 46-row table
+    it was asked to remove (measured on job 4j00f2377Y). A table row restates;
+    it does not find.
+    """
+    prose = _without_table_rows(body)
+    marks = set(re.findall(r"\[(\d+)\]", body))
+    if marks - surv_marks:
+        return False
+    return not any(n and n.lower() in (head + prose).lower()
+                   and n.lower() not in surv_low for n in pw_names)
+
+
+def _strip_reintroduced_furniture(report, pw_names, stats):
+    """Remove dossier furniture that a post-gate rewrite put back.
+
+    The Results section is written BEFORE the exit gate, on purpose -- its prose
+    then gets top-up, the Claim Verifier and the programmatic net like any other
+    draft. But two of those steps hand the WHOLE report back to the synthesizer
+    (the top-up candidate and the correction rewrite), and the synthesizer's
+    standing instructions say to include a "Key Findings" summary at the top.
+    So a run whose Results section was written, accepted and measured
+    (`results_section: true`) can still be stored with a bulleted Key Findings
+    block above it -- which is exactly what job `m4gs607z4Z` came back with when
+    a citation correction fired.
+
+    Rather than fight the system prompt, the same test that decided furniture in
+    the first place is applied once more at the end: a section goes only if
+    every citation marker in it survives elsewhere and it names no pathway that
+    would otherwise go unmentioned. Idempotent, and it cannot delete evidence.
+    """
+    preamble, secs, tail = _split_pathway_sections(report)
+    suspect = [i for i, (h, _) in enumerate(secs)
+               if any(k in h.lower() for k in RESULTS_FURNITURE)]
+    if not suspect:
+        return report
+    surviving = preamble + "\n".join(h + b for i, (h, b) in enumerate(secs)
+                                     if i not in set(suspect))
+    surv_marks = set(re.findall(r"\[(\d+)\]", surviving))
+    surv_low = _without_table_rows(surviving).lower()
+    drop = {i for i in suspect
+            if _loses_nothing(secs[i][0], secs[i][1], surv_marks, surv_low,
+                              pw_names)}
+    if not drop:
+        return report
+    stats["results_furniture_restripped"] = len(drop)
+    kept = "".join(h + b for i, (h, b) in enumerate(secs) if i not in drop)
+    return (preamble.rstrip() + "\n\n" + kept.strip() + "\n\n" + tail).strip()
 
 
 def _partition_sections(report, pw_names, stats):
@@ -2541,10 +2604,6 @@ def _partition_sections(report, pw_names, stats):
     which is how the four production rejections were reproduced.
     """
     preamble, secs, tail = _split_pathway_sections(report)
-    # Headings that USUALLY introduce framing rather than a pathway finding.
-    # A name is a suspicion, not a verdict -- see the evidence test below.
-    SKIP = ("key findings", "cross-pathway", "detailed pathway analysis",
-            "pathway clusters", "enriched pathway summary", "summary of")
     # Caveats close a Results section; they are not a finding to reorganise.
     # Grouped with the pathways they landed third of six, which reads as the
     # report giving up halfway through. Follow-up experiments belong with them:
@@ -2555,7 +2614,7 @@ def _partition_sections(report, pw_names, stats):
     for h, b in secs:
         low = h.lower()
         kinds.append(("last" if any(k in low for k in LAST)
-                      else "skip" if any(k in low for k in SKIP)
+                      else "skip" if any(k in low for k in RESULTS_FURNITURE)
                       else "path", h, b))
 
     # A SKIP-named section is dropped only if dropping it LOSES NOTHING.
@@ -2584,24 +2643,9 @@ def _partition_sections(report, pw_names, stats):
             # Findings` is on no name list and held all 12 pathways of job
             # Yj5oty03Uf under `###`.
             pathway_secs.extend(_explode_container(h, b, pw_names))
+        elif _loses_nothing(h, b, surv_marks, surv_low, pw_names):
+            continue                           # genuinely furniture
         else:
-            # Markers count wherever they are -- a citation is evidence even
-            # in a table cell. Pathway NAMES count only in PROSE, because the
-            # enriched-pathway summary and the cluster table are furniture by
-            # construction: rows of data the job already holds, appended
-            # deterministically below the report, naming dozens of pathways the
-            # prose never discusses. Judge their cells as findings and every
-            # one of those names reads as an orphan, the whole table is
-            # readmitted as evidence, and the rewrite ships with exactly the
-            # 46-row table it was asked to remove (measured on job 4j00f2377Y).
-            # A table row restates; it does not find.
-            prose = _without_table_rows(b)
-            marks = set(re.findall(r"\[(\d+)\]", b))
-            orphan_names = [n for n in pw_names
-                            if n and n.lower() in (h + prose).lower()
-                            and n.lower() not in surv_low]
-            if not (marks - surv_marks) and not orphan_names:
-                continue                       # genuinely furniture
             stats["results_furniture_kept"] = (
                 stats.get("results_furniture_kept", 0) + 1)
             pathway_secs.extend(_explode_container(h, b, pw_names))
@@ -3797,6 +3841,14 @@ async def _run_loop_async(job_instance, job_id, experiment_design, budgets,
         # another verified citation survives with the bad marker stripped, so the
         # two numbers can differ by a factor of three.
         stats["sentences_dropped"] = last_sentences_dropped()
+    # Last, after every step that could hand the whole report back to the
+    # synthesizer: take the dossier furniture off again. See
+    # _strip_reintroduced_furniture -- `results_section: true` is not a promise
+    # that the stored report still looks like one.
+    if results_written:
+        report = _strip_reintroduced_furniture(
+            report, [p.get("name") for p in (pathways or []) if p.get("name")],
+            stats)
     report, citation_mapping = renumber_citations(report)
     report = sort_references_section(report)
     if citation_mapping:

--- a/PaintomicsServer/src/tests/test_the_results_stage_keeps_the_evidence.py
+++ b/PaintomicsServer/src/tests/test_the_results_stage_keeps_the_evidence.py
@@ -378,6 +378,87 @@ class ALeadInIsOnlySplitWhenItIsAContainer(unittest.TestCase):
                       "the container's own framing can carry a citation")
 
 
+@unittest.skipUnless(IMPORTED, "agent_loop did not import")
+class FurnitureIsTakenOffAgainAfterTheGate(unittest.TestCase):
+    """`results_section: true` is not a promise about the STORED report.
+
+    The Results section is written before the exit gate on purpose, so its prose
+    is graded by the same machinery as any other draft. But two gate steps hand
+    the WHOLE report back to the synthesizer -- the top-up candidate and the
+    citation-correction rewrite -- and the synthesizer's standing instructions
+    say to include a "Key Findings" summary at the top. Job `m4gs607z4Z`, run
+    through the UI, recorded `results_section: true`, `results_pathways_kept: 9`
+    of 9, `results_citations_kept: 24` -- and was stored with a bulleted
+    `# Key Findings` block above the prose, because a correction fired.
+    """
+
+    REWRITTEN = """# Key Findings
+
+- **Chromatin remodeling precedes transcription**: accessibility leads mRNA.
+- **Coordinated inflammatory shutdown**: Ccr2 and Ccl2 fall together.
+
+---
+
+## Chromatin remodeling precedes a multi-layered inflammatory program
+
+Accessibility at 2-6 h preceded mRNA at 12-24 h [1], and Ccr2 fell to
+-7.69 at 24 h [2]. Lysosome Biogenesis followed [3].
+
+## Limitations and Caveats
+Time points are sparse.
+""" + REFS
+
+    def test_a_reintroduced_summary_is_taken_off_again(self):
+        stats = {}
+        out = al._strip_reintroduced_furniture(self.REWRITTEN, NAMES, stats)
+        self.assertNotIn("Key Findings", out)
+        self.assertEqual(stats.get("results_furniture_restripped"), 1)
+
+    def test_it_never_costs_a_citation(self):
+        """The same rule as everywhere else: a section goes only if everything
+        in it survives elsewhere."""
+        report = self.REWRITTEN.replace(
+            "- **Coordinated inflammatory shutdown**: Ccr2 and Ccl2 fall together.",
+            "- **Coordinated inflammatory shutdown**: Ccr2 and Ccl2 fall [7].")
+        out = al._strip_reintroduced_furniture(report, NAMES, {})
+        self.assertIn("7", _marks(out), "[7] lives only in the summary")
+        self.assertIn("Key Findings", out)
+
+    def test_it_keeps_the_reference_list(self):
+        out = al._strip_reintroduced_furniture(self.REWRITTEN, NAMES, {})
+        self.assertIn("### References", out)
+
+    def test_it_is_idempotent(self):
+        """It runs on a report the stage may already have cleaned."""
+        once = al._strip_reintroduced_furniture(self.REWRITTEN, NAMES, {})
+        self.assertEqual(al._strip_reintroduced_furniture(once, NAMES, {}), once)
+
+    def test_a_report_with_no_furniture_is_returned_untouched(self):
+        clean = ("## A finding\n\nProse [1].\n\n## Limitations\nSparse.\n"
+                 + REFS)
+        self.assertEqual(al._strip_reintroduced_furniture(clean, NAMES, {}),
+                         clean)
+
+    def test_it_runs_only_when_a_results_section_was_written(self):
+        """On a dossier run the Key Findings block is the report's own
+        structure, not a rewrite undoing itself."""
+        with open(SRC) as fh:
+            src = fh.read()
+        self.assertIn("if results_written:\n        report = "
+                      "_strip_reintroduced_furniture(", src)
+
+    def test_it_runs_after_every_step_that_can_rewrite_the_report(self):
+        """Before renumbering, but after top-up and correction -- otherwise the
+        very rewrites that reintroduce the block run afterwards."""
+        with open(SRC) as fh:
+            src = fh.read()
+        strip = src.index("_strip_reintroduced_furniture(\n            report,")
+        self.assertLess(src.index("stats[\"topup_added\"]"), strip)
+        self.assertLess(src.index("loop correction rewrite"), strip)
+        self.assertLess(strip, src.index("report, citation_mapping = "
+                                         "renumber_citations(report)"))
+
+
 class TheChunkKeepsItsSourceWhenItCannotConserveIt(unittest.TestCase):
     """Source-level: the second half of the production failure.
 

--- a/docs/ai-agent-benchmark.md
+++ b/docs/ai-agent-benchmark.md
@@ -6226,3 +6226,42 @@ the actual UI produced the fourth. `results_section: true` on a report that
 still reads like a dossier is also the sharper warning: a stage that grades
 itself on conservation will pass whenever it conserves everything by changing
 nothing.
+
+### `results_section: true` is not a promise about the stored report
+
+The `###` fix was verified the same way -- re-run the reports, then run a job
+through the UI. Job `m4gs607z4Z` came back with the prose the stage exists to
+produce: two finding-titled subsections, continuous prose, no tables, 24
+citations in first-appearance order. **And a bulleted `# Key Findings` block
+sitting above them.**
+
+The archive again said success, and again it was telling the truth about what
+the stage produced: `results_section: true`, 9 of 9 pathways, 24 citations kept,
+2 chunks, 17 s. What it could not say is what happened *after*.
+
+The Results section is written BEFORE the exit gate, deliberately, so its prose
+is graded by the same machinery as any other draft. But two gate steps hand the
+**whole report** back to the synthesizer -- the top-up candidate and the
+citation-correction rewrite (`agent_loop.py`, `report = resolve_pmid_mentions(
+str(corr.final_output), ...)`) -- and the synthesizer's standing instructions
+say to include a "Key Findings" summary at the top (`prompts.py` lines 46 and
+91). This run's stitch was rejected (`merge_rejected: cites 24->20, GROUNDED
+22->19`) and a citation correction fired; the correction obeyed its system
+prompt and put the dossier's hat back on.
+
+`_strip_reintroduced_furniture` applies the same test one last time, after every
+step that can rewrite the report and before renumbering: a section goes only if
+every citation marker in it survives elsewhere and it names no pathway that
+would otherwise go unmentioned. Measured on the stored report: 24 markers in,
+24 out, bullets 10 -> 5 (the residue is the caveats list), references intact,
+idempotent. Across all **eleven** stored UV reports it removes 1-7 furniture
+sections each and loses no marker and no prose-named pathway in any of them.
+
+**The generalisable point, and the third time this document has recorded it in
+one day:** a stage that reports on its own output is reporting on its own
+output. `results_section: true` meant the rewrite was written and accepted --
+it never meant the user would see it. Three separate defects hid behind that
+flag: a classifier that discarded the evidence before the model ran, a splitter
+that handed the model a whole report and called it a chunk, and a later stage
+that undid the result. Only the last one was visible from the flag at all, and
+only because the *rendered page* was read rather than the metric.


### PR DESCRIPTION
## `results_section: true` is not a promise about the stored report

Third UI run, after PR #60. Job `m4gs607z4Z` came back with exactly the prose
the stage exists to produce — **two finding-titled subsections, continuous
prose, no tables, 24 citations in first-appearance order** — and a bulleted
`# Key Findings` block sitting above them.

The archive said success, and it was telling the truth about what the *stage*
produced:

```
results_section: true    results_chunks: 2       results_s: 17.0
results_pathways_kept: 9  results_pathways_before: 9
results_citations_kept: 24
```

What it cannot say is what happened **after**.

## Cause: two gate steps hand the whole report back to the synthesizer

The Results section is written *before* the exit gate on purpose, so its prose
gets top-up, the Claim Verifier and the programmatic net like any other draft.
But two of those steps regenerate the entire document —

* the top-up candidate, and
* the citation-correction rewrite
  (`report = resolve_pmid_mentions(str(corr.final_output), …)`)

— and the synthesizer's standing instructions say to *"Include a Key Findings
summary at the top"* (`prompts.py` lines 46 and 91). This run's stitch was
rejected (`merge_rejected: cites 24→20, GROUNDED 22→19`) and a citation
correction fired; the correction obeyed its system prompt and put the dossier's
hat back on.

## Fix

Rather than fight the system prompt, the test that decided furniture in the
first place is applied **once more at the end** — after every step that can
rewrite the report, before renumbering: a section goes only if every citation
marker in it survives elsewhere and it names no pathway that would otherwise go
unmentioned. The predicate is now shared (`_loses_nothing`) rather than
duplicated, and the heading list is a module constant both users read.

**Measured on the stored report:** 24 markers in, 24 out; bullets 10 → 5 (the
residue is the caveats list, carried verbatim by design); references intact;
idempotent. Across all **eleven** stored UV reports it removes 1–7 furniture
sections each and loses **no marker and no prose-named pathway** in any of them.

`results_furniture_restripped` is archived — non-zero means a post-gate rewrite
is undoing the Results section, which `results_section` cannot show.

Full suite: **224 suites, 219 pass, 0 introduced.** Seven new cases, including
that the strip never costs a citation, keeps the reference list, is idempotent,
leaves a clean report untouched, and runs *after* top-up and correction but
*before* renumbering.

## The pattern, three for three

Three separate defects hid behind one flag: a classifier that discarded the
evidence before the model ran, a splitter that handed the model a whole report
and called it a chunk, and now a later stage that undid the result. **A stage
that reports on its own output is reporting on its own output** — every one of
these was found by reading the rendered page, never by reading the metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
