### PR TITLE
Colour the heatmaps by the range the data actually occupies

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
@@ -6921,6 +6921,65 @@ PA_Step3RegulationView.prototype = new View();
 
 
 /**
+ * The colour range for one observed (low, high) pair.
+ *
+ * Every branch of getMinMax below used to do this inline, identically:
+ *
+ *     max = ((high < 0) ? 0 : Math.max(Math.abs(low), Math.abs(high)));
+ *     min = ((low  > 0) ? 0 : -max);
+ *
+ * i.e. force the range to be symmetric about zero, always. For data that
+ * crosses zero that is exactly right and is kept: bwr and rbg are DIVERGING
+ * scales whose whole meaning is a zero midpoint, and a range of -2..+8 drawn
+ * asymmetrically would paint -2 and +2 in different intensities and claim a
+ * difference the data does not contain.
+ *
+ * For data that never crosses zero it threw the range away. An omic measured
+ * 1.93..20.93 -- all positive, which is the normal shape for abundances,
+ * counts, intensities and MORE's regulator expression -- came back as 0..20.93,
+ * so:
+ *
+ *   * `value > 0` in getColor is true for every point, so red is pinned at 255
+ *     and the entire blue half of blue-white-red is unreachable;
+ *   * the 0..1.93 stretch at the pale end carries no data at all, and the
+ *     interquartile range (half the points, 10.99..13.73) was compressed into
+ *     rgb(255,121,121)..rgb(255,88,88) -- 33 of 255, 13% of the strip. Whole
+ *     diagrams came out one flat red.
+ *
+ * Neither could be worked around from the interface. The custom-range slider
+ * runs through the same clamp: dragging its low end to 5 sets
+ * dataDistributionSummaries[11] = 5, `(5 > 0)` is true, and min is 0 again --
+ * the control silently did nothing.
+ *
+ * And all-negative data was worse than compressed, it was broken: high < 0 made
+ * max 0, low < 0 made min -0, and getColor divided by (absMin - min) = 0 and
+ * returned the string "rgb(255, 255,-Infinity)" for every value.
+ *
+ * So: symmetric when the data crosses zero, the observed range when it does
+ * not.
+ *
+ * @param {Number} low
+ * @param {Number} high
+ * @returns {Object} {min, max}
+ */
+var paColourRange = function (low, high) {
+	/* An inverted pair is not impossible -- [11] and [12] come from a slider --
+	   and it would otherwise flow into a negative denominator downstream. */
+	if (low > high) {
+		var swap = low; low = high; high = swap;
+	}
+
+	if (low < 0 && high > 0) {
+		/* Diverging: keep the symmetry, so equal magnitudes read equally. */
+		var extent = Math.max(Math.abs(low), Math.abs(high));
+		return {min: -extent, max: extent};
+	}
+
+	/* Sequential: the data's own range is the ramp. */
+	return {min: low, max: high};
+};
+
+/**
 		* This function returns the MIN/MAX values that will be used as references
 		* for painting (i.e. min and max colors).
 		*
@@ -6935,46 +6994,44 @@ var getMinMax = function(dataDistributionSummaries, option) {
 	//
 	//   0        1       2    3    4    5     6,   7   8      9        10      11          12
 	//[MAPPED, UNMAPPED, MIN, P10, Q1, MEDIAN, Q3, P90, MAX, MIN_IR, Max_IR, MIN_CUSTOM, MAX_CUSTOM]]
-	var min, max, absMin, absMax;
+	var range, absRange;
 
-	absMax = ((dataDistributionSummaries[8] < 0) ? 0 : Math.max(Math.abs(dataDistributionSummaries[2]), Math.abs(dataDistributionSummaries[8])));
-	absMin = ((dataDistributionSummaries[2] > 0) ? 0 : -absMax);
+	// absMin/absMax are the FULL observed range and are only consulted when the
+	// selected reference clips (p10p90, riMinMax, custom): getColor measures how
+	// far past the clip an outlier sits against them. They therefore have to be
+	// derived the same way, or a clipped range could sit outside the range it is
+	// measured against.
+	absRange = paColourRange(dataDistributionSummaries[2], dataDistributionSummaries[8]);
 
 	if (option === "absoluteMinMax") { //IF USE MIN MAX FOR ORIGINAL DATA (INCLUDE OUTLIERS)
-		max = ((dataDistributionSummaries[8] < 0) ? 0 : Math.max(Math.abs(dataDistributionSummaries[2]), Math.abs(dataDistributionSummaries[8])));
-		min = ((dataDistributionSummaries[2] > 0) ? 0 : -max);
+		range = paColourRange(dataDistributionSummaries[2], dataDistributionSummaries[8]);
 	} else if (option === "riMinMax") { //IF USE MIN MAX FOR INTERQUARTIL RANGE (OMIT OUTLIERS)
-		max = ((dataDistributionSummaries[10] < 0) ? 0 : Math.max(Math.abs(dataDistributionSummaries[9]), Math.abs(dataDistributionSummaries[10])));
-		min = ((dataDistributionSummaries[9] > 0) ? 0 : -max);
+		range = paColourRange(dataDistributionSummaries[9], dataDistributionSummaries[10]);
 
 		//    } else if (option === "localMinMax") {//IF USE MIN MAX FOR INTERQUARTIL RANGE (OMIT OUTLIERS)
 		//        //TODO: IMPLEMENT
 	} else if (option === "p10p90") { //IF USE PERCENTILES 10 AND 90
-		max = ((dataDistributionSummaries[7] < 0) ? 0 : Math.max(Math.abs(dataDistributionSummaries[3]), Math.abs(dataDistributionSummaries[7])));
-		min = ((dataDistributionSummaries[3] > 0) ? 0 : -max);
-
-		absMax = ((dataDistributionSummaries[8] < 0) ? 0 : Math.max(Math.abs(dataDistributionSummaries[2]), Math.abs(dataDistributionSummaries[8])));
-		absMin = ((dataDistributionSummaries[2] > 0) ? 0 : -absMax);
+		range = paColourRange(dataDistributionSummaries[3], dataDistributionSummaries[7]);
+		absRange = paColourRange(dataDistributionSummaries[2], dataDistributionSummaries[8]);
 	} else if (option == "custom") { //USE SLIDER CUSTOM VALUES
 		if (dataDistributionSummaries.length < 12) {
 			console.error("No custom range provided: using absolute min/max");
 
-			max = absMax;
-			min = absMin;
+			range = absRange;
 		} else {
-			max = ((dataDistributionSummaries[12] < 0) ? 0 : Math.max(Math.abs(dataDistributionSummaries[11]), Math.abs(dataDistributionSummaries[12])));
-			min = ((dataDistributionSummaries[11] > 0) ? 0 : -max);
+			range = paColourRange(dataDistributionSummaries[11], dataDistributionSummaries[12]);
 		}
 	} else {
 		console.error("getMinMax:" + option + "Not implemented!!");
 		debugger;
+		range = absRange;
 	}
-	//KEEP RANGE SIMETRY
+
 	return {
-		min: min,
-		max: max,
-		absMin: absMin,
-		absMax: absMax
+		min: range.min,
+		max: range.max,
+		absMin: absRange.min,
+		absMax: absRange.max
 	};
 
 };
@@ -7019,9 +7076,21 @@ var paRampPosition = function (limits, value) {
 		lo = 0;
 		hi = (value > 0) ? limits.max : limits.min;
 	} else {
-		/* Sequential: the observed range is the ramp. */
-		lo = limits.min;
-		hi = limits.max;
+		/* Sequential: the observed range is the ramp, anchored at the end
+		 * NEARER ZERO. For all-positive data that is the minimum, which is
+		 * what "palest is the smallest value" means. For all-negative data it
+		 * is the maximum: -12..-5 anchored at the minimum would paint -12
+		 * palest and -5 the deepest blue, i.e. announce the least negative
+		 * point as the strongest downward effect. Saturation tracks distance
+		 * from zero in both directions, which is the one thing the diverging
+		 * scale is for. */
+		if (Math.abs(limits.min) <= Math.abs(limits.max)) {
+			lo = limits.min;
+			hi = limits.max;
+		} else {
+			lo = limits.max;
+			hi = limits.min;
+		}
 	}
 
 	if (hi === lo) {
@@ -7030,7 +7099,16 @@ var paRampPosition = function (limits, value) {
 		return 0;
 	}
 
-	return Math.abs((value - lo) / (hi - lo));
+	/* Clamped below, NOT Math.abs. The absolute value was safe only while `lo`
+	 * was always 0 and the ramp could not be entered from underneath. Now that
+	 * `lo` can be a real clip -- p10 = 8.5 on data reaching down to 1.93 --
+	 * a point below the clip gives a negative position, and abs() would fold
+	 * it back up the ramp and paint the SMALLEST value the most intense. It
+	 * belongs at the pale end. Positions above 1 are left alone: getColor
+	 * reads them to darken outliers past the clip. */
+	var position = (value - lo) / (hi - lo);
+
+	return (position < 0) ? 0 : position;
 };
 
 var getColor = function (limits, value, colorScale) {

--- a/PaintomicsServer/src/tests/test_heatmap_colour_and_column_space.py
+++ b/PaintomicsServer/src/tests/test_heatmap_colour_and_column_space.py
@@ -56,9 +56,13 @@ STEP3_VIEWS = os.path.abspath(os.path.join(
     os.path.dirname(__file__),
     "../../../PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js"))
 
-# The helpers under test, plus the one they delegate to.
-HELPERS = ("paRampPosition", "getColor", "paValuesForHeader",
-           "paTruncateTail", "paConditionAxis")
+# The helpers under test, plus the ones they delegate to. getMinMax and
+# paColourRange are here because the tests below that hand-build a `limits`
+# object prove less than they appear to: nothing in the application ever builds
+# one by hand, and for two years getMinMax could not produce the very shape
+# those tests assert on. See SequentialRangeReachableTest.
+HELPERS = ("paColourRange", "getMinMax", "paRampPosition", "getColor",
+           "paValuesForHeader", "paTruncateTail", "paConditionAxis")
 
 
 def read_source():
@@ -179,6 +183,204 @@ class ColourStopTest(unittest.TestCase):
         self.assertEqual(result["atMin"], "rgb(0, 0,255)")
         self.assertEqual(result["atZero"], "rgb(255, 255,255)")
         self.assertEqual(result["atMax"], "rgb(255, 0,0)")
+
+
+# [MAPPED, UNMAPPED, MIN, P10, Q1, MEDIAN, Q3, P90, MAX, MIN_IR, MAX_IR,
+#  MIN_CUSTOM, MAX_CUSTOM] -- the layout getMinMax documents and indexes.
+def summary(minimum, p10, q1, median, q3, p90, maximum,
+            minIR=None, maxIR=None, customMin=None, customMax=None):
+    row = [0, 0, minimum, p10, q1, median, q3, p90, maximum,
+           p10 if minIR is None else minIR,
+           p90 if maxIR is None else maxIR]
+    if customMin is not None:
+        row.extend([customMin, customMax])
+    return row
+
+
+class SequentialRangeReachableTest(unittest.TestCase):
+    """The ramp that stretches to the data has to be REACHABLE from real data.
+
+    test_a_sequential_range_uses_the_whole_ramp above passes, and passed before
+    any of this was fixed, because it writes its own limits:
+
+        const limits = {min: 5, max: 14.71, ...}
+
+    Nothing in the application does. Every `limits` comes from getMinMax, and
+    getMinMax ended each branch with
+
+        min = ((low > 0) ? 0 : -max);
+
+    so for data that never went below zero it returned min: 0, always. The
+    stretch existed, was covered by a test, and could not be entered. The
+    measured consequence, on the bundled MORE regulator omic (1.93..20.93):
+    every value satisfied `value > 0`, red was pinned at 255, and the
+    interquartile range -- half the points -- was drawn across 33 of 255, so
+    whole pathway diagrams came out one flat red.
+
+    These tests therefore start where the application starts: at a distribution
+    summary.
+    """
+
+    def _limits(self, row, option="absoluteMinMax"):
+        return run_in_node(
+            "process.stdout.write(JSON.stringify(getMinMax(%s, %s)));"
+            % (json.dumps(row), json.dumps(option)))
+
+    def test_all_positive_data_keeps_its_own_minimum(self):
+        """The regression, at the only place that can produce it."""
+        limits = self._limits(summary(1.93, 8.50, 10.99, 12.75, 13.73, 14.71, 20.93))
+
+        self.assertAlmostEqual(limits["min"], 1.93,
+                               msg="the observed minimum was replaced by 0, so "
+                                   "the pale end of the ramp carries no data "
+                                   "and every box is red")
+        self.assertAlmostEqual(limits["max"], 20.93)
+
+    def test_all_positive_data_reaches_white_at_its_minimum(self):
+        """End to end: summary -> getMinMax -> getColor."""
+        row = summary(1.93, 8.50, 10.99, 12.75, 13.73, 14.71, 20.93)
+        result = run_in_node("""
+            const limits = getMinMax(%s, "absoluteMinMax");
+            process.stdout.write(JSON.stringify({
+              atMin: getColor(limits, 1.93, "bwr"),
+              atMax: getColor(limits, 20.93, "bwr")
+            }));
+        """ % json.dumps(row))
+
+        self.assertEqual(result["atMin"], "rgb(255, 255,255)")
+        self.assertEqual(result["atMax"], "rgb(255, 0,0)")
+
+    def test_the_interquartile_range_is_no_longer_compressed(self):
+        """The complaint, quantified.
+
+        Anchored at zero the middle half of this omic spanned 33 of the 255
+        available steps. Spanning the data instead has to widen that materially
+        -- not merely change it -- or the diagram still reads as flat.
+        """
+        row = summary(1.93, 8.50, 10.99, 12.75, 13.73, 14.71, 20.93)
+        result = run_in_node("""
+            const limits = getMinMax(%s, "absoluteMinMax");
+            const channel = v => parseInt(getColor(limits, v, "bwr").split(",")[1], 10);
+            process.stdout.write(JSON.stringify({q1: channel(10.99), q3: channel(13.73)}));
+        """ % json.dumps(row))
+
+        spread = result["q1"] - result["q3"]
+        self.assertGreater(spread, 33,
+                           "the interquartile range still occupies no more of "
+                           "the ramp than it did when anchored at zero")
+
+    def test_diverging_data_still_gets_a_symmetric_range(self):
+        """The half that must NOT change.
+
+        A range of -2..+8 drawn asymmetrically would paint -2 and +2 at
+        different intensities and assert a difference the data does not hold.
+        Zero-crossing data keeps the symmetry it always had.
+        """
+        limits = self._limits(summary(-2, -1.5, -0.5, 0.5, 3, 6, 8))
+
+        self.assertEqual(limits["min"], -8)
+        self.assertEqual(limits["max"], 8)
+
+    def test_all_negative_data_no_longer_paints_an_invalid_colour(self):
+        """`rgb(255, 255,-Infinity)` was the literal output, for every value.
+
+        With `max = ((high < 0) ? 0 : ...)` and `min = -max`, an all-negative
+        omic collapsed to {min: 0, max: 0}; getColor then divided by
+        (absMin - min) = 0 and emitted -Infinity into the blue channel. CSS
+        discards the declaration, so the cell fell back to whatever was under
+        it -- a heatmap that silently showed no data at all.
+        """
+        row = summary(-12, -10, -9, -8, -7, -6, -5)
+        result = run_in_node("""
+            const limits = getMinMax(%s, "absoluteMinMax");
+            const values = [-12, -10, -8, -6, -5];
+            process.stdout.write(JSON.stringify({
+              limits: limits,
+              colours: values.map(v => getColor(limits, v, "bwr"))
+            }));
+        """ % json.dumps(row))
+
+        for colour in result["colours"]:
+            self.assertNotIn("Infinity", colour)
+            self.assertNotIn("NaN", colour)
+
+        self.assertEqual(result["limits"]["min"], -12)
+        self.assertEqual(result["limits"]["max"], -5)
+
+    def test_all_negative_data_saturates_at_the_most_negative_value(self):
+        """Direction, not just validity.
+
+        Anchoring an all-negative ramp at its minimum would paint -12 palest
+        and -5 the deepest blue -- announcing the least negative point as the
+        strongest downward effect. Saturation has to track distance from zero.
+        """
+        row = summary(-12, -10, -9, -8, -7, -6, -5)
+        result = run_in_node("""
+            const limits = getMinMax(%s, "absoluteMinMax");
+            process.stdout.write(JSON.stringify({
+              nearestZero: getColor(limits, -5, "bwr"),
+              furthest: getColor(limits, -12, "bwr")
+            }));
+        """ % json.dumps(row))
+
+        self.assertEqual(result["nearestZero"], "rgb(255, 255,255)")
+        self.assertEqual(result["furthest"], "rgb(0, 0,255)")
+
+    def test_the_custom_slider_can_actually_move_the_low_end(self):
+        """The setting that looked like a workaround and was not one.
+
+        Visual settings offers a two-handled range slider, initialised from
+        getMinMax(..., "absoluteMinMax"). Dragging its low end to 5 stores 5 in
+        MIN_CUSTOM -- and the custom branch ran the same `(low > 0) ? 0` clamp,
+        so the value was discarded and the range stayed 0..12. Anyone trying to
+        fix the flat-red diagram by hand found the control did nothing.
+        """
+        row = summary(1, 2, 3, 5, 8, 10, 12, customMin=5, customMax=12)
+        limits = self._limits(row, "custom")
+
+        self.assertEqual(limits["min"], 5,
+                         "the custom range's low end is still being clamped "
+                         "to zero, so the slider does nothing on positive data")
+        self.assertEqual(limits["max"], 12)
+
+    def test_a_value_below_a_clipped_range_lands_at_the_pale_end(self):
+        """paRampPosition used Math.abs, which folds under-range points back up.
+
+        Safe only while `lo` was pinned at 0 and the ramp could not be entered
+        from underneath. Once p10 is a real 8.5 on data reaching to 1.93, the
+        absolute value turns a position of -1.06 into +1.06 and paints the
+        SMALLEST value the most intense one on the map.
+        """
+        row = summary(1.93, 8.50, 10.99, 12.75, 13.73, 14.71, 20.93)
+        result = run_in_node("""
+            const limits = getMinMax(%s, "p10p90");
+            process.stdout.write(JSON.stringify({
+              belowClip: getColor(limits, 1.93, "bwr"),
+              atClip: getColor(limits, 8.50, "bwr")
+            }));
+        """ % json.dumps(row))
+
+        self.assertEqual(result["belowClip"], "rgb(255, 255,255)")
+        self.assertEqual(result["atClip"], "rgb(255, 255,255)")
+
+    def test_an_outlier_above_a_clipped_range_is_still_darkened(self):
+        """The clamp must not cost the outlier shading above the clip.
+
+        Positions above 1 stay as they are; only the negative side is clamped.
+        """
+        row = summary(1.93, 8.50, 10.99, 12.75, 13.73, 14.71, 20.93)
+        result = run_in_node("""
+            const limits = getMinMax(%s, "p10p90");
+            process.stdout.write(JSON.stringify({
+              atClip: getColor(limits, 14.71, "bwr"),
+              beyond: getColor(limits, 20.93, "bwr")
+            }));
+        """ % json.dumps(row))
+
+        self.assertEqual(result["atClip"], "rgb(255, 0,0)")
+        self.assertNotEqual(result["beyond"], result["atClip"],
+                            "a value past the p90 clip is drawn identically to "
+                            "the clip itself, so the outlier shading is gone")
 
 
 # 12 conditions plus the leading feature-id column.


### PR DESCRIPTION
## The defect

`getMinMax` forced every colour range symmetric about zero. Every branch ended:

```js
min = ((low > 0) ? 0 : -max);
```

For data that **crosses zero** that is right, and it is kept — `bwr` and `rbg` are diverging scales whose whole meaning is a zero midpoint, and `-2..+8` drawn asymmetrically would paint `-2` and `+2` at different intensities and assert a difference the data does not hold.

For data that **never crosses zero** it discarded the range. An omic measured `1.93..20.93` — the ordinary shape for abundances, counts, intensities and MORE's regulator expression — came back as `0..20.93`. Two things follow:

- `value > 0` in `getColor` is then true for every point, so red is pinned at 255 and the entire blue half is unreachable;
- the pale end covers `0..1.93`, where there is no data.

Measured on the bundled STATegra job, the interquartile range — half the points, `10.99..13.73` — was drawn across `rgb(255,121,121)..rgb(255,88,88)`: **33 of 255 steps**. Whole pathway diagrams came out one flat red. That is what prompted this.

## Three things that made it hard to see

1. **`paRampPosition` already had the stretch, and a test already asserted it — and both were unreachable.** `test_a_sequential_range_uses_the_whole_ramp` writes `{min: 5, max: 14.71}` by hand; nothing in the application builds a limits object by hand, `getMinMax` is the only producer, and it could not return that shape. A green test over a dead path.
2. **The custom-range slider could not work around it.** It runs through the same clamp: drag the low handle to 5, `MIN_CUSTOM = 5`, `(5 > 0)` is true, range is `0..max` again. The control silently did nothing.
3. **All-negative data was broken, not merely compressed.** `high < 0` made `max` 0, `min` became `-0`, and `getColor` divided by `(absMin - min) = 0` and emitted the string `rgb(255, 255,-Infinity)` for every value. CSS discards the declaration, so those cells showed nothing at all. Latent — no omic in the local corpus is all-negative — and fixed here because unclamping is what makes the path reachable.

## The fix

`paColourRange(low, high)`: symmetric when the data crosses zero, the observed range when it does not. The four branches of `getMinMax` now share it instead of repeating the clamp.

Two consequences of unclamping, both tested:

- `paRampPosition` took `Math.abs` of the position, safe only while `lo` was pinned at 0 and the ramp could not be entered from underneath. With `p10 = 8.5` on data reaching `1.93` it folds `-1.06` to `+1.06` and paints the **smallest** value the most intense. Clamped below instead, leaving positions above 1 alone so outliers past the clip are still darkened.
- An all-negative ramp anchors at the end **nearer zero**, or `-12..-5` announces `-5` as the strongest downward effect.

## Blast radius, measured

Swept old vs new `getMinMax` over **every omic summary in the local database — 1,009 of them**:

- **998 cross zero → not one changes**
- 11 are all-positive → all 11 gain their real minimum
- 0 are all-negative

## Verification

- The existing 12 tests still pass unchanged, including the diverging-anchor one.
- 9 new tests that start where the application starts — at a distribution summary — instead of hand-writing limits.
- **Mutation-tested**: restoring the old clamp fails 7; dropping the nearer-zero anchor fails exactly the all-negative direction test; restoring `Math.abs` fails exactly the below-clip test.
- **In Chrome** on `mmu04330`: boxes now range white → pink → full red instead of reading as a single block of red.

No `?v=` bump needed — `PA_Step3Views.js` is loaded by `application.loadModule` via `$.ajax({dataType:"script"})`, which appends its own `_dc=`; `test_versioned_assets_are_bumped` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)