### PR TITLE
Keep jobs for as long as the interface says, and no longer

### DIFF
--- a/PaintomicsClient/public_html/admin/controllers/users.controller.js
+++ b/PaintomicsClient/public_html/admin/controllers/users.controller.js
@@ -47,6 +47,7 @@
 						UserList.setAvailableSpace(response.data.availableSpace);
 						$scope.max_guest_days = response.data.max_guest_days;
 						$scope.max_jobs_days = response.data.max_jobs_days;
+						$scope.max_guest_job_days = response.data.max_guest_job_days;
 
 						if(callback_function !== undefined){
 							callback_caller[callback_function]();

--- a/PaintomicsClient/public_html/admin/templates/users-management.tpl.html
+++ b/PaintomicsClient/public_html/admin/templates/users-management.tpl.html
@@ -14,6 +14,7 @@
 				<p>Current criteria for cleaning data are:</p>
 				<p><b>Max time for Guest accounts: </b> {{max_guest_days}} days</p>
 				<p><b>Max time for users' jobs: </b> {{max_jobs_days}} days</p>
+				<p><b>Max time for guest and anonymous jobs: </b> {{max_guest_job_days}} days</p>
 				<p>You can change this values in the main application settings.</p>
 				<a class="clickable btn btn-sm btn-info" ng-click="controller.sendCleanDatabasesRequest();">
 					<i class="fa fa-trash-o" aria-hidden="true"></i> Clean databases now

--- a/PaintomicsServer/src/AdminTools/scripts/clean_databases.py
+++ b/PaintomicsServer/src/AdminTools/scripts/clean_databases.py
@@ -21,6 +21,20 @@ from conf.serverconf import (
 
 from src.common.Util import sendEmail
 
+# serverconf.py is per-site and gitignored, so a deploy carries new code to a
+# configuration file that predates it. A hard `from conf.serverconf import
+# MAX_GUEST_JOB_DAYS` therefore does not fail here, it fails in AdminServlet at
+# import time and the server does not start at all -- verified by running the
+# clean export against a serverconf with the setting removed:
+#
+#     ImportError: cannot import name 'MAX_GUEST_JOB_DAYS' from 'conf.serverconf'
+#
+# A missing retention setting is not worth a site outage, so it falls back to
+# the number the interface promises. Sites that set it explicitly are
+# unaffected, and example_serverconf ships it so new installs always have it.
+import conf.serverconf as _serverconf
+MAX_GUEST_JOB_DAYS = getattr(_serverconf, "MAX_GUEST_JOB_DAYS", 7)
+
 # Directories directly under CLIENT_TMP that are NOT user directories.
 #
 # Everything else there is read as a "<userID>" directory, and STEP 7 rmtree's
@@ -30,6 +44,19 @@ from src.common.Util import sendEmail
 # will ever own it, so every cleanup run would have deleted the whole cache and
 # made the next regions-to-genes job re-parse its annotation from scratch.
 NON_USER_CLIENT_TMP_DIRS = ("nologin", "gtfcache")
+
+# Where an anonymous job's files live, and the userID its record carries.
+#
+# A job run without signing in is stored with userID None; JobInformationManager
+# writes its files under CLIENT_TMP/nologin/jobsData/<jobID>. BSON round-trips
+# have historically turned that None into the string "None" in places, so both
+# spellings count as anonymous rather than only the one this database happens to
+# hold today.
+ANONYMOUS_DIR = "nologin"
+ANONYMOUS_USER_IDS = (None, "None")
+
+# How long before a registered user's job expires they are warned about it.
+REMINDER_WINDOW_DAYS = 7
 
 # Every index the running server depends on, as (collection, create_index keys).
 # Shared with paintomicsserver so startup and the nightly cron cannot drift:
@@ -78,7 +105,8 @@ def cleanDatabases(force=False):
     jobs_to_remind = {}
     #In addition we have to clean all files from db and dir
 
-    # TODO: "nologin" user will not be present in the DB
+    # The "nologin" user is not in the database and never will be, so this loop
+    # cannot see anonymous jobs. STEP 3b below is where they are handled.
     for user in users_list:
         user_id = int(user["userID"])
         if str(user_id) in user_dirs:
@@ -89,8 +117,13 @@ def cleanDatabases(force=False):
             log("User " + str(user_id) + " marked to be fixed.")
             users_to_fix.append(user_id)
 
+        # A guest account's jobs are the "7 days for guests" the interface
+        # promises; a registered account's are the 14.
+        isGuest = bool(user.get("is_guest"))
+        maxJobDays = MAX_GUEST_JOB_DAYS if isGuest else MAX_JOB_DAYS
+
         force_remove = False
-        if "is_guest" in user and user["is_guest"] == True and checkRemoveGuestUser(user, user_id):
+        if isGuest and checkRemoveGuestUser(user, user_id):
             # If guest user, check if should be removed
             users_to_remove.append(user_id)
             force_remove = True
@@ -104,9 +137,22 @@ def cleanDatabases(force=False):
 
 
         # If check if user has jobs that should be removed
-        aux = checkRemoveJobsForUser(connection, user_id, force_remove)
+        aux = checkRemoveJobsForUser(connection, user_id, force_remove, maxJobDays)
         if len(aux) > 0:
             jobs_to_remove[user_id] = aux
+
+    # STEP 3b. ANONYMOUS JOBS.
+    #
+    # These were never examined. The loop above walks userCollection and asks
+    # for {"userID": str(user_id)}, and a job run without signing in stores
+    # userID None -- so it matches no user and no rule, and the original author
+    # left a "TODO: nologin user will not be present in the DB" against exactly
+    # this. On paintomics.uv.es that was 159 of 218 jobs: the majority of the
+    # server, retained forever, while the interface told those same users their
+    # work would be removed after seven days.
+    anonymous_to_remove = checkRemoveAnonymousJobs(connection)
+    if anonymous_to_remove:
+        jobs_to_remove[ANONYMOUS_DIR] = anonymous_to_remove
 
     log("Summary:")
     log("   - " + str(str(sum(len(x) for x in jobs_to_remove.values()))) + " jobs will be removed.")
@@ -160,17 +206,57 @@ def checkRemoveGuestUser(user, user_id):
         log("User " + str(user_id) + " marked to be removed.")
     return remove
 
-def checkRemoveJobsForUser(connection, user_id, force_remove=False):
+def jobAccessDate(job):
+    """The day a job was last opened, or None if it cannot be read.
+
+    accessDate is a "%Y%m%d%H%M" string rewritten by /pa_touch_job every time
+    the job is shown. A record that predates the field, or carries a malformed
+    one, must not be read as "infinitely old" -- that would delete it on the
+    next run. Returning None means "no opinion", and every caller keeps it.
+    """
+    raw = job.get("accessDate")
+    if not raw:
+        return None
+    try:
+        return datetime.datetime.strptime(str(raw)[0:8], "%Y%m%d").date()
+    except (ValueError, TypeError):
+        log("Job " + str(job.get("jobID")) + " has an unreadable accessDate " +
+            repr(raw) + "; leaving it alone.")
+        return None
+
+
+def checkRemoveJobsForUser(connection, user_id, force_remove=False,
+                           max_job_days=MAX_JOB_DAYS):
     #Get all jobs for user
     jobs_list = connection[MONGODB_DATABASE]['jobInstanceCollection'].find({"userID":str(user_id)})
-    max_date = datetime.date.today() - datetime.timedelta(days=MAX_JOB_DAYS)
+    max_date = datetime.date.today() - datetime.timedelta(days=max_job_days)
     jobs_remove = []
     # for each job
     for job in jobs_list:
         #Check if date OR if force_remove
-        date = datetime.datetime.strptime(job['accessDate'][0:8], "%Y%m%d").date()
+        date = jobAccessDate(job)
+        if date is None and not force_remove:
+            continue
         if force_remove or date < max_date:
             log("Job " + str(job["jobID"]) + " (user " + str(user_id) + ") marked to be removed.")
+            jobs_remove.append(job['jobID'])
+    return jobs_remove
+
+
+def checkRemoveAnonymousJobs(connection):
+    """Jobs run without signing in, older than MAX_GUEST_JOB_DAYS.
+
+    Selected on userID rather than by walking users, because that is the whole
+    point: these belong to no user, so no per-user pass can reach them.
+    """
+    jobs_list = connection[MONGODB_DATABASE]['jobInstanceCollection'].find(
+        {"userID": {"$in": list(ANONYMOUS_USER_IDS)}})
+    max_date = datetime.date.today() - datetime.timedelta(days=MAX_GUEST_JOB_DAYS)
+    jobs_remove = []
+    for job in jobs_list:
+        date = jobAccessDate(job)
+        if date is not None and date < max_date:
+            log("Job " + str(job["jobID"]) + " (anonymous) marked to be removed.")
             jobs_remove.append(job['jobID'])
     return jobs_remove
 
@@ -179,15 +265,28 @@ def checkRemindJobsForUser(connection, user_id):
     jobs_list = connection[MONGODB_DATABASE]['jobInstanceCollection'].find({"userID":str(user_id),
                                                                             "reminderSent": {"$exists": False}
                                                                             })
-    max_date = datetime.date.today() - datetime.timedelta(days=MAX_JOB_DAYS + 7)
-    min_date = datetime.date.today() - datetime.timedelta(days=MAX_JOB_DAYS)
+    # A warning has to arrive BEFORE the thing it warns about. This selected
+    # jobs whose accessDate was between MAX_JOB_DAYS and MAX_JOB_DAYS + 7 days
+    # old -- every one of which is also older than MAX_JOB_DAYS, so STEP 4 had
+    # already deleted it by the time STEP 8 mailed about it. The comment even
+    # says "avoid sending reminders of jobs that will be deleted today", which
+    # is what the window was meant to do and the opposite of what it did.
+    #
+    # The reminder now covers the last REMINDER_WINDOW_DAYS of a job's life:
+    # still present, deleted soon. With a 14-day retention that is a warning on
+    # day 7, and /pa_touch_job clears `reminderSent` so simply opening the job
+    # both saves it and re-arms the warning for next time.
+    warn_from = datetime.date.today() - datetime.timedelta(days=MAX_JOB_DAYS)
+    warn_until = datetime.date.today() - datetime.timedelta(
+        days=max(0, MAX_JOB_DAYS - REMINDER_WINDOW_DAYS))
     jobs_remind = []
     # for each job
     for job in jobs_list:
-        #Check if date OR if force_remove
-        date = datetime.datetime.strptime(job['accessDate'][0:8], "%Y%m%d").date()
-        # Avoid sending reminders of jobs that will be deleted today
-        if date >= max_date and date < min_date:
+        date = jobAccessDate(job)
+        if date is None:
+            continue
+        # Older than warn_from is already being deleted in this same run.
+        if warn_from < date <= warn_until:
             log("Job " + str(job["jobID"]) + " (user " + str(user_id) + ") marked to be reminded.")
             jobs_remind.append(job['jobID'])
     return jobs_remind
@@ -203,9 +302,18 @@ def removeJobByJobID(connection, user_id, job_id):
     connection[MONGODB_DATABASE]['pathwaysCollection'].delete_many({"jobID": job_id})
     #STEP 4. REMOVE ALL THE FOUND FEATURES ASSOCIATED TO JOB
     connection[MONGODB_DATABASE]['foundFeaturesCollection'].delete_many({"jobID": job_id})
-    #STEP 5. REMOVE THE JOB FROM DATABASE
+    #STEP 5. REMOVE THE AI INTERPRETATION OF THE JOB
+    #
+    # This collection was never in this list. Every expired or deleted job left
+    # its interpretation behind, and on paintomics.uv.es that had reached 366 of
+    # 437 records -- 84% of them belonging to jobs that no longer existed. They
+    # are not small: 88KB on average, and they hold the report text, the cited
+    # papers and the user's chat with the agent, which is to say the most
+    # sensitive part of the job outliving the job itself.
+    connection[MONGODB_DATABASE]['aiInterpretationCollection'].delete_many({"jobID": job_id})
+    #STEP 6. REMOVE THE JOB FROM DATABASE
     connection[MONGODB_DATABASE]['jobInstanceCollection'].delete_many({"jobID": job_id})
-    #STEP 6. REMOVE THE JOB DIRECTORY FROM USER DIR
+    #STEP 7. REMOVE THE JOB DIRECTORY FROM USER DIR
     removeDirectoryByUserID(user_id, job_id)
 
 

--- a/PaintomicsServer/src/common/DAO/PathwayAcquisitionJobDAO.py
+++ b/PaintomicsServer/src/common/DAO/PathwayAcquisitionJobDAO.py
@@ -185,4 +185,22 @@ class PathwayAcquisitionJobDAO(DAO):
         FeatureDAO().removeAll({"jobID": id})
         PathwayDAO(dbManager=self.dbManager).removeAll({"jobID": id})
 
+        # The cascade stopped at features and pathways, so deleting a job left
+        # three collections holding its data. aiInterpretationCollection is the
+        # one that matters: 88KB per record carrying the report, the cited
+        # papers and the user's conversation with the agent. On
+        # paintomics.uv.es 366 of 437 AI records belonged to jobs that had
+        # already been deleted -- and since this is the path a user takes when
+        # they press Delete in My Jobs, every one of those is someone who asked
+        # for their work to be removed and had the most revealing part of it
+        # kept.
+        #
+        # Done here rather than in the servlet so it is tied to the ownership
+        # check above: everything below this point only runs when a job
+        # belonging to this caller was actually deleted.
+        for collectionName in ("aiInterpretationCollection",
+                               "foundFeaturesCollection",
+                               "visualOptionsCollection"):
+            self.dbManager.getCollection(collectionName).delete_many({"jobID": id})
+
         return True

--- a/PaintomicsServer/src/resources/example_serverconf.py
+++ b/PaintomicsServer/src/resources/example_serverconf.py
@@ -86,8 +86,29 @@ ROOT_DIRECTORY            = ""                                         # Blank =
 CLIENT_TMP_DIR            = os.getenv("PAINTOMICS_CLIENT_TMP", "/data/CLIENT_TMP") + "/"
 KEGG_DATA_DIR             = os.getenv("PAINTOMICS_KEGG_DATA", "/data/KEGG_DATA") + "/"
 MAX_CLIENT_SPACE          = 200 * pow(1024, 2)
+
+# How long a job survives after it was last OPENED, not after it was created:
+# the client POSTs /pa_touch_job every time a job is shown, which rewrites
+# accessDate and clears any reminder already sent. A job someone keeps coming
+# back to therefore never expires.
+#
+# These two numbers are the ones the interface promises. pa_recover_job tells
+# every user whose job has gone:
+#
+#     "jobs are automatically removed after 7 days for guests and 14 days for
+#      registered users"
+#
+# and until now the configuration said 90 and 365 while the anonymous jobs that
+# make up most of the server were never examined at all -- so the sentence was
+# wrong in both directions at once. If you change these, change that sentence
+# too; test_retention_matches_the_promise fails if they drift apart again.
+MAX_GUEST_JOB_DAYS        = 7      # anonymous jobs, and jobs of is_guest accounts
+MAX_JOB_DAYS              = 14     # jobs belonging to a registered account
+
+# Separate question, and deliberately not one of the two above: how long a
+# GUEST ACCOUNT itself survives without being logged into. Its jobs are already
+# gone long before this, under MAX_GUEST_JOB_DAYS.
 MAX_GUEST_DAYS            = 90
-MAX_JOB_DAYS              = 365
 MAX_NUMBER_FEATURES       = 1000000
 
 # ========== MONGO DB SETTINGS ==========

--- a/PaintomicsServer/src/servlets/AdminServlet.py
+++ b/PaintomicsServer/src/servlets/AdminServlet.py
@@ -31,6 +31,7 @@ from datetime import datetime
 
 from src.common.UserSessionManager import UserSessionManager
 from src.common.ServerErrorManager import handleException
+import src.conf.serverconf as _serverconf
 from src.common.DAO.UserDAO import UserDAO
 from src.common.DAO.JobDAO import JobDAO
 from src.common.DAO.FileDAO import FileDAO
@@ -423,7 +424,7 @@ def adminServletGetAllUsers(request, response):
                 usedSpace = dir_total_size(CLIENT_TMP_DIR + str(userInstance.getUserId()))
             userSummaries.append(summarizeUserForAdmin(userInstance, usedSpace))
 
-        response.setContent({"success": True, "userList": userSummaries,  "availableSpace": MAX_CLIENT_SPACE, "max_jobs_days": MAX_JOB_DAYS, "max_guest_days" : MAX_GUEST_DAYS})
+        response.setContent({"success": True, "userList": userSummaries,  "availableSpace": MAX_CLIENT_SPACE, "max_jobs_days": MAX_JOB_DAYS, "max_guest_job_days": getattr(_serverconf, "MAX_GUEST_JOB_DAYS", 7), "max_guest_days" : MAX_GUEST_DAYS})
 
     except Exception as ex:
         handleException(response, ex, __file__ , "adminServletGetAllUsers")

--- a/PaintomicsServer/src/tests/test_retention_deletes_the_right_jobs.py
+++ b/PaintomicsServer/src/tests/test_retention_deletes_the_right_jobs.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""The retention rules, exercised against a real database.
+
+Why this exists
+---------------
+`test_retention_matches_the_promise` reads the source and checks the policy is
+stated consistently. That cannot tell you whether the code deletes the right
+jobs, and this code deletes people's work: getting the boundary wrong by a day,
+or the userID matching wrong by a type, destroys data with no undo.
+
+So this builds a scratch database, seeds one job at every interesting age for
+every kind of owner, runs the real selection functions against it, and asserts
+exactly which job ids come back. Nothing is stubbed except the clock, which is
+not stubbed either -- ages are seeded relative to today.
+
+The scratch database is created and dropped here; the server's own database is
+never opened. Follows the pattern of test_pymongo4_compat and
+test_user_identity_security.
+
+Skips cleanly when MongoDB is not reachable.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_retention_deletes_the_right_jobs
+"""
+import datetime
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+SCRATCH_DB = "PaintomicsRetentionTestDB"
+
+
+def _stamp(daysAgo):
+    """An accessDate as the application writes it: "%Y%m%d%H%M"."""
+    day = datetime.date.today() - datetime.timedelta(days=daysAgo)
+    return day.strftime("%Y%m%d") + "1200"
+
+
+class RetentionSelectionTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            from pymongo import MongoClient
+            from src.conf.serverconf import MONGODB_HOST, MONGODB_PORT
+            cls.client = MongoClient(MONGODB_HOST, MONGODB_PORT,
+                                     serverSelectionTimeoutMS=3000)
+            cls.client.server_info()
+        except Exception as ex:
+            raise unittest.SkipTest("MongoDB is not reachable: %s" % ex)
+
+        import src.AdminTools.scripts.clean_databases as cleaner
+        cls.cleaner = cleaner
+        cls.guestDays = cleaner.MAX_GUEST_JOB_DAYS
+        cls.userDays = cleaner.MAX_JOB_DAYS
+
+        cls.client.drop_database(SCRATCH_DB)
+        db = cls.client[SCRATCH_DB]
+
+        # One registered user (id 7) and one guest account (id 9).
+        db.userCollection.insert_many([
+            {"userID": 7, "userName": "registered", "is_guest": False,
+             "last_login": datetime.date.today().strftime("%Y%m%d")},
+            {"userID": 9, "userName": "guest", "is_guest": True,
+             "last_login": datetime.date.today().strftime("%Y%m%d")},
+        ])
+
+        # Jobs straddling every boundary that matters. The names say what each
+        # one is asserting, so a failure reads as a sentence.
+        cls.jobs = [
+            # registered user: 14-day window
+            ("reg_fresh",        "7",  1),
+            ("reg_day13",        "7",  cls.userDays - 1),
+            ("reg_exactly14",    "7",  cls.userDays),
+            ("reg_day15",        "7",  cls.userDays + 1),
+            ("reg_ancient",      "7",  400),
+            # guest account: 7-day window
+            ("guest_fresh",      "9",  1),
+            ("guest_day6",       "9",  cls.guestDays - 1),
+            ("guest_exactly7",   "9",  cls.guestDays),
+            ("guest_day8",       "9",  cls.guestDays + 1),
+            # anonymous: 7-day window, and the reason this change exists
+            ("anon_fresh",       None, 1),
+            ("anon_day6",        None, cls.guestDays - 1),
+            ("anon_exactly7",    None, cls.guestDays),
+            ("anon_day8",        None, cls.guestDays + 1),
+            ("anon_ancient",     None, 300),
+            # the string spelling of None that BSON round-trips have produced
+            ("anon_str_day8",   "None", cls.guestDays + 1),
+        ]
+        db.jobInstanceCollection.insert_many([
+            {"jobID": jid, "userID": uid, "accessDate": _stamp(age)}
+            for jid, uid, age in cls.jobs
+        ])
+        # A job whose accessDate cannot be parsed must never be deleted.
+        db.jobInstanceCollection.insert_one(
+            {"jobID": "malformed_date", "userID": "7", "accessDate": "not-a-date"})
+        db.jobInstanceCollection.insert_one(
+            {"jobID": "missing_date", "userID": "7"})
+
+        cls.db = db
+        cls.connection = {SCRATCH_DB: db}
+
+    @classmethod
+    def tearDownClass(cls):
+        if getattr(cls, "client", None) is not None:
+            cls.client.drop_database(SCRATCH_DB)
+            cls.client.close()
+
+    def setUp(self):
+        # The cleaner reads MONGODB_DATABASE at call time; point it at scratch.
+        self._realDb = self.cleaner.MONGODB_DATABASE
+        self.cleaner.MONGODB_DATABASE = SCRATCH_DB
+
+    def tearDown(self):
+        self.cleaner.MONGODB_DATABASE = self._realDb
+
+    # ---------------------------------------------------------------- guests
+
+    def test_anonymous_jobs_past_the_window_are_selected(self):
+        """The whole point: these were previously unreachable."""
+        picked = set(self.cleaner.checkRemoveAnonymousJobs(self.client))
+        self.assertIn("anon_day8", picked)
+        self.assertIn("anon_ancient", picked)
+
+    def test_anonymous_jobs_inside_the_window_are_kept(self):
+        picked = set(self.cleaner.checkRemoveAnonymousJobs(self.client))
+        self.assertNotIn("anon_fresh", picked)
+        self.assertNotIn("anon_day6", picked)
+
+    def test_the_anonymous_boundary_day_is_kept(self):
+        """"Removed after 7 days" means day 7 is still yours."""
+        picked = set(self.cleaner.checkRemoveAnonymousJobs(self.client))
+        self.assertNotIn("anon_exactly7", picked)
+
+    def test_the_string_none_spelling_counts_as_anonymous(self):
+        picked = set(self.cleaner.checkRemoveAnonymousJobs(self.client))
+        self.assertIn("anon_str_day8", picked)
+
+    def test_anonymous_selection_touches_no_owned_job(self):
+        picked = set(self.cleaner.checkRemoveAnonymousJobs(self.client))
+        for jid in ("reg_ancient", "guest_day8", "reg_day15"):
+            self.assertNotIn(jid, picked,
+                             "%s has an owner and must not be swept up by the "
+                             "anonymous pass" % jid)
+
+    def test_a_guest_accounts_jobs_use_the_guest_window(self):
+        picked = set(self.cleaner.checkRemoveJobsForUser(
+            self.client, 9, False, self.guestDays))
+        self.assertIn("guest_day8", picked)
+        self.assertNotIn("guest_exactly7", picked)
+        self.assertNotIn("guest_fresh", picked)
+
+    # ------------------------------------------------------------ registered
+
+    def test_a_registered_users_jobs_use_the_longer_window(self):
+        picked = set(self.cleaner.checkRemoveJobsForUser(
+            self.client, 7, False, self.userDays))
+        self.assertIn("reg_day15", picked)
+        self.assertIn("reg_ancient", picked)
+        self.assertNotIn("reg_exactly14", picked)
+        self.assertNotIn("reg_day13", picked)
+        self.assertNotIn("reg_fresh", picked)
+
+    def test_a_registered_job_survives_the_guest_window(self):
+        """Signing in has to be worth something: day 8 is safe for a user."""
+        picked = set(self.cleaner.checkRemoveJobsForUser(
+            self.client, 7, False, self.userDays))
+        self.assertNotIn("reg_day13", picked)
+
+    # --------------------------------------------------------- unreadable dates
+
+    def test_an_unreadable_access_date_is_never_deleted(self):
+        """"Cannot tell how old this is" must not mean "infinitely old"."""
+        picked = set(self.cleaner.checkRemoveJobsForUser(
+            self.client, 7, False, self.userDays))
+        self.assertNotIn("malformed_date", picked)
+        self.assertNotIn("missing_date", picked)
+
+    def test_a_forced_removal_still_takes_undated_jobs(self):
+        """When the account itself is going, its jobs go with it regardless."""
+        picked = set(self.cleaner.checkRemoveJobsForUser(
+            self.client, 7, True, self.userDays))
+        self.assertIn("malformed_date", picked)
+        self.assertIn("reg_fresh", picked)
+
+    # ------------------------------------------------------------- reminders
+
+    def test_the_reminder_fires_before_deletion_not_after(self):
+        """Every reminded job must still be alive after the removal pass."""
+        reminded = set(self.cleaner.checkRemindJobsForUser(self.client, 7))
+        removed = set(self.cleaner.checkRemoveJobsForUser(
+            self.client, 7, False, self.userDays))
+        self.assertEqual(set(), reminded & removed,
+                         "these jobs are mailed about and deleted in the same "
+                         "run: %s" % sorted(reminded & removed))
+
+    def test_the_reminder_covers_the_last_week_of_a_jobs_life(self):
+        reminded = set(self.cleaner.checkRemindJobsForUser(self.client, 7))
+        self.assertIn("reg_day13", reminded)
+        self.assertNotIn("reg_fresh", reminded)
+
+    # -------------------------------------------------------------- cascade
+
+    def test_removing_a_job_removes_its_ai_interpretation(self):
+        self.db.jobInstanceCollection.insert_one(
+            {"jobID": "cascade_probe", "userID": "7", "accessDate": _stamp(1)})
+        self.db.aiInterpretationCollection.insert_one(
+            {"jobID": "cascade_probe", "report": "secret", "status": "done"})
+        self.db.featuresCollection.insert_one({"jobID": "cascade_probe"})
+
+        self.cleaner.removeJobByJobID(self.client, "7", "cascade_probe")
+
+        self.assertIsNone(
+            self.db.aiInterpretationCollection.find_one({"jobID": "cascade_probe"}),
+            "the job is gone but its AI interpretation was left behind")
+        self.assertIsNone(
+            self.db.jobInstanceCollection.find_one({"jobID": "cascade_probe"}))
+        self.assertIsNone(
+            self.db.featuresCollection.find_one({"jobID": "cascade_probe"}))
+
+    def test_removing_a_job_leaves_other_jobs_alone(self):
+        self.db.jobInstanceCollection.insert_one(
+            {"jobID": "victim", "userID": "7", "accessDate": _stamp(1)})
+        self.db.aiInterpretationCollection.insert_many([
+            {"jobID": "victim", "report": "a"},
+            {"jobID": "bystander", "report": "b"},
+        ])
+
+        self.cleaner.removeJobByJobID(self.client, "7", "victim")
+
+        self.assertIsNotNone(
+            self.db.aiInterpretationCollection.find_one({"jobID": "bystander"}),
+            "removing one job deleted another job's interpretation")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_retention_matches_the_promise.py
+++ b/PaintomicsServer/src/tests/test_retention_matches_the_promise.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""The server keeps jobs for exactly as long as it tells users it will.
+
+Why this exists
+---------------
+`pathwayAcquisitionRecoverJob` tells every user whose job has gone:
+
+    "Job <id> not found at database. Please, note that jobs are automatically
+     removed after 7 days for guests and 14 days for registered users."
+
+That sentence was wrong in both directions at the same time.
+
+  * The configuration said `MAX_JOB_DAYS = 365` and `MAX_GUEST_DAYS = 90`, so a
+    registered user's job survived a year, not a fortnight.
+  * Anonymous jobs -- run without signing in, stored with `userID: None` --
+    were never examined at all. `cleanDatabases` walks `userCollection` and
+    asks for `{"userID": str(user_id)}`, and a job belonging to nobody matches
+    no user, so no rule ever reached it. The original author left a
+    "TODO: nologin user will not be present in the DB" against precisely this.
+    On paintomics.uv.es that was **159 of 218 jobs** -- the majority of the
+    server -- retained indefinitely while being told they had seven days.
+
+Every one of the 13 cleanup runs in the production logs reported the same
+thing, and it was true: `0 jobs will be removed. 0 users will be removed.`
+
+The sentence is the contract, because it is the only statement of the policy a
+user ever sees. So it is what the configuration is checked against here, by
+reading the number out of the servlet's own text rather than restating it --
+change the message without changing the policy, or the policy without the
+message, and this fails.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_retention_matches_the_promise
+"""
+import io
+import os
+import re
+import sys
+import tokenize
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+HERE = os.path.dirname(__file__)
+SERVLET = os.path.join(HERE, "../servlets/PathwayAcquisitionServlet.py")
+CLEANER = os.path.join(HERE, "../AdminTools/scripts/clean_databases.py")
+
+PROMISE = re.compile(
+    r"removed after\s+(\d+)\s+days? for guests and\s+(\d+)\s+days? for registered users")
+
+
+def _read(path):
+    with open(path, "r", encoding="utf-8", errors="replace") as handle:
+        return handle.read()
+
+
+def _stripComments(text):
+    """Prose is not behaviour.
+
+    Every assertion below that says "this construct must be gone" has to read
+    code only: the comment explaining why it was removed necessarily quotes it,
+    and would otherwise keep the test red forever.
+    """
+    try:
+        tokens = [t for t in tokenize.generate_tokens(io.StringIO(text).readline)
+                  if t.type != tokenize.COMMENT]
+        return tokenize.untokenize(tokens)
+    except Exception:
+        return text
+
+
+def _block(source, header, indent=""):
+    """The body of the def that starts with `header`, to the next def at `indent`."""
+    start = source.index(header)
+    rest = source[start + len(header):]
+    marker = "\n" + indent + "def "
+    end = rest.find(marker)
+    return source[start:] if end == -1 else source[start:start + len(header) + end]
+
+
+def promisedDays():
+    """(guest days, registered days) as the interface states them."""
+    match = PROMISE.search(_read(SERVLET))
+    if match is None:
+        raise AssertionError(
+            "the retention sentence is no longer in PathwayAcquisitionServlet. "
+            "If it moved, point this test at its new home; if it was deleted, "
+            "there is no longer any statement of the policy for users to rely "
+            "on, which is its own problem.")
+    return int(match.group(1)), int(match.group(2))
+
+
+class PromiseMatchesConfigTest(unittest.TestCase):
+
+    def setUp(self):
+        try:
+            from src.conf import serverconf
+        except Exception as ex:      # pragma: no cover - environment, not behaviour
+            self.skipTest("serverconf is not importable here: %s" % ex)
+        self.conf = serverconf
+        self.guestDays, self.userDays = promisedDays()
+
+    def test_guest_retention_is_what_the_message_says(self):
+        self.assertEqual(
+            getattr(self.conf, "MAX_GUEST_JOB_DAYS", None), self.guestDays,
+            "the interface promises guests %d days; MAX_GUEST_JOB_DAYS says "
+            "otherwise" % self.guestDays)
+
+    def test_registered_retention_is_what_the_message_says(self):
+        self.assertEqual(
+            self.conf.MAX_JOB_DAYS, self.userDays,
+            "the interface promises registered users %d days; MAX_JOB_DAYS "
+            "says otherwise" % self.userDays)
+
+    def test_a_guest_job_does_not_outlive_a_registered_one(self):
+        """Ordering, not just the numbers -- signing in must be worth something."""
+        self.assertLessEqual(self.conf.MAX_GUEST_JOB_DAYS, self.conf.MAX_JOB_DAYS)
+
+    def test_the_guest_account_lifetime_is_a_separate_setting(self):
+        """MAX_GUEST_DAYS is about accounts, and must not be read as job retention.
+
+        It was the only "guest" number in the configuration, which is how it
+        came to be mistaken for the one the message is about.
+        """
+        self.assertTrue(hasattr(self.conf, "MAX_GUEST_DAYS"))
+        self.assertTrue(hasattr(self.conf, "MAX_GUEST_JOB_DAYS"))
+
+
+class AnonymousJobsAreReachableTest(unittest.TestCase):
+    """The half that no number could fix: jobs nothing ever looked at."""
+
+    def setUp(self):
+        self.source = _read(CLEANER)
+
+    def test_the_cleaner_selects_jobs_by_anonymous_user_id(self):
+        self.assertIn("checkRemoveAnonymousJobs", self.source,
+                      "nothing collects jobs that belong to no user, so the "
+                      "seven-day promise cannot apply to most of the server")
+
+    def test_anonymous_jobs_are_queried_directly_not_via_the_user_loop(self):
+        """A per-user pass structurally cannot reach a job with no user."""
+        block = _block(self.source, "def checkRemoveAnonymousJobs")
+        self.assertIn("ANONYMOUS_USER_IDS", block)
+        self.assertIn("jobInstanceCollection", block)
+
+    def test_the_anonymous_window_is_the_guest_window(self):
+        block = _block(self.source, "def checkRemoveAnonymousJobs")
+        self.assertIn("MAX_GUEST_JOB_DAYS", block)
+
+    def test_the_result_is_actually_queued_for_removal(self):
+        """Collecting them and not deleting them would pass the tests above."""
+        self.assertRegex(
+            self.source,
+            r"jobs_to_remove\[ANONYMOUS_DIR\]\s*=\s*anonymous_to_remove",
+            "anonymous jobs are collected but never handed to the removal step")
+
+
+class DeletingAJobDeletesItsInterpretationTest(unittest.TestCase):
+    """A deleted job must not leave its AI report behind.
+
+    Two independent paths delete jobs and both omitted the collection: the
+    nightly `removeJobByJobID`, and `JobDAO.remove`, which is what runs when a
+    user presses Delete in My Jobs. On production 366 of 437 AI records
+    belonged to jobs that no longer existed -- 88KB each of report text, cited
+    papers and the user's conversation with the agent, kept after the user
+    asked for the job to go.
+    """
+
+    def test_the_nightly_cleanup_removes_the_ai_record(self):
+        block = _block(_read(CLEANER), "def removeJobByJobID")
+        self.assertIn("aiInterpretationCollection", _stripComments(block))
+
+    def test_the_user_facing_delete_removes_the_ai_record(self):
+        dao = _read(os.path.join(HERE, "../common/DAO/PathwayAcquisitionJobDAO.py"))
+        block = _block(dao, "    def remove(self", indent="    ")
+        self.assertIn("aiInterpretationCollection", _stripComments(block))
+
+    def test_the_user_facing_delete_still_checks_ownership_first(self):
+        """The cascade must stay behind the deleted_count gate.
+
+        Moving the new deletes above it would let an anonymous caller wipe the
+        interpretation of a job they do not own -- the same defect that gate
+        was added to close for features and pathways.
+        """
+        dao = _read(os.path.join(HERE, "../common/DAO/PathwayAcquisitionJobDAO.py"))
+        block = _stripComments(_block(dao, "    def remove(self", indent="    "))
+        gate = block.index("deleted_count == 0")
+        self.assertLess(gate, block.index("aiInterpretationCollection"),
+                        "the AI record is deleted before ownership is checked")
+
+
+class ReminderArrivesBeforeDeletionTest(unittest.TestCase):
+    """A warning has to come before the thing it warns about.
+
+    The window selected jobs whose accessDate was between MAX_JOB_DAYS and
+    MAX_JOB_DAYS + 7 days old -- all of which are also older than
+    MAX_JOB_DAYS, so STEP 4 deleted them in the same run that STEP 8 mailed
+    about them. Harmless at 365 days because it never fired; at 14 it would
+    have meant every reminder was a notification of a deletion that had just
+    happened.
+    """
+
+    def setUp(self):
+        self.block = _stripComments(
+            _block(_read(CLEANER), "def checkRemindJobsForUser"))
+
+    def test_the_window_ends_at_the_deletion_boundary(self):
+        self.assertIn("REMINDER_WINDOW_DAYS", self.block)
+
+    def test_the_old_inverted_window_is_gone(self):
+        self.assertNotIn("MAX_JOB_DAYS + 7", self.block,
+                         "the reminder window still reaches past the deletion "
+                         "boundary, so it warns about jobs already deleted")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The promise

`pa_recover_job` tells every user whose job has gone:

> jobs are automatically removed after **7 days for guests** and **14 days for registered users**

That sentence was wrong in both directions at once.

| | promised | actual |
|---|---|---|
| registered user's job | 14 days | `MAX_JOB_DAYS = 365` |
| guest / anonymous job | 7 days | **never examined at all** |

`cleanDatabases` walks `userCollection` asking for `{"userID": str(user_id)}`. A job run without signing in stores `userID: None`, so it matches no user and no rule could reach it — the original author left a `TODO: "nologin" user will not be present in the DB` against exactly this. On `paintomics.uv.es` that was **159 of 218 jobs**: the majority of the server, retained indefinitely, while those same users were told they had seven days.

Every one of the 13 cleanup runs in the production logs agreed, and was telling the truth:

```
clean_databases.py - 0 jobs will be removed.
clean_databases.py - 0 users will be removed.
```

## The change

- `MAX_JOB_DAYS` → **14**. New `MAX_GUEST_JOB_DAYS` → **7**, covering anonymous jobs *and* the jobs of `is_guest` accounts.
- `checkRemoveAnonymousJobs` selects on `userID` instead of walking users — because that is the whole point: no per-user pass can reach a job with no user.
- `MAX_GUEST_DAYS` stays 90 and keeps its own meaning: how long a guest **account** survives unused. It was the only "guest" number in the configuration, which is how it came to be mistaken for the one the message is about.

Retention is measured from `accessDate`, which `/pa_touch_job` rewrites every time a job is shown — so a job someone keeps coming back to never expires.

## Three defects found on the way

Each was harmless at 365 days and would have bitten at 14.

1. **The reminder arrived after the funeral.** It selected jobs aged `MAX_JOB_DAYS` … `MAX_JOB_DAYS + 7` — every one of which is *also* older than `MAX_JOB_DAYS`, so STEP 4 deleted them in the same run that STEP 8 mailed about them. Its own comment says "avoid sending reminders of jobs that will be deleted today". Now covers the last 7 days of a job's life.
2. **An unreadable `accessDate` was parsed unguarded** — it would have thrown mid-run, and read as infinitely old. "Cannot tell how old this is" now means *leave it alone*, except under `force_remove`.
3. **Neither delete path removed `aiInterpretationCollection`.** On production **366 of 437 AI records** belonged to jobs that no longer existed — 88 KB each of report text, cited papers and the user's conversation with the agent. `JobDAO.remove` is what runs when a user presses Delete in My Jobs, so every one of those is someone who asked for their work to be removed and had the most revealing part of it kept. Both paths now cascade, and in `JobDAO.remove` the cascade stays **behind the `deleted_count` gate** so it cannot be used to wipe a job you do not own.

## A deploy hazard this would have had

`serverconf.py` is per-site and gitignored, so a deploy carries new code to a configuration file that predates it. A hard `from conf.serverconf import MAX_GUEST_JOB_DAYS` does not fail in the cleanup script — it fails in `AdminServlet` at import time and **the server does not start at all**. Reproduced by running a clean `git archive` export against a `serverconf` with the setting removed:

```
ImportError: cannot import name 'MAX_GUEST_JOB_DAYS' from 'conf.serverconf'
```

Both consumers now fall back to the number the interface promises, and the server was re-verified to import cleanly against a copy of production's current config.

## Verification

- **13 static tests** pinning the configuration to the sentence in the servlet — read out of the servlet's own text rather than restated, so the two cannot drift apart again.
- **14 functional tests against a real MongoDB**: a scratch database seeded with a job at every interesting age for every kind of owner, running the real selection functions and asserting exactly which ids come back — including that **day 7 and day 14 are still yours**, that the anonymous pass touches no owned job, and that removing one job leaves another job's interpretation alone.
- **Mutation-tested**: an off-by-one on the boundary, an empty anonymous pass, a dropped AI cascade, and "treat unreadable as ancient" each fail the suite.
- Clean-checkout import gate: 8/8 servlets.
- Full suite: 228 suites, 0 introduced. Three suites flagged by `run_all` were checked individually — `test_delegation_cache` (11/14) and `test_submit_nudges` (9/11) fail identically on plain `origin/master` and belong in BASELINE; `test_example_bundle` passes on this branch in isolation and is the known shared-example-directory interference.

## Production impact, measured before merging

**19 jobs** would be deleted on the first run (one of them carrying an AI report); **201 survive**. The cron fires ~24 h after a restart, so nothing is deleted at deploy time.

Deploying also needs `serverconf.py` edited on the server — it is gitignored, so `MAX_JOB_DAYS` would otherwise stay 365 there even with this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)