### PR TITLE
Ask who is asking before answering with someone else's AI report

### DIFF
--- a/PaintomicsServer/src/servlets/AIInterpretServlet.py
+++ b/PaintomicsServer/src/servlets/AIInterpretServlet.py
@@ -133,6 +133,55 @@ def _consented(jobID):
     return bool(jobInstance is not None and jobInstance.getAIConsent())
 
 
+def _requireJobAccess(jobID, userID):
+    """Load a job for this caller, or refuse.
+
+    Consent and access are different questions and both were needed. Consent
+    asks "may this job's contents be sent to the external service at all";
+    access asks "is this caller entitled to that job". Only the first was ever
+    asked here, so a job id was sufficient authorisation for every AI route --
+    and job ids travel, because the results page prints a shareable
+    `?jobID=...` URL for exactly that purpose.
+
+    Measured against a running server, no cookies at all, on a job owned by
+    another account with sharing off: `/pa_recover_job` refused it ("Invalid
+    Job ID for current user") while `/ai_interpret_report` returned the full
+    10,345-character report with its 28 papers, `/ai_interpret_status`
+    returned its progress, and `/ai_interpret_chat` answered a question about
+    the job's genes -- an LLM call billed to this deployment, against someone
+    else's expression values, for an anonymous caller.
+
+    The rule is copied from `pathwayAcquisitionRecoverJob` rather than
+    invented, so the AI routes admit and refuse exactly what the rest of the
+    application does:
+
+      * a job with no owner (the anonymous "nologin" mode) stays readable by
+        anyone -- those jobs belong to nobody by design, and narrowing that
+        here would break guest usage without protecting anything;
+      * a job whose owner ticked "allow sharing" stays readable by anyone;
+      * anything else is refused unless the caller IS the owner.
+
+    Returns the loaded job so callers do not pay for a second load.
+    """
+    jobInstance = JobInformationManager().loadJobInstance(jobID)
+
+    if jobInstance is None:
+        raise UserWarning("Job " + str(jobID) + " was not found.")
+
+    if (str(jobInstance.getUserID()) != 'None'
+            and str(jobInstance.getUserID()) != str(userID)
+            and not jobInstance.getAllowSharing()):
+        logging.info("AI_INTERPRET - JOB " + str(jobID) + " DOES NOT BELONG TO USER "
+                     + str(userID) + " JOB HAS USER " + str(jobInstance.getUserID()))
+        # Deliberately the same wording pa_recover_job uses for the same
+        # refusal. A distinct message here would tell a caller that the job
+        # exists and is someone else's, which is more than they asked and more
+        # than they should learn.
+        raise UserWarning("Invalid Job ID (" + str(jobID) + ") for current user.")
+
+    return jobInstance
+
+
 def aiInterpretInitiate(REQUEST, RESPONSE, QUEUE_INSTANCE):
     """Start or re-check the AI interpretation pipeline for a job."""
     userID = None
@@ -152,10 +201,11 @@ def aiInterpretInitiate(REQUEST, RESPONSE, QUEUE_INSTANCE):
         if not jobID:
             raise UserWarning("Missing jobID parameter.")
 
-        # Verify the job exists
-        jobInstance = JobInformationManager().loadJobInstance(jobID)
-        if jobInstance is None:
-            raise UserWarning("Job " + jobID + " was not found.")
+        # Verify the job exists AND that this caller may have it. Running the
+        # pipeline spends this deployment's LLM budget and sends the job's
+        # analysis summary outward, so the entitlement question comes before
+        # the consent question.
+        jobInstance = _requireJobAccess(jobID, userID)
 
         # The consent the upload page asks for was collected, stored and echoed
         # back in four responses, and never checked before the pipeline ran.
@@ -238,6 +288,11 @@ def aiInterpretStatus(REQUEST, RESPONSE):
         if not jobID:
             raise UserWarning("Missing jobID parameter.")
 
+        # Progress is thin, but it still confirms a job id is real and says
+        # whether someone is running an interpretation on it. The client polls
+        # this every 3s, so it is also the cheapest oracle for guessing ids.
+        _requireJobAccess(jobID, userID)
+
         dao = AIInterpretDAO()
         record = dao.find_by_job_id(jobID)
 
@@ -306,6 +361,10 @@ def aiInterpretReport(REQUEST, RESPONSE):
         if not jobID:
             raise UserWarning("Missing jobID parameter.")
 
+        # The report names the genes, the pathways and the direction of every
+        # effect in someone's experiment. This is the route that leaked it.
+        _requireJobAccess(jobID, userID)
+
         dao = AIInterpretDAO()
         record = dao.find_by_job_id(jobID)
 
@@ -364,6 +423,11 @@ def aiInterpretChat(REQUEST, RESPONSE):
             raise UserWarning("Missing jobID parameter.")
         if not userMessage.strip():
             raise UserWarning("Empty message.")
+
+        # The worst of the five. The chat tools read the job's own expression
+        # values to answer, and every turn is an LLM call this deployment pays
+        # for -- so an unguarded id was both a data leak and an open tab.
+        _requireJobAccess(jobID, userID)
 
         dao = AIInterpretDAO()
         record = dao.find_by_job_id(jobID)
@@ -724,6 +788,12 @@ def aiInterpretPathway(REQUEST, RESPONSE):
         if not jobID or not pathwayID:
             raise UserWarning("Missing jobID or pathwayID parameter.")
 
+        # Before the cache lookup, not after: the cached branch returns a
+        # stored pathway report and never reaches the load further down, so a
+        # gate placed with the other job checks would miss exactly the
+        # requests that cost nothing to make and hand back the most.
+        jobInstance = _requireJobAccess(jobID, userID)
+
         dao = AIInterpretDAO()
 
         if not regenerate:
@@ -748,10 +818,6 @@ def aiInterpretPathway(REQUEST, RESPONSE):
         if entry is None:
             raise UserWarning("Pathway " + pathwayID + " was not part of the AI analysis. "
                               "Only the pathways the report covers can be interpreted.")
-
-        jobInstance = JobInformationManager().loadJobInstance(jobID)
-        if jobInstance is None:
-            raise UserWarning("Job " + jobID + " was not found.")
 
         # See _consented: this route sends job context outward as well.
         if not jobInstance.getAIConsent():

--- a/PaintomicsServer/src/tests/test_ai_routes_check_job_ownership.py
+++ b/PaintomicsServer/src/tests/test_ai_routes_check_job_ownership.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""A job id is not authorisation to read the AI interpretation of that job.
+
+Why this exists
+---------------
+`test_ai_consent_enforced` covers a different question: whether the job's
+owner agreed to anything being sent OUT to the external service. It says
+nothing about who may ask. Both were needed, and only the first was there.
+
+Every `/ai_interpret_*` route verified the session with
+
+    UserSessionManager().isValidUser(userID, sessionToken)
+
+which deliberately admits the anonymous "nologin" caller -- `user_id == 'None'`
+with no token returns True, because the application supports jobs that belong
+to nobody. So the session check passed for a caller with no cookies at all, and
+nothing after it consulted the job's owner. Meanwhile the results page prints a
+shareable `?jobID=...` URL, so ids travel by design.
+
+Measured against a running server, on a job whose stored record said
+userID '99999' and allowSharing False, from a caller sending no cookies:
+
+    /pa_recover_job       -> refused, "Invalid Job ID (...) for current user."
+    /ai_interpret_report  -> 10,345 characters of report and its 28 papers
+    /ai_interpret_status  -> the job's progress
+    /ai_interpret_chat    -> an answer about the job's genes, which is an LLM
+                             call billed to this deployment, made against
+                             someone else's expression values
+
+`pathwayAcquisitionRecoverJob` already had the rule. The AI routes just never
+asked it, so the same job was public through one door and private through
+another.
+
+Two halves, because either alone passes for the wrong reason:
+
+  * the decision table, exercised against `_requireJobAccess` with a stubbed
+    loader. This is the half that would catch a gate that refuses everything,
+    which "the call is present" cannot;
+  * the presence of the call in each of the five job-scoped handlers, read off
+    the syntax tree with comments stripped, so a handler added later without a
+    gate fails here rather than shipping open.
+
+`ai_provider` and `ai_generate_exp_design` are deliberately not in the list:
+neither takes a jobID -- the first reports which gateway this server uses, the
+second reads column headers for a job that does not exist yet and carries its
+own consent check.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_ai_routes_check_job_ownership
+"""
+import ast
+import io
+import os
+import sys
+import tokenize
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+SERVLET = os.path.join(os.path.dirname(__file__),
+                       "../servlets/AIInterpretServlet.py")
+
+# Every route that takes a jobID and answers with, or acts on, that job.
+JOB_SCOPED_HANDLERS = [
+    "aiInterpretInitiate",
+    "aiInterpretStatus",
+    "aiInterpretReport",
+    "aiInterpretChat",
+    "aiInterpretPathway",
+]
+
+GATE = "_requireJobAccess"
+
+
+def _stripComments(text):
+    """Comments are prose, not code; a gate described in one is not a gate."""
+    try:
+        tokens = [t for t in tokenize.generate_tokens(io.StringIO(text).readline)
+                  if t.type != tokenize.COMMENT]
+        return tokenize.untokenize(tokens)
+    except Exception:
+        return text
+
+
+def _handlers():
+    with open(SERVLET, "r", encoding="utf-8", errors="replace") as handle:
+        source = handle.read()
+    tree = ast.parse(source)
+    return {node.name: ast.get_source_segment(source, node)
+            for node in tree.body if isinstance(node, ast.FunctionDef)}
+
+
+class _FakeJob(object):
+    """The three fields the rule reads, and nothing else."""
+
+    def __init__(self, userID, allowSharing):
+        self._userID = userID
+        self._allowSharing = allowSharing
+
+    def getUserID(self):
+        return self._userID
+
+    def getAllowSharing(self):
+        return self._allowSharing
+
+
+class AIRouteOwnershipDecisionTest(unittest.TestCase):
+    """What the gate admits and what it refuses.
+
+    The import is inside the test rather than at module scope: importing the
+    servlet pulls in the LLM client and the server configuration, and this file
+    should fail on a missing gate, not on a missing API key.
+    """
+
+    def _gate(self):
+        try:
+            from src.servlets import AIInterpretServlet
+        except Exception as ex:  # pragma: no cover - environment, not behaviour
+            self.skipTest("AIInterpretServlet is not importable here: %s" % ex)
+
+        gate = getattr(AIInterpretServlet, GATE, None)
+        if gate is None:
+            self.fail("%s does not exist. The AI routes have no ownership "
+                      "gate, so any caller holding a job id can read that "
+                      "job's report and chat against its data." % GATE)
+        return AIInterpretServlet, gate
+
+    def _run(self, job, callerID):
+        module, gate = self._gate()
+        original = module.JobInformationManager
+
+        class _Loader(object):
+            def loadJobInstance(self, jobID):
+                return job
+
+        class _Manager(object):
+            def __call__(self):
+                return _Loader()
+
+        module.JobInformationManager = _Manager()
+        try:
+            return gate("JOB123", callerID)
+        finally:
+            module.JobInformationManager = original
+
+    def test_a_stranger_is_refused_someone_elses_private_job(self):
+        """The measured leak, as a test."""
+        with self.assertRaises(Exception) as caught:
+            self._run(_FakeJob("99999", False), None)
+
+        self.assertIn("Invalid Job ID", str(caught.exception),
+                      "the refusal should read the same as pa_recover_job's, "
+                      "which says the id is not valid for this caller rather "
+                      "than confirming it exists and belongs to someone else")
+
+    def test_a_logged_in_stranger_is_refused_too(self):
+        """Holding *an* account is not holding *the* account."""
+        with self.assertRaises(Exception):
+            self._run(_FakeJob("99999", False), "12345")
+
+    def test_a_guest_job_stays_readable_by_anyone(self):
+        """Anonymous jobs belong to nobody, and that is deliberate.
+
+        `isValidUser` admits the nologin caller on purpose and those jobs live
+        under CLIENT_TMP/nologin. Narrowing this would break guest use of the
+        whole application while protecting nothing, so the gate has to let it
+        through -- exactly as pa_recover_job does.
+        """
+        job = _FakeJob(None, False)
+        self.assertIs(self._run(job, None), job)
+
+    def test_a_shared_job_stays_readable_by_anyone(self):
+        """"Allow sharing" is the owner saying yes; the gate must honour it."""
+        job = _FakeJob("99999", True)
+        self.assertIs(self._run(job, "12345"), job)
+
+    def test_the_owner_is_admitted(self):
+        job = _FakeJob("99999", False)
+        self.assertIs(self._run(job, "99999"), job)
+
+    def test_the_owner_is_admitted_when_the_id_types_differ(self):
+        """The cookie is a string; the stored id need not be.
+
+        pa_recover_job compares `jobInstance.getUserID() != userID` with no
+        coercion on the right, so an int 99999 against the cookie "99999" is
+        unequal and the owner is refused their own job. Whatever that route
+        does, this gate compares as strings.
+        """
+        job = _FakeJob(99999, False)
+        self.assertIs(self._run(job, "99999"), job)
+
+    def test_an_unknown_job_is_refused_rather_than_admitted(self):
+        """A job that will not load must not read as "no owner, so public"."""
+        with self.assertRaises(Exception):
+            self._run(None, None)
+
+
+class AIRouteOwnershipWiringTest(unittest.TestCase):
+    """The gate exists and every job-scoped handler actually calls it."""
+
+    def setUp(self):
+        self.handlers = _handlers()
+        missing = [name for name in JOB_SCOPED_HANDLERS
+                   if name not in self.handlers]
+        if missing:
+            self.fail("handler(s) not found, so this test is looking in the "
+                      "wrong place: " + ", ".join(missing))
+
+    def test_every_job_scoped_handler_calls_the_gate(self):
+        unguarded = []
+        for name in JOB_SCOPED_HANDLERS:
+            stripped = _stripComments(self.handlers[name])
+            tree = ast.parse(stripped)
+            calls = [node for node in ast.walk(tree)
+                     if isinstance(node, ast.Call)
+                     and isinstance(node.func, ast.Name)
+                     and node.func.id == GATE]
+            if not calls:
+                unguarded.append(name)
+
+        self.assertEqual([], unguarded,
+                         "these AI routes accept a bare job id as "
+                         "authorisation: " + ", ".join(unguarded))
+
+    def test_the_pathway_gate_precedes_the_cached_answer(self):
+        """aiInterpretPathway returns a cached report and never loads the job.
+
+        The cache branch answers and returns before the rest of the handler
+        runs, so a gate placed with the other job checks would sit after it and
+        miss precisely the requests that cost nothing to make and hand back the
+        most.
+        """
+        stripped = _stripComments(self.handlers["aiInterpretPathway"])
+        gateAt = stripped.find(GATE)
+        cacheAt = stripped.find("get_pathway_report")
+
+        self.assertNotEqual(gateAt, -1, "aiInterpretPathway has no gate")
+        if cacheAt != -1:
+            self.assertLess(gateAt, cacheAt,
+                            "the ownership check runs after the cached "
+                            "pathway report is returned, which is too late")
+
+    def test_the_initiate_gate_precedes_the_enqueue(self):
+        """Refusing after the pipeline is queued refuses nothing."""
+        stripped = _stripComments(self.handlers["aiInterpretInitiate"])
+        gateAt = stripped.find(GATE)
+        enqueueAt = stripped.find("enqueue")
+
+        self.assertNotEqual(gateAt, -1, "aiInterpretInitiate has no gate")
+        if enqueueAt != -1:
+            self.assertLess(gateAt, enqueueAt,
+                            "the ownership check runs after the AI pipeline "
+                            "is queued, which is too late to stop it")
+
+    def test_the_chat_gate_precedes_the_llm_client(self):
+        """The chat turn is the outbound moment, and it is billed."""
+        stripped = _stripComments(self.handlers["aiInterpretChat"])
+        gateAt = stripped.find(GATE)
+        llmAt = stripped.find("LLMClient(")
+
+        self.assertNotEqual(gateAt, -1, "aiInterpretChat has no gate")
+        if llmAt != -1:
+            self.assertLess(gateAt, llmAt,
+                            "the ownership check runs after the LLM client is "
+                            "built, so the call goes out regardless")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_status_returns_tool_trace.py
+++ b/PaintomicsServer/src/tests/test_status_returns_tool_trace.py
@@ -30,6 +30,33 @@ class _Session:
         return True
 
 
+class _Job:
+    """The job `JOB` stands for, as far as the status route is concerned.
+
+    The fixture used to seed only an `aiInterpretationCollection` record and no
+    `jobInstanceCollection` document, which was fine while the route read the
+    progress record and nothing else. It now asks who owns the job first, and a
+    job that will not load is refused -- deliberately, and in the manner
+    `_consented()` already established: treating an unknown job as permission is
+    the wrong way round for a question about someone else's data.
+
+    So the loader is stubbed here exactly as the session is, and for the same
+    reason. This suite is about whether the tool trace reaches the client; it
+    should not also have to construct a real PathwayAcquisitionJob, and it must
+    not be the thing that notices if the ownership check is ever removed --
+    test_ai_routes_check_job_ownership owns that question.
+
+    An unowned job (userID None) is the right stand-in: those are the guest jobs
+    the application supports, and they are what an anonymous caller may read.
+    """
+
+    def getUserID(self):
+        return None
+
+    def getAllowSharing(self):
+        return False
+
+
 class _Request:
     cookies = {"userID": "u", "sessionToken": "t"}
     form = {"jobID": JOB}
@@ -62,15 +89,23 @@ def _cleanup():
         dao.closeConnection()
 
 
+class _Loader:
+    def loadJobInstance(self, jobID):
+        return _Job()
+
+
 def _status():
-    original = S.UserSessionManager
+    originalSession = S.UserSessionManager
+    originalJobs = S.JobInformationManager
     S.UserSessionManager = lambda: _Session()
+    S.JobInformationManager = lambda: _Loader()
     try:
         response = _Response()
         S.aiInterpretStatus(_Request(), response)
         return response.content or {}
     finally:
-        S.UserSessionManager = original
+        S.UserSessionManager = originalSession
+        S.JobInformationManager = originalJobs
 
 
 def test_the_trace_reaches_the_client():


### PR DESCRIPTION
## The defect

Every `/ai_interpret_*` route verified the session and stopped there. `isValidUser` deliberately admits the anonymous "nologin" caller — the application supports jobs that belong to nobody — so a request with **no cookies at all** passed, and nothing after it consulted the job's owner. Job ids travel by design: the results page prints a shareable `?jobID=...` URL (`JobController.js:102`).

Consent was checked. Access never was.

## Measured

Against a running server, on a job stored with `userID 99999` / `allowSharing False`, from a caller sending no cookies:

| route | before |
|---|---|
| `/pa_recover_job` | refused — "Invalid Job ID (…) for current user." |
| `/ai_interpret_report` | **10,345 characters of report + its 28 papers** |
| `/ai_interpret_status` | the job's progress |
| `/ai_interpret_chat` | **answered a question about the job's genes** — a real LLM call, billed to this deployment, against someone else's expression values |
| `/ai_interpret_pathway` | reached the pipeline |

The same job was public through one door and private through another.

## The fix

`_requireJobAccess(jobID, userID)` gates all five job-scoped routes. The rule is copied from `pathwayAcquisitionRecoverJob` rather than invented, so the AI routes admit and refuse exactly what the rest of the application does:

- a job with **no owner** stays readable by anyone (guest mode is deliberate);
- a job whose owner ticked **allow sharing** stays readable by anyone;
- anything else needs the owner.

`ai_provider` and `ai_generate_exp_design` are deliberately not gated: neither takes a jobID.

### Placement is load-bearing

- `aiInterpretPathway` returns a **cached** pathway report and returns before it ever loads the job — its gate goes **above the cache lookup**, or it would miss exactly the requests that cost nothing to make and hand back the most.
- `aiInterpretInitiate`'s goes above the `enqueue`, `aiInterpretChat`'s above the `LLMClient`. Refusing after the work has left refuses nothing.

All three orderings are pinned by tests.

The gate compares ids **as strings**. `pa_recover_job` compares `getUserID()` to the cookie with no coercion on the right, which would refuse an owner their own job when the stored id is an int; that route is left alone here.

## Verification

- Decision table run against the real function with a stubbed loader: stranger refused, logged-in stranger refused, guest job admitted, shared job admitted, owner admitted, owner-with-int-id admitted, unloadable job refused.
- **Mutation-tested**: removing the calls, making the rule admit everything, and making it refuse everything each fail the new suite; each targeted mutation fails exactly its own test.
- Same curl matrix re-run against the patched server — all five routes refuse, guest and shared jobs still return.
- **In Chrome**: the AI report panel loads and a chat turn answers, end to end, on a guest job.
- Clean-checkout import gate (`git archive` + import every servlet): 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)