### PR TITLE
Surface the real reason when a conversion request is refused

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js
@@ -139,7 +139,14 @@
             });
             var body = await res.json();
             if (!body || !body.ticket) {
-                throw new Error((body && body.errorMessage) || "The conversion service refused the request.");
+                // ServerErrorManager answers with `message`, prefixed by the
+                // file and function it was raised in; the readable half is
+                // after "ERROR MESSAGE:". Same split PA_Step1Views already does,
+                // so a disabled server says so plainly instead of "refused".
+                var raw = (body && (body.errorMessage || body.message)) || "";
+                var half = raw.split("ERROR MESSAGE:");
+                var reason = (half.length > 1 ? half[1] : raw).trim();
+                throw new Error(reason || "The conversion service refused the request.");
             }
             // Poll rather than hold a request open: the site has four request
             // threads and the gateway takes about a minute.

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -144,7 +144,7 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.5"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=0.3"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=0.4"></script>
 	<!--MORE REGULATOR–TARGET NETWORK VIEW -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js?v=0.7"></script>
 	<!--OMNIPATH PATHWAY NETWORK VIEW (OmniPath ships no diagram; its pathways render as graphs) -->

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -98,7 +98,7 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js": (
         "0.5", "aba9f81cf637615a055d7259d7568a000b83af65c2e20cd413050928b8260478"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js": (
-        "0.3", "293ee4fe003cd9e388f8e246d5e76036cc38d631875894d240febfc6bf7827a4"),
+        "0.4", "b9d1aff2eb3830c5485f53443ed494847b168bf12372aab39b98b2c4faa75c3c"),
     "app/view/common/Util.js": (
         "2.1", "12359b8bf746394f63a7e0a15513a4f9ac82de1a25bbaa0e91e6b2fdd7e0050e"),
     "app/view/common/ExtJS_extensions.js": (


### PR DESCRIPTION
## What

The AI input-converter drawer read only `body.errorMessage` from a refused
`input_convert/turn` response. But `ServerErrorManager` answers with
`body.message` (prefixed by the file/function and an `ERROR MESSAGE:` marker),
so **every** server-side refusal collapsed into the generic
*"The conversion service refused the request."* — hiding the actual cause.

Most visibly, a server with `AI_INPUT_CONVERTER` unset returns
*"AI file conversion is not enabled on this server."*, but the user only saw
the generic line. The same masking hit the daily-limit, "server busy", and
raw-data-guard refusals.

## Fix

Parse `message` the way `PA_Step1Views`' `serverErrorText` already does: take
the half after `ERROR MESSAGE:`, and fall back to the generic line only when
the body carries no message at all. `convert-drawer.js` 0.3 → 0.4, digest
rebumped in `test_versioned_assets_are_bumped.py`.

## Verified

- Reproduced against a live flag-off server: old code → *"…refused the
  request."*; new code → *"AI file conversion is not enabled on this server."*
- 48 client unit tests + the versioned-asset bump test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)