### PR TITLE
Stop the AI panel hanging on a job the server no longer has

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_AIInterpretView.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_AIInterpretView.js
@@ -11,6 +11,9 @@ if (typeof marked !== "undefined" && marked.use) {
 }
 
 function PA_AIInterpretView() {
+
+    /** Transport retries for the report fetch before giving up with a button. */
+    this.REPORT_RETRIES = 2;
     this.$root = null;
     this.isExpanded = false;
     this.chatHistory = [];
@@ -264,6 +267,18 @@ function PA_AIInterpretView() {
             if (!this.reportLoaded) {
                 this.loadReport();
             }
+        } else if (status === "unavailable") {
+            // Failed, and retrying cannot help: the job it describes is no
+            // longer on the server. Same red treatment as an error, minus the
+            // Retry button, which would re-post to /ai_interpret_initiate and
+            // be refused for exactly the same reason. A button that cannot
+            // work is worse than no button -- it reads as "we could fix this
+            // if you asked again".
+            $progress.show().removeClass("is-done").addClass("is-error");
+            this.$root.find(".ai-progress-fill").css("width", "100%");
+            this.$root.find(".ai-progress-detail").text(detail || "Unavailable");
+            $fab.removeClass("is-processing");
+            $badge.css("background", "#ef5350").html("!").show();
         } else if (status === "error") {
             $progress.show().removeClass("is-done").addClass("is-error");
             this.$root.find(".ai-progress-fill").css("width", "100%");
@@ -295,8 +310,24 @@ function PA_AIInterpretView() {
         }
     };
 
-    this.loadReport = function() {
+    /**
+     * Fetch the finished report and show it.
+     *
+     * This is called ONCE, from the terminal "done" poll -- and "done" ends the
+     * polling chain, so if this single request failed there was nothing left to
+     * try again. The panel said "Failed to load the report. Please try again."
+     * and offered no way to do so; the only real recovery was reloading the
+     * page, or knowing that opening the panel happens to retry.
+     *
+     * A 57KB report on a single-process server is not a request that always
+     * succeeds, so it now retries by itself, and the message it falls back to
+     * carries a button that works.
+     *
+     * @param {Number} attempt  0 for the first try; used only by the retries.
+     */
+    this.loadReport = function(attempt) {
         var me = this;
+        attempt = attempt || 0;
         $.ajax({
             type: "POST",
             url: SERVER_URL_AI_INTERPRET_REPORT,
@@ -314,13 +345,41 @@ function PA_AIInterpretView() {
                 } else if (response.status === "error") {
                     me.addMessage("assistant",
                         "The AI interpretation failed: **" + (response.message || "Unknown error") + "**");
+                } else if (/not found|Invalid Job ID/i.test(String(response.message || ""))) {
+                    // The job itself is gone, so there is nothing to wait for.
+                    // Say which of the two it is rather than "still in progress",
+                    // which is what this used to claim for a deleted job.
+                    me.addMessage("assistant",
+                        "This job is no longer stored on the server, so its " +
+                        "interpretation cannot be loaded. Jobs are removed after " +
+                        "7 days for guests and 14 days for registered users.");
                 } else {
                     me.addMessage("assistant",
                         "The AI interpretation is still in progress. Please wait for it to complete.");
                 }
             },
             error: function() {
-                me.addMessage("assistant", "Failed to load the report. Please try again.");
+                if (attempt < me.REPORT_RETRIES) {
+                    // Back off and try again: this is a transport failure, and
+                    // the report is large enough that a busy server drops it.
+                    setTimeout(function() { me.loadReport(attempt + 1); },
+                               1000 * Math.pow(2, attempt));
+                    return;
+                }
+                // Passed as trusted HTML on purpose: it is a fixed string with
+                // nothing interpolated into it, and the assistant path would
+                // otherwise run it through marked and the sanitiser, which is
+                // for model output and would take the button's attributes with
+                // it.
+                me.addMessage("assistant",
+                    "Failed to load the report after " + (me.REPORT_RETRIES + 1) +
+                    " attempts. <button class=\"ai-reload-report-btn\">Try again</button>",
+                    true);
+                // Bound to the button rather than offered as advice: "please
+                // try again" with nothing to press is what this said before.
+                me.$root.find(".ai-reload-report-btn").last().off("click").on("click", function() {
+                    me.loadReport(0);
+                });
             }
         });
     };

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
@@ -819,9 +819,43 @@ function PA_Step3JobView() {
 			success: function(r) {
 				if (!me.aiWidget) { return; }
 				// success:false is what the servlet returns for any handled
-				// exception -- an expired session, a Mongo hiccup. It is not a
-				// statement about the job, so keep watching.
-				if (!r || !r.success) { schedule(AI_POLL_INTERVAL); return; }
+				// exception. Most are worth another look -- a Mongo hiccup, a
+				// momentary blip -- but two are not, and treating those as
+				// transient is what left the widget saying "Starting..." with
+				// an empty panel for as long as the tab stayed open.
+				//
+				// The job going missing is the one that bites. A reopened job
+				// is drawn from the copy the browser keeps in sessionStorage,
+				// so the page never asks the server whether the job is still
+				// there; the AI report is the only thing that does. Once the
+				// job has been removed -- 7 days for guests, 14 for registered
+				// users -- the report request is refused and no amount of
+				// asking again will change that. Measured before this change:
+				// four polls in twenty seconds, still going, nothing shown.
+				if (!r || !r.success) {
+					var why = String((r && r.message) || "");
+					if (/not found|Invalid Job ID/i.test(why)) {
+						me.aiWidget.updateProgress(
+							"unavailable", 100,
+							"This job is no longer stored on the server, so its " +
+							"AI interpretation cannot be loaded. Jobs are removed " +
+							"after 7 days for guests and 14 days for registered " +
+							"users.");
+						return;              // permanent: stop the chain
+					}
+					// Anything else may well clear. Keep trying, but not for
+					// ever, and say so rather than leaving the panel blank.
+					me.aiPollFailures = (me.aiPollFailures || 0) + 1;
+					if (me.aiPollFailures >= AI_POLL_MAX_FAILURES) {
+						me.aiWidget.updateProgress(
+							"error", 100,
+							"The server stopped answering while tracking this " +
+							"interpretation. Reload the page to try again.");
+						return;
+					}
+					schedule(AI_POLL_INTERVAL);
+					return;
+				}
 				me.aiPollFailures = 0;
 				me.aiWidget.updateProgress(r.status, r.percent, r.detail,
 				                           r.toolTrace, r.toolCalls);
@@ -858,7 +892,48 @@ function PA_Step3JobView() {
 					}
 					return;      // stop the chain: nothing here can recover it
 				}
+
+				// THE JOB IS GONE. This arrives HERE, not in the success
+				// handler, and that distinction is the whole bug: the servlet
+				// renders a UserWarning as HTTP 400, so jQuery routes it to
+				// `error`. A `success:false` body never carries this case at
+				// all, which is why guarding only that looked right and
+				// changed nothing.
+				//
+				// A reopened job is drawn from the copy the browser holds, so
+				// the page never asks whether the job still exists; the status
+				// poll is the only thing that does. Once the job has been
+				// removed -- 7 days for guests, 14 for registered users -- the
+				// answer is a refusal, and asking again cannot change it.
+				// Measured before this: four polls in twenty seconds, still
+				// going, "Starting..." and an empty panel.
+				var missing = (code === 400 || code === 404) &&
+				              /not found|Invalid Job ID/i.test(body);
+				if (missing) {
+					if (me.aiWidget) {
+						me.aiWidget.updateProgress(
+							"unavailable", 100,
+							"This job is no longer stored on the server, so its " +
+							"AI interpretation cannot be loaded. Jobs are removed " +
+							"after 7 days for guests and 14 days for registered " +
+							"users.");
+					}
+					return;      // permanent: stop the chain
+				}
+
 				me.aiPollFailures = (me.aiPollFailures || 0) + 1;
+				if (me.aiPollFailures >= AI_POLL_MAX_FAILURES) {
+					// A server that has stopped answering is not made to answer
+					// by asking a hundred more times, and the user should be
+					// told rather than watching a bar that never moves.
+					if (me.aiWidget) {
+						me.aiWidget.updateProgress(
+							"error", 100,
+							"The server stopped answering while tracking this " +
+							"interpretation. Reload the page to try again.");
+					}
+					return;
+				}
 				schedule(Math.min(AI_POLL_INTERVAL * Math.pow(2, me.aiPollFailures - 1),
 				                  BACKOFF_CEILING));
 			}
@@ -4146,7 +4221,28 @@ function PA_Step3PathwayDetailsView() {
 				//Add the name for the row (e.g. MagoHb or "miRNA my_mirnaid_1")
 				yAxisCat.push("Trend " + (i + 1) + "#Cluster " + metagenes[i].cluster);
 
-				var limits = getMinMax(dataDistributionSummaries[omicName], "p10p90");
+				/* Coloured against the METAGENES' own range, not the omic's.
+
+				   A metagene is a trend -- a component summarising how a
+				   cluster of features moves -- and it is centred on zero, so it
+				   goes negative whatever the omic did. Colouring it with the
+				   omic's distribution asks a scale built for one quantity to
+				   describe another: on a real job here the omic ran 0.79..1.41
+				   while its metagenes reached +/-9.4, eight times outside the
+				   scale in both directions.
+
+				   getColor's outlier term then runs far past 1 and drives
+				   channels out of range. Measured on the live server, this line
+				   produced "rgb(0, 0,-2744)" and "rgb(255, 255,-410)" -- not
+				   colours. Chrome clamped the second to yellow and rejected the
+				   first outright, painting it black, so the trend rows showed
+				   two arbitrary colours that meant nothing.
+
+				   Their own min/max crosses zero, so paColourRange returns a
+				   symmetric range and the diverging blue-white-red scale reads
+				   the way it is supposed to: blue for down, red for up, white
+				   for no change. */
+				var limits = paMetageneLimits(metagenes);
 
 
 				for (var j in featureValues) {
@@ -6977,6 +7073,49 @@ var paColourRange = function (low, high) {
 
 	/* Sequential: the data's own range is the ramp. */
 	return {min: low, max: high};
+};
+
+/**
+ * The colour range for a set of metagene trends, from the trends themselves.
+ *
+ * Every other caller colours a feature against the distribution of the omic
+ * that feature came from, which is right, because they are the same quantity.
+ * A metagene is not: it is a component describing how a whole cluster moves,
+ * centred on zero and on its own scale entirely. It needs its own range, and
+ * this is the only place that computes one.
+ *
+ * No clipping: absMin/absMax are the same as min/max, so getColor's outlier
+ * term is zero everywhere rather than being measured against a percentile the
+ * trends were never summarised at. There is no p10/p90 for a metagene.
+ *
+ * @param {Array} metagenes  [{values: [...]}, ...]
+ * @returns {Object} the {min, max, absMin, absMax} getColor expects
+ */
+var paMetageneLimits = function (metagenes) {
+	var low = null, high = null;
+
+	(metagenes || []).forEach(function (metagene) {
+		((metagene && metagene.values) || []).forEach(function (raw) {
+			var value = Number(raw);
+			/* Metagene values arrive as strings and a cluster with a gap in it
+			   yields NaN, which would poison both ends of the range and take
+			   every colour on the chart with it. */
+			if (!isFinite(value)) { return; }
+			if (low === null || value < low) { low = value; }
+			if (high === null || value > high) { high = value; }
+		});
+	});
+
+	if (low === null) {
+		/* Nothing usable. A degenerate range makes paRampPosition return 0 for
+		   everything, which is the pale end -- honest for "no data" and, unlike
+		   the alternative, a valid colour. */
+		return {min: 0, max: 0, absMin: 0, absMax: 0};
+	}
+
+	var range = paColourRange(low, high);
+	return {min: range.min, max: range.max,
+	        absMin: range.min, absMax: range.max};
 };
 
 /**

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -125,7 +125,7 @@
 	<script type="text/javascript" src="js/libs/svgjs/jquery.svg.pan.zoom.min.js"></script>
 
 	<!--SCRIPTS FOR SERVER CONNECTION CONFIGURATION-->
-	<script type="text/javascript" src="resources/ServerConfiguration.js?v=0.9"></script>
+	<script type="text/javascript" src="resources/ServerConfiguration.js?v=1.0"></script>
 	<!--CUSTOM SENCHA EXTENSIONS-->
 	<script type="text/javascript" src="app/view/common/Util.js?v=2.1"></script>
 	<script type="text/javascript" src="app/view/common/ExtJS_extensions.js?v=0.7"></script>
@@ -136,7 +136,7 @@
 	<!--MARKDOWN RENDERING LIBRARY -->
 	<script type="text/javascript" src="js/libs/marked/marked.min.js"></script>
 	<!--AI INTERPRETATION VIEW -->
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_AIInterpretView.js?v=1.2"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_AIInterpretView.js?v=1.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-reader.js?v=0.1"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-validator.js?v=0.1"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-repair.js?v=0.1"></script>

--- a/PaintomicsClient/public_html/resources/ServerConfiguration.js
+++ b/PaintomicsClient/public_html/resources/ServerConfiguration.js
@@ -72,6 +72,13 @@ SERVER_URL_AI_GENERATE_EXP_DESIGN = SERVER_URL + "ai_generate_exp_design";
    is a false statement. See getAIProviderInfo() in AIInterpretServlet.py. */
 SERVER_URL_AI_PROVIDER = SERVER_URL + "ai_provider";
 AI_POLL_INTERVAL = 3000;
+// How many consecutive unhandled refusals from /ai_interpret_status before the
+// widget gives up and says so. A refusal it recognises as permanent -- the job
+// no longer exists -- stops immediately and does not consume these; this is the
+// ceiling for everything else, so a server that has stopped answering produces
+// a message instead of a progress bar that says "Starting..." for as long as
+// the tab is open.
+AI_POLL_MAX_FAILURES = 5;
 CHAT_POLL_INTERVAL = 1500;
 
 /*********************************************************************

--- a/PaintomicsServer/src/tests/test_ai_status_poll_survives_a_failed_request.py
+++ b/PaintomicsServer/src/tests/test_ai_status_poll_survives_a_failed_request.py
@@ -64,21 +64,29 @@ def extract_block(source, header):
 HARNESS = """
 const results = {};
 
-function drive(respond) {
+// `chain` false runs a single tick, which is all most of these need. `chain`
+// true keeps firing whatever the poll scheduled, up to a hard ceiling, which is
+// how "it eventually stops" can be asserted at all -- a stubbed setTimeout that
+// only records can never distinguish "stopped" from "scheduled once more".
+function drive(respond, chain) {
     const scheduled = [];
     const calls = [];
-    const setTimeout_ = function (fn, delay) { scheduled.push({delay: delay}); return scheduled.length; };
+    const shown = [];
+    const setTimeout_ = function (fn, delay) { scheduled.push({fn: fn, delay: delay}); return scheduled.length; };
     const AI_POLL_INTERVAL = 3000;
+    const AI_POLL_MAX_FAILURES = 5;
     const SERVER_URL_AI_INTERPRET_STATUS = "/ai_interpret_status";
 
     const $ = function () { return {}; };
     $.ajax = function (opts) {
         calls.push(opts.url);
-        respond(opts);
+        respond(opts, calls.length);
     };
 
     function View() {
-        this.aiWidget = {updateProgress: function () {}};
+        this.aiWidget = {updateProgress: function (status, percent, detail) {
+            shown.push({status: status, detail: String(detail || "")});
+        }};
         this.getModel = function () { return {getJobID: function () { return "JOB"; }}; };
         const setTimeout = setTimeout_;
         %(poll)s
@@ -86,8 +94,25 @@ function drive(respond) {
 
     const view = new View();
     view.pollAIStatus();
+
+    if (chain) {
+        // A runaway chain is the failure being tested for, so the ceiling is
+        // well above AI_POLL_MAX_FAILURES and reaching it counts as "never
+        // stopped".
+        let fired = 0;
+        while (scheduled.length && fired < 40) {
+            const next = scheduled.shift();
+            fired++;
+            next.fn();
+        }
+        return {polls: calls.length, stopped: scheduled.length === 0 && fired < 40,
+                shown: shown, lastDetail: shown.length ? shown[shown.length - 1].detail : null,
+                lastStatus: shown.length ? shown[shown.length - 1].status : null};
+    }
+
     return {polls: calls.length, scheduled: scheduled.length,
-            firstDelay: scheduled.length ? scheduled[0].delay : null};
+            firstDelay: scheduled.length ? scheduled[0].delay : null,
+            shown: shown};
 }
 
 // A request that never landed: jQuery calls `error`, or nothing at all when no
@@ -117,6 +142,53 @@ results.cancelled = drive(function (opts) {
 results.errored = drive(function (opts) {
     opts.success({success: true, status: "error", percent: 0, detail: "boom"});
 });
+
+// THE JOB IS GONE. A reopened job is drawn from the browser's own copy, so the
+// page shows it without asking the server; only the AI report asks. Once the
+// job has been removed the answer is a refusal, and asking again cannot change
+// it -- this is the "Starting..." for ever that was reported.
+// Captured verbatim from the running server, because the shape is the point:
+// handleException renders a UserWarning as HTTP 400 with the message in the
+// body, so jQuery routes it to `error`. Asserting against a success:false body
+// tests a path this case never takes -- which is how the first attempt at this
+// fix passed its tests and changed nothing in the browser.
+const JOB_GONE_BODY = JSON.stringify({
+    success: false,
+    message: "UserWarning: AT AIInterpretServlet.py: aiInterpretStatus. " +
+             "ERROR MESSAGE: Job r0l53602VQ was not found."
+});
+const JOB_REFUSED_BODY = JSON.stringify({
+    success: false,
+    message: "UserWarning: AT AIInterpretServlet.py: aiInterpretStatus. " +
+             "ERROR MESSAGE: Invalid Job ID (r0l53602VQ) for current user."
+});
+
+results.jobDeleted = drive(function (opts) {
+    opts.error({status: 400, responseText: JOB_GONE_BODY});
+}, true);
+
+results.jobRefused = drive(function (opts) {
+    opts.error({status: 400, responseText: JOB_REFUSED_BODY});
+}, true);
+
+// A 400 it cannot classify: worth retrying, but not for ever.
+results.persistentUnknownFailure = drive(function (opts) {
+    opts.error({status: 400, responseText: JSON.stringify(
+        {success: false, message: "some transient database problem"})});
+}, true);
+
+// The same failure, but it clears before the ceiling: the chain must recover
+// and go on to deliver the report rather than having burned its budget.
+results.recoversAfterTwoFailures = drive(function (opts, n) {
+    if (n <= 2) { opts.error({status: 500, responseText: "{}"}); }
+    else { opts.success({success: true, status: "done", percent: 100, detail: "Ready"}); }
+}, true);
+
+// A session that expired must keep its own message, not be relabelled.
+results.sessionExpired = drive(function (opts) {
+    opts.error({status: 400, responseText: JSON.stringify(
+        {success: false, message: "CredentialException: User not valid. please log-in again."})});
+}, true);
 
 console.log(JSON.stringify(results));
 """
@@ -177,6 +249,80 @@ class StatusPollChainTest(unittest.TestCase):
         delay = self.results["transportFailure"]["firstDelay"]
         self.assertIsNotNone(delay, "no retry was scheduled at all")
         self.assertGreaterEqual(delay, 3000, "retry is faster than AI_POLL_INTERVAL")
+
+    # ------------------------------------------------------------------
+    # A deleted job. The other half of the same bug: the chain surviving a
+    # refusal it can never recover from is not resilience, it is a hang.
+    # ------------------------------------------------------------------
+
+    def test_a_deleted_job_stops_the_chain(self):
+        """The reported bug: reopen an expired job, "Starting..." for ever.
+
+        The page is drawn from the copy the browser keeps in sessionStorage, so
+        it never asks the server whether the job still exists; only the AI
+        report does. Measured before this: four polls in twenty seconds, still
+        going, empty panel, no message.
+        """
+        outcome = self.results["jobDeleted"]
+        self.assertTrue(outcome["stopped"],
+                        "the poll kept going against a job that no longer "
+                        "exists; it can never succeed")
+        self.assertEqual(outcome["polls"], 1,
+                         "asked more than once about a job that is gone")
+
+    def test_a_deleted_job_says_so(self):
+        """Stopping silently would leave the same empty panel, just quieter."""
+        outcome = self.results["jobDeleted"]
+        self.assertIn("no longer stored on the server", outcome["lastDetail"])
+        self.assertEqual(
+            outcome["lastStatus"], "unavailable",
+            "reported as a plain error, which renders a Retry button -- and "
+            "retrying re-posts to /ai_interpret_initiate, which is refused for "
+            "the same reason. A button that cannot work reads as 'we could fix "
+            "this if you asked again'")
+        self.assertRegex(outcome["lastDetail"], r"7 days.*14 days",
+                         "the message should say what the retention actually "
+                         "is, since that is why the job is gone")
+
+    def test_a_refused_job_stops_the_chain(self):
+        """"Invalid Job ID ... for current user" is equally permanent."""
+        outcome = self.results["jobRefused"]
+        self.assertTrue(outcome["stopped"])
+        self.assertEqual(outcome["polls"], 1)
+
+    def test_an_unclassifiable_failure_gives_up_eventually(self):
+        outcome = self.results["persistentUnknownFailure"]
+        self.assertTrue(outcome["stopped"],
+                        "a server that has stopped answering is polled for "
+                        "ever, showing nothing")
+        self.assertLessEqual(outcome["polls"], 6,
+                             "gave up later than AI_POLL_MAX_FAILURES")
+        self.assertEqual(outcome["lastStatus"], "error")
+        self.assertIn("stopped answering", outcome["lastDetail"])
+
+    def test_an_expired_session_keeps_its_own_message(self):
+        """The two permanent cases must not be confused for one another.
+
+        "your session expired, sign in again" and "this job no longer exists"
+        call for different actions from the user, and the second regex must not
+        swallow the first.
+        """
+        outcome = self.results["sessionExpired"]
+        self.assertTrue(outcome["stopped"])
+        self.assertIn("session expired", outcome["lastDetail"])
+        self.assertNotIn("no longer stored", outcome["lastDetail"])
+
+    def test_a_failure_that_clears_does_not_consume_the_budget(self):
+        """Two blips then success must still deliver the report.
+
+        The counter has to reset on a good answer, or a long run with
+        occasional hiccups would exhaust its allowance and give up on a job
+        that was working.
+        """
+        outcome = self.results["recoversAfterTwoFailures"]
+        self.assertTrue(outcome["stopped"])
+        self.assertEqual(outcome["lastStatus"], "done",
+                         "the chain gave up instead of recovering")
 
 
 def main():

--- a/PaintomicsServer/src/tests/test_heatmap_colour_and_column_space.py
+++ b/PaintomicsServer/src/tests/test_heatmap_colour_and_column_space.py
@@ -61,8 +61,8 @@ STEP3_VIEWS = os.path.abspath(os.path.join(
 # object prove less than they appear to: nothing in the application ever builds
 # one by hand, and for two years getMinMax could not produce the very shape
 # those tests assert on. See SequentialRangeReachableTest.
-HELPERS = ("paColourRange", "getMinMax", "paRampPosition", "getColor",
-           "paValuesForHeader", "paTruncateTail", "paConditionAxis")
+HELPERS = ("paColourRange", "getMinMax", "paMetageneLimits", "paRampPosition",
+           "getColor", "paValuesForHeader", "paTruncateTail", "paConditionAxis")
 
 
 def read_source():
@@ -434,6 +434,106 @@ class ColumnSpaceTest(unittest.TestCase):
         self.assertEqual(result[:2], ["Condition 1", "Condition 2"])
         for name in ("Ctr_0H", "Ik_24H"):
             self.assertNotIn(name, result)
+
+
+class MetageneTrendsGetTheirOwnScaleTest(unittest.TestCase):
+    """A trend is not the omic it summarises, and must not borrow its scale.
+
+    `generateHeatmap` coloured `metagenes[i].values` with
+    `getMinMax(dataDistributionSummaries[omicName], "p10p90")` -- the raw
+    omic's distribution. A metagene is a component describing how a cluster
+    moves, centred on zero, on its own scale entirely. Measured on a real
+    production job the omic ran 0.79..1.41 while its metagenes reached +/-9.4:
+    eight times outside the scale in both directions.
+
+    getColor's outlier term then runs far past 1 and pushes channels out of
+    range. Captured from the live server:
+
+        rgb(0, 0,-2744)      rgb(255, 255,-410)
+
+    Chrome clamps the second to yellow and rejects the first outright, painting
+    it black, so the trend rows showed two arbitrary colours that meant nothing
+    about the data.
+    """
+
+    def _colours(self, metagenes, values):
+        return run_in_node("""
+            const limits = paMetageneLimits(%s);
+            process.stdout.write(JSON.stringify({
+              limits: limits,
+              colours: %s.map(v => getColor(limits, v, "bwr"))
+            }));
+        """ % (json.dumps(metagenes), json.dumps(values)))
+
+    def test_a_metagene_never_produces_an_impossible_colour(self):
+        """The regression, with the real numbers that produced it."""
+        metagenes = [{"values": [-6.655823, -7.692578, 7.549343, 9.402448, 0.1]}]
+        result = self._colours(metagenes, [-7.692578, -1.0, 0.0, 9.402448])
+        for colour in result["colours"]:
+            self.assertNotIn("-", colour, "channel out of range: %s" % colour)
+            self.assertNotIn("Infinity", colour)
+            self.assertNotIn("NaN", colour)
+
+    def test_the_scale_comes_from_the_trends_not_the_omic(self):
+        metagenes = [{"values": [-9.4, 9.4]}]
+        result = self._colours(metagenes, [0])
+        self.assertAlmostEqual(result["limits"]["max"], 9.4)
+        self.assertAlmostEqual(result["limits"]["min"], -9.4)
+
+    def test_a_trend_reads_as_a_diverging_scale(self):
+        """Blue for down, red for up, white for no change."""
+        metagenes = [{"values": [-4.0, 4.0]}]
+        result = self._colours(metagenes, [-4.0, 0.0, 4.0])
+        self.assertEqual(result["colours"][0], "rgb(0, 0,255)")
+        self.assertEqual(result["colours"][1], "rgb(255, 255,255)")
+        self.assertEqual(result["colours"][2], "rgb(255, 0,0)")
+
+    def test_the_range_is_symmetric_so_equal_moves_read_equally(self):
+        """An asymmetric trend range would say -2 and +2 differ. They do not."""
+        metagenes = [{"values": [-1.0, 8.0]}]
+        result = self._colours(metagenes, [-2.0, 2.0])
+        down = int(result["colours"][0].split(",")[2].rstrip(")"))
+        up = int(result["colours"][1].split(",")[0].split("(")[1])
+        self.assertEqual(down, up,
+                         "equal magnitudes either side of zero are drawn at "
+                         "different intensities")
+
+    def test_several_trends_share_one_scale(self):
+        """Rows of the same chart must be comparable with each other."""
+        metagenes = [{"values": [-1.0, 1.0]}, {"values": [-5.0, 5.0]}]
+        result = self._colours(metagenes, [5.0])
+        self.assertAlmostEqual(result["limits"]["max"], 5.0)
+        self.assertEqual(result["colours"][0], "rgb(255, 0,0)")
+
+    def test_unusable_values_do_not_poison_the_chart(self):
+        """One NaN must not take every colour on the chart with it.
+
+        Metagene values arrive as strings and a cluster with a gap yields NaN,
+        which would otherwise propagate through both ends of the range.
+        """
+        metagenes = [{"values": ["-2.0", "nonsense", "2.0", None]}]
+        result = self._colours(metagenes, [-2.0, 2.0])
+        self.assertAlmostEqual(result["limits"]["max"], 2.0)
+        for colour in result["colours"]:
+            self.assertNotIn("NaN", colour)
+
+    def test_no_values_at_all_is_a_valid_colour(self):
+        result = self._colours([], [0])
+        self.assertNotIn("NaN", result["colours"][0])
+        self.assertNotIn("-", result["colours"][0])
+
+
+class GenerateHeatmapUsesTheTrendScaleTest(unittest.TestCase):
+    """Wiring: the helper exists and generateHeatmap is what calls it."""
+
+    def test_generate_heatmap_no_longer_borrows_the_omic_distribution(self):
+        source = read_source()
+        start = source.index("this.generateHeatmap = function")
+        block = source[start:start + 2500]
+        self.assertIn("paMetageneLimits(metagenes)", block)
+        self.assertNotIn('getMinMax(dataDistributionSummaries[omicName], "p10p90")', block,
+                         "the trend heatmap is still coloured with the raw "
+                         "omic's distribution")
 
 
 if __name__ == "__main__":

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -113,8 +113,11 @@ PUBLISHED = {
     # copy exactly as it would for view code.
     "app/view/common/AlignmentGuides.js": (
         "4.2", "ce2ba85063e8059eb2cc4c8e1992744854a14ad0db6f866213b8df1136650a59"),
+    # v=1.3: the report fetch retries instead of dead-ending, and a job that no
+    # longer exists is named as such rather than reported as "still in
+    # progress".
     "app/view/PathwayAcquisitionViews/PA_AIInterpretView.js": (
-        "1.2", "ccc26e131bb8de5db31a3ca7b4d6d73da3986496ed329f3a35bd0fbf39a1a2ff"),
+        "1.3", "595b18822379aa51b7962357402663b19a7938ca6200bd78b8d77c3a3ea220a1"),
     "app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js": (
         "0.7", "b135712a9564f8ae0eac94daf9c567ef275c4c748dbc270fdbdeb7d25fc79e34"),
     # OmniPath ships no diagram, so its pathways render as an interactive graph
@@ -125,8 +128,11 @@ PUBLISHED = {
     # v=0.8 WITHOUT a bump, which this guard caught: a returning browser keeps
     # this file for up to 12 hours, so the evidence overlay would have POSTed
     # to `undefined` for everyone who had already loaded the site.
+    # v=1.0 adds AI_POLL_MAX_FAILURES. A browser keeping the old copy would
+    # read it as undefined, and `failures >= undefined` is false for ever --
+    # which is precisely the endless poll this release exists to stop.
     "resources/ServerConfiguration.js": (
-        "0.9", "320717bdad3a27746dcf2070b7d11654a2f0c75fccaf2d242c266214ce7c3ac3"),
+        "1.0", "6d9d416610b8384c78fb7e46b10aa4414aea0886d720a840499904aec0e9fe85"),
     # The evidence layer itself: MORE relationships drawn on the diagram and
     # classified against KEGG, Reactome and OmniPath.
     "app/view/PathwayAcquisitionViews/PA_Step4EvidenceOverlay.js": (


### PR DESCRIPTION
Two fixes to the AI panel. The first is a reported bug; the second is a visual defect in the same panel that the colour-range change made more conspicuous.

## 1. "Starting…" for ever when you reopen a job

Reopen a job and the panel could sit on `Starting...` for as long as the tab stayed open — no report, no error, nothing. Measured before this change: **four polls in twenty seconds, still going, empty panel.**

Two things combine.

**The page doesn't ask the server whether the job exists.** `app.js` `continueBoot` only calls `pa_recover_job` when there is no cached model or it is still at step 2; otherwise the job is drawn from the copy the browser holds. The AI report is the only thing that goes to the server — and once the job has been removed (7 days for guests, 14 for registered users) that request is refused, because the ownership check cannot say who owns a job that is not there.

**Then the client hid the refusal.** `pollAIStatus` treated every failure as transient, which is right for a Mongo hiccup and wrong for a refusal that can never change.

A job that is gone is now recognised and named. Anything unclassifiable is retried up to `AI_POLL_MAX_FAILURES` and then reported rather than polled for ever; the counter resets on a good answer, so hiccups during a fifteen-minute run don't exhaust the allowance.

**The report fetch had its own dead end.** It is called once, from the terminal `done` poll — and `done` ends the chain, so a single failed request left `"Failed to load the report. Please try again."` with no way to do so. A 57 KB report on a single-process server is not a request that always succeeds. It now retries with backoff and falls back to a message carrying a button that works.

## 2. Metagene trend rows were coloured with the wrong scale

`generateHeatmap` coloured `metagenes[i].values` using the **raw omic's** distribution. A metagene is a component describing how a cluster moves — centred on zero, on its own scale. On a real job the omic ran `0.79..1.41` while its metagenes reached `±9.4`.

Side by side on live data, same job, same values:

| value | old (omic's scale) | new (own scale) |
|---|---|---|
| −7.69 | `rgb(255, 255,-60)` **invalid** | `rgb(46, 46,255)` strong blue |
| −1.0 | `rgb(255, 255,70)` yellow-green | `rgb(228, 228,255)` pale blue |
| 0.0 | white | white |
| **+9.40 (the maximum)** | `rgb(255, 218,218)` faint pink | `rgb(255, 0,0)` full red |

Inverted as well as invalid. Chrome clamps `-60` to yellow and rejects `-Infinity` outright, painting it black — which is why these cells looked like two arbitrary colours.

`paMetageneLimits` derives the range from the trends themselves. They cross zero, so `paColourRange` returns a symmetric range and the diverging scale reads properly. Non-numeric values are skipped rather than poisoning both ends.

**This predates the colour-range change that shipped this morning**, and that was verified rather than assumed: running the pre-change code from `24a5b820` against the exact values the live page requested gives byte-identical output for zero-crossing omics — 998 of the 1,009 in the corpus. What changed was *which* invalid colour appears, because the two strings fail CSS parsing differently.

## Two things the browser caught that the tests had not

**My first attempt did nothing.** I put the logic in the `success` handler, but the servlet renders a `UserWarning` as **HTTP 400**, so jQuery routes it to `error`. The unit test simulated a `success:false` body that never occurs for this case — it passed while changing nothing in the browser. The scenarios now use the response captured verbatim from the running server.

**The message shipped a dead Retry button.** Retrying re-posts to `/ai_interpret_initiate`, refused for the same reason. There is now a distinct `unavailable` state — same red treatment, no button — because a button that cannot work reads as "we could fix this if you asked again".

## Verification

- Extended the two suites that already own this ground rather than adding parallel ones. The poll harness now **runs the chain** instead of one tick of it: a stubbed `setTimeout` that only records cannot tell *stopped* from *scheduled once more*.
- A test that the two permanent cases stay distinct — "your session expired" and "this job no longer exists" call for different actions, and the new regex must not swallow the first.
- **Mutation-tested**: retry-for-ever fails 4, stopping silently fails 1, giving metagenes the omic's scale back fails the wiring test, dropping the symmetry fails the diverging assertions.
- **In Chrome**, reproducing the real orphan condition (load job → delete it → restart to clear the server's job cache → re-run the widget's load path): **1 poll instead of endless**, chain stopped, clear message, no dead button. And on `mmu01200`: 48 `getColor` calls, **0 invalid** where there were 4.
- Full suite: 229 suites, 222 pass. The 2 flagged (`test_delegation_cache`, `test_submit_nudges`) fail identically on plain `origin/master` and belong in BASELINE.

`ServerConfiguration.js` and `PA_AIInterpretView.js` are hand-versioned, so both markers are bumped and both digests recorded. A browser keeping the old `ServerConfiguration` would read `AI_POLL_MAX_FAILURES` as `undefined`, and `failures >= undefined` is false for ever — the exact hang this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)