### PR TITLE
Redesign the AI input-format converter front end and the Step 1 upload form

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js
@@ -319,6 +319,10 @@
                 return { ok: false, stage: "profile", traceback: profileRun.stdout, history: history };
             }
 
+            // The description as the model will receive it, for the UI to show:
+            // "what the AI sees" is only checkable if the user can see it too.
+            emit(onEvent, { type: "profile", profile: profile });
+
             var tableNote = (profile.tables || []).map(function (t) {
                 if (t.empty) return t.name + ": empty";
                 var rows = t.exact ? t.exact.data_rows : t.sampled_rows;
@@ -418,6 +422,11 @@
                                traceback: run.traceback });
                 state.history = history;
                 continue;
+            }
+
+            // Whatever the script printed, beside the script that printed it.
+            if (run.stdout && String(run.stdout).trim()) {
+                emit(onEvent, { type: "output", stdout: run.stdout, attempt: attempt });
             }
 
             step(onEvent, "validating", "Checking the result",

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js
@@ -389,9 +389,9 @@
      */
     function renderAnatomy(profile, fileName, who) {
         var card = el("section", "pa-convert-anatomy");
-        card.setAttribute("aria-label", "What the AI sees");
+        card.setAttribute("aria-label", "What the agent sees");
         var head = el("div", "pa-convert-anatomy-head");
-        head.appendChild(el("p", "pa-convert-eyebrow", "What the AI sees"));
+        head.appendChild(el("p", "pa-convert-eyebrow", "What the agent sees"));
         var meta = el("div", "pa-convert-anatomy-meta");
         var chars = profile.description_chars ? fmtInt(profile.description_chars) + " characters" : "structure only";
         meta.textContent = chars + (who ? " · sent to " + who : "");
@@ -405,8 +405,8 @@
             : (profile.separator ? profile.separator + "-separated text" : "a text table") +
               (profile.encoding ? ", " + String(profile.encoding).toUpperCase() : "") +
               (profile.preamble_lines ? ", " + plural(profile.preamble_lines, "preamble line") + " skipped" : "");
-        lead.innerHTML = "<b></b> is " + container + ". Only the names, kinds and counts below, plus a few example rows, " +
-                         "describe it to the model; the measurements stay in this browser.";
+        lead.innerHTML = "<b></b> · " + container + ". Only what is listed here goes to the model; " +
+                         "the measurements stay in this browser.";
         lead.querySelector("b").textContent = fileName;
         card.appendChild(lead);
 
@@ -508,7 +508,7 @@
         var panel = el("section", "pa-convert-panel");
         panel.setAttribute("role", "dialog");
         panel.setAttribute("aria-modal", "true");
-        panel.setAttribute("aria-label", "Convert " + file.name + " with PaintOmics AI");
+        panel.setAttribute("aria-label", "Convert " + file.name + " with the PaintOmics AI agent");
         panel.tabIndex = -1;
 
         // The destination omic's hue, so the sheet and its chosen result wear
@@ -527,7 +527,7 @@
         mark.innerHTML = typeof window.getAIMark === "function" ? window.getAIMark() : svg("thinking");
         header.appendChild(mark);
         var titles = el("div", "pa-convert-titles");
-        titles.appendChild(el("h2", "pa-convert-title", "Convert with PaintOmics AI"));
+        titles.appendChild(el("h2", "pa-convert-title", "Convert with the PaintOmics AI agent"));
         var subject = el("p", "pa-convert-subject");
         subject.appendChild(el("span", "pa-convert-filename", file.name));
         if (omicLabel) subject.appendChild(el("span", "pa-convert-omic", omicLabel));
@@ -567,7 +567,7 @@
         var anatomyHost = el("div", "pa-convert-anatomyhost");
         body.appendChild(anatomyHost);
         var timeline = el("ol", "pa-convert-timeline");
-        timeline.setAttribute("aria-label", "What the AI did");
+        timeline.setAttribute("aria-label", "What the agent did");
         body.appendChild(timeline);
         var reviewHost = el("div", "pa-convert-reviewhost");
         body.appendChild(reviewHost);
@@ -578,15 +578,15 @@
         var composer = el("form", "pa-convert-composer");
         var composerInput = el("textarea", "pa-convert-composer-input");
         composerInput.rows = 2;
-        composerInput.setAttribute("aria-label", "Instruction for the AI");
+        composerInput.setAttribute("aria-label", "Instruction for the agent");
         var composerSend = el("button", "pa-convert-composer-send", "Revise");
         composerSend.type = "submit";
         composer.appendChild(composerInput);
         composer.appendChild(composerSend);
         dock.appendChild(composer);
         var composerHint = el("p", "pa-convert-composer-hint");
-        composerHint.innerHTML = "Your words go to the AI as an instruction; the script is revised and re-checked. " +
-                                 "Your data stays on this computer. <kbd>Enter</kbd> sends · <kbd>Shift</kbd>+<kbd>Enter</kbd> new line.";
+        composerHint.innerHTML = "Revises the script and re-checks it; your data stays here. " +
+                                 "<kbd>Enter</kbd> sends · <kbd>Shift</kbd>+<kbd>Enter</kbd> new line.";
         dock.appendChild(composerHint);
         var actions = el("footer", "pa-convert-actions");
         dock.appendChild(actions);
@@ -761,8 +761,8 @@
             composerInput.placeholder = state === "asking"
                 ? "…or answer in your own words"
                 : state === "busy"
-                    ? "The AI is working — you can steer it once it has something to show."
-                    : "Tell the AI what to change — “keep the flagged genes”, “use the reads sheet, not TPM”, “column A is a KEGG ID”";
+                    ? "The agent is working — you can steer it once it has something to show."
+                    : "Tell the agent what to change — “keep the flagged genes”, “use the reads sheet, not TPM”, “column A is a KEGG ID”";
             composer.classList.toggle("pa-convert-composer-busy", state === "busy");
         }
 
@@ -919,8 +919,7 @@
                 // The boot is a real step that takes a few seconds; a blank
                 // timeline for that long reads as nothing happening.
                 addStep({ phase: "profiling", title: "Starting the Python sandbox",
-                          detail: "A Pyodide interpreter in an isolated frame: no access to this page, " +
-                                  "your cookies or the network. The conversion script will run there." });
+                          detail: "An isolated interpreter with no access to this page or the network." });
                 await sandbox.boot();
                 setNow("Reading your file");
                 bytes = new Uint8Array(await file.arrayBuffer());
@@ -1146,7 +1145,7 @@
             if (result && result.attempts) head.appendChild(el("span", "pa-convert-review-count", plural(result.attempts, "attempt") + " used"));
             review.appendChild(head);
             review.appendChild(el("p", "pa-convert-summary",
-                "Tell the AI what the file contains in the box below and it will try again — " +
+                "Tell the agent what the file contains in the box below and it will try again — " +
                 "which sheet matters, what the columns are, what the identifiers are. " +
                 "The script it wrote is in the timeline above; a colleague who knows pandas can take it from there."));
             if (result && result.outputs) {

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js
@@ -1,29 +1,34 @@
 /*
- * The conversion drawer: what the user watches while the agent works, and
+ * The conversion sheet: what the user watches while the agent works, and
  * where they review what it made and steer it.
  *
- * It is a transcript, not a spinner. Every step the agent takes is named as it
- * happens, the generated code is available at each one, and the bar advances
- * against the attempt budget, which is a real quantity rather than a guess at
- * completion.
+ * It is a notebook of the run, not a spinner. The stage rail across the top
+ * follows the agent's own state machine -- read, plan, run, check, apply,
+ * review -- so the bar can only say things that are true. Below it, "What the
+ * AI sees" is the description of the file that actually left this computer:
+ * sheet names, column names and kinds, counts, a few example rows, and never a
+ * measurement. Then every step the agent takes is named as it happens with the
+ * seconds it cost, the generated script is one click away at the step that ran
+ * it, and the validator's verdict is quoted rather than summarised.
  *
- * When the agent finishes, the drawer does not simply hand back "a file". A
+ * When the agent finishes, the sheet does not simply hand back "a file". A
  * real upload often holds several tables -- one per sheet, one per measurement
  * family -- and a significance column that should become the relevant-features
- * list. So the review shows every table the agent produced with a preview, the
- * columns it kept and dropped, and lets the user choose which one goes into
- * this omic box, attach the relevant list, add the others as separate omics,
- * or download any of them. Nothing the file held is silently lost.
+ * list. So the review shows every table with a preview, the columns it kept
+ * and dropped, and lets the user choose which one goes into this omic box,
+ * attach the relevant list, add the others as separate omics, or download any
+ * of them. Nothing the file held is silently lost.
  *
- * And the user can talk back. A composer at the bottom sends an instruction
+ * And the user can talk back. The composer at the bottom sends an instruction
  * ("keep the flagged genes", "the first column is a KEGG ID", "use the reads
- * sheet, not TPM") and the agent revises the accepted script rather than
- * starting over. The same composer answers a question in the user's own words
- * when none of the offered options fit.
+ * sheet") and the agent revises the accepted script rather than starting over.
+ * The same composer answers a question in the user's own words when none of
+ * the offered options fit.
  *
  * Nothing here is decorative. Showing the code is what lets a bioinformatician
  * check the transformation; showing the validator's report is what stops the
- * model grading its own work.
+ * model grading its own work; showing the profile is what makes the privacy
+ * claim checkable instead of asserted.
  */
 (function (root, factory) {
     if (typeof module === "object" && module.exports) module.exports = factory();
@@ -52,9 +57,69 @@
         return new TextDecoder("utf-8", { fatal: false }).decode(bytes);
     }
 
-    var PHASE_ICON = {
-        profiling: "◴", thinking: "✦", running: "▶", validating: "✓", finalising: "⇶",
-        asking: "?", done: "✓", failed: "✕", user: "✎"
+    function fmtInt(n) { return Number(n).toLocaleString(); }
+
+    function fmtSeconds(ms) {
+        var s = ms / 1000;
+        if (s < 10) return s.toFixed(1) + " s";
+        if (s < 60) return Math.round(s) + " s";
+        return Math.floor(s / 60) + " min " + Math.round(s % 60) + " s";
+    }
+
+    function plural(n, word) { return fmtInt(n) + " " + word + (n === 1 ? "" : "s"); }
+
+    /* ------------------------------------------------------------------ *
+     * Glyphs
+     *
+     * Drawn, not typed. A unicode glyph is a different picture in every
+     * system font; these are one picture everywhere, in currentColor so the
+     * node's own colour paints them. The planning node uses the AI mark's
+     * own geometry, so "the model is thinking" wears the mark.
+     * ------------------------------------------------------------------ */
+
+    var STROKE = 'fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round"';
+
+    var GLYPH = {
+        profiling:  '<rect x="4" y="5" width="16" height="14" rx="2" ' + STROKE + '/><path d="M4 10h16M9 10v9" ' + STROKE + '/>',
+        running:    '<path d="M8.5 5.5 L18 12 L8.5 18.5 Z" fill="currentColor"/>',
+        validating: '<path d="M5 12.5 L10 17.5 L19 7.5" ' + STROKE + '/>',
+        done:       '<path d="M5 12.5 L10 17.5 L19 7.5" ' + STROKE + '/>',
+        finalising: '<path d="M6 6 L12 12 L6 18 M12.5 6 L18.5 12 L12.5 18" ' + STROKE + '/>',
+        asking:     '<path d="M9.3 9.6a2.8 2.8 0 1 1 4.2 2.4c-1 .6-1.5 1.2-1.5 2.5" ' + STROKE + '/><circle cx="12" cy="17.6" r="1.1" fill="currentColor"/>',
+        failed:     '<path d="M7.5 7.5 L16.5 16.5 M16.5 7.5 L7.5 16.5" ' + STROKE + '/>',
+        user:       '<path d="M4.5 19.5 L8.5 18.5 L19 8 L16 5 L5.5 15.5 Z" ' + STROKE + '/>',
+        output:     '<path d="M6 8 L10 12 L6 16 M12 16 H18" ' + STROKE + '/>',
+        download:   '<path d="M12 4.5v10M7.5 10.5 12 15l4.5-4.5M5 18.5h14" ' + STROKE + '/>',
+        list:       '<path d="M5 7h14M5 12h14M5 17h9" ' + STROKE + '/>',
+        table:      '<rect x="4" y="5" width="16" height="14" rx="2" ' + STROKE + '/><path d="M4 10h16M10 10v9" ' + STROKE + '/>'
+    };
+
+    function svg(name) {
+        var paths = name === "thinking" && typeof window.getAIMarkPaths === "function"
+            ? window.getAIMarkPaths() : (GLYPH[name] || GLYPH.profiling);
+        return '<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">' + paths + '</svg>';
+    }
+
+    /* ------------------------------------------------------------------ *
+     * The stage rail
+     *
+     * Six stages, in the order the loop visits them. A phase from the agent
+     * maps onto one of them; reaching a stage lights every stage before it
+     * and clears every stage after it, so a retry visibly goes back to Plan
+     * rather than pretending to be further along than it is.
+     * ------------------------------------------------------------------ */
+
+    var STAGES = [
+        { key: "read",   label: "Read" },
+        { key: "plan",   label: "Plan" },
+        { key: "run",    label: "Run" },
+        { key: "check",  label: "Check" },
+        { key: "apply",  label: "Apply" },
+        { key: "review", label: "Review" }
+    ];
+    var PHASE_STAGE = {
+        profiling: "read", thinking: "plan", asking: "plan", user: "plan",
+        running: "run", output: "run", validating: "check", finalising: "apply", done: "review"
     };
 
     /* ------------------------------------------------------------------ *
@@ -108,7 +173,7 @@
         return {
             async boot() {
                 await ready();
-                if (onProgress) onProgress("Starting the Python sandbox…");
+                if (onProgress) onProgress("Starting the Python sandbox");
                 return send({ type: "boot" }, 240000);
             },
             run: function (code, files) {
@@ -162,6 +227,19 @@
         };
     }
 
+    /* Who is on the other end of the transport. The same gateway the AI
+       interpretation uses, so the same endpoint answers; shown in the
+       anatomy card because "your data goes to a model" should name which. */
+    var providerPromise = null;
+    function provider() {
+        if (!providerPromise) {
+            providerPromise = fetch("ai_provider", { credentials: "same-origin" })
+                .then(function (r) { return r.json(); })
+                .catch(function () { return null; });
+        }
+        return providerPromise;
+    }
+
     /* ------------------------------------------------------------------ *
      * Talking to the Step 1 form
      * ------------------------------------------------------------------ */
@@ -182,8 +260,12 @@
         setTimeout(function () { document.body.removeChild(a); URL.revokeObjectURL(url); }, 0);
     }
 
+    function omicCardOf(inputEl) {
+        return inputEl && inputEl.closest ? inputEl.closest(".omicbox") : null;
+    }
+
     function omicComponentOf(inputEl) {
-        var box = inputEl && inputEl.closest ? inputEl.closest(".omicbox") : null;
+        var box = omicCardOf(inputEl);
         return (box && window.Ext && Ext.getCmp) ? Ext.getCmp(box.id) : null;
     }
 
@@ -265,127 +347,410 @@
     }
 
     /* ------------------------------------------------------------------ *
-     * The drawer
+     * Shared fragments
+     * ------------------------------------------------------------------ */
+
+    function previewTable(preview, maxCols) {
+        var wrap = el("div", "pa-convert-preview");
+        var table = el("table");
+        var limit = maxCols || 7;
+        var cols = preview.header ? preview.header.length : (preview.rows[0] || []).length;
+        var shown = Math.min(cols, limit);
+        if (preview.header) {
+            var tr = el("tr");
+            preview.header.slice(0, shown).forEach(function (h) { tr.appendChild(el("th", null, h)); });
+            if (cols > shown) tr.appendChild(el("th", "pa-convert-more", "+" + (cols - shown)));
+            table.appendChild(tr);
+        }
+        preview.rows.forEach(function (r) {
+            var tr = el("tr");
+            r.slice(0, shown).forEach(function (c, i) { tr.appendChild(el("td", i === 0 ? "pa-convert-id" : null, c)); });
+            if (cols > shown) tr.appendChild(el("td", "pa-convert-more", "…"));
+            table.appendChild(tr);
+        });
+        wrap.appendChild(table);
+        return wrap;
+    }
+
+    function iconButton(glyph, title, onClick) {
+        var b = el("button", "pa-convert-iconbtn");
+        b.type = "button";
+        b.title = title;
+        b.setAttribute("aria-label", title);
+        b.innerHTML = svg(glyph);
+        b.addEventListener("click", onClick);
+        return b;
+    }
+
+    /*
+     * "What the AI sees": the profile, rendered. This is the literal payload
+     * that describes the file to the model -- names, kinds, counts, example
+     * rows -- so a user who wants to check the privacy claim can.
+     */
+    function renderAnatomy(profile, fileName, who) {
+        var card = el("section", "pa-convert-anatomy");
+        card.setAttribute("aria-label", "What the AI sees");
+        var head = el("div", "pa-convert-anatomy-head");
+        head.appendChild(el("p", "pa-convert-eyebrow", "What the AI sees"));
+        var meta = el("div", "pa-convert-anatomy-meta");
+        var chars = profile.description_chars ? fmtInt(profile.description_chars) + " characters" : "structure only";
+        meta.textContent = chars + (who ? " · sent to " + who : "");
+        head.appendChild(meta);
+        card.appendChild(head);
+
+        var tables = profile.tables || [];
+        var lead = el("p", "pa-convert-anatomy-lead");
+        var container = profile.container === "workbook"
+            ? "a workbook with " + plural(tables.length, "sheet")
+            : (profile.separator ? profile.separator + "-separated text" : "a text table") +
+              (profile.encoding ? ", " + String(profile.encoding).toUpperCase() : "") +
+              (profile.preamble_lines ? ", " + plural(profile.preamble_lines, "preamble line") + " skipped" : "");
+        lead.innerHTML = "<b></b> is " + container + ". Only the names, kinds and counts below, plus a few example rows, " +
+                         "describe it to the model; the measurements stay in this browser.";
+        lead.querySelector("b").textContent = fileName;
+        card.appendChild(lead);
+
+        if (profile.parse_error) {
+            var err = el("p", "pa-convert-anatomy-lead");
+            err.textContent = "It could not be parsed as a table yet: " + profile.parse_error;
+            card.appendChild(err);
+        }
+
+        var MAX_TABLES = 6, MAX_COLS = 28;
+        tables.slice(0, MAX_TABLES).forEach(function (t) {
+            var block = el("div", "pa-convert-table");
+            var th = el("div", "pa-convert-table-head");
+            th.appendChild(el("span", "pa-convert-table-name",
+                t.name === "(single table)" ? "The table" : t.name));
+            if (t.empty) {
+                th.appendChild(el("span", "pa-convert-table-note", "empty"));
+                block.appendChild(th);
+                card.appendChild(block);
+                return;
+            }
+            var rows = t.exact ? t.exact.data_rows : t.sampled_rows;
+            th.appendChild(el("span", "pa-convert-table-dims",
+                fmtInt(rows) + " rows × " + fmtInt(t.n_columns) + " columns" +
+                (t.exact ? "" : " (sampled)")));
+            if (t.header_row !== null && t.header_row !== undefined && t.header_row > 0) {
+                th.appendChild(el("span", "pa-convert-table-note", "header on row " + (t.header_row + 1)));
+            } else if (t.header_row === null || t.header_row === undefined) {
+                th.appendChild(el("span", "pa-convert-table-note", "no header row"));
+            }
+            block.appendChild(th);
+
+            var idIndex = {};
+            ((t.exact && t.exact.id_candidates) || []).forEach(function (c) { idIndex[c.index] = c; });
+            var strip = el("div", "pa-convert-colstrip");
+            var cols = t.columns || [];
+            cols.slice(0, MAX_COLS).forEach(function (c) {
+                var cand = idIndex[c.index];
+                var chip = el("span", "pa-convert-col " +
+                    (cand ? "pa-convert-col-id" : (c.kind === "numeric" ? "pa-convert-col-numeric" : "pa-convert-col-text")));
+                chip.appendChild(document.createTextNode(c.name));
+                var title = c.name + " — " + (cand ? "identifier candidate" : c.kind);
+                if (c.kind === "numeric" && c.min !== undefined) title += ", " + c.min + " to " + c.max;
+                if (c.kind === "text" && c.distinct !== undefined) title += ", " + fmtInt(c.distinct) + " distinct";
+                if (cand && cand.duplicates > 0) {
+                    chip.appendChild(el("span", "pa-convert-col-dup", "×" + fmtInt(cand.duplicates) + " dup"));
+                    title += ", " + fmtInt(cand.duplicates) + " repeated";
+                }
+                chip.title = title;
+                strip.appendChild(chip);
+            });
+            var hidden = (t.n_columns || cols.length) - Math.min(cols.length, MAX_COLS);
+            if (hidden > 0) strip.appendChild(el("span", "pa-convert-col pa-convert-col-more", "+" + fmtInt(hidden) + " more"));
+            block.appendChild(strip);
+
+            if (t.column_families && t.column_families.length) {
+                var fam = el("p", "pa-convert-families");
+                fam.innerHTML = t.column_families.slice(0, 3).map(function (f) {
+                    return fmtInt(f.count) + " columns share <code></code>";
+                }).join(" · ");
+                var codes = fam.querySelectorAll("code");
+                t.column_families.slice(0, 3).forEach(function (f, i) { codes[i].textContent = f.family; });
+                block.appendChild(fam);
+            }
+            card.appendChild(block);
+        });
+        if (tables.length > MAX_TABLES) {
+            card.appendChild(el("p", "pa-convert-families", "+" + (tables.length - MAX_TABLES) + " more sheets described the same way."));
+        }
+
+        if (tables.some(function (t) { return !t.empty; })) {
+            var legend = el("div", "pa-convert-legend");
+            [["is-id", "identifier candidate"], ["is-numeric", "numeric"], ["", "text"]].forEach(function (pair) {
+                var s = el("span");
+                s.appendChild(el("i", pair[0] || null));
+                s.appendChild(document.createTextNode(pair[1]));
+                legend.appendChild(s);
+            });
+            card.appendChild(legend);
+
+            var first = tables.filter(function (t) { return t.first_rows && t.first_rows.length; })[0];
+            if (first) {
+                var rowsBox = el("details", "pa-convert-rows");
+                rowsBox.appendChild(el("summary", null, "Example rows it was shown (" + first.first_rows.length +
+                    (tables.length > 1 ? ", from " + first.name : "") + ")"));
+                rowsBox.appendChild(previewTable({ header: null, rows: first.first_rows.slice(0, 6) }, 8));
+                card.appendChild(rowsBox);
+            }
+        }
+        return card;
+    }
+
+    /* ------------------------------------------------------------------ *
+     * The sheet
      * ------------------------------------------------------------------ */
 
     function openDrawer(input, file, fieldName, context) {
         var overlay = el("div", "pa-convert-overlay");
         var panel = el("section", "pa-convert-panel");
         panel.setAttribute("role", "dialog");
-        panel.setAttribute("aria-label", "Convert " + file.name);
+        panel.setAttribute("aria-modal", "true");
+        panel.setAttribute("aria-label", "Convert " + file.name + " with PaintOmics AI");
+        panel.tabIndex = -1;
+
+        // The destination omic's hue, so the sheet and its chosen result wear
+        // the same bar the omic card does.
+        var card = omicCardOf(input);
+        var titleBar = card && card.querySelector(".omicboxTitle");
+        var hue = titleBar ? getComputedStyle(titleBar).getPropertyValue("--pa-omic-color").trim() : "";
+        if (hue) panel.style.setProperty("--cv-omic", hue);
+
+        var omicLabel = (context && context.omicType && context.omicType !== "unknown") ? context.omicType : "";
+        var speciesLabel = (context && context.species && context.species !== "unknown") ? context.species : "";
 
         // ---- header -------------------------------------------------------
         var header = el("header", "pa-convert-header");
-        var title = el("div", "pa-convert-title");
-        if (typeof window.getAIMark === "function") {
-            var mark = el("span", "pa-convert-mark");
-            mark.innerHTML = window.getAIMark();
-            title.appendChild(mark);
-        }
+        var mark = el("span", "pa-convert-mark");
+        mark.innerHTML = typeof window.getAIMark === "function" ? window.getAIMark() : svg("thinking");
+        header.appendChild(mark);
         var titles = el("div", "pa-convert-titles");
-        titles.appendChild(el("h2", null, "Converting your file"));
-        titles.appendChild(el("p", "pa-convert-filename", file.name));
-        title.appendChild(titles);
-        header.appendChild(title);
-
+        titles.appendChild(el("h2", "pa-convert-title", "Convert with PaintOmics AI"));
+        var subject = el("p", "pa-convert-subject");
+        subject.appendChild(el("span", "pa-convert-filename", file.name));
+        if (omicLabel) subject.appendChild(el("span", "pa-convert-omic", omicLabel));
+        if (speciesLabel) subject.appendChild(el("span", "pa-convert-species", speciesLabel));
+        titles.appendChild(subject);
+        header.appendChild(titles);
         var close = el("button", "pa-convert-close", "✕");
         close.type = "button";
-        close.setAttribute("aria-label", "Cancel conversion");
+        close.setAttribute("aria-label", "Close and cancel the conversion");
         header.appendChild(close);
         panel.appendChild(header);
 
-        // ---- progress -----------------------------------------------------
-        var progressWrap = el("div", "pa-convert-progress");
-        var bar = el("div", "pa-convert-bar");
-        var fill = el("div", "pa-convert-fill");
-        bar.appendChild(fill);
-        progressWrap.appendChild(bar);
-        var progressText = el("div", "pa-convert-progress-text", "Starting…");
-        progressWrap.appendChild(progressText);
-        var elapsed = el("span", "pa-convert-elapsed", "0s");
-        progressWrap.appendChild(elapsed);
-        panel.appendChild(progressWrap);
+        // ---- status band --------------------------------------------------
+        var status = el("div", "pa-convert-status");
+        var stages = el("ol", "pa-convert-stages");
+        stages.setAttribute("aria-label", "Stages");
+        var stageEls = {};
+        STAGES.forEach(function (s) {
+            var li = el("li", "pa-convert-stage", s.label);
+            li.dataset.state = "todo";
+            stageEls[s.key] = li;
+            stages.appendChild(li);
+        });
+        status.appendChild(stages);
+        var now = el("div", "pa-convert-now");
+        var nowText = el("div", "pa-convert-now-text", "Starting the Python sandbox");
+        nowText.setAttribute("role", "status");
+        nowText.setAttribute("aria-live", "polite");
+        var nowMeta = el("div", "pa-convert-now-meta");
+        now.appendChild(nowText);
+        now.appendChild(nowMeta);
+        status.appendChild(now);
+        panel.appendChild(status);
 
-        // ---- transcript + review ------------------------------------------
+        // ---- body ---------------------------------------------------------
         var body = el("div", "pa-convert-body");
-        var steps = el("ol", "pa-convert-steps");
-        body.appendChild(steps);
+        var anatomyHost = el("div", "pa-convert-anatomyhost");
+        body.appendChild(anatomyHost);
+        var timeline = el("ol", "pa-convert-timeline");
+        timeline.setAttribute("aria-label", "What the AI did");
+        body.appendChild(timeline);
         var reviewHost = el("div", "pa-convert-reviewhost");
         body.appendChild(reviewHost);
         panel.appendChild(body);
 
-        // ---- composer -----------------------------------------------------
+        // ---- dock: composer, then the decision ----------------------------
+        var dock = el("div", "pa-convert-dock");
         var composer = el("form", "pa-convert-composer");
         var composerInput = el("textarea", "pa-convert-composer-input");
-        composerInput.rows = 1;
-        composerInput.placeholder = "Tell the AI what to change — e.g. “keep the flagged genes”, “use the reads sheet”, “column A is a KEGG ID”";
+        composerInput.rows = 2;
         composerInput.setAttribute("aria-label", "Instruction for the AI");
         var composerSend = el("button", "pa-convert-composer-send", "Revise");
         composerSend.type = "submit";
         composer.appendChild(composerInput);
         composer.appendChild(composerSend);
-        var composerHint = el("div", "pa-convert-composer-hint",
-            "Your words go to the AI as an instruction; the script is revised and re-checked. Your data stays on this computer.");
-        panel.appendChild(composer);
-        panel.appendChild(composerHint);
-
-        var footer = el("footer", "pa-convert-footer");
-        panel.appendChild(footer);
+        dock.appendChild(composer);
+        var composerHint = el("p", "pa-convert-composer-hint");
+        composerHint.innerHTML = "Your words go to the AI as an instruction; the script is revised and re-checked. " +
+                                 "Your data stays on this computer. <kbd>Enter</kbd> sends · <kbd>Shift</kbd>+<kbd>Enter</kbd> new line.";
+        dock.appendChild(composerHint);
+        var actions = el("footer", "pa-convert-actions");
+        dock.appendChild(actions);
+        panel.appendChild(dock);
 
         overlay.appendChild(panel);
         document.body.appendChild(overlay);
-        requestAnimationFrame(function () { overlay.classList.add("pa-convert-open"); });
+        requestAnimationFrame(function () { overlay.classList.add("pa-convert-open"); panel.focus(); });
 
+        // The textarea grows with what is typed, up to the stylesheet's cap.
+        composerInput.addEventListener("input", function () {
+            composerInput.style.height = "auto";
+            composerInput.style.height = Math.min(200, composerInput.scrollHeight) + "px";
+        });
+
+        // ---- state --------------------------------------------------------
         var startedAt = Date.now();
-        var timer = setInterval(function () {
-            var s = Math.round((Date.now() - startedAt) / 1000);
-            elapsed.textContent = s < 60 ? s + "s" : Math.floor(s / 60) + "m " + (s % 60) + "s";
-        }, 1000);
-
         var currentStep = null;
         var running = false;
         var cancelled = false;
+        var finished = false;
         var last = null;                     // the latest agent result
         var pendingAnswer = null;            // resolver while a question is open
+        var pendingCode = null;              // code arrives before the step that runs it
+        var attemptNow = 1, attemptMax = 0;
+        var providerName = "";
+        var profileShown = null;
+
+        function syncMeta() {
+            var bits = [];
+            if (attemptMax > 1 && (attemptNow > 1 || running)) bits.push("<b>attempt " + attemptNow + "</b> of " + attemptMax);
+            bits.push(fmtSeconds(Date.now() - startedAt));
+            nowMeta.innerHTML = bits.join(" · ");
+        }
+
+        var timer = setInterval(function () {
+            if (finished) return;
+            syncMeta();
+            if (currentStep && currentStep.__time && !currentStep.__frozen) {
+                currentStep.__time.textContent = fmtSeconds(Date.now() - currentStep.__t0);
+            }
+        }, 1000);
+
+        function setStage(key, state) {
+            var reached = false;
+            STAGES.forEach(function (s) {
+                var li = stageEls[s.key];
+                if (s.key === key) {
+                    li.dataset.state = state || "current";
+                    reached = true;
+                } else if (!reached) {
+                    li.dataset.state = "done";
+                } else {
+                    li.dataset.state = "todo";
+                }
+            });
+        }
+
+        function setNow(text) { nowText.textContent = text; syncMeta(); }
+
+        function freezeCurrent() {
+            if (!currentStep) return;
+            currentStep.classList.remove("is-current");
+            if (currentStep.__time && !currentStep.__frozen) {
+                var spent = Date.now() - currentStep.__t0;
+                currentStep.__time.textContent = spent >= 400 ? fmtSeconds(spent) : "";
+                currentStep.__frozen = true;
+            }
+        }
 
         function addStep(event) {
-            var li = el("li", "pa-convert-step pa-phase-" + event.phase);
-            var icon = el("span", "pa-convert-icon", PHASE_ICON[event.phase] || "•");
-            li.appendChild(icon);
-            var content = el("div", "pa-convert-step-body");
-            content.appendChild(el("div", "pa-convert-step-title", event.title));
-            if (event.detail) content.appendChild(el("div", "pa-convert-step-detail", event.detail));
-            li.appendChild(content);
-            if (event.attempt > 1) {
-                li.appendChild(el("span", "pa-convert-attempt",
-                                  "try " + event.attempt + "/" + event.maxAttempts));
+            freezeCurrent();
+            var li = el("li", "pa-convert-event is-current");
+            li.dataset.phase = event.phase;
+            var node = el("span", "pa-convert-node");
+            node.innerHTML = svg(event.phase);
+            li.appendChild(node);
+            var content = el("div", "pa-convert-event-body");
+            var head = el("div", "pa-convert-event-head");
+            head.appendChild(el("span", "pa-convert-event-title", event.title));
+            if (event.attempt > 1 && event.phase !== "user") {
+                head.appendChild(el("span", "pa-convert-attempt", "attempt " + event.attempt + "/" + event.maxAttempts));
             }
-            if (currentStep) currentStep.classList.remove("pa-convert-current");
-            li.classList.add("pa-convert-current");
+            var time = el("span", "pa-convert-event-time", "");
+            head.appendChild(time);
+            content.appendChild(head);
+            if (event.detail) {
+                // The validator's report is one failure per line; keep them.
+                var lines = String(event.detail).split("\n").filter(function (l) { return l.trim(); });
+                if (event.phase === "validating" && lines.length && /Not accepted/i.test(event.title)) {
+                    var verdict = el("div", "pa-convert-verdict");
+                    var ul = el("ul");
+                    lines.forEach(function (l) { ul.appendChild(el("li", null, l)); });
+                    verdict.appendChild(ul);
+                    content.appendChild(verdict);
+                    li.classList.add("is-rejected");
+                } else {
+                    content.appendChild(el("p", "pa-convert-event-detail", event.detail));
+                }
+            }
+            if (/failed/i.test(event.title) && event.phase === "running") li.classList.add("is-rejected");
+            li.appendChild(content);
+            li.__t0 = Date.now();
+            li.__time = time;
+            li.__body = content;
             currentStep = li;
-            steps.appendChild(li);
+            timeline.appendChild(li);
+            if (pendingCode && event.phase === "running") { attachCode(pendingCode); pendingCode = null; }
             body.scrollTop = body.scrollHeight;
             return li;
         }
 
-        function setProgress(fraction, label) {
-            fill.style.width = Math.round(Math.max(0.02, Math.min(1, fraction)) * 100) + "%";
-            if (label) progressText.textContent = label;
+        function disclosureRow(step) {
+            var row = step.__body.querySelector(".pa-convert-disclosures");
+            if (!row) { row = el("div", "pa-convert-disclosures"); step.__body.appendChild(row); }
+            return row;
+        }
+
+        function addDisclosure(step, label, small, kind, text) {
+            var row = disclosureRow(step);
+            var toggle = el("button", "pa-convert-disclose");
+            toggle.type = "button";
+            toggle.setAttribute("aria-expanded", "false");
+            toggle.appendChild(document.createTextNode(label));
+            if (small) { toggle.appendChild(document.createTextNode(" ")); toggle.appendChild(el("small", null, small)); }
+            var box = el("div", "pa-convert-codebox");
+            box.hidden = true;
+            var head = el("div", "pa-convert-codebox-head");
+            var kindLabel = el("span"); kindLabel.innerHTML = "<b>" + kind + "</b>";
+            head.appendChild(kindLabel);
+            var copy = el("button", "pa-convert-copy", "Copy");
+            copy.type = "button";
+            copy.addEventListener("click", function () {
+                if (!navigator.clipboard) return;
+                navigator.clipboard.writeText(text).then(function () {
+                    copy.textContent = "Copied";
+                    setTimeout(function () { copy.textContent = "Copy"; }, 1400);
+                });
+            });
+            head.appendChild(copy);
+            box.appendChild(head);
+            var pre = el("pre", "pa-convert-code");
+            pre.appendChild(el("code", null, text));
+            box.appendChild(pre);
+            toggle.addEventListener("click", function () {
+                box.hidden = !box.hidden;
+                toggle.setAttribute("aria-expanded", String(!box.hidden));
+            });
+            row.appendChild(toggle);
+            // The box goes after the row so every disclosure's content stacks
+            // below the buttons rather than between them.
+            step.__body.appendChild(box);
         }
 
         function attachCode(code) {
-            if (!currentStep) return;
-            var toggle = el("button", "pa-convert-codetoggle", "▸ show the code");
-            toggle.type = "button";
-            var pre = el("pre", "pa-convert-code");
-            pre.appendChild(el("code", null, code));
-            pre.hidden = true;
-            toggle.addEventListener("click", function () {
-                pre.hidden = !pre.hidden;
-                toggle.textContent = (pre.hidden ? "▸ show" : "▾ hide") + " the code";
-            });
-            currentStep.querySelector(".pa-convert-step-body").appendChild(toggle);
-            currentStep.querySelector(".pa-convert-step-body").appendChild(pre);
+            if (!currentStep) { pendingCode = code; return; }
+            var lines = String(code).split("\n").length;
+            addDisclosure(currentStep, "Script", lines + " lines", "python · runs in your browser", code);
+        }
+
+        function attachOutput(stdout) {
+            if (!currentStep || !stdout || !String(stdout).trim()) return;
+            var text = String(stdout).trim();
+            addDisclosure(currentStep, "Output", text.split("\n").length + " lines", "what the script printed", text);
         }
 
         function setComposerState(state) {
@@ -395,20 +760,23 @@
             composerSend.textContent = state === "asking" ? "Answer" : "Revise";
             composerInput.placeholder = state === "asking"
                 ? "…or answer in your own words"
-                : "Tell the AI what to change — e.g. “keep the flagged genes”, “use the reads sheet”, “column A is a KEGG ID”";
+                : state === "busy"
+                    ? "The AI is working — you can steer it once it has something to show."
+                    : "Tell the AI what to change — “keep the flagged genes”, “use the reads sheet, not TPM”, “column A is a KEGG ID”";
             composer.classList.toggle("pa-convert-composer-busy", state === "busy");
         }
 
         function askUser(question) {
             return new Promise(function (resolve) {
-                var card = el("div", "pa-convert-question");
-                card.appendChild(el("p", "pa-convert-question-text", question.text));
+                var qcard = el("div", "pa-convert-question");
+                qcard.appendChild(el("p", "pa-convert-question-text", question.text));
                 var opts = el("div", "pa-convert-options");
                 var settle = function (answer) {
-                    card.querySelectorAll("button").forEach(function (x) { x.disabled = true; });
-                    card.appendChild(el("div", "pa-convert-answer", "You chose: " + answer));
+                    qcard.querySelectorAll("button").forEach(function (x) { x.disabled = true; });
+                    qcard.appendChild(el("div", "pa-convert-answer", "You chose: " + answer));
                     pendingAnswer = null;
                     setComposerState("busy");
+                    setNow("Thanks — continuing");
                     resolve(answer);
                 };
                 (question.options && question.options.length
@@ -421,16 +789,18 @@
                     });
                     opts.appendChild(b);
                 });
-                card.appendChild(opts);
-                currentStep.querySelector(".pa-convert-step-body").appendChild(card);
+                qcard.appendChild(opts);
+                qcard.appendChild(el("p", "pa-convert-question-hint", "Or answer in your own words in the box below."));
+                currentStep.__body.appendChild(qcard);
                 body.scrollTop = body.scrollHeight;
                 pendingAnswer = settle;
                 setComposerState("asking");
+                setNow("Waiting for your answer");
                 composerInput.focus();
             });
         }
 
-        var sandbox = createSandbox(function (msg) { setProgress(0.03, msg); });
+        var sandbox = createSandbox(function (msg) { setNow(msg); });
 
         function shutdown() {
             clearInterval(timer);
@@ -441,7 +811,13 @@
             }, 200);
         }
 
-        close.addEventListener("click", function () { cancelled = true; shutdown(); });
+        function cancel() { cancelled = true; shutdown(); }
+        close.addEventListener("click", cancel);
+        // Escape closes once there is nothing in flight; mid-run it would throw
+        // away a minute of work on a reflex.
+        panel.addEventListener("keydown", function (event) {
+            if (event.key === "Escape" && !running && !pendingAnswer) cancel();
+        });
 
         var bytes = null;
         var fileKey = safeName(file.name) || "input";
@@ -449,17 +825,39 @@
         function onEvent(event) {
             if (cancelled) return;
             if (event.type === "step") {
+                attemptNow = event.attempt || attemptNow;
+                attemptMax = event.maxAttempts || attemptMax;
                 addStep(event);
-                setProgress(event.progress, event.title);
+                setStage(PHASE_STAGE[event.phase] || "plan", event.phase === "done" ? "ready" : "current");
+                setNow(event.title);
             } else if (event.type === "code") {
-                attachCode(event.code);
+                pendingCode = event.code;
+            } else if (event.type === "output") {
+                attachOutput(event.stdout);
+            } else if (event.type === "profile" && event.profile && !profileShown) {
+                profileShown = event.profile;
+                anatomyHost.innerHTML = "";
+                anatomyHost.appendChild(renderAnatomy(event.profile, file.name, providerName));
+            } else if (event.type === "failed") {
+                setStage(PHASE_STAGE.profiling, "failed");
             }
         }
 
+        provider().then(function (p) {
+            if (!p || !p.success) return;
+            providerName = (p.operator || p.provider || "") + (p.host ? " (" + p.host + ")" : "");
+            var meta = anatomyHost.querySelector(".pa-convert-anatomy-meta");
+            if (meta && profileShown) {
+                var chars = profileShown.description_chars ? fmtInt(profileShown.description_chars) + " characters" : "structure only";
+                meta.textContent = chars + " · sent to " + providerName;
+            }
+        });
+
         async function runOnce(extra) {
             running = true;
+            finished = false;
             setComposerState("busy");
-            footer.innerHTML = "";
+            actions.innerHTML = "";
             reviewHost.innerHTML = "";
             var result = await api().runAgent(Object.assign({
                 api: api(),
@@ -477,6 +875,7 @@
             running = false;
             if (cancelled) return result;
             last = result;
+            if (result.profile && !profileShown) onEvent({ type: "profile", profile: result.profile });
             renderReview(result);
             setComposerState("idle");
             return result;
@@ -485,7 +884,8 @@
         async function revise(instruction) {
             if (!last) return;
             addStep({ phase: "user", title: "Your instruction", detail: instruction });
-            setProgress(0.1, "Revising");
+            setStage("plan", "current");
+            setNow("Revising with your instruction");
             var instructions = (last.instructions || []).concat([instruction]);
             await runOnce({
                 profile: last.profile,
@@ -500,6 +900,7 @@
             var text = composerInput.value.trim();
             if (!text) return;
             composerInput.value = "";
+            composerInput.style.height = "";
             if (pendingAnswer) { pendingAnswer(text); return; }
             if (running) return;
             revise(text);
@@ -507,22 +908,30 @@
         composerInput.addEventListener("keydown", function (event) {
             if (event.key === "Enter" && !event.shiftKey) {
                 event.preventDefault();
-                composer.requestSubmit ? composer.requestSubmit() : composer.dispatchEvent(new Event("submit"));
+                if (composer.requestSubmit) composer.requestSubmit(); else composer.dispatchEvent(new Event("submit"));
             }
         });
 
         return (async function () {
             try {
                 setComposerState("busy");
+                setStage("read", "current");
+                // The boot is a real step that takes a few seconds; a blank
+                // timeline for that long reads as nothing happening.
+                addStep({ phase: "profiling", title: "Starting the Python sandbox",
+                          detail: "A Pyodide interpreter in an isolated frame: no access to this page, " +
+                                  "your cookies or the network. The conversion script will run there." });
                 await sandbox.boot();
-                setProgress(0.05, "Reading your file");
+                setNow("Reading your file");
                 bytes = new Uint8Array(await file.arrayBuffer());
                 return await runOnce();
             } catch (err) {
                 if (!cancelled) {
                     addStep({ phase: "failed", title: "The conversion could not finish",
                               detail: String(err && err.message || err) });
-                    setProgress(1, "Stopped");
+                    var lit = STAGES.filter(function (s) { return stageEls[s.key].dataset.state === "current"; })[0];
+                    setStage(lit ? lit.key : "plan", "failed");
+                    setNow("Stopped");
                     renderFailure(null);
                     setComposerState(last ? "idle" : "busy");
                 }
@@ -532,98 +941,103 @@
 
         /* ---- review ---------------------------------------------------- */
 
-        function previewTable(preview) {
-            var wrap = el("div", "pa-convert-preview");
-            var table = el("table");
-            var maxCols = 7;
-            var cols = preview.header ? preview.header.length : (preview.rows[0] || []).length;
-            var shown = Math.min(cols, maxCols);
-            if (preview.header) {
-                var tr = el("tr");
-                preview.header.slice(0, shown).forEach(function (h) { tr.appendChild(el("th", null, h)); });
-                if (cols > shown) tr.appendChild(el("th", "pa-convert-more", "+" + (cols - shown)));
-                table.appendChild(tr);
-            }
-            preview.rows.forEach(function (r) {
-                var tr = el("tr");
-                r.slice(0, shown).forEach(function (c, i) { tr.appendChild(el("td", i === 0 ? "pa-convert-id" : null, c)); });
-                if (cols > shown) tr.appendChild(el("td", "pa-convert-more", "…"));
-                table.appendChild(tr);
-            });
-            wrap.appendChild(table);
-            return wrap;
-        }
-
         function chips(label, names, cls) {
             if (!names || !names.length) return null;
+            var frag = document.createDocumentFragment();
+            frag.appendChild(el("span", "pa-convert-columns-label", label + " " + names.length));
             var box = el("div", "pa-convert-chips " + (cls || ""));
-            box.appendChild(el("span", "pa-convert-chips-label", label));
             names.slice(0, 12).forEach(function (n) { box.appendChild(el("span", "pa-convert-chip", n)); });
             if (names.length > 12) box.appendChild(el("span", "pa-convert-chip pa-convert-chip-more", "+" + (names.length - 12) + " more"));
-            return box;
+            frag.appendChild(box);
+            return frag;
+        }
+
+        function linkedRow(glyph, html, bytesToDownload, name) {
+            var row = el("div", "pa-convert-linked");
+            var icon = el("span", "pa-convert-linked-icon");
+            icon.innerHTML = svg(glyph);
+            row.appendChild(icon);
+            var text = el("span");
+            text.innerHTML = html;
+            row.appendChild(text);
+            row.appendChild(iconButton("download", "Download " + name, function () { download(bytesToDownload, name); }));
+            return row;
+        }
+
+        function escapeHtml(s) {
+            return String(s).replace(/[&<>"]/g, function (c) {
+                return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+            });
         }
 
         function renderReview(result) {
-            clearInterval(timer);
+            finished = true;
+            freezeCurrent();
             if (!result.ok) { renderFailure(result); return; }
-            setProgress(1, "Ready to review");
+            setStage("review", "ready");
+            setNow("Ready to review");
 
             var out = describeOutputs(result);
             var review = el("section", "pa-convert-review");
-            review.appendChild(el("h3", null, out.values.length > 1
+            review.setAttribute("aria-label", "Review the result");
+            var head = el("div", "pa-convert-review-head");
+            head.appendChild(el("h3", "pa-convert-review-title", out.values.length > 1
                 ? out.values.length + " tables ready" : "Converted"));
+            var attemptsUsed = result.attempts || 1;
+            head.appendChild(el("span", "pa-convert-review-count",
+                plural(out.files.length, "file") + " · " + plural(attemptsUsed, "attempt") + " · " + fmtSeconds(Date.now() - startedAt)));
+            review.appendChild(head);
             if (out.manifest.summary) review.appendChild(el("p", "pa-convert-summary", out.manifest.summary));
 
             var chosen = out.values.filter(function (f) { return f.recommended; })[0] || out.values[0];
             var addOthers = false;
 
             out.values.forEach(function (f) {
-                var card = el("article", "pa-convert-card" + (f === chosen ? " pa-convert-card-chosen" : ""));
-                var head = el("header", "pa-convert-card-head");
+                var rcard = el("article", "pa-convert-result" + (f === chosen ? " pa-convert-result-chosen" : ""));
+                var rhead = el("header", "pa-convert-result-head");
                 var pick = el("label", "pa-convert-pick");
                 var radio = document.createElement("input");
                 radio.type = "radio"; radio.name = "pa-convert-choice"; radio.checked = f === chosen;
+                radio.setAttribute("aria-label", "Use " + f.label + " for this omic");
                 radio.addEventListener("change", function () {
                     chosen = f;
-                    review.querySelectorAll(".pa-convert-card").forEach(function (c) { c.classList.remove("pa-convert-card-chosen"); });
-                    card.classList.add("pa-convert-card-chosen");
-                    syncFooter();
+                    review.querySelectorAll(".pa-convert-result").forEach(function (c) { c.classList.remove("pa-convert-result-chosen"); });
+                    rcard.classList.add("pa-convert-result-chosen");
+                    syncActions();
                 });
                 pick.appendChild(radio);
-                var labels = el("div", "pa-convert-card-titles");
-                labels.appendChild(el("div", "pa-convert-card-title", f.label));
-                var meta = [f.source, f.nRows != null ? f.nRows.toLocaleString() + " rows" : null,
-                            f.nCols ? (f.nCols - 1) + " conditions" : null].filter(Boolean).join(" · ");
-                labels.appendChild(el("div", "pa-convert-card-meta", meta));
+                var labels = el("div", "pa-convert-result-titles");
+                labels.appendChild(el("div", "pa-convert-result-title", f.label));
+                var meta = [f.source ? "from " + f.source : null,
+                            f.nRows != null ? plural(f.nRows, "row") : null,
+                            f.nCols ? plural(f.nCols - 1, "condition") : null,
+                            (f.rowsIn != null && f.rowsOut != null && f.rowsIn !== f.rowsOut)
+                                ? fmtInt(f.rowsIn - f.rowsOut) + " rows left out" : null]
+                           .filter(Boolean).join(" · ");
+                labels.appendChild(el("div", "pa-convert-result-meta", meta));
                 pick.appendChild(labels);
-                head.appendChild(pick);
-                if (f.recommended) head.appendChild(el("span", "pa-convert-badge", "Recommended"));
-                var dl = el("button", "pa-convert-iconbtn", "⤓");
-                dl.type = "button"; dl.title = "Download " + f.name;
-                dl.addEventListener("click", function () { download(f.bytes, f.name); });
-                head.appendChild(dl);
-                card.appendChild(head);
+                rhead.appendChild(pick);
+                if (f.recommended) rhead.appendChild(el("span", "pa-convert-badge", "Recommended"));
+                rhead.appendChild(iconButton("download", "Download " + f.name, function () { download(f.bytes, f.name); }));
+                rcard.appendChild(rhead);
 
-                card.appendChild(previewTable(f.preview));
+                rcard.appendChild(previewTable(f.preview));
                 var kept = chips("Kept", f.kept, "pa-convert-kept");
                 var dropped = chips("Left out", f.dropped, "pa-convert-dropped");
-                if (kept) card.appendChild(kept);
-                if (dropped) card.appendChild(dropped);
-                if (f.note) card.appendChild(el("p", "pa-convert-card-note", f.note));
-                var linked = out.lists.filter(function (l) { return l.relevantFor === f.name; });
-                linked.forEach(function (l) {
-                    var row = el("div", "pa-convert-linked");
-                    row.appendChild(el("span", "pa-convert-linked-icon", "≡"));
-                    row.appendChild(el("span", null, l.label + " — " + (l.nRows != null ? l.nRows.toLocaleString() : "?") +
-                                                      " identifiers, attached as the relevant-features list" +
-                                                      (l.note ? " (" + l.note + ")" : "")));
-                    var ldl = el("button", "pa-convert-iconbtn", "⤓");
-                    ldl.type = "button"; ldl.title = "Download " + l.name;
-                    ldl.addEventListener("click", function () { download(l.bytes, l.name); });
-                    row.appendChild(ldl);
-                    card.appendChild(row);
+                if (kept || dropped) {
+                    var cols = el("div", "pa-convert-columns");
+                    if (kept) cols.appendChild(kept);
+                    if (dropped) cols.appendChild(dropped);
+                    rcard.appendChild(cols);
+                }
+                if (f.note) rcard.appendChild(el("p", "pa-convert-result-note", f.note));
+                out.lists.filter(function (l) { return l.relevantFor === f.name; }).forEach(function (l) {
+                    rcard.appendChild(linkedRow("list",
+                        "<b>" + escapeHtml(l.label) + "</b> — " + (l.nRows != null ? fmtInt(l.nRows) : "?") +
+                        " identifiers, attached as the relevant-features list" +
+                        (l.note ? " (" + escapeHtml(l.note) + ")" : ""), l.bytes, l.name));
                 });
-                review.appendChild(card);
+                review.appendChild(rcard);
             });
 
             var unlinked = out.lists.filter(function (l) {
@@ -631,17 +1045,11 @@
             });
             if (unlinked.length || out.others.length) {
                 var extras = el("div", "pa-convert-extras");
-                extras.appendChild(el("h4", null, out.values.length ? "Also produced" : "Produced"));
+                extras.appendChild(el("h4", "pa-convert-extras-title", out.values.length ? "Also produced" : "Produced"));
                 unlinked.concat(out.others).forEach(function (f) {
-                    var row = el("div", "pa-convert-linked");
-                    row.appendChild(el("span", "pa-convert-linked-icon", f.role === "relevant" ? "≡" : "▤"));
-                    row.appendChild(el("span", null, f.label + " — " + (f.nRows != null ? f.nRows.toLocaleString() + " rows" : "") +
-                                                      (f.note ? " (" + f.note + ")" : "")));
-                    var fdl = el("button", "pa-convert-iconbtn", "⤓");
-                    fdl.type = "button"; fdl.title = "Download " + f.name;
-                    fdl.addEventListener("click", function () { download(f.bytes, f.name); });
-                    row.appendChild(fdl);
-                    extras.appendChild(row);
+                    extras.appendChild(linkedRow(f.role === "relevant" ? "list" : "table",
+                        "<b>" + escapeHtml(f.label) + "</b>" + (f.nRows != null ? " — " + plural(f.nRows, "row") : "") +
+                        (f.note ? " (" + escapeHtml(f.note) + ")" : ""), f.bytes, f.name));
                 });
                 review.appendChild(extras);
             }
@@ -650,8 +1058,9 @@
                 var skipped = el("details", "pa-convert-skipped");
                 skipped.appendChild(el("summary", null, "Not converted (" + out.manifest.skipped.length + ")"));
                 out.manifest.skipped.forEach(function (s) {
-                    skipped.appendChild(el("div", "pa-convert-skipped-row",
-                        (s.source || "?") + " — " + (s.reason || "")));
+                    var row = el("div", "pa-convert-skipped-row");
+                    row.innerHTML = "<b>" + escapeHtml(s.source || "?") + "</b> — " + escapeHtml(s.reason || "");
+                    skipped.appendChild(row);
                 });
                 review.appendChild(skipped);
             }
@@ -660,7 +1069,7 @@
                 var addLabel = el("label", "pa-convert-addothers");
                 var addBox = document.createElement("input");
                 addBox.type = "checkbox";
-                addBox.addEventListener("change", function () { addOthers = addBox.checked; syncFooter(); });
+                addBox.addEventListener("change", function () { addOthers = addBox.checked; syncActions(); });
                 addLabel.appendChild(addBox);
                 addLabel.appendChild(el("span", null, "Also add the other " + (out.values.length - 1) +
                     " table" + (out.values.length > 2 ? "s" : "") + " as separate omics, named after their source"));
@@ -670,7 +1079,7 @@
             reviewHost.innerHTML = "";
             reviewHost.appendChild(review);
 
-            // ---- footer -------------------------------------------------
+            // ---- the decision -------------------------------------------
             var accept = el("button", "pa-convert-accept", "Use this table");
             accept.type = "button";
             var downloadAll = el("button", "pa-convert-dismiss", "Download all");
@@ -678,20 +1087,20 @@
             downloadAll.addEventListener("click", function () {
                 out.files.forEach(function (f, i) { setTimeout(function () { download(f.bytes, f.name); }, i * 150); });
             });
-            var dismiss = el("button", "pa-convert-dismiss", "Cancel");
+            var dismiss = el("button", "pa-convert-dismiss is-quiet", "Cancel");
             dismiss.type = "button";
-            dismiss.addEventListener("click", function () { cancelled = true; shutdown(); });
-            footer.innerHTML = "";
-            if (out.values.length) footer.appendChild(accept);
-            footer.appendChild(downloadAll);
-            footer.appendChild(dismiss);
+            dismiss.addEventListener("click", cancel);
+            actions.innerHTML = "";
+            actions.appendChild(dismiss);
+            actions.appendChild(downloadAll);
+            if (out.values.length) actions.appendChild(accept);
 
-            function syncFooter() {
+            function syncActions() {
                 accept.textContent = addOthers
                     ? "Use this table + add " + (out.values.length - 1) + " more"
                     : (out.values.length > 1 ? "Use this table" : "Use this file");
             }
-            syncFooter();
+            syncActions();
 
             accept.addEventListener("click", function () {
                 if (!chosen) return;
@@ -709,42 +1118,59 @@
                         if (!added) { download(v.bytes, v.name); if (vList) download(vList.bytes, vList.name); }
                     });
                 }
+                // Provenance for the strip in the omic card: which file this
+                // table came from, so the card can say so and offer a redo.
+                input.__paConverted = { from: file.name, original: file, fieldName: fieldName,
+                                        label: chosen.label, attempts: result.attempts || 1,
+                                        relevant: !!linkedList };
                 setFile(input, chosen.bytes, chosen.name);
                 var secondary = fileInputIn(component, "secondaryFileSelector");
                 if (linkedList && secondary) setFile(secondary, linkedList.bytes, linkedList.name);
                 shutdown();
             });
-            body.scrollTop = reviewHost.offsetTop - 8;
+            // Bring the review's own heading to the top of the scroll area.
+            // offsetTop is measured from the sheet, not from the scrolling
+            // body, so it has to be taken relative to the body's rect.
+            body.scrollTop = review.getBoundingClientRect().top - body.getBoundingClientRect().top + body.scrollTop - 10;
         }
 
         function renderFailure(result) {
-            setProgress(1, "Could not finish");
+            finished = true;
+            freezeCurrent();
+            var lit = STAGES.filter(function (s) { return stageEls[s.key].dataset.state === "current"; })[0];
+            setStage(lit ? lit.key : "check", "failed");
+            setNow("Could not finish");
             var review = el("section", "pa-convert-review pa-convert-review-failed");
-            review.appendChild(el("h3", null, "Could not finish this one"));
+            var head = el("div", "pa-convert-review-head");
+            head.appendChild(el("h3", "pa-convert-review-title", "Could not finish this one"));
+            if (result && result.attempts) head.appendChild(el("span", "pa-convert-review-count", plural(result.attempts, "attempt") + " used"));
+            review.appendChild(head);
             review.appendChild(el("p", "pa-convert-summary",
                 "Tell the AI what the file contains in the box below and it will try again — " +
                 "which sheet matters, what the columns are, what the identifiers are. " +
-                "The script it wrote is above; a colleague who knows pandas can take it from there."));
+                "The script it wrote is in the timeline above; a colleague who knows pandas can take it from there."));
             if (result && result.outputs) {
                 var out = describeOutputs(result);
                 if (out.files.length) {
-                    var p = el("p", "pa-convert-summary", "Its best attempt produced " + out.files.length + " file(s) that did not pass the check: ");
+                    review.appendChild(el("p", "pa-convert-summary",
+                        "Its best attempt produced " + plural(out.files.length, "file") + " that did not pass the check:"));
+                    var row = el("div", "pa-convert-failed-files");
                     out.files.forEach(function (f) {
-                        var b = el("button", "pa-convert-codetoggle", "⤓ " + f.name);
+                        var b = el("button", "pa-convert-disclose", "⤓ " + f.name);
                         b.type = "button";
                         b.addEventListener("click", function () { download(f.bytes, f.name); });
-                        p.appendChild(b);
+                        row.appendChild(b);
                     });
-                    review.appendChild(p);
+                    review.appendChild(row);
                 }
             }
             reviewHost.innerHTML = "";
             reviewHost.appendChild(review);
-            footer.innerHTML = "";
+            actions.innerHTML = "";
             var dismiss = el("button", "pa-convert-dismiss", "Close");
             dismiss.type = "button";
-            dismiss.addEventListener("click", function () { cancelled = true; shutdown(); });
-            footer.appendChild(dismiss);
+            dismiss.addEventListener("click", cancel);
+            actions.appendChild(dismiss);
             body.scrollTop = body.scrollHeight;
         }
     }
@@ -769,5 +1195,6 @@
     }
 
     return { openDrawer: openDrawer, openConvertDrawer: openConvertDrawer,
-             createSandbox: createSandbox, describeOutputs: describeOutputs };
+             createSandbox: createSandbox, describeOutputs: describeOutputs,
+             renderAnatomy: renderAnatomy };
 });

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
@@ -44,7 +44,7 @@
     /* What the AI actually does, in the user's terms. People are right to
        be wary of "AI will fix your data"; saying that it writes a script,
        runs it locally, and shows both is what makes it trustworthy. */
-    var AI_EXPLAINER = "PaintOmics AI can convert it here in your browser: it reads the file's structure, writes a short script, runs it locally and checks the result. You see the script, the tables and what it left out before anything is used.";
+    var AI_EXPLAINER = "The PaintOmics AI agent can convert it here in your browser: it reads the file's structure, writes a short script, runs it locally and checks the result. You see the script, the tables and what it left out before anything is used.";
 
     function el(tag, className, text) {
         var node = document.createElement(tag);
@@ -283,11 +283,47 @@
         icon.innerHTML = typeof window.getAIMark === "function" ? window.getAIMark() : "✦";
         strip.appendChild(icon);
         var text = el("span", "pa-format-text");
-        text.appendChild(document.createTextNode("Any spreadsheet or export works. If it is not already in PaintOmics’ format, "));
-        text.appendChild(el("b", null, "PaintOmics AI"));
-        text.appendChild(document.createTextNode(" converts it here, in your browser."));
+        if (aiOptedIn()) {
+            text.appendChild(document.createTextNode("Any format works — the "));
+            text.appendChild(el("b", null, "PaintOmics AI agent"));
+            text.appendChild(document.createTextNode(" converts it here if needed."));
+        } else {
+            text.appendChild(document.createTextNode("AI conversion is off: tab-separated, identifier first, numbers after."));
+        }
         strip.appendChild(text);
     }
+
+    /*
+     * The Section 3 consent box. Ticked by default because ticking it sends
+     * nothing -- a file goes to the model only when the user presses Convert
+     * on it -- and unticking it withdraws that offer from every card, so a
+     * user who does not want a third party to see even column names is not
+     * shown a button that would.
+     */
+    function aiOptedIn() {
+        var box = document.getElementById("paUploadAiOptIn");
+        return !box || box.checked;
+    }
+
+    function aiActions(input, file, fieldName) {
+        if (!aiOptedIn()) return [];
+        return [{ label: "Convert it for me", primary: true, ai: true,
+                  onClick: function () { requestAgent(input, file, fieldName); } }];
+    }
+
+    function aiExplainer() {
+        return aiOptedIn()
+            ? AI_EXPLAINER
+            : "AI conversion is switched off above; tick it to have the PaintOmics AI agent convert this file, " +
+              "or export a tab-separated table with the identifier first and numbers after.";
+    }
+
+    // Unticking or ticking the box repaints the standing offer on every card
+    // that has no file yet; cards with a verdict keep it until re-checked.
+    document.addEventListener("change", function (event) {
+        if (!event.target || event.target.id !== "paUploadAiOptIn") return;
+        document.querySelectorAll(".pa-format-strip.pa-format-idle").forEach(renderIdle);
+    }, true);
 
     function renderOk(strip, summary, partial, input) {
         strip.className = "pa-format-strip pa-format-ok";
@@ -321,7 +357,7 @@
             mark.innerHTML = typeof window.getAIMark === "function" ? window.getAIMark() : "✦";
             prov.appendChild(mark);
             var what = el("span", "pa-format-provenance-text");
-            what.appendChild(document.createTextNode("Converted by PaintOmics AI from "));
+            what.appendChild(document.createTextNode("Converted by the PaintOmics AI agent from "));
             what.appendChild(el("b", null, converted.from));
             var extras = [];
             if (converted.label) extras.push("table “" + converted.label + "”");
@@ -488,9 +524,8 @@
             renderProblem(strip, "err",
                 "This spreadsheet needs converting.",
                 file.name + " is a workbook — it may hold several sheets and " +
-                "columns that are not measurements. " + AI_EXPLAINER,
-                [{ label: "Convert it for me", primary: true, ai: true,
-                   onClick: function () { requestAgent(input, file, fieldName); } }]);
+                "columns that are not measurements. " + aiExplainer(),
+                aiActions(input, file, fieldName));
             return;
         }
 
@@ -508,10 +543,9 @@
                 markBlocked(fieldName, { fieldName: fieldName, fileName: file.name,
                                          input: input, omic: strip.__omic, fixable: false });
                 renderProblem(strip, "err", "The file is not saved as UTF-8.",
-                    "Re-save it as UTF-8 (in Excel: Save As → CSV UTF-8), or let " +
-                    "PaintOmics AI convert it. " + AI_EXPLAINER,
-                    [{ label: "Convert it for me", primary: true,
-                       onClick: function () { requestAgent(input, file); } }]);
+                    "Re-save it as UTF-8 (in Excel: Save As → CSV UTF-8)" +
+                    (aiOptedIn() ? ", or let the PaintOmics AI agent convert it. " + AI_EXPLAINER : "."),
+                    aiActions(input, file, fieldName));
                 return;
             }
 
@@ -568,9 +602,8 @@
                 });
             }
             renderProblem(strip, "err", describeProblems(result),
-                (partial ? "Checked the first few megabytes of a large file. " : "") + AI_EXPLAINER,
-                [{ label: "Convert it for me", primary: true, ai: true,
-                   onClick: function () { requestAgent(input, file, fieldName); } }]);
+                (partial ? "Checked the first few megabytes of a large file. " : "") + aiExplainer(),
+                aiActions(input, file, fieldName));
         };
         reader.readAsArrayBuffer(slice);
     }
@@ -645,14 +678,14 @@
             bar.appendChild(fix);
         }
 
-        if (fixable.length !== entries.length) {
+        if (fixable.length !== entries.length && aiOptedIn()) {
             var convert = el("button", "pa-format-button pa-format-primary");
             convert.type = "button";
             if (typeof window.getAIMark === "function") {
                 convert.innerHTML = window.getAIMark();
-                convert.appendChild(document.createTextNode(" Convert with PaintOmics AI"));
+                convert.appendChild(document.createTextNode(" Convert with the PaintOmics AI agent"));
             } else {
-                convert.textContent = "Convert with PaintOmics AI";
+                convert.textContent = "Convert with the PaintOmics AI agent";
             }
             convert.addEventListener("click", function () {
                 var first = entries[0];

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
@@ -283,47 +283,21 @@
         icon.innerHTML = typeof window.getAIMark === "function" ? window.getAIMark() : "✦";
         strip.appendChild(icon);
         var text = el("span", "pa-format-text");
-        if (aiOptedIn()) {
-            text.appendChild(document.createTextNode("Any format works — the "));
-            text.appendChild(el("b", null, "PaintOmics AI agent"));
-            text.appendChild(document.createTextNode(" converts it here if needed."));
-        } else {
-            text.appendChild(document.createTextNode("AI conversion is off: tab-separated, identifier first, numbers after."));
-        }
+        text.appendChild(document.createTextNode("Any format works — the "));
+        text.appendChild(el("b", null, "PaintOmics AI agent"));
+        text.appendChild(document.createTextNode(" converts it here if needed."));
         strip.appendChild(text);
     }
 
-    /*
-     * The Section 3 consent box. Ticked by default because ticking it sends
-     * nothing -- a file goes to the model only when the user presses Convert
-     * on it -- and unticking it withdraws that offer from every card, so a
-     * user who does not want a third party to see even column names is not
-     * shown a button that would.
-     */
-    function aiOptedIn() {
-        var box = document.getElementById("paUploadAiOptIn");
-        return !box || box.checked;
-    }
-
+    /* The one AI action a problem strip offers. Pressing it is the consent:
+       nothing leaves this computer until the user does, so there is no box to
+       tick beforehand. */
     function aiActions(input, file, fieldName) {
-        if (!aiOptedIn()) return [];
         return [{ label: "Convert it for me", primary: true, ai: true,
                   onClick: function () { requestAgent(input, file, fieldName); } }];
     }
 
-    function aiExplainer() {
-        return aiOptedIn()
-            ? AI_EXPLAINER
-            : "AI conversion is switched off above; tick it to have the PaintOmics AI agent convert this file, " +
-              "or export a tab-separated table with the identifier first and numbers after.";
-    }
-
-    // Unticking or ticking the box repaints the standing offer on every card
-    // that has no file yet; cards with a verdict keep it until re-checked.
-    document.addEventListener("change", function (event) {
-        if (!event.target || event.target.id !== "paUploadAiOptIn") return;
-        document.querySelectorAll(".pa-format-strip.pa-format-idle").forEach(renderIdle);
-    }, true);
+    function aiExplainer() { return AI_EXPLAINER; }
 
     function renderOk(strip, summary, partial, input) {
         strip.className = "pa-format-strip pa-format-ok";
@@ -543,8 +517,7 @@
                 markBlocked(fieldName, { fieldName: fieldName, fileName: file.name,
                                          input: input, omic: strip.__omic, fixable: false });
                 renderProblem(strip, "err", "The file is not saved as UTF-8.",
-                    "Re-save it as UTF-8 (in Excel: Save As → CSV UTF-8)" +
-                    (aiOptedIn() ? ", or let the PaintOmics AI agent convert it. " + AI_EXPLAINER : "."),
+                    "Re-save it as UTF-8 (in Excel: Save As → CSV UTF-8), or let the PaintOmics AI agent convert it. " + AI_EXPLAINER,
                     aiActions(input, file, fieldName));
                 return;
             }
@@ -678,7 +651,7 @@
             bar.appendChild(fix);
         }
 
-        if (fixable.length !== entries.length && aiOptedIn()) {
+        if (fixable.length !== entries.length) {
             var convert = el("button", "pa-format-button pa-format-primary");
             convert.type = "button";
             if (typeof window.getAIMark === "function") {

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
@@ -44,7 +44,7 @@
     /* What the AI actually does, in the user's terms. People are right to
        be wary of "AI will fix your data"; saying that it writes a script,
        runs it locally, and shows both is what makes it trustworthy. */
-    var AI_EXPLAINER = "PaintOmics AI reads the file, writes a short conversion script, runs it here in your browser, and checks the result against the format PaintOmics needs. Your data never leaves this computer, and you see the script and the result before anything is used.";
+    var AI_EXPLAINER = "PaintOmics AI can convert it here in your browser: it reads the file's structure, writes a short script, runs it locally and checks the result. You see the script, the tables and what it left out before anything is used.";
 
     function el(tag, className, text) {
         var node = document.createElement(tag);
@@ -160,7 +160,10 @@
      * around any of those. Each grew the card and left every sibling in place.
      */
     function hostFor(input) {
-        var component = cardComponentFor(input);
+        return hostForComponent(cardComponentFor(input));
+    }
+
+    function hostForComponent(component) {
         if (!component) return null;
 
         var existing = component.down && component.down("[itemId=paFormatHost]");
@@ -192,7 +195,10 @@
      * message would clip the new one.
      */
     function syncCardHeight(input) {
-        var component = cardComponentFor(input);
+        syncCardHeightFor(cardComponentFor(input));
+    }
+
+    function syncCardHeightFor(component) {
         if (!component || component.__paBaseHeight === undefined) return;
         var host = component.down && component.down("[itemId=paFormatHost]");
         if (!host || !host.getEl()) return;
@@ -264,6 +270,25 @@
      * Rendering
      * ------------------------------------------------------------------ */
 
+    /*
+     * The resting state of a card that has no file yet. It is the first thing
+     * the AI says on this form, so it says the one thing that matters -- any
+     * file will do -- and nothing else. No tint, no border: a promise is not a
+     * verdict.
+     */
+    function renderIdle(strip) {
+        strip.className = "pa-format-strip pa-format-idle";
+        strip.innerHTML = "";
+        var icon = el("span", "pa-format-icon pa-format-icon-ai");
+        icon.innerHTML = typeof window.getAIMark === "function" ? window.getAIMark() : "✦";
+        strip.appendChild(icon);
+        var text = el("span", "pa-format-text");
+        text.appendChild(document.createTextNode("Any spreadsheet or export works. If it is not already in PaintOmics’ format, "));
+        text.appendChild(el("b", null, "PaintOmics AI"));
+        text.appendChild(document.createTextNode(" converts it here, in your browser."));
+        strip.appendChild(text);
+    }
+
     function renderOk(strip, summary, partial, input) {
         strip.className = "pa-format-strip pa-format-ok";
         strip.innerHTML = "";
@@ -273,12 +298,51 @@
             bits.push("IDs like " + summary.idSample.slice(0, 3).join(", "));
         }
         strip.appendChild(el("span", "pa-format-icon", "✓"));
-        strip.appendChild(el("span", "pa-format-text",
-            (strip.__omic ? strip.__omic + ": " : "") + bits.join(" · ")));
+        var body = el("div", "pa-format-body");
+        var line = el("div", "pa-format-text",
+            (strip.__omic ? strip.__omic + ": " : "") + bits.join(" · "));
         if (partial) {
-            strip.appendChild(el("span", "pa-format-note",
+            line.appendChild(el("span", "pa-format-note",
                 " (checked the first " + Math.round(PARTIAL_CHECK_BYTES / 1048576) + " MB)"));
         }
+        body.appendChild(line);
+
+        /*
+         * Provenance. A file the AI produced looks exactly like one the user
+         * made, and the card would otherwise forget that within a second of
+         * the sheet closing. Saying which table came from which upload is what
+         * lets the user -- and a reviewer reading their methods -- know.
+         */
+        var converted = strip.__converted;
+        if (converted) {
+            strip.classList.add("pa-format-converted");
+            var prov = el("div", "pa-format-provenance");
+            var mark = el("span", "pa-format-provenance-mark");
+            mark.innerHTML = typeof window.getAIMark === "function" ? window.getAIMark() : "✦";
+            prov.appendChild(mark);
+            var what = el("span", "pa-format-provenance-text");
+            what.appendChild(document.createTextNode("Converted by PaintOmics AI from "));
+            what.appendChild(el("b", null, converted.from));
+            var extras = [];
+            if (converted.label) extras.push("table “" + converted.label + "”");
+            if (converted.relevant) extras.push("relevant-features list attached");
+            if (extras.length) what.appendChild(document.createTextNode(" (" + extras.join(", ") + ")"));
+            what.appendChild(document.createTextNode("."));
+            if (converted.original) {
+                // Inline, at the end of the sentence: a control on its own line
+                // under a one-line note reads as a second message.
+                var again = el("button", "pa-format-linkbtn", "Convert again");
+                again.type = "button";
+                again.title = "Reopen the AI conversion for " + converted.from;
+                again.addEventListener("click", function () {
+                    requestAgent(input, converted.original, converted.fieldName || strip.__field);
+                });
+                what.appendChild(again);
+            }
+            prov.appendChild(what);
+            body.appendChild(prov);
+        }
+        strip.appendChild(body);
         if (input) { setCardState(input, "ok"); syncCardHeight(input); }
     }
 
@@ -408,7 +472,13 @@
         var strip = hostFor(input);
         if (!strip) return;
         strip.__input = input;
+        strip.__field = fieldName;
         strip.__omic = omicNameFor(fieldName);
+        // Set by the conversion sheet just before it hands the table over;
+        // consumed here so a file the user picks by hand afterwards carries no
+        // stale provenance.
+        strip.__converted = input.__paConverted || null;
+        input.__paConverted = null;
         strip.className = "pa-format-strip pa-format-busy";
         strip.textContent = "Checking " + file.name + "…";
 
@@ -719,6 +789,86 @@
      */
     // Capture phase: ExtJS re-dispatches and sometimes stops change events on
     // its own wrappers, and capture runs before any of that.
+    /*
+     * Every omic card starts with the AI's standing offer in its strip, so the
+     * upload step reads as "bring any file" before a file is picked rather
+     * than only after one fails. Cards are created by ExtJS on drag or on the
+     * plus button, so they are found by watching the DOM; the strip is added
+     * only once the card has been laid out, because hostFor records the
+     * card's height as the base to grow from and a card measured before its
+     * first layout is 0px tall.
+     */
+    function primeCard(cardEl) {
+        if (!cardEl || cardEl.__paPrimed || !window.Ext || !Ext.getCmp) return;
+        var component = Ext.getCmp(cardEl.id);
+        if (!component || !component.query) return;
+        var hasValuesField = component.query("filefield").some(function (f) {
+            return VALUES_FIELD.test(f.name || "");
+        });
+        if (!hasValuesField) return;
+        cardEl.__paPrimed = true;
+        var prime = function () {
+            if (component.isDestroyed || component.down("[itemId=paFormatHost]")) return;
+            var strip = hostForComponent(component);
+            if (!strip) return;
+            renderIdle(strip);
+            syncCardHeightFor(component);
+        };
+        if (component.rendered && component.getHeight() > 100) prime();
+        else component.on("afterlayout", prime, null, { single: true, delay: 30 });
+    }
+
+    function primeCardsIn(root) {
+        if (!root || root.nodeType !== 1) return;
+        if (root.matches && root.matches(".omicbox")) primeCard(root);
+        if (root.querySelectorAll) {
+            root.querySelectorAll(".omicbox").forEach(primeCard);
+        }
+    }
+
+    if (typeof MutationObserver === "function") {
+        var observer = new MutationObserver(function (records) {
+            var found = [];
+            records.forEach(function (r) {
+                r.addedNodes.forEach(function (n) {
+                    if (n.nodeType !== 1) return;
+                    if (n.matches && n.matches(".omicbox")) found.push(n);
+                    if (n.querySelectorAll) n.querySelectorAll(".omicbox").forEach(function (c) { found.push(c); });
+                });
+            });
+            if (!found.length) return;
+            requestAnimationFrame(function () {
+                found.forEach(function (c) {
+                    try { primeCard(c); }
+                    catch (e) { if (window.console && console.warn) console.warn("[inputformat] prime failed", e); }
+                });
+            });
+        });
+        observer.observe(document.body || document.documentElement, { childList: true, subtree: true });
+        primeCardsIn(document.body);
+    }
+
+    /* The Section 3 callout names where the structure goes; the name comes
+       from the same endpoint the AI interpretation consent uses. */
+    function fillProviderName() {
+        var slot = document.getElementById("paUploadAiProvider");
+        if (!slot || slot.dataset.filled) return;
+        slot.dataset.filled = "1";
+        fetch("ai_provider", { credentials: "same-origin" })
+            .then(function (r) { return r.json(); })
+            .then(function (p) {
+                if (!p || !p.success || !p.operator) return;
+                slot.textContent = p.operator + (p.host ? " (" + p.host + ")" : "");
+            })
+            .catch(function () { /* the static text stands */ });
+    }
+    document.addEventListener("DOMContentLoaded", fillProviderName);
+    setTimeout(fillProviderName, 1500);
+    if (typeof MutationObserver === "function") {
+        new MutationObserver(function () { fillProviderName(); })
+            .observe(document.body || document.documentElement, { childList: true, subtree: true });
+    }
+
     document.addEventListener("change", function (event) {
         var input = event.target;
         if (!input || input.type !== "file" || !input.files || !input.files.length) return;

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
@@ -881,27 +881,6 @@
         primeCardsIn(document.body);
     }
 
-    /* The Section 3 callout names where the structure goes; the name comes
-       from the same endpoint the AI interpretation consent uses. */
-    function fillProviderName() {
-        var slot = document.getElementById("paUploadAiProvider");
-        if (!slot || slot.dataset.filled) return;
-        slot.dataset.filled = "1";
-        fetch("ai_provider", { credentials: "same-origin" })
-            .then(function (r) { return r.json(); })
-            .then(function (p) {
-                if (!p || !p.success || !p.operator) return;
-                slot.textContent = p.operator + (p.host ? " (" + p.host + ")" : "");
-            })
-            .catch(function () { /* the static text stands */ });
-    }
-    document.addEventListener("DOMContentLoaded", fillProviderName);
-    setTimeout(fillProviderName, 1500);
-    if (typeof MutationObserver === "function") {
-        new MutationObserver(function () { fillProviderName(); })
-            .observe(document.body || document.documentElement, { childList: true, subtree: true });
-    }
-
     document.addEventListener("change", function (event) {
         var input = event.target;
         if (!input || input.type !== "file" || !input.files || !input.files.length) return;

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -1685,7 +1685,125 @@ function PA_Step1JobView() {
 							xtype: "container", flex: 1, layout: "anchor",
 							items: [
 								{
+									/* Three things were wrong here, and the first hid the other two.
+									
+									   The placeholder read: e.g., "RNA-seq wildtype vs knockout mouse
+									   liver, n=3 per group". ExtJS writes emptyText into a
+									   placeholder="..." attribute, so the first embedded double quote
+									   closed the attribute and everything after it was parsed as stray
+									   markup -- on screen the hint was "e.g.," and nothing more. The
+									   example is the useful half of a placeholder and nobody had ever
+									   seen it. Curly quotes carry the same meaning through intact.
+									
+									   Then the label: labelWidth 150, right-aligned, inside a column
+									   already narrowed by the callout beside it -- which left roughly
+									   250px to compose prose in. It goes on top now and the input takes
+									   the full column.
+									
+									   And 90px is three lines for free text describing an experiment.
+									   It opens taller, and .po-exp-design lets it be dragged further.
+
+									   96 now, not 132, plus growExpDesignToFit below. This field
+									   is the tallest thing in the callout, so it alone sets the
+									   section's height -- the left column runs out of content well
+									   above it -- and for the whole time the form sits unfilled it
+									   is 132px of empty box.
+
+									   Sizing it to hold a draft was the obvious alternative and it
+									   does not work: measured, a real draft off the STATegra
+									   headers was 510 characters and wanted 153px, so 132 was
+									   already too short for the case it was tall for. Picking a
+									   height that fits the longest plausible draft would make the
+									   idle form taller still, to no benefit.
+
+									   So: short while empty -- 96 is the two-line placeholder plus
+									   a line -- and grown to fit the moment there is something to
+									   fit, which is the only moment the height is worth paying.
+									   Dragging it still works; growing sets a height, not a cap. */
+									xtype: "textarea", fieldLabel: "Experiment design (optional)",
+									name: 'experimentDesign',
+									labelAlign: 'top', anchor: '100%', height: 120,
+									cls: 'po-exp-design',
+									emptyText: 'e.g. RNA-seq of wildtype vs knockout mouse liver, 3 replicates per group, sampled at 24 h',
+									maxLength: 2000,
+									listeners: {
+										/* The one free-text field on the form also names the job:
+										   its first line, cut to the 100 characters the server keeps,
+										   goes into the hidden jobDescription field. On change rather
+										   than on submit so whatever gathers the form's values -- the
+										   submit, a draft, an example load -- finds it already set. */
+										change: function(field, value) {
+											var hidden = Ext.ComponentQuery.query('hiddenfield[name=jobDescription]')[0];
+											if (!hidden) return;
+											var firstLine = String(value || '').split(/\r?\n/)
+												.map(function(l) { return l.trim(); })
+												.filter(Boolean)[0] || '';
+											hidden.setValue(firstLine.slice(0, 100));
+										}
+									}
+								},
+								/* A blank box asking a user to describe their own design in
+								   prose is the least-filled field on this form, and the design
+								   is already written down in the header row of the file they
+								   are about to upload. This reads those headers in the browser
+								   and asks the model to turn them into the sentence.
+
+								   Gated twice on purpose. The button is disabled until the
+								   consent box is ticked, because pressing it sends the column
+								   names outward -- earlier than Run, which is the moment the
+								   rest of the form treats as the boundary -- and the request
+								   carries an explicit consent flag that the servlet checks, so
+								   the guarantee does not rest on a disabled attribute.
+
+								   The hint moved in here, from its own box above. It was two
+								   full-width lines followed by a button on a third row, under a
+								   field whose left column had already run out of content -- the
+								   three tallest rows in the callout were the three carrying the
+								   least. Beside the button it is one row, and it reads as a
+								   caption for the control rather than a second paragraph.
+								   Shortened to match: "Describe the comparison your data
+								   represents. The interpretation uses it to say which direction
+								   of change means what." said the same thing in two sentences,
+								   and the placeholder in the field above already shows the
+								   shape of an answer. */
+								{
+									xtype: "box", cls: 'po-exp-design-draft',
+									html: '<button type="button" class="button btn-secondary btn-small po-exp-design-draft-btn" ' +
+									      'id="expDesignDraftBtn" disabled>' + getAIMark() + ' Draft this for me</button>' +
+									      '<span class="po-exp-design-hint">Names the job in your list and tells the interpretation which direction of change means what.</span>' +
+									      '<span class="po-exp-design-draft-note" id="expDesignDraftNote"></span>',
+									listeners: {
+										afterrender: function() {
+											var box = this;
+											/* The consent checkbox and the omic panels are built by
+											   other parts of this view, so the wiring waits a tick
+											   for the form to finish rendering rather than reaching
+											   up through a parent that may not exist yet. */
+											setTimeout(function() { initExpDesignDraft(box); }, 200);
+										}
+									}
+								}
+							]
+						}, {
+							/* The decision column. One right column for the whole form:
+							   400px here, the same 400px for the "Works with" column under
+							   Section 3, and the Help panel below starts on the same x (422
+							   wide, because it runs to the card edge where this column
+							   stops 22px short of it inside the panel's padding). Measured:
+							   all three start at 1185px on a 1867px viewport.
+
+							   The columns swapped sides on 2026-08-21: the experiment
+							   design -- the thing the user does -- is the wide field on the
+							   left, and the switch, one line, three pills and the privacy
+							   link -- the thing the user decides -- sit here, where a
+							   settings control belongs. */
+							xtype: "container", width: 400, margin: '0 0 0 32', layout: "anchor",
+							items: [
+								{
 									xtype: 'checkboxfield',
+									/* Label first, switch at the row's end: the settings-row shape,
+									   where the eye reads the name and finds the control at the edge. */
+									boxLabelAlign: 'before',
 									/* Both colours were written inline, which put them out of reach of
 									   dark.css -- an inline style beats a stylesheet -- so this
 									   sentence stayed #C44500 on the dark surface and measured 3.29:1
@@ -1802,180 +1920,14 @@ function PA_Step1JobView() {
 									}
 								},
 								{
+									/* What the switch turns on, in one line and three tokens. The
+									   paragraph this replaces listed the agent's phases in prose; as
+									   pills they scan, and the full account -- what is sent, where,
+									   which fields -- is the Data privacy notice the link opens. */
 									xtype: "box",
-									/* This paragraph was written in the marketing register -- "revolutionary",
-									   "breathtaking computational power", "Next-Generation Agentic AI
-									   Swarm", "the world's most powerful Large Language Models". It sits
-									   directly above a consent checkbox, which is the one place in this
-									   application where the careful voice is not optional: someone
-									   deciding whether to send their data somewhere needs to know what
-									   happens to it, not how remarkable it is.
-
-									   It was also wrong. It described a fleet of agents dynamically
-									   selecting among frontier models; pipeline.py makes sequential
-									   calls to the one model the server is configured for, with a retry
-									   loop. #aiProviderInline is filled in from /ai_provider once that
-									   answers, so the recipient is named here rather than described as
-									   "external". */
-									/* "asks a large language model to explain" undersold what
-									   actually runs, and a consent notice is the wrong place to be
-									   vague about that. src/classes/AIInterpret/pipeline.py runs six
-									   phases - triage, search planning, literature retrieval,
-									   interpretation, synthesis, verification - and along the way it
-									   plans its own searches, calls tools against the job's own data
-									   (get_gene_timecourse, get_pathway_genes, compare_genes), and
-									   spawns sub-agents: one per search, and one per citation to
-									   check it. Someone deciding whether to send their data is
-									   entitled to know it is an agent doing that and not a single
-									   prompt. The wording below names the parts that exist in the
-									   code and nothing more. */
-									/* Size, colour, leading and margin were an inline `style` here,
-									   which no stylesheet can reach: the paragraph could not take the
-									   AI type scale, and dark.css had to chase its colour with an
-									   attribute selector. Now .ai-intro-copy in ai-interpret.css. */
-									/* Seven lines, then four, now two. This paragraph exists to
-									   introduce two controls; it had grown into the largest block
-									   of text on a page whose subject is the user's data.
-
-									   What went, in order. The AgentEvolve sentence: a
-									   benchmarking framework is a fact about how the feature was
-									   built, not one the reader needs to tick or leave the box.
-									   The enumeration of the agent's phases, compressed to the
-									   verbs that distinguish it from a single prompt. And now
-									   #aiProviderInline, which is the interesting one.
-
-									   That span printed "This server sends the data to a gateway
-									   operated by IIIA-CSIC (the Artificial Intelligence Research
-									   Institute of the Spanish National Research Council), on
-									   hardware in Spain" -- two of the four lines, and a
-									   restatement of the sentence in the checkbox directly below
-									   it, which already says the data goes "to IIIA-CSIC
-									   (llm.iiia.es)". The recipient is still named, on the
-									   control where the decision is actually made and where the
-									   design system requires it, and the (i) notice still gives
-									   the full operator, the country and every field that leaves
-									   the server. Saying it twice bought nothing and cost half
-									   the callout's height.
-
-									   fillAIProvenance guards each placeholder with `if (el)`,
-									   so it keeps working with this one absent. */
-									html: '<p class="ai-intro-copy">' +
-										'The <b>PaintOmics AI agent</b> drafts the write-up of your results: it triages your top-ranked ' +
-										'pathways, searches PubMed and Europe PMC, checks the patterns against your uploaded ' +
-										'values, and verifies every citation. Check its draft before you use it. ' +
-										'<a href="javascript:void(0)" class="ai-gdpr-info-link" id="aiGdprInfoIcon" title="Data privacy &amp; compliance \u2014 what is sent, and where"><i class="fa fa-info-circle"></i> Data privacy</a>' +
-										'</p>'
-								}
-							]
-						}, {
-							/* One right column for the whole form. 400px here, the same
-							   400px for the "Works with" column under Section 3, and the
-							   Help panel below starts on the same x (422 wide, because it
-							   runs to the card edge where this column stops 22px short of
-							   it inside the panel's padding). Measured: all three start at
-							   1185px on a 1867px viewport. A flex share put this one at
-							   1077 and the Help panel at 1267 -- three right edges for one
-							   page. */
-							xtype: "container", width: 400, margin: '0 0 0 32', layout: "anchor",
-							items: [
-								{
-									/* Three things were wrong here, and the first hid the other two.
-									
-									   The placeholder read: e.g., "RNA-seq wildtype vs knockout mouse
-									   liver, n=3 per group". ExtJS writes emptyText into a
-									   placeholder="..." attribute, so the first embedded double quote
-									   closed the attribute and everything after it was parsed as stray
-									   markup -- on screen the hint was "e.g.," and nothing more. The
-									   example is the useful half of a placeholder and nobody had ever
-									   seen it. Curly quotes carry the same meaning through intact.
-									
-									   Then the label: labelWidth 150, right-aligned, inside a column
-									   already narrowed by the callout beside it -- which left roughly
-									   250px to compose prose in. It goes on top now and the input takes
-									   the full column.
-									
-									   And 90px is three lines for free text describing an experiment.
-									   It opens taller, and .po-exp-design lets it be dragged further.
-
-									   96 now, not 132, plus growExpDesignToFit below. This field
-									   is the tallest thing in the callout, so it alone sets the
-									   section's height -- the left column runs out of content well
-									   above it -- and for the whole time the form sits unfilled it
-									   is 132px of empty box.
-
-									   Sizing it to hold a draft was the obvious alternative and it
-									   does not work: measured, a real draft off the STATegra
-									   headers was 510 characters and wanted 153px, so 132 was
-									   already too short for the case it was tall for. Picking a
-									   height that fits the longest plausible draft would make the
-									   idle form taller still, to no benefit.
-
-									   So: short while empty -- 96 is the two-line placeholder plus
-									   a line -- and grown to fit the moment there is something to
-									   fit, which is the only moment the height is worth paying.
-									   Dragging it still works; growing sets a height, not a cap. */
-									xtype: "textarea", fieldLabel: "Experiment design (optional)",
-									name: 'experimentDesign',
-									labelAlign: 'top', anchor: '100%', height: 120,
-									cls: 'po-exp-design',
-									emptyText: 'e.g. RNA-seq of wildtype vs knockout mouse liver, 3 replicates per group, sampled at 24 h',
-									maxLength: 2000,
-									listeners: {
-										/* The one free-text field on the form also names the job:
-										   its first line, cut to the 100 characters the server keeps,
-										   goes into the hidden jobDescription field. On change rather
-										   than on submit so whatever gathers the form's values -- the
-										   submit, a draft, an example load -- finds it already set. */
-										change: function(field, value) {
-											var hidden = Ext.ComponentQuery.query('hiddenfield[name=jobDescription]')[0];
-											if (!hidden) return;
-											var firstLine = String(value || '').split(/\r?\n/)
-												.map(function(l) { return l.trim(); })
-												.filter(Boolean)[0] || '';
-											hidden.setValue(firstLine.slice(0, 100));
-										}
-									}
-								},
-								/* A blank box asking a user to describe their own design in
-								   prose is the least-filled field on this form, and the design
-								   is already written down in the header row of the file they
-								   are about to upload. This reads those headers in the browser
-								   and asks the model to turn them into the sentence.
-
-								   Gated twice on purpose. The button is disabled until the
-								   consent box is ticked, because pressing it sends the column
-								   names outward -- earlier than Run, which is the moment the
-								   rest of the form treats as the boundary -- and the request
-								   carries an explicit consent flag that the servlet checks, so
-								   the guarantee does not rest on a disabled attribute.
-
-								   The hint moved in here, from its own box above. It was two
-								   full-width lines followed by a button on a third row, under a
-								   field whose left column had already run out of content -- the
-								   three tallest rows in the callout were the three carrying the
-								   least. Beside the button it is one row, and it reads as a
-								   caption for the control rather than a second paragraph.
-								   Shortened to match: "Describe the comparison your data
-								   represents. The interpretation uses it to say which direction
-								   of change means what." said the same thing in two sentences,
-								   and the placeholder in the field above already shows the
-								   shape of an answer. */
-								{
-									xtype: "box", cls: 'po-exp-design-draft',
-									html: '<button type="button" class="button btn-secondary btn-small po-exp-design-draft-btn" ' +
-									      'id="expDesignDraftBtn" disabled>' + getAIMark() + ' Draft this for me</button>' +
-									      '<span class="po-exp-design-hint">Names the job in your list and tells the interpretation which direction of change means what.</span>' +
-									      '<span class="po-exp-design-draft-note" id="expDesignDraftNote"></span>',
-									listeners: {
-										afterrender: function() {
-											var box = this;
-											/* The consent checkbox and the omic panels are built by
-											   other parts of this view, so the wiring waits a tick
-											   for the form to finish rendering rather than reaching
-											   up through a parent that may not exist yet. */
-											setTimeout(function() { initExpDesignDraft(box); }, 200);
-										}
-									}
+									html: '<p class="ai-intro-copy po-ai-oneliner">A cited draft of what your results mean, written by the <b>PaintOmics AI agent</b> for you to check.</p>' +
+										'<ul class="po-pill-list po-ai-facts"><li>PubMed &amp; Europe PMC</li><li>Every citation verified</li><li>Reads your uploaded values</li></ul>' +
+										'<p class="po-ai-privacy"><a href="javascript:void(0)" class="ai-gdpr-info-link" id="aiGdprInfoIcon" title="Data privacy &amp; compliance \u2014 what is sent, and where">Data privacy</a></p>'
 								}
 							]
 						}]
@@ -2019,7 +1971,7 @@ function PA_Step1JobView() {
 							'</div>' +
 							'<div class="po-upload-ai-aside">' +
 								'<div class="po-upload-ai-aside-title">Works with</div>' +
-								'<ul class="po-upload-ai-formats">' +
+								'<ul class="po-pill-list po-upload-ai-formats">' +
 									'<li>DESeq2</li><li>edgeR</li><li>limma</li><li>MaxQuant</li><li>Spectronaut</li><li>DIA-NN</li>' +
 									'<li>MetaboLights MAF</li><li>Excel workbooks</li><li>CSV / TSV</li>' +
 								'</ul>' +

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -1945,16 +1945,16 @@ function PA_Step1JobView() {
 						   upload step accepts files as they come out of the tools
 						   people use, and the AI conversion is how.
 
-						   A plain row, not a second blue panel: the panel above is the
-						   one decision on this form (send results out, or not), and a
-						   second panel with a second box read as that decision asked
-						   twice. Conversion needs no box -- pressing Convert on a file
-						   is the act -- so this row only says what happens, in the
+						   On the same blue panel as the Section 2 callout (the owner
+						   asked for it back once the row no longer carried a second
+						   checkbox): the two AI surfaces on the form share one surface.
+						   Conversion needs no box -- pressing Convert on a file is the
+						   act -- so this panel only says what happens, in the
 						   interpretation's own type (.ai-intro-copy), on the same two
 						   columns: sentence left, the formats it handles right (styles
 						   in inputformat.css). */
 						xtype: "box",
-						cls: "po-upload-ai",
+						cls: "po-ai-section-body po-upload-ai",
 						html: '<div class="po-upload-ai-grid">' +
 							'<div class="po-upload-ai-text">' +
 								/* Two paragraphs, not one with a bold lead-in: a lone

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -1580,15 +1580,15 @@ function PA_Step1JobView() {
 						{
 							xtype: "container", layout: { type: "vbox", align: "stretch" }, flex: 0.5, items: [
 							{
-								xtype: "textfield",
-								fieldLabel: "Enter a job description",
-								allowBlank: true,
-								name: 'jobDescription',
-								style: "margin: 10px 26px 10px 20px;",
-								labelWidth: 150,
-								width: 650,
-								flex: 0,
-								maxLength: 100
+								/* The job's name, which the server takes from this field
+								   (PathwayAcquisitionServlet: setName(jobDescription[:100])).
+								   It was a visible "Enter a job description" box beside the
+								   organism, one free-text field above another that asks for the
+								   same sentence -- the experiment design below. Now hidden and
+								   filled from that design's first line as it is typed, so the
+								   form asks once and the job list still gets a name. */
+								xtype: "hiddenfield",
+								name: 'jobDescription'
 							}
 							]
 						}
@@ -1760,12 +1760,14 @@ function PA_Step1JobView() {
 									   with --pa-ai-consent-warn -- a token it already declared for
 									   exactly this and had no way to apply. Same fix, same reason, as
 									   .formMessage. */
-									/* "sends your results to X", not "your pathway results and the
-									   values of the matched features to X": the long form wrapped the
-									   label to three lines and buried the recipient. The enumeration
-									   of exactly which fields leave the server belongs to - and stays
-									   in - the (i) notice this label links to. */
-									boxLabel: 'Enable AI pathway interpretation (<span class="ai-consent-warn">sends your results to <span id="aiProviderName">an external AI service</span></span>) ' +
+									/* The label used to carry "(sends your results to IIIA-CSIC
+									   (llm.iiia.es))". Trimmed to the verb on the owner's call
+									   (2026-08-21): the gateway is operated by CSIC, as is the host,
+									   and the statement of what leaves and who receives it -- the
+									   recipient, the operator, the country, every field -- stays in
+									   the (i) notice this label links to, one click away. Keep the
+									   icon: it is the only remaining way to that notice from here. */
+									boxLabel: 'Enable AI pathway interpretation ' +
 										'<i class="fa fa-exclamation-circle ai-gdpr-info-icon" id="aiGdprInfoIcon" title="Data privacy &amp; compliance \u2014 click to learn what data is sent"></i>',
 									name: 'aiConsent', inputValue: 'true', uncheckedValue: 'false',
 									/* Off everywhere but a local instance -- a pre-ticked consent
@@ -1906,7 +1908,22 @@ function PA_Step1JobView() {
 									labelAlign: 'top', anchor: '100%', height: 96,
 									cls: 'po-exp-design',
 									emptyText: 'e.g. RNA-seq of wildtype vs knockout mouse liver, 3 replicates per group, sampled at 24 h',
-									maxLength: 2000
+									maxLength: 2000,
+									listeners: {
+										/* The one free-text field on the form also names the job:
+										   its first line, cut to the 100 characters the server keeps,
+										   goes into the hidden jobDescription field. On change rather
+										   than on submit so whatever gathers the form's values -- the
+										   submit, a draft, an example load -- finds it already set. */
+										change: function(field, value) {
+											var hidden = Ext.ComponentQuery.query('hiddenfield[name=jobDescription]')[0];
+											if (!hidden) return;
+											var firstLine = String(value || '').split(/\r?\n/)
+												.map(function(l) { return l.trim(); })
+												.filter(Boolean)[0] || '';
+											hidden.setValue(firstLine.slice(0, 100));
+										}
+									}
 								},
 								/* A blank box asking a user to describe their own design in
 								   prose is the least-filled field on this form, and the design
@@ -1936,7 +1953,7 @@ function PA_Step1JobView() {
 									xtype: "box", cls: 'po-exp-design-draft',
 									html: '<button type="button" class="button btn-secondary btn-small po-exp-design-draft-btn" ' +
 									      'id="expDesignDraftBtn" disabled>' + getAIMark() + ' Draft this for me</button>' +
-									      '<span class="po-exp-design-hint">Tells the interpretation which direction of change means what.</span>' +
+									      '<span class="po-exp-design-hint">Names the job in your list and tells the interpretation which direction of change means what.</span>' +
 									      '<span class="po-exp-design-draft-note" id="expDesignDraftNote"></span>',
 									listeners: {
 										afterrender: function() {
@@ -1990,7 +2007,10 @@ function PA_Step1JobView() {
 								   this row on the rail Section 2's Ext checkbox row keeps. */
 								'<div class="po-upload-ai-consent">' +
 									'<input type="checkbox" id="paUploadAiOptIn" checked>' +
-									'<label for="paUploadAiOptIn">Convert with the PaintOmics AI agent when a file needs it (<span class="ai-consent-warn">sends only the file’s structure to <span id="paUploadAiProvider">an external AI service</span></span>)</label>' +
+									/* No recipient clause here either (see the Section 2 label):
+									   the sheet's "What the agent sees" card shows exactly what is
+									   sent, at the moment it is sent, which is the better place. */
+									'<label for="paUploadAiOptIn">Convert with the PaintOmics AI agent when a file needs it</label>' +
 								'</div>' +
 							'</div>' +
 							'<div class="po-upload-ai-aside">' +

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -1382,7 +1382,7 @@ function PA_Step1JobView() {
 								   worth less without it. */
 								'<div class="po-hero-ai-highlight">' +
 									'<div class="po-hero-ai-head"><span class="po-ai-icon">' + getAIMark() + '</span><strong>AI-powered pathway interpretation</strong></div>' +
-									'<p>An <b>agent</b> writes an interpretation of your ranked pathways &mdash; a draft, for you to check.</p>' +
+									'<p>The <b>PaintOmics AI agent</b> writes an interpretation of your ranked pathways &mdash; a draft, for you to check.</p>' +
 									'<ul class="po-hero-ai-does">' +
 										'<li>queries your values</li>' +
 										'<li>runs its own literature searches</li>' +
@@ -1743,7 +1743,7 @@ function PA_Step1JobView() {
 									   fillAIProvenance guards each placeholder with `if (el)`,
 									   so it keeps working with this one absent. */
 									html: '<p class="ai-intro-copy">' +
-										'An <b>agent</b> drafts the write-up of your results: it triages your top-ranked ' +
+										'The <b>PaintOmics AI agent</b> drafts the write-up of your results: it triages your top-ranked ' +
 										'pathways, searches PubMed and Europe PMC, checks the patterns against your uploaded ' +
 										'values, and verifies every citation. Check its draft before you use it.' +
 										'</p>'
@@ -1974,21 +1974,32 @@ function PA_Step1JobView() {
 						   said (styles in inputformat.css). */
 						xtype: "box",
 						cls: "po-ai-section-body po-upload-ai",
+						/* Same skeleton as Section 2, on purpose: one sentence in the
+						   interpretation's own type (.ai-intro-copy), then the consent
+						   control that names what leaves and to whom; the right column
+						   holds what the prose would otherwise have to list. The box is
+						   ticked by default because ticking it sends nothing -- a file
+						   only goes to the model when the user presses Convert on it;
+						   unticking removes that offer from every card. */
 						html: '<div class="po-upload-ai-grid">' +
 							'<div class="po-upload-ai-text">' +
-								'<div class="po-hero-ai-head"><span class="po-upload-ai-icon">' + getAIMark() + '</span><strong>Bring your files as they are</strong></div>' +
-								'<p>A DESeq2 or edgeR table, a MaxQuant or Spectronaut export, a MetaboLights MAF, a workbook with several sheets: pick it and PaintOmics checks it on the spot. If it is not in PaintOmics’ format, <b>PaintOmics AI</b> converts it here, in your browser.</p>' +
-								'<ul class="po-upload-ai-does">' +
-									'<li>reads the file’s structure</li>' +
-									'<li>writes a short script and runs it in your browser</li>' +
-									'<li>checks the result against PaintOmics’ exact format</li>' +
-									'<li>shows you the script, the tables and what it left out before anything is used</li>' +
+								'<p class="ai-intro-copy"><b>Bring your files as they are.</b> Each file is checked the moment you pick it; if it is not in PaintOmics’ format, the <b>PaintOmics AI agent</b> writes a short script, runs it in your browser and shows you the result before anything is used.</p>' +
+								/* Input THEN label, as siblings: the alignment overlay judges a
+								   label led by a checkbox from the box's edge only in that
+								   shape (AlignmentGuides.js ~331), which is also what puts
+								   this row on the rail Section 2's Ext checkbox row keeps. */
+								'<div class="po-upload-ai-consent">' +
+									'<input type="checkbox" id="paUploadAiOptIn" checked>' +
+									'<label for="paUploadAiOptIn">Convert with the PaintOmics AI agent when a file needs it (<span class="ai-consent-warn">sends only the file’s structure to <span id="paUploadAiProvider">an external AI service</span></span>)</label>' +
+								'</div>' +
+							'</div>' +
+							'<div class="po-upload-ai-aside">' +
+								'<div class="po-upload-ai-aside-title">Works with</div>' +
+								'<ul class="po-upload-ai-formats">' +
+									'<li>DESeq2</li><li>edgeR</li><li>limma</li><li>MaxQuant</li><li>Spectronaut</li><li>DIA-NN</li>' +
+									'<li>MetaboLights MAF</li><li>Excel workbooks</li><li>CSV / TSV</li>' +
 								'</ul>' +
 							'</div>' +
-							'<aside class="po-upload-ai-aside">' +
-								'<div class="po-upload-ai-aside-title">What leaves your computer</div>' +
-								'<p>Only the file’s structure: column names, counts and a few example rows, sent to <span id="paUploadAiProvider">the AI gateway</span>. The measurements never leave this browser.</p>' +
-							'</aside>' +
 						'</div>'
 					},
 					{
@@ -2048,7 +2059,7 @@ function PA_Step1JobView() {
 							flex: 1,
 							layout: {type: 'vbox',align: "stretch"},
 							items: [
-								{xtype: 'box',html: '<div class="content"><h5><i class="fa fa-info-circle"></i> Help</h5><p>Drag <i>omics</i> from <b>Available omics</b> to <b>Selected omics</b>, or click the <i class="fa fa-plus-circle"></i> button.</p><p>Remove any you do not need with <span class="po-nowrap"><i class="fa fa-trash"></i>.</span></p><p>Pick your files as they are: each one is checked the moment you choose it, and if it is not in PaintOmics’ format, <b>PaintOmics AI</b> converts it in your browser.</p><p>When you are done, click <b>Run PaintOmics</b> in the top-right corner.</p></div>'}
+								{xtype: 'box',html: '<div class="content"><h5><i class="fa fa-info-circle"></i> Help</h5><p>Drag <i>omics</i> from <b>Available omics</b> to <b>Selected omics</b>, or click the <i class="fa fa-plus-circle"></i> button.</p><p>Remove any you do not need with <span class="po-nowrap"><i class="fa fa-trash"></i>.</span></p><p>Files are checked as you pick them; the <b>PaintOmics AI agent</b> converts any that are not in PaintOmics’ format.</p><p>When you are done, click <b>Run PaintOmics</b> in the top-right corner.</p></div>'}
 							]
 						}]
 					}					

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -1801,9 +1801,6 @@ function PA_Step1JobView() {
 							items: [
 								{
 									xtype: 'checkboxfield',
-									/* Label first, switch at the row's end: the settings-row shape,
-									   where the eye reads the name and finds the control at the edge. */
-									boxLabelAlign: 'before',
 									/* Both colours were written inline, which put them out of reach of
 									   dark.css -- an inline style beats a stylesheet -- so this
 									   sentence stayed #C44500 on the dark surface and measured 3.29:1
@@ -1820,10 +1817,10 @@ function PA_Step1JobView() {
 									   and the statement of what leaves and who receives it -- the
 									   recipient, the operator, the country, every field -- stays in
 									   the privacy notice, one click away. The red (!) icon that used
-									   to sit here is now the quiet "Data privacy" link at the end of
-									   the sentence below -- the way every other AI product links its
-									   notice -- and the row leads the panel as a switch: the decision
-									   first, the explanation under it. */
+									   to sit here is now the quiet "Data privacy" link under the
+									   pills. The control is the application's own checkbox -- a
+									   switch was tried on 2026-08-21 and the owner did not like it --
+									   with its label set as the column's title. */
 									boxLabel: 'Enable AI pathway interpretation',
 									name: 'aiConsent', inputValue: 'true', uncheckedValue: 'false',
 									/* Off everywhere but a local instance -- a pre-ticked consent

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -1682,7 +1682,7 @@ function PA_Step1JobView() {
 						   half blank. Two columns give the explanation its measure and put the
 						   two controls in the space the prose cannot use. */
 						items: [{
-							xtype: "container", flex: 3, layout: "anchor",
+							xtype: "container", flex: 1, layout: "anchor",
 							items: [
 								{
 									xtype: "box",
@@ -1865,7 +1865,15 @@ function PA_Step1JobView() {
 								}
 							]
 						}, {
-							xtype: "container", flex: 2, margin: '0 0 0 32', layout: "anchor",
+							/* One right column for the whole form. 400px here, the same
+							   400px for the "Works with" column under Section 3, and the
+							   Help panel below starts on the same x (422 wide, because it
+							   runs to the card edge where this column stops 22px short of
+							   it inside the panel's padding). Measured: all three start at
+							   1185px on a 1867px viewport. A flex share put this one at
+							   1077 and the Help panel at 1267 -- three right edges for one
+							   page. */
+							xtype: "container", width: 400, margin: '0 0 0 32', layout: "anchor",
 							items: [
 								{
 									/* Three things were wrong here, and the first hid the other two.
@@ -1983,35 +1991,28 @@ function PA_Step1JobView() {
 					{
 						/* The standing offer, stated before any file is picked: the
 						   upload step accepts files as they come out of the tools
-						   people use, and the AI conversion is how. Same panel as
-						   the Section 2 callout so the two AI surfaces on this form
-						   read as one feature. The prose gets a reading measure; the
-						   aside states what leaves the machine, because a sentence
-						   about AI next to a file picker is where that has to be
-						   said (styles in inputformat.css). */
+						   people use, and the AI conversion is how.
+
+						   A plain row, not a second blue panel: the panel above is the
+						   one decision on this form (send results out, or not), and a
+						   second panel with a second box read as that decision asked
+						   twice. Conversion needs no box -- pressing Convert on a file
+						   is the act -- so this row only says what happens, in the
+						   interpretation's own type (.ai-intro-copy), on the same two
+						   columns: sentence left, the formats it handles right (styles
+						   in inputformat.css). */
 						xtype: "box",
-						cls: "po-ai-section-body po-upload-ai",
-						/* Same skeleton as Section 2, on purpose: one sentence in the
-						   interpretation's own type (.ai-intro-copy), then the consent
-						   control that names what leaves and to whom; the right column
-						   holds what the prose would otherwise have to list. The box is
-						   ticked by default because ticking it sends nothing -- a file
-						   only goes to the model when the user presses Convert on it;
-						   unticking removes that offer from every card. */
+						cls: "po-upload-ai",
 						html: '<div class="po-upload-ai-grid">' +
 							'<div class="po-upload-ai-text">' +
-								'<p class="ai-intro-copy"><b>Bring your files as they are.</b> Each file is checked the moment you pick it; if it is not in PaintOmics’ format, the <b>PaintOmics AI agent</b> writes a short script, runs it in your browser and shows you the result before anything is used.</p>' +
-								/* Input THEN label, as siblings: the alignment overlay judges a
-								   label led by a checkbox from the box's edge only in that
-								   shape (AlignmentGuides.js ~331), which is also what puts
-								   this row on the rail Section 2's Ext checkbox row keeps. */
-								'<div class="po-upload-ai-consent">' +
-									'<input type="checkbox" id="paUploadAiOptIn" checked>' +
-									/* No recipient clause here either (see the Section 2 label):
-									   the sheet's "What the agent sees" card shows exactly what is
-									   sent, at the moment it is sent, which is the better place. */
-									'<label for="paUploadAiOptIn">Convert with the PaintOmics AI agent when a file needs it</label>' +
-								'</div>' +
+								/* Two paragraphs, not one with a bold lead-in: a lone
+								   paragraph in this column is one measured row, and the
+								   alignment overlay dissolves a one-row column into its row
+								   and judges it against the other column's rail. The lead on
+								   its own line is also the head-plus-sentence shape the
+								   Section 2 hero uses. */
+								'<p class="ai-intro-copy po-upload-ai-lead"><b>Bring your files as they are.</b></p>' +
+								'<p class="ai-intro-copy">Each file is checked the moment you pick it; if it is not in PaintOmics’ format, the <b>PaintOmics AI agent</b> offers to convert it: it writes a short script, runs it in your browser and shows you the result before anything is used.</p>' +
 							'</div>' +
 							'<div class="po-upload-ai-aside">' +
 								'<div class="po-upload-ai-aside-title">Works with</div>' +
@@ -2071,12 +2072,16 @@ function PA_Step1JobView() {
 							xtype: "container",
 							id: "additionalInfoContainer",
 							minHeight: 150,
-							minWidth: 200,
-							maxWidth: 340,
+							/* 422, not a flex share: the page has one right column, and it
+							   starts where Section 2's experiment-design field and Section
+							   3's "Works with" column start (see the note on Section 2's
+							   right container). Those two stop 22px short of the card edge
+							   inside their panel padding; this panel runs to the edge, hence
+							   the extra 22. */
+							width: 422,
 							/* Left margin only - it is the gutter. The right side is the card
 							   inset, which the row already carries. */
 							margin: "10 0 10 10",
-							flex: 1,
 							layout: {type: 'vbox',align: "stretch"},
 							items: [
 								{xtype: 'box',html: '<div class="content"><h5><i class="fa fa-info-circle"></i> Help</h5><p>Drag <i>omics</i> from <b>Available omics</b> to <b>Selected omics</b>, or click the <i class="fa fa-plus-circle"></i> button.</p><p>Remove any you do not need with <span class="po-nowrap"><i class="fa fa-trash"></i>.</span></p><p>Files are checked as you pick them; the <b>PaintOmics AI agent</b> converts any that are not in PaintOmics’ format.</p><p>When you are done, click <b>Run PaintOmics</b> in the top-right corner.</p></div>'}

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -1685,70 +1685,6 @@ function PA_Step1JobView() {
 							xtype: "container", flex: 1, layout: "anchor",
 							items: [
 								{
-									xtype: "box",
-									/* This paragraph was written in the marketing register -- "revolutionary",
-									   "breathtaking computational power", "Next-Generation Agentic AI
-									   Swarm", "the world's most powerful Large Language Models". It sits
-									   directly above a consent checkbox, which is the one place in this
-									   application where the careful voice is not optional: someone
-									   deciding whether to send their data somewhere needs to know what
-									   happens to it, not how remarkable it is.
-
-									   It was also wrong. It described a fleet of agents dynamically
-									   selecting among frontier models; pipeline.py makes sequential
-									   calls to the one model the server is configured for, with a retry
-									   loop. #aiProviderInline is filled in from /ai_provider once that
-									   answers, so the recipient is named here rather than described as
-									   "external". */
-									/* "asks a large language model to explain" undersold what
-									   actually runs, and a consent notice is the wrong place to be
-									   vague about that. src/classes/AIInterpret/pipeline.py runs six
-									   phases - triage, search planning, literature retrieval,
-									   interpretation, synthesis, verification - and along the way it
-									   plans its own searches, calls tools against the job's own data
-									   (get_gene_timecourse, get_pathway_genes, compare_genes), and
-									   spawns sub-agents: one per search, and one per citation to
-									   check it. Someone deciding whether to send their data is
-									   entitled to know it is an agent doing that and not a single
-									   prompt. The wording below names the parts that exist in the
-									   code and nothing more. */
-									/* Size, colour, leading and margin were an inline `style` here,
-									   which no stylesheet can reach: the paragraph could not take the
-									   AI type scale, and dark.css had to chase its colour with an
-									   attribute selector. Now .ai-intro-copy in ai-interpret.css. */
-									/* Seven lines, then four, now two. This paragraph exists to
-									   introduce two controls; it had grown into the largest block
-									   of text on a page whose subject is the user's data.
-
-									   What went, in order. The AgentEvolve sentence: a
-									   benchmarking framework is a fact about how the feature was
-									   built, not one the reader needs to tick or leave the box.
-									   The enumeration of the agent's phases, compressed to the
-									   verbs that distinguish it from a single prompt. And now
-									   #aiProviderInline, which is the interesting one.
-
-									   That span printed "This server sends the data to a gateway
-									   operated by IIIA-CSIC (the Artificial Intelligence Research
-									   Institute of the Spanish National Research Council), on
-									   hardware in Spain" -- two of the four lines, and a
-									   restatement of the sentence in the checkbox directly below
-									   it, which already says the data goes "to IIIA-CSIC
-									   (llm.iiia.es)". The recipient is still named, on the
-									   control where the decision is actually made and where the
-									   design system requires it, and the (i) notice still gives
-									   the full operator, the country and every field that leaves
-									   the server. Saying it twice bought nothing and cost half
-									   the callout's height.
-
-									   fillAIProvenance guards each placeholder with `if (el)`,
-									   so it keeps working with this one absent. */
-									html: '<p class="ai-intro-copy">' +
-										'The <b>PaintOmics AI agent</b> drafts the write-up of your results: it triages your top-ranked ' +
-										'pathways, searches PubMed and Europe PMC, checks the patterns against your uploaded ' +
-										'values, and verifies every citation. Check its draft before you use it.' +
-										'</p>'
-								},
-								{
 									xtype: 'checkboxfield',
 									/* Both colours were written inline, which put them out of reach of
 									   dark.css -- an inline style beats a stylesheet -- so this
@@ -1765,10 +1701,12 @@ function PA_Step1JobView() {
 									   (2026-08-21): the gateway is operated by CSIC, as is the host,
 									   and the statement of what leaves and who receives it -- the
 									   recipient, the operator, the country, every field -- stays in
-									   the (i) notice this label links to, one click away. Keep the
-									   icon: it is the only remaining way to that notice from here. */
-									boxLabel: 'Enable AI pathway interpretation ' +
-										'<i class="fa fa-exclamation-circle ai-gdpr-info-icon" id="aiGdprInfoIcon" title="Data privacy &amp; compliance \u2014 click to learn what data is sent"></i>',
+									   the privacy notice, one click away. The red (!) icon that used
+									   to sit here is now the quiet "Data privacy" link at the end of
+									   the sentence below -- the way every other AI product links its
+									   notice -- and the row leads the panel as a switch: the decision
+									   first, the explanation under it. */
+									boxLabel: 'Enable AI pathway interpretation',
 									name: 'aiConsent', inputValue: 'true', uncheckedValue: 'false',
 									/* Off everywhere but a local instance -- a pre-ticked consent
 									   box is not consent. See LOCAL INSTANCE DEFAULTS in
@@ -1862,6 +1800,71 @@ function PA_Step1JobView() {
 											}, 200);
 										}
 									}
+								},
+								{
+									xtype: "box",
+									/* This paragraph was written in the marketing register -- "revolutionary",
+									   "breathtaking computational power", "Next-Generation Agentic AI
+									   Swarm", "the world's most powerful Large Language Models". It sits
+									   directly above a consent checkbox, which is the one place in this
+									   application where the careful voice is not optional: someone
+									   deciding whether to send their data somewhere needs to know what
+									   happens to it, not how remarkable it is.
+
+									   It was also wrong. It described a fleet of agents dynamically
+									   selecting among frontier models; pipeline.py makes sequential
+									   calls to the one model the server is configured for, with a retry
+									   loop. #aiProviderInline is filled in from /ai_provider once that
+									   answers, so the recipient is named here rather than described as
+									   "external". */
+									/* "asks a large language model to explain" undersold what
+									   actually runs, and a consent notice is the wrong place to be
+									   vague about that. src/classes/AIInterpret/pipeline.py runs six
+									   phases - triage, search planning, literature retrieval,
+									   interpretation, synthesis, verification - and along the way it
+									   plans its own searches, calls tools against the job's own data
+									   (get_gene_timecourse, get_pathway_genes, compare_genes), and
+									   spawns sub-agents: one per search, and one per citation to
+									   check it. Someone deciding whether to send their data is
+									   entitled to know it is an agent doing that and not a single
+									   prompt. The wording below names the parts that exist in the
+									   code and nothing more. */
+									/* Size, colour, leading and margin were an inline `style` here,
+									   which no stylesheet can reach: the paragraph could not take the
+									   AI type scale, and dark.css had to chase its colour with an
+									   attribute selector. Now .ai-intro-copy in ai-interpret.css. */
+									/* Seven lines, then four, now two. This paragraph exists to
+									   introduce two controls; it had grown into the largest block
+									   of text on a page whose subject is the user's data.
+
+									   What went, in order. The AgentEvolve sentence: a
+									   benchmarking framework is a fact about how the feature was
+									   built, not one the reader needs to tick or leave the box.
+									   The enumeration of the agent's phases, compressed to the
+									   verbs that distinguish it from a single prompt. And now
+									   #aiProviderInline, which is the interesting one.
+
+									   That span printed "This server sends the data to a gateway
+									   operated by IIIA-CSIC (the Artificial Intelligence Research
+									   Institute of the Spanish National Research Council), on
+									   hardware in Spain" -- two of the four lines, and a
+									   restatement of the sentence in the checkbox directly below
+									   it, which already says the data goes "to IIIA-CSIC
+									   (llm.iiia.es)". The recipient is still named, on the
+									   control where the decision is actually made and where the
+									   design system requires it, and the (i) notice still gives
+									   the full operator, the country and every field that leaves
+									   the server. Saying it twice bought nothing and cost half
+									   the callout's height.
+
+									   fillAIProvenance guards each placeholder with `if (el)`,
+									   so it keeps working with this one absent. */
+									html: '<p class="ai-intro-copy">' +
+										'The <b>PaintOmics AI agent</b> drafts the write-up of your results: it triages your top-ranked ' +
+										'pathways, searches PubMed and Europe PMC, checks the patterns against your uploaded ' +
+										'values, and verifies every citation. Check its draft before you use it. ' +
+										'<a href="javascript:void(0)" class="ai-gdpr-info-link" id="aiGdprInfoIcon" title="Data privacy &amp; compliance \u2014 what is sent, and where"><i class="fa fa-info-circle"></i> Data privacy</a>' +
+										'</p>'
 								}
 							]
 						}, {
@@ -1913,7 +1916,7 @@ function PA_Step1JobView() {
 									   Dragging it still works; growing sets a height, not a cap. */
 									xtype: "textarea", fieldLabel: "Experiment design (optional)",
 									name: 'experimentDesign',
-									labelAlign: 'top', anchor: '100%', height: 96,
+									labelAlign: 'top', anchor: '100%', height: 120,
 									cls: 'po-exp-design',
 									emptyText: 'e.g. RNA-seq of wildtype vs knockout mouse liver, 3 replicates per group, sampled at 24 h',
 									maxLength: 2000,

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -1958,7 +1958,38 @@ function PA_Step1JobView() {
 						// this hands over the datasets "Load example" actually
 						// offers. The old static file was built in 2017 and shared
 						// no filename with any current scenario.
-						html: '<h3>3. Choose the files to upload <a class="button btn-right btn-small" href="' + SERVER_URL_EXAMPLE_DATASETS_DOWNLOAD + '"><i class="fa fa-download"></i> Download example data</a></h3>'
+						// The mark leads the heading exactly as it does on Section 2's,
+						// so main.css's `div.contentbox h3 > svg.po-ai-mark` rule sizes
+						// and places it, and the two AI headings on the form match.
+						html: '<h3>' + getAIMark() + ' 3. Choose the files to upload <a class="button btn-right btn-small" href="' + SERVER_URL_EXAMPLE_DATASETS_DOWNLOAD + '"><i class="fa fa-download"></i> Download example data</a></h3>'
+					},
+					{
+						/* The standing offer, stated before any file is picked: the
+						   upload step accepts files as they come out of the tools
+						   people use, and the AI conversion is how. Same panel as
+						   the Section 2 callout so the two AI surfaces on this form
+						   read as one feature. The prose gets a reading measure; the
+						   aside states what leaves the machine, because a sentence
+						   about AI next to a file picker is where that has to be
+						   said (styles in inputformat.css). */
+						xtype: "box",
+						cls: "po-ai-section-body po-upload-ai",
+						html: '<div class="po-upload-ai-grid">' +
+							'<div class="po-upload-ai-text">' +
+								'<div class="po-hero-ai-head"><span class="po-upload-ai-icon">' + getAIMark() + '</span><strong>Bring your files as they are</strong></div>' +
+								'<p>A DESeq2 or edgeR table, a MaxQuant or Spectronaut export, a MetaboLights MAF, a workbook with several sheets: pick it and PaintOmics checks it on the spot. If it is not in PaintOmics’ format, <b>PaintOmics AI</b> converts it here, in your browser.</p>' +
+								'<ul class="po-upload-ai-does">' +
+									'<li>reads the file’s structure</li>' +
+									'<li>writes a short script and runs it in your browser</li>' +
+									'<li>checks the result against PaintOmics’ exact format</li>' +
+									'<li>shows you the script, the tables and what it left out before anything is used</li>' +
+								'</ul>' +
+							'</div>' +
+							'<aside class="po-upload-ai-aside">' +
+								'<div class="po-upload-ai-aside-title">What leaves your computer</div>' +
+								'<p>Only the file’s structure: column names, counts and a few example rows, sent to <span id="paUploadAiProvider">the AI gateway</span>. The measurements never leave this browser.</p>' +
+							'</aside>' +
+						'</div>'
 					},
 					{
 						xtype: "container",
@@ -2017,7 +2048,7 @@ function PA_Step1JobView() {
 							flex: 1,
 							layout: {type: 'vbox',align: "stretch"},
 							items: [
-								{xtype: 'box',html: '<div class="content"><h5><i class="fa fa-info-circle"></i> Help</h5><p>Drag <i>omics</i> from <b>Available omics</b> to <b>Selected omics</b>, or click the <i class="fa fa-plus-circle"></i> button.</p><p>Remove any you do not need with <span class="po-nowrap"><i class="fa fa-trash"></i>.</span></p><p>When you are done, click <b>Run PaintOmics</b> in the top-right corner.</p></div>'}
+								{xtype: 'box',html: '<div class="content"><h5><i class="fa fa-info-circle"></i> Help</h5><p>Drag <i>omics</i> from <b>Available omics</b> to <b>Selected omics</b>, or click the <i class="fa fa-plus-circle"></i> button.</p><p>Remove any you do not need with <span class="po-nowrap"><i class="fa fa-trash"></i>.</span></p><p>Pick your files as they are: each one is checked the moment you choose it, and if it is not in PaintOmics’ format, <b>PaintOmics AI</b> converts it in your browser.</p><p>When you are done, click <b>Run PaintOmics</b> in the top-right corner.</p></div>'}
 							]
 						}]
 					}					

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -40,15 +40,15 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
 	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.07" />
-	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=1.5" />
-	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.2" />
+	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=1.6" />
+	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.3" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.1" />
 	<!-- Shared chrome for both of Step 3's graph surfaces. Before more-network.css,
 	     which layers this view's own legend and layout on top of it. -->
 	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=0.8" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
 	<link rel="stylesheet" type="text/css" href="resources/css/evidence-overlay.css?v=0.8" />
-	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.7" />
+	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.8" />
 
 	<!-- Theme, resolved before the first paint.
 	     Deliberately inline and here rather than in Util.js: the stylesheets
@@ -140,11 +140,11 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-reader.js?v=0.1"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-validator.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-repair.js?v=0.1"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=1.5"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=1.6"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js?v=0.3"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.5"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=0.4"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.6"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=0.5"></script>
 	<!--MORE REGULATOR–TARGET NETWORK VIEW -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js?v=0.7"></script>
 	<!--OMNIPATH PATHWAY NETWORK VIEW (OmniPath ships no diagram; its pathways render as graphs) -->

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -40,7 +40,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
 	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.07" />
-	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=1.7" />
+	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=1.8" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.3" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.1" />
 	<!-- Shared chrome for both of Step 3's graph surfaces. Before more-network.css,
@@ -140,7 +140,7 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-reader.js?v=0.1"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-validator.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-repair.js?v=0.1"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=1.7"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=1.8"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.6"></script>

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -40,7 +40,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
 	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.10" />
-	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.1" />
+	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.2" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.3" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.2" />
 	<!-- Shared chrome for both of Step 3's graph surfaces. Before more-network.css,

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,8 +39,8 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.10" />
-	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.2" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.12" />
+	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.3" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.3" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.2" />
 	<!-- Shared chrome for both of Step 3's graph surfaces. Before more-network.css,

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -40,7 +40,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
 	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.07" />
-	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=1.8" />
+	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=1.9" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.3" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.1" />
 	<!-- Shared chrome for both of Step 3's graph surfaces. Before more-network.css,
@@ -48,7 +48,7 @@
 	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=0.8" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
 	<link rel="stylesheet" type="text/css" href="resources/css/evidence-overlay.css?v=0.8" />
-	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.8" />
+	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.9" />
 
 	<!-- Theme, resolved before the first paint.
 	     Deliberately inline and here rather than in Util.js: the stylesheets
@@ -140,7 +140,7 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-reader.js?v=0.1"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-validator.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-repair.js?v=0.1"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=1.8"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=1.9"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.6"></script>

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -40,7 +40,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
 	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.07" />
-	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=1.6" />
+	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=1.7" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.3" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.1" />
 	<!-- Shared chrome for both of Step 3's graph surfaces. Before more-network.css,
@@ -140,11 +140,11 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-reader.js?v=0.1"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-validator.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-repair.js?v=0.1"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=1.6"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=1.7"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.6"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=0.5"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=0.6"></script>
 	<!--MORE REGULATOR–TARGET NETWORK VIEW -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js?v=0.7"></script>
 	<!--OMNIPATH PATHWAY NETWORK VIEW (OmniPath ships no diagram; its pathways render as graphs) -->

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,16 +39,16 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.07" />
-	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=1.9" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.08" />
+	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.0" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.3" />
-	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.1" />
+	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.2" />
 	<!-- Shared chrome for both of Step 3's graph surfaces. Before more-network.css,
 	     which layers this view's own legend and layout on top of it. -->
 	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=0.8" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
 	<link rel="stylesheet" type="text/css" href="resources/css/evidence-overlay.css?v=0.8" />
-	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=0.9" />
+	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=1.0" />
 
 	<!-- Theme, resolved before the first paint.
 	     Deliberately inline and here rather than in Util.js: the stylesheets

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.09" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.10" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.1" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.3" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.2" />
@@ -48,7 +48,7 @@
 	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=0.8" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
 	<link rel="stylesheet" type="text/css" href="resources/css/evidence-overlay.css?v=0.8" />
-	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=1.0" />
+	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=1.1" />
 
 	<!-- Theme, resolved before the first paint.
 	     Deliberately inline and here rather than in Util.js: the stylesheets

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.12" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.13" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.3" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.3" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.2" />
@@ -48,7 +48,7 @@
 	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=0.8" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
 	<link rel="stylesheet" type="text/css" href="resources/css/evidence-overlay.css?v=0.8" />
-	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=1.1" />
+	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=1.2" />
 
 	<!-- Theme, resolved before the first paint.
 	     Deliberately inline and here rather than in Util.js: the stylesheets

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,8 +39,8 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.08" />
-	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.0" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.09" />
+	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.1" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.3" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.2" />
 	<!-- Shared chrome for both of Step 3's graph surfaces. Before more-network.css,

--- a/PaintomicsClient/public_html/resources/css/ai-interpret.css
+++ b/PaintomicsClient/public_html/resources/css/ai-interpret.css
@@ -756,15 +756,8 @@ tr.ai-cluster-row-flash > td {
    colour as an inline `style` in PA_Step1Views.js, which no stylesheet can
    override, so the dark theme could not lighten them and the sentence sat at
    3.29:1. #C44500 is 5.00:1 on white; dark.css takes it from here. */
-.ai-consent-warn,
-.ai-gdpr-info-icon {
+.ai-consent-warn {
     color: #C44500;
-}
-.ai-gdpr-info-icon {
-    vertical-align: middle;
-    margin-left: 4px;
-    cursor: pointer;
-    font-size: var(--pa-ai-glyph);
 }
 .ai-gdpr-overlay {
     position: fixed;

--- a/PaintomicsClient/public_html/resources/css/dark.css
+++ b/PaintomicsClient/public_html/resources/css/dark.css
@@ -1591,10 +1591,21 @@
    style on the boxLabel; #F08A5D is 6.66:1 on the surface underneath, against
    the 3.29:1 the light-theme #C44500 was managing there. This is the sentence
    naming the recipient of the data, so it has to be read, not decoded. */
-[data-theme="dark"] .ai-consent-warn,
-[data-theme="dark"] .ai-gdpr-info-icon {
+[data-theme="dark"] .ai-consent-warn {
 	color: var(--pa-ai-consent-warn);
 }
+/* The consent switch's off track, and the privacy link, on the dark surface. */
+[data-theme="dark"] .po-ai-section-body .x-form-cb-wrap > .x-form-checkbox {
+	background-color: #3B4049;
+	box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+[data-theme="dark"] .po-ai-section-body .x-form-cb-checked .x-form-cb-wrap > .x-form-checkbox {
+	background-color: var(--pa-accent-blue);
+	box-shadow: none;
+}
+[data-theme="dark"] .po-ai-section-body .x-form-cb-wrap > .x-form-cb-label { color: var(--pa-ink-title); }
+[data-theme="dark"] .ai-gdpr-info-link { color: var(--pa-ink-muted); }
+[data-theme="dark"] .ai-gdpr-info-link:hover { color: var(--pa-accent-blue); }
 
 /* The account dialog. main.css states its surface literally (so that the
    framework's #f2f2f2 panel fill loses), which means it is restated here.

--- a/PaintomicsClient/public_html/resources/css/dark.css
+++ b/PaintomicsClient/public_html/resources/css/dark.css
@@ -1594,15 +1594,7 @@
 [data-theme="dark"] .ai-consent-warn {
 	color: var(--pa-ai-consent-warn);
 }
-/* The consent switch's off track, and the privacy link, on the dark surface. */
-[data-theme="dark"] .po-ai-section-body .x-form-cb-wrap > .x-form-checkbox {
-	background-color: #3B4049;
-	box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
-}
-[data-theme="dark"] .po-ai-section-body .x-form-cb-checked .x-form-cb-wrap > .x-form-checkbox {
-	background-color: var(--pa-accent-blue);
-	box-shadow: none;
-}
+/* The consent box's title label, and the privacy link, on the dark surface. */
 [data-theme="dark"] .po-ai-section-body .x-form-cb-wrap > .x-form-cb-label { color: var(--pa-ink-title); }
 [data-theme="dark"] .ai-gdpr-info-link { color: var(--pa-ink-muted); }
 [data-theme="dark"] .ai-gdpr-info-link:hover { color: var(--pa-accent-blue); }

--- a/PaintomicsClient/public_html/resources/css/dark.css
+++ b/PaintomicsClient/public_html/resources/css/dark.css
@@ -1812,3 +1812,33 @@
 	background: var(--pa-surface-quiet);
 	color: var(--pa-ink-muted);
 }
+
+/* The AI conversion sheet and the Step 1 upload strips. The sheet declares
+   its own tints as --cv-* custom properties (inputconvert.css), so one block
+   restates them; everything else in it already reads the tokens above. */
+[data-theme="dark"] .pa-convert-panel {
+  --cv-line: rgba(255, 255, 255, 0.09);
+  --cv-line-strong: rgba(255, 255, 255, 0.17);
+  --cv-ai-bg: #1B2431;
+  --cv-ai-line: #2C3E55;
+  --cv-ai-tint: #243247;
+  --cv-ok-bg: #182619;
+  --cv-ok-line: rgba(107, 196, 106, 0.35);
+  --cv-warn-bg: #2A2118;
+  --cv-warn-line: rgba(227, 138, 90, 0.35);
+  --cv-bad: #F28B82;
+  --cv-bad-ink: #F6B1AB;
+  --cv-bad-bg: #2E1B1B;
+  --cv-bad-line: rgba(242, 139, 130, 0.35);
+  box-shadow: -24px 0 60px -20px rgba(0, 0, 0, 0.7);
+}
+[data-theme="dark"] .pa-convert-overlay.pa-convert-open { background: rgba(0, 0, 0, 0.62); }
+[data-theme="dark"] .pa-convert-col-numeric { color: #B9CCE6; }
+[data-theme="dark"] .pa-convert-kept .pa-convert-chip { color: #A8DDA6; }
+[data-theme="dark"] .pa-convert-preview th { background: rgba(255, 255, 255, 0.05); }
+[data-theme="dark"] .pa-convert-accept { background: #2F7A2F; border-color: #3E9A3E; }
+[data-theme="dark"] .pa-convert-accept:hover { background: #358A35; }
+[data-theme="dark"] .pa-convert-composer-send { background: var(--pa-accent-blue); border-color: var(--pa-accent-blue); color: #0F1A2B; }
+[data-theme="dark"] .pa-convert-composer-send:hover:not(:disabled) { background: #86B8F4; }
+[data-theme="dark"] .pa-convert-composer-input:focus { box-shadow: 0 0 0 3px rgba(107, 168, 240, 0.25); }
+[data-theme="dark"] .po-upload-ai-aside { background: var(--pa-surface); border-color: #2C3E55; }

--- a/PaintomicsClient/public_html/resources/css/dark.css
+++ b/PaintomicsClient/public_html/resources/css/dark.css
@@ -1594,8 +1594,7 @@
 [data-theme="dark"] .ai-consent-warn {
 	color: var(--pa-ai-consent-warn);
 }
-/* The consent box's title label, and the privacy link, on the dark surface. */
-[data-theme="dark"] .po-ai-section-body .x-form-cb-wrap > .x-form-cb-label { color: var(--pa-ink-title); }
+/* The privacy link on the dark surface. */
 [data-theme="dark"] .ai-gdpr-info-link { color: var(--pa-ink-muted); }
 [data-theme="dark"] .ai-gdpr-info-link:hover { color: var(--pa-accent-blue); }
 

--- a/PaintomicsClient/public_html/resources/css/dark.css
+++ b/PaintomicsClient/public_html/resources/css/dark.css
@@ -1841,4 +1841,3 @@
 [data-theme="dark"] .pa-convert-composer-send { background: var(--pa-accent-blue); border-color: var(--pa-accent-blue); color: #0F1A2B; }
 [data-theme="dark"] .pa-convert-composer-send:hover:not(:disabled) { background: #86B8F4; }
 [data-theme="dark"] .pa-convert-composer-input:focus { box-shadow: 0 0 0 3px rgba(107, 168, 240, 0.25); }
-[data-theme="dark"] .po-upload-ai-aside { background: var(--pa-surface); border-color: #2C3E55; }

--- a/PaintomicsClient/public_html/resources/css/inputconvert.css
+++ b/PaintomicsClient/public_html/resources/css/inputconvert.css
@@ -1,14 +1,70 @@
 /*
- * The conversion drawer.
+ * The conversion sheet.
  *
  * A right-hand sheet rather than a modal: the Step 1 form stays visible and
- * intact behind it, so the user can see the omic this belongs to and nothing is
- * unmounted while a conversion runs.
+ * intact behind it, so the user can see the omic box this belongs to and
+ * nothing is unmounted while a conversion runs.
  *
- * Colours come from the tokens in main.css, which dark.css redefines, so this
- * needs no dark-mode branch and must contain no inline styles -- dark.css
- * cannot reach those.
+ * It is laid out as a notebook of the run, top to bottom:
+ *
+ *   header   -- what is being converted, for which omic, and a way out
+ *   status   -- the stage rail (Read > Plan > Run > Check > Apply > Review),
+ *               lit as the agent's own state machine reaches each stage, with
+ *               the attempt count and the clock beside it
+ *   body     -- "What the AI sees" (the structure that actually left this
+ *               computer), then the timeline of every step with its cost in
+ *               seconds, the script, the validator's verdicts, the questions;
+ *               and when it is done, the tables it produced
+ *   dock     -- the composer to steer it, then the decision row
+ *
+ * Two rails hold the whole sheet together. Every box -- header, stage rail,
+ * anatomy card, result cards, composer -- starts at --cv-inset; every line of
+ * timeline type starts one node plus one gap further in, at --cv-rail. Nothing
+ * else is allowed to invent a third left edge.
+ *
+ * Colours come from the tokens in main.css, which dark.css redefines, so the
+ * sheet follows the theme. The few literal tints it needs (the AI callout
+ * blue, the green/orange/red verdict washes) are declared once here as
+ * --cv-* custom properties so dark.css can restate them in one block. No
+ * inline colours anywhere: dark.css cannot reach those.
  */
+
+.pa-convert-panel {
+    --cv-inset: 24px;
+    --cv-node: 28px;
+    --cv-gap: 12px;
+    --cv-rail: calc(var(--cv-node) + var(--cv-gap));
+    --cv-line: rgba(24, 24, 27, 0.09);
+    --cv-line-strong: rgba(24, 24, 27, 0.16);
+    --cv-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+    /* The AI blue every AI surface in the application uses (the mark, the
+       hero panel's bar) and its darker ink for small type, which needs 4.5:1
+       where the mark only needs 3:1. */
+    --cv-ai: var(--pa-ai-blue, #4A90D9);
+    --cv-ai-ink: var(--pa-accent-blue, #19589E);
+    --cv-ai-bg: #F4F8FC;
+    --cv-ai-line: #CFE0F0;
+    --cv-ai-tint: #E8EFF7;
+
+    --cv-ok: var(--pa-accent-green, #247B21);
+    --cv-ok-bg: #F4F9F3;
+    --cv-ok-line: rgba(36, 123, 33, 0.30);
+    --cv-warn: var(--pa-accent-orange, #AD5022);
+    --cv-warn-bg: #FBF7F2;
+    --cv-warn-line: rgba(173, 80, 34, 0.30);
+    --cv-bad: #B3261E;
+    --cv-bad-ink: #7A1C16;
+    --cv-bad-bg: #F7E9ED;
+    --cv-bad-line: rgba(179, 38, 30, 0.28);
+
+    /* The destination omic's hue, written onto the panel by the drawer from
+       the card it was opened from; the chosen result carries it as a bar, the
+       same bar the omic card wears on Step 1. */
+    --cv-omic: var(--pa-accent-blue, #19589E);
+}
+
+/* ---- the sheet ---------------------------------------------------------- */
 
 .pa-convert-overlay {
     position: fixed;
@@ -19,11 +75,10 @@
     justify-content: flex-end;
     transition: background 180ms ease;
 }
-
 .pa-convert-overlay.pa-convert-open { background: rgba(24, 24, 27, 0.42); }
 
 .pa-convert-panel {
-    width: min(620px, 100%);
+    width: min(680px, 100%);
     height: 100%;
     display: flex;
     flex-direction: column;
@@ -32,406 +87,923 @@
     transform: translateX(100%);
     transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
     font-family: var(--pa-font-sans);
+    font-size: 13px;
     color: var(--pa-ink, #18181B);
+    outline: none;
 }
-
 .pa-convert-open .pa-convert-panel { transform: translateX(0); }
 
 @media (prefers-reduced-motion: reduce) {
     .pa-convert-panel, .pa-convert-overlay { transition: none; }
+    .pa-convert-event { animation: none; }
+    .pa-convert-event.is-current .pa-convert-node::after,
+    .pa-convert-stage[data-state="current"]::before { animation: none; }
 }
 
-/* ---- header ------------------------------------------------------------ */
+/* ---- header ------------------------------------------------------------- */
 
 .pa-convert-header {
-    display: flex;
-    align-items: flex-start;
-    gap: 12px;
-    padding: 20px 20px 14px;
-    border-bottom: 1px solid rgba(24, 24, 27, 0.08);
+    display: grid;
+    grid-template-columns: var(--cv-node) 1fr auto;
+    column-gap: var(--cv-gap);
+    align-items: start;
+    padding: 18px var(--cv-inset) 14px;
+    border-bottom: 1px solid var(--cv-line);
 }
 
-.pa-convert-title { display: flex; gap: 11px; align-items: flex-start; flex: 1 1 auto; min-width: 0; }
-.pa-convert-mark { font-size: 22px; line-height: 1; color: var(--pa-accent-blue, #19589E); }
-.pa-convert-titles h2 { margin: 0; font-size: 17px; font-weight: 650; letter-spacing: -0.01em; }
+.pa-convert-mark {
+    width: var(--cv-node);
+    height: var(--cv-node);
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+    background: var(--cv-ai-bg);
+    border: 1px solid var(--cv-ai-line);
+    color: var(--cv-ai);
+    font-size: 17px;
+    line-height: 1;
+}
 
-.pa-convert-filename {
-    margin: 3px 0 0;
+.pa-convert-titles { min-width: 0; }
+
+/* The global h2 is 23px terracotta; this one names a sheet, not a page. */
+.pa-convert-panel h2.pa-convert-title {
+    margin: 2px 0 0;
+    font-size: 17px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    line-height: 1.3;
+    color: var(--pa-ink, #18181B);
+}
+
+.pa-convert-subject {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 4px 10px;
+    margin: 4px 0 0;
     font-size: 12.5px;
     color: var(--pa-ink-muted, #595959);
+}
+.pa-convert-filename {
+    font-weight: 600;
+    color: var(--pa-ink-control, #3F3F46);
     overflow-wrap: anywhere;
+}
+.pa-convert-omic {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+}
+.pa-convert-omic::before {
+    content: "";
+    width: 9px;
+    height: 9px;
+    border-radius: 2px;
+    background: var(--cv-omic);
 }
 
 .pa-convert-close {
-    flex: 0 0 auto;
-    width: 30px; height: 30px;
-    border: 0; border-radius: 8px;
+    width: 30px;
+    height: 30px;
+    margin-top: -2px;
+    border: 0;
+    border-radius: var(--pa-radius-sm, 6px);
     background: transparent;
     color: var(--pa-ink-muted, #595959);
-    font-size: 14px; cursor: pointer;
+    font-size: 15px;
+    line-height: 1;
+    cursor: pointer;
 }
-.pa-convert-close:hover { background: var(--pa-surface-quiet, #F3F2ED); }
+.pa-convert-close:hover { background: var(--pa-surface-quiet, #F3F2ED); color: var(--pa-ink, #18181B); }
+.pa-convert-close:focus-visible,
+.pa-convert-option:focus-visible,
+.pa-convert-disclose:focus-visible,
+.pa-convert-iconbtn:focus-visible,
+.pa-convert-accept:focus-visible,
+.pa-convert-dismiss:focus-visible,
+.pa-convert-composer-send:focus-visible {
+    outline: 2px solid var(--pa-focus-ring, #0A84FF);
+    outline-offset: 2px;
+}
 
-/* ---- progress ---------------------------------------------------------- */
+/* ---- status band: the stage rail ---------------------------------------- */
 
-.pa-convert-progress {
+.pa-convert-status {
+    padding: 12px var(--cv-inset) 11px;
+    border-bottom: 1px solid var(--cv-line);
+    background: var(--pa-surface-subtle, #F9F8F4);
+}
+
+.pa-convert-stages {
+    list-style: none;
+    margin: 0;
+    padding: 0;
     display: grid;
-    grid-template-columns: 1fr auto;
-    grid-template-areas: "bar bar" "text elapsed";
-    gap: 7px 10px;
-    padding: 14px 20px 12px;
+    grid-template-columns: repeat(6, 1fr);
+    gap: 6px;
 }
 
-.pa-convert-bar {
-    grid-area: bar;
-    height: 5px;
+.pa-convert-stage {
+    position: relative;
+    padding-top: 10px;
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--pa-ink-muted, #595959);
+    white-space: nowrap;
+    overflow: hidden;
+}
+/* The bar. A 4px track per stage, filled as the agent reaches it; the one in
+   flight carries a moving sheen so a minute-long wait on the gateway reads as
+   alive rather than hung -- the same device the AI widget's bar uses. */
+.pa-convert-stage::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    height: 4px;
     border-radius: 99px;
+    background: var(--pa-surface-sunken, #F5F4EF);
+    box-shadow: inset 0 0 0 1px var(--cv-line);
+    transition: background-color 420ms ease;
+}
+.pa-convert-stage[data-state="done"]::before { background: var(--cv-ai); box-shadow: none; }
+.pa-convert-stage[data-state="done"] { color: var(--pa-ink-control, #3F3F46); }
+.pa-convert-stage[data-state="current"] { color: var(--cv-ai-ink); }
+.pa-convert-stage[data-state="current"]::before {
+    background: linear-gradient(90deg, var(--cv-ai) 0%, var(--cv-ai) 45%, var(--cv-ai-tint) 45%, var(--cv-ai-tint) 100%);
+    background-size: 200% 100%;
+    box-shadow: none;
+    animation: pa-convert-sheen 1.4s linear infinite;
+}
+.pa-convert-stage[data-state="failed"] { color: var(--cv-bad); }
+.pa-convert-stage[data-state="failed"]::before { background: var(--cv-bad); box-shadow: none; }
+.pa-convert-stage[data-state="ready"] { color: var(--cv-ok); }
+.pa-convert-stage[data-state="ready"]::before { background: var(--cv-ok); box-shadow: none; }
+
+@keyframes pa-convert-sheen {
+    from { background-position: 100% 0; }
+    to   { background-position: -100% 0; }
+}
+
+.pa-convert-now {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin-top: 9px;
+}
+.pa-convert-now-text {
+    flex: 1 1 auto;
+    min-width: 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--pa-ink-control, #3F3F46);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.pa-convert-now-meta {
+    flex: 0 0 auto;
+    font-size: 11.5px;
+    font-variant-numeric: tabular-nums;
+    color: var(--pa-ink-muted, #595959);
+}
+.pa-convert-now-meta b { font-weight: 600; color: var(--pa-ink-control, #3F3F46); }
+
+/* ---- body --------------------------------------------------------------- */
+
+.pa-convert-body {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: 4px var(--cv-inset) 20px;
+}
+
+/* ---- "What the AI sees" ------------------------------------------------- */
+
+.pa-convert-anatomy {
+    margin: 14px 0 4px;
+    padding: 12px 14px 12px 15px;
+    border-radius: var(--pa-radius, 8px);
+    border: 1px solid var(--cv-ai-line);
+    border-left: 3px solid var(--cv-ai);
+    background: var(--cv-ai-bg);
+}
+.pa-convert-anatomy-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+}
+.pa-convert-eyebrow {
+    margin: 0;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--cv-ai-ink);
+}
+.pa-convert-anatomy-meta {
+    font-size: 11.5px;
+    color: var(--pa-ink-muted, #595959);
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+.pa-convert-anatomy-lead {
+    margin: 6px 0 0;
+    font-size: 12.5px;
+    line-height: 1.5;
+    color: var(--pa-ink-control, #3F3F46);
+    max-width: var(--pa-measure-note, 78ch);
+}
+.pa-convert-anatomy-lead b { font-weight: 600; }
+
+.pa-convert-table { margin-top: 10px; }
+.pa-convert-table + .pa-convert-table { padding-top: 10px; border-top: 1px dashed var(--cv-ai-line); }
+.pa-convert-table-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 4px 10px;
+    font-size: 12.5px;
+}
+.pa-convert-table-name { font-weight: 650; color: var(--pa-ink, #18181B); overflow-wrap: anywhere; }
+.pa-convert-table-dims { color: var(--pa-ink-muted, #595959); font-variant-numeric: tabular-nums; }
+.pa-convert-table-note { color: var(--pa-ink-muted, #595959); font-style: italic; }
+
+.pa-convert-colstrip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-top: 6px;
+}
+.pa-convert-col {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    max-width: 190px;
+    padding: 2px 7px;
+    border-radius: 5px;
+    border: 1px solid var(--cv-line-strong);
+    background: var(--pa-surface, #FFFFFF);
+    font-family: var(--cv-mono);
+    font-size: 10.5px;
+    line-height: 1.6;
+    color: var(--pa-ink-control, #3F3F46);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.pa-convert-col-numeric {
+    background: var(--cv-ai-tint);
+    border-color: transparent;
+    color: #2F4A6B;
+}
+.pa-convert-col-id {
+    border-color: var(--cv-ai-ink);
+    color: var(--cv-ai-ink);
+    font-weight: 700;
+}
+.pa-convert-col-id::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+    flex: 0 0 auto;
+}
+.pa-convert-col-dup {
+    margin-left: 2px;
+    font-family: var(--pa-font-sans);
+    font-size: 10px;
+    font-weight: 700;
+    color: var(--cv-warn);
+}
+.pa-convert-col-more {
+    background: transparent;
+    border-style: dashed;
+    color: var(--pa-ink-muted, #595959);
+}
+.pa-convert-families {
+    margin: 6px 0 0;
+    font-size: 11.5px;
+    line-height: 1.5;
+    color: var(--pa-ink-muted, #595959);
+}
+.pa-convert-families code { font-family: var(--cv-mono); font-size: 10.5px; color: var(--pa-ink-control, #3F3F46); }
+
+.pa-convert-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 14px;
+    margin-top: 10px;
+    font-size: 11px;
+    color: var(--pa-ink-muted, #595959);
+}
+.pa-convert-legend span { display: inline-flex; align-items: center; gap: 5px; }
+/* Swatches shaped like the chips they explain -- a wide pill, not a square,
+   which at this size reads as a checkbox. */
+.pa-convert-legend i {
+    width: 16px;
+    height: 9px;
+    border-radius: 3px;
+    border: 1px solid var(--cv-line-strong);
+    background: var(--pa-surface, #FFFFFF);
+}
+.pa-convert-legend i.is-numeric { background: var(--cv-ai-tint); border-color: transparent; }
+.pa-convert-legend i.is-id {
+    border-color: var(--cv-ai-ink);
+    background: radial-gradient(circle at 5px 50%, var(--cv-ai-ink) 0 1.6px, transparent 2px) var(--pa-surface, #FFFFFF);
+}
+
+/* The raw rows it was shown, behind a disclosure: they are part of what left
+   the machine, so they are inspectable, but they are noise until asked for. */
+.pa-convert-rows { margin-top: 8px; font-size: 11.5px; color: var(--pa-ink-muted, #595959); }
+.pa-convert-rows summary { cursor: pointer; font-weight: 600; }
+.pa-convert-rows summary:hover { color: var(--cv-ai-ink); }
+.pa-convert-rows .pa-convert-preview { margin: 6px 0 0; background: var(--pa-surface, #FFFFFF); }
+
+/* ---- the timeline ------------------------------------------------------- */
+
+.pa-convert-timeline {
+    list-style: none;
+    margin: 10px 0 0;
+    padding: 0;
+    position: relative;
+}
+/* The rail down the node column. Drawn once behind every node rather than as
+   a border on each row, so it never breaks at a row boundary. */
+.pa-convert-timeline::before {
+    content: "";
+    position: absolute;
+    left: calc(var(--cv-node) / 2 - 0.5px);
+    top: 16px;
+    bottom: 16px;
+    width: 1px;
+    background: var(--cv-line);
+}
+
+.pa-convert-event {
+    display: grid;
+    grid-template-columns: var(--cv-node) 1fr;
+    column-gap: var(--cv-gap);
+    padding: 7px 0;
+    position: relative;
+    animation: pa-convert-in 220ms ease both;
+}
+@keyframes pa-convert-in {
+    from { opacity: 0; transform: translateY(4px); }
+    to   { opacity: 1; transform: none; }
+}
+
+.pa-convert-node {
+    position: relative;
+    z-index: 1;
+    width: var(--cv-node);
+    height: var(--cv-node);
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+    background: var(--pa-surface, #FFFFFF);
+    border: 1px solid var(--cv-line-strong);
+    color: var(--pa-ink-muted, #595959);
+}
+.pa-convert-node svg { width: 14px; height: 14px; display: block; }
+
+.pa-convert-event[data-phase="thinking"]   .pa-convert-node,
+.pa-convert-event[data-phase="running"]    .pa-convert-node,
+.pa-convert-event[data-phase="finalising"] .pa-convert-node,
+.pa-convert-event[data-phase="output"]     .pa-convert-node {
+    color: var(--cv-ai-ink);
+    background: var(--cv-ai-bg);
+    border-color: var(--cv-ai-line);
+}
+.pa-convert-event[data-phase="thinking"] .pa-convert-node svg { width: 17px; height: 17px; }
+.pa-convert-event[data-phase="validating"] .pa-convert-node,
+.pa-convert-event[data-phase="done"]       .pa-convert-node {
+    color: var(--cv-ok);
+    background: var(--cv-ok-bg);
+    border-color: var(--cv-ok-line);
+}
+.pa-convert-event[data-phase="asking"] .pa-convert-node {
+    color: var(--cv-warn);
+    background: var(--cv-warn-bg);
+    border-color: var(--cv-warn-line);
+}
+.pa-convert-event[data-phase="failed"] .pa-convert-node,
+.pa-convert-event.is-rejected          .pa-convert-node {
+    color: var(--cv-bad);
+    background: var(--cv-bad-bg);
+    border-color: var(--cv-bad-line);
+}
+.pa-convert-event[data-phase="user"] .pa-convert-node {
+    color: var(--pa-ink, #18181B);
+    background: var(--pa-surface-quiet, #F3F2ED);
+}
+
+/* The step in flight: a ring that breathes, so the eye finds "now" in a long
+   transcript without reading it. */
+.pa-convert-event.is-current .pa-convert-node::after {
+    content: "";
+    position: absolute;
+    inset: -5px;
+    border-radius: 50%;
+    border: 2px solid currentColor;
+    opacity: 0.3;
+    animation: pa-convert-pulse 1.6s ease-out infinite;
+}
+@keyframes pa-convert-pulse {
+    0%   { transform: scale(0.85); opacity: 0.45; }
+    100% { transform: scale(1.25); opacity: 0; }
+}
+
+.pa-convert-event-body { min-width: 0; padding-top: 5px; }
+.pa-convert-event-head {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    min-width: 0;
+}
+.pa-convert-event-title {
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 18px;
+    color: var(--pa-ink, #18181B);
+}
+.pa-convert-event.is-rejected .pa-convert-event-title,
+.pa-convert-event[data-phase="failed"] .pa-convert-event-title { color: var(--cv-bad-ink); }
+.pa-convert-event-time {
+    margin-left: auto;
+    flex: 0 0 auto;
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    color: var(--pa-ink-muted, #595959);
+    white-space: nowrap;
+}
+.pa-convert-event.is-current .pa-convert-event-time { color: var(--cv-ai-ink); }
+.pa-convert-attempt {
+    flex: 0 0 auto;
+    padding: 1px 7px;
+    border-radius: 99px;
+    background: var(--pa-surface-sunken, #F5F4EF);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    font-variant-numeric: tabular-nums;
+    color: var(--pa-ink-muted, #595959);
+}
+.pa-convert-event-detail {
+    margin: 3px 0 0;
+    font-size: 12.5px;
+    line-height: 1.5;
+    color: var(--pa-ink-muted, #595959);
+    overflow-wrap: anywhere;
+    max-width: var(--pa-measure-note, 78ch);
+}
+.pa-convert-event[data-phase="user"] .pa-convert-event-detail {
+    color: var(--pa-ink, #18181B);
+    font-style: italic;
+}
+
+/* The validator's verdict, as a list: one failure per line is what lets a
+   bioinformatician see exactly which file and which rule. */
+.pa-convert-verdict {
+    margin: 7px 0 0;
+    padding: 8px 11px;
+    border-radius: var(--pa-radius-sm, 6px);
+    border: 1px solid var(--cv-bad-line);
+    background: var(--cv-bad-bg);
+    color: var(--cv-bad-ink);
+    font-size: 12px;
+    line-height: 1.5;
+}
+.pa-convert-verdict ul { margin: 0; padding: 0 0 0 16px; }
+.pa-convert-verdict li + li { margin-top: 3px; }
+.pa-convert-verdict code { font-family: var(--cv-mono); font-size: 11px; }
+
+/* ---- disclosures: the script and its output ----------------------------- */
+
+.pa-convert-disclosures { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 7px; }
+.pa-convert-disclose {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 9px 3px 7px;
+    border-radius: 99px;
+    border: 1px solid var(--cv-line-strong);
+    background: var(--pa-control-bg, #FFFFFF);
+    font: inherit;
+    font-size: 11.5px;
+    font-weight: 600;
+    color: var(--pa-ink-control, #3F3F46);
+    cursor: pointer;
+}
+.pa-convert-disclose::before {
+    content: "";
+    width: 0;
+    height: 0;
+    border-left: 4px solid currentColor;
+    border-top: 3.5px solid transparent;
+    border-bottom: 3.5px solid transparent;
+    transition: transform 150ms ease;
+}
+.pa-convert-disclose[aria-expanded="true"]::before { transform: rotate(90deg); }
+.pa-convert-disclose:hover { border-color: var(--cv-ai-ink); color: var(--cv-ai-ink); }
+.pa-convert-disclose small { font-weight: 500; color: var(--pa-ink-muted, #595959); }
+
+.pa-convert-codebox {
+    margin: 7px 0 0;
+    border-radius: var(--pa-radius-sm, 6px);
+    border: 1px solid var(--cv-line);
     background: var(--pa-surface-sunken, #F5F4EF);
     overflow: hidden;
 }
-
-.pa-convert-fill {
-    height: 100%;
-    width: 2%;
-    border-radius: 99px;
-    background: var(--pa-accent-blue, #19589E);
-    /* Eased and slow: the bar tracks a budget of attempts, and snapping it
-       between steps would suggest a precision the estimate does not have. */
-    transition: width 420ms cubic-bezier(0.22, 1, 0.36, 1);
-}
-
-.pa-convert-progress-text {
-    grid-area: text;
-    font-size: 12.5px; font-weight: 600;
-    color: var(--pa-ink-control, #3F3F46);
-}
-
-.pa-convert-elapsed {
-    grid-area: elapsed;
-    font-size: 12px;
-    font-variant-numeric: tabular-nums;
-    color: var(--pa-ink-muted, #595959);
-}
-
-/* ---- transcript -------------------------------------------------------- */
-
-.pa-convert-body { flex: 1 1 auto; overflow-y: auto; padding: 4px 20px 20px; }
-
-.pa-convert-steps { list-style: none; margin: 0; padding: 0; }
-
-.pa-convert-step {
-    display: grid;
-    grid-template-columns: 22px 1fr auto;
+.pa-convert-codebox[hidden] { display: none; }
+.pa-convert-codebox-head {
+    display: flex;
+    align-items: center;
     gap: 10px;
-    padding: 9px 0;
-    border-bottom: 1px solid rgba(24, 24, 27, 0.05);
-    animation: pa-convert-in 220ms ease both;
-}
-
-@keyframes pa-convert-in {
-    from { opacity: 0; transform: translateY(4px); }
-    to { opacity: 1; transform: none; }
-}
-
-.pa-convert-icon {
-    width: 22px; height: 22px;
-    display: grid; place-items: center;
-    border-radius: 50%;
+    padding: 5px 8px 5px 11px;
+    border-bottom: 1px solid var(--cv-line);
     font-size: 11px;
-    background: var(--pa-surface-sunken, #F5F4EF);
     color: var(--pa-ink-muted, #595959);
 }
-
-.pa-phase-running .pa-convert-icon   { background: #E8EFF7; color: var(--pa-accent-blue, #19589E); }
-.pa-phase-validating .pa-convert-icon,
-.pa-phase-done .pa-convert-icon      { background: #E9F3E8; color: var(--pa-accent-green, #247B21); }
-.pa-phase-asking .pa-convert-icon    { background: #FBF0E6; color: var(--pa-accent-orange, #AD5022); }
-.pa-phase-failed .pa-convert-icon    { background: #F7E9ED; color: #B3261E; }
-
-/* The step in flight, so the eye knows where "now" is in a long transcript. */
-.pa-convert-current .pa-convert-icon { box-shadow: 0 0 0 3px rgba(25, 88, 158, 0.12); }
-
-.pa-convert-step-title { font-size: 13px; font-weight: 600; }
-.pa-convert-step-detail {
-    margin-top: 2px;
-    font-size: 12.5px; line-height: 1.5;
-    color: var(--pa-ink-muted, #595959);
-    overflow-wrap: anywhere;
-}
-
-.pa-convert-attempt {
+.pa-convert-codebox-head b { font-weight: 600; color: var(--pa-ink-control, #3F3F46); }
+.pa-convert-copy {
+    margin-left: auto;
+    padding: 2px 8px;
+    border-radius: 4px;
+    border: 1px solid transparent;
+    background: transparent;
+    font: inherit;
     font-size: 11px;
-    font-variant-numeric: tabular-nums;
-    color: var(--pa-ink-muted, #595959);
-    align-self: start;
-}
-
-/* ---- generated code ---------------------------------------------------- */
-
-.pa-convert-codetoggle {
-    margin-top: 7px;
-    padding: 0;
-    border: 0; background: none;
-    font: inherit; font-size: 12px;
     color: var(--pa-link, #0060BA);
     cursor: pointer;
 }
-.pa-convert-codetoggle:hover { text-decoration: underline; }
-
+.pa-convert-copy:hover { border-color: var(--cv-line-strong); background: var(--pa-control-bg, #FFFFFF); }
 .pa-convert-code {
-    margin: 7px 0 0;
-    padding: 11px 12px;
-    border-radius: 8px;
-    background: var(--pa-surface-sunken, #F5F4EF);
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 11.5px; line-height: 1.55;
-    overflow-x: auto;          /* long lines scroll here, never the drawer */
+    margin: 0;
+    padding: 10px 12px;
+    font-family: var(--cv-mono);
+    font-size: 11.5px;
+    line-height: 1.55;
+    color: var(--pa-ink, #18181B);
+    overflow-x: auto;          /* long lines scroll here, never the sheet */
     white-space: pre;
+    tab-size: 4;
+    max-height: 420px;
+    overflow-y: auto;
 }
 
-/* ---- questions --------------------------------------------------------- */
+/* ---- questions ---------------------------------------------------------- */
 
 .pa-convert-question {
-    margin-top: 9px;
-    padding: 12px;
-    border-radius: 10px;
-    background: #FBF7F2;
-    border: 1px solid rgba(173, 80, 34, 0.28);
+    margin: 8px 0 0;
+    padding: 12px 13px;
+    border-radius: var(--pa-radius, 8px);
+    background: var(--cv-warn-bg);
+    border: 1px solid var(--cv-warn-line);
 }
-
-.pa-convert-question-text { margin: 0 0 9px; font-size: 12.5px; line-height: 1.5; }
+.pa-convert-question-text {
+    margin: 0 0 10px;
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.45;
+    color: var(--pa-ink, #18181B);
+}
 .pa-convert-options { display: flex; flex-wrap: wrap; gap: 8px; }
-
 .pa-convert-option {
-    min-height: 30px;
+    min-height: 32px;
     padding: 6px 12px;
-    border-radius: 7px;
+    border-radius: var(--pa-radius-sm, 6px);
     border: 1px solid var(--pa-ink-label, #52525B);
     background: var(--pa-control-bg, #FFFFFF);
-    font: inherit; font-size: 12px;
+    color: var(--pa-ink-control, #3F3F46);
+    font: inherit;
+    font-size: 12.5px;
     cursor: pointer;
 }
-.pa-convert-option:hover:not(:disabled) { border-color: var(--pa-accent-blue, #19589E); }
+.pa-convert-option:hover:not(:disabled) { border-color: var(--cv-ai-ink); color: var(--cv-ai-ink); }
 .pa-convert-option:disabled { opacity: 0.45; cursor: default; }
-.pa-convert-option-chosen {
-    border-color: var(--pa-accent-green, #247B21);
-    color: var(--pa-accent-green, #247B21);
+.pa-convert-option-chosen,
+.pa-convert-option-chosen:disabled {
+    border-color: var(--cv-ok);
+    background: var(--cv-ok-bg);
+    color: var(--cv-ok);
     font-weight: 600;
     opacity: 1;
 }
+.pa-convert-question-hint { margin: 9px 0 0; font-size: 11.5px; color: var(--pa-ink-muted, #595959); }
+.pa-convert-answer { margin: 9px 0 0; font-size: 12px; font-weight: 600; color: var(--cv-ok); }
 
-/* ---- review ------------------------------------------------------------ */
+/* ---- the review --------------------------------------------------------- */
 
-.pa-convert-review { margin-top: 16px; }
-.pa-convert-review h3 { margin: 0 0 9px; font-size: 14px; font-weight: 650; }
-
-.pa-convert-files { list-style: none; margin: 0; padding: 0; }
-.pa-convert-files li {
-    display: flex; flex-direction: column; gap: 2px;
-    padding: 10px 12px; margin-bottom: 7px;
-    border-radius: 9px;
-    background: #F4F9F3;
-    border: 1px solid rgba(36, 123, 33, 0.25);
+.pa-convert-review {
+    margin-top: 18px;
+    padding-top: 14px;
+    border-top: 1px solid var(--cv-line);
 }
-.pa-convert-file { font-size: 12.5px; font-weight: 600; overflow-wrap: anywhere; }
-.pa-convert-filestat { font-size: 12px; color: var(--pa-ink-muted, #595959); }
+.pa-convert-review-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
+.pa-convert-panel h3.pa-convert-review-title {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--pa-ink, #18181B);
+}
+.pa-convert-review-failed h3.pa-convert-review-title { color: var(--cv-bad-ink); }
+.pa-convert-review-count { font-size: 11.5px; color: var(--pa-ink-muted, #595959); font-variant-numeric: tabular-nums; }
+.pa-convert-summary {
+    margin: 6px 0 12px;
+    font-size: 12.5px;
+    line-height: 1.55;
+    color: var(--pa-ink-control, #3F3F46);
+    max-width: var(--pa-measure-note, 78ch);
+}
 
-/* ---- footer ------------------------------------------------------------ */
+.pa-convert-result {
+    position: relative;
+    margin-bottom: 10px;
+    /* 16px on the left: border 1 + bar 4 + 11 of air puts the radio's label
+       on the 64px type rail the timeline uses (measured, not chosen). */
+    padding: 12px 14px 12px 16px;
+    border-radius: var(--pa-radius, 8px);
+    border: 1px solid var(--cv-line-strong);
+    background: var(--pa-surface, #FFFFFF);
+    box-shadow: inset 4px 0 0 var(--cv-line), var(--pa-shadow, 0 1px 3px rgba(24, 24, 27, 0.08));
+    transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+.pa-convert-result-chosen {
+    border-color: var(--cv-omic);
+    box-shadow: inset 4px 0 0 var(--cv-omic), var(--pa-shadow, 0 1px 3px rgba(24, 24, 27, 0.08));
+}
 
-.pa-convert-footer {
-    display: flex; gap: 10px; justify-content: flex-end;
-    padding: 14px 20px;
-    border-top: 1px solid rgba(24, 24, 27, 0.08);
+.pa-convert-result-head { display: flex; align-items: flex-start; gap: 10px; }
+.pa-convert-pick {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    flex: 1 1 auto;
+    min-width: 0;
+    cursor: pointer;
+}
+.pa-convert-pick input { margin: 3px 0 0; flex: 0 0 auto; accent-color: var(--cv-omic); }
+.pa-convert-result-titles { min-width: 0; }
+.pa-convert-result-title { font-size: 13.5px; font-weight: 650; overflow-wrap: anywhere; color: var(--pa-ink, #18181B); }
+.pa-convert-result-meta { margin-top: 2px; font-size: 11.5px; color: var(--pa-ink-muted, #595959); font-variant-numeric: tabular-nums; }
+
+.pa-convert-badge {
+    flex: 0 0 auto;
+    align-self: center;
+    padding: 2px 8px;
+    border-radius: 99px;
+    background: var(--cv-ok-bg);
+    border: 1px solid var(--cv-ok-line);
+    color: var(--cv-ok);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.pa-convert-iconbtn {
+    flex: 0 0 auto;
+    width: 28px;
+    height: 28px;
+    display: grid;
+    place-items: center;
+    border: 1px solid var(--cv-line-strong);
+    border-radius: var(--pa-radius-sm, 6px);
+    background: var(--pa-control-bg, #FFFFFF);
+    color: var(--pa-ink-control, #3F3F46);
+    cursor: pointer;
+}
+.pa-convert-iconbtn svg { width: 14px; height: 14px; display: block; }
+.pa-convert-iconbtn:hover { border-color: var(--cv-ai-ink); color: var(--cv-ai-ink); }
+
+.pa-convert-preview {
+    margin: 10px 0 0;
+    border-radius: var(--pa-radius-sm, 6px);
+    border: 1px solid var(--cv-line);
+    background: var(--pa-surface-sunken, #F5F4EF);
+    overflow-x: auto;         /* wide previews scroll here, never the sheet */
+}
+.pa-convert-preview table { border-collapse: collapse; font-family: var(--cv-mono); font-size: 11px; }
+.pa-convert-preview th, .pa-convert-preview td {
+    padding: 4px 9px;
+    border-bottom: 1px solid var(--cv-line);
+    white-space: nowrap;
+    text-align: left;
+    max-width: 170px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.pa-convert-preview tr:last-child td { border-bottom: 0; }
+.pa-convert-preview th { font-weight: 650; color: var(--pa-ink-control, #3F3F46); background: rgba(24, 24, 27, 0.035); }
+.pa-convert-preview td { font-variant-numeric: tabular-nums; color: var(--pa-ink, #18181B); }
+.pa-convert-preview .pa-convert-id { font-weight: 600; }
+.pa-convert-preview .pa-convert-more { color: var(--pa-ink-muted, #595959); font-weight: 500; }
+
+/* Kept / left out. The label column has a fixed width so the two chip rows
+   start on the same line. */
+.pa-convert-columns { margin-top: 9px; display: grid; grid-template-columns: 58px 1fr; row-gap: 5px; column-gap: 6px; align-items: start; }
+.pa-convert-columns-label {
+    padding-top: 2px;
+    font-size: 11px;
+    font-weight: 650;
+    letter-spacing: 0.02em;
+    color: var(--pa-ink-muted, #595959);
+}
+.pa-convert-chips { display: flex; flex-wrap: wrap; gap: 4px; }
+.pa-convert-chip {
+    padding: 1px 7px;
+    border-radius: 99px;
+    font-family: var(--cv-mono);
+    font-size: 10.5px;
+    line-height: 1.6;
+    background: var(--pa-surface-quiet, #F3F2ED);
+    color: var(--pa-ink-control, #3F3F46);
+    max-width: 220px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.pa-convert-kept .pa-convert-chip { background: var(--cv-ok-bg); color: #1F5E1D; }
+.pa-convert-dropped .pa-convert-chip { text-decoration: line-through; opacity: 0.75; }
+.pa-convert-chip-more { text-decoration: none !important; opacity: 1 !important; font-family: var(--pa-font-sans); }
+
+.pa-convert-result-note {
+    margin: 9px 0 0;
+    font-size: 11.5px;
+    line-height: 1.5;
+    color: var(--pa-ink-muted, #595959);
+}
+
+.pa-convert-linked {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 9px;
+    padding: 7px 9px;
+    border-radius: var(--pa-radius-sm, 6px);
+    background: var(--cv-ok-bg);
+    border: 1px solid var(--cv-ok-line);
+    font-size: 11.5px;
+    line-height: 1.45;
+    color: var(--pa-ink-control, #3F3F46);
+}
+.pa-convert-linked > span:nth-child(2) { flex: 1 1 auto; min-width: 0; overflow-wrap: anywhere; }
+.pa-convert-linked-icon { color: var(--cv-ok); display: grid; place-items: center; }
+.pa-convert-linked-icon svg { width: 14px; height: 14px; }
+.pa-convert-linked b { font-weight: 600; }
+
+.pa-convert-extras { margin-top: 12px; }
+.pa-convert-panel h4.pa-convert-extras-title {
+    margin: 0 0 4px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--pa-ink-muted, #595959);
+}
+.pa-convert-extras .pa-convert-linked { background: var(--pa-surface-quiet, #F3F2ED); border-color: var(--cv-line); }
+.pa-convert-extras .pa-convert-linked-icon { color: var(--pa-ink-muted, #595959); }
+
+.pa-convert-skipped { margin-top: 10px; font-size: 11.5px; color: var(--pa-ink-muted, #595959); }
+.pa-convert-skipped summary { cursor: pointer; font-weight: 600; }
+.pa-convert-skipped-row { padding: 3px 0 0 14px; }
+.pa-convert-skipped-row b { font-weight: 600; color: var(--pa-ink-control, #3F3F46); }
+
+.pa-convert-addothers {
+    display: flex;
+    gap: 9px;
+    align-items: flex-start;
+    margin-top: 12px;
+    padding: 10px 12px;
+    border-radius: var(--pa-radius, 8px);
+    border: 1px dashed var(--cv-ai-line);
+    background: var(--cv-ai-bg);
+    font-size: 12.5px;
+    line-height: 1.45;
+    color: var(--pa-ink-control, #3F3F46);
+    cursor: pointer;
+}
+.pa-convert-addothers input { margin-top: 3px; accent-color: var(--cv-ai-ink); }
+
+.pa-convert-failed-files { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+
+/* ---- the dock: composer, then the decision ------------------------------ */
+
+.pa-convert-dock {
+    flex: 0 0 auto;
+    padding: 12px var(--cv-inset) 14px;
+    border-top: 1px solid var(--cv-line);
     background: var(--pa-surface-toolbar, #F6F5F0);
 }
+
+.pa-convert-composer {
+    display: flex;
+    gap: 8px;
+    align-items: flex-end;
+}
+/* Two lines tall at rest and growing with what is typed. A one-row box
+   clipped its own placeholder mid-sentence. */
+.pa-convert-composer-input {
+    flex: 1 1 auto;
+    min-height: 66px;
+    max-height: 200px;
+    padding: 10px 12px;
+    border-radius: var(--pa-radius, 8px);
+    border: 1px solid var(--cv-line-strong);
+    background: var(--pa-control-bg, #FFFFFF);
+    color: var(--pa-ink, #18181B);
+    font: inherit;
+    font-size: 13px;
+    line-height: 1.45;
+    resize: none;
+    box-shadow: var(--pa-shadow-inset, inset 0 1px 2px rgba(24, 24, 27, 0.06));
+}
+.pa-convert-composer-input::placeholder { color: var(--pa-ink-muted, #595959); opacity: 0.85; }
+.pa-convert-composer-input:focus {
+    outline: none;
+    border-color: var(--cv-ai-ink);
+    box-shadow: 0 0 0 3px rgba(25, 88, 158, 0.14);
+}
+.pa-convert-composer-input:disabled { opacity: 0.55; }
+.pa-convert-composer-send {
+    flex: 0 0 auto;
+    min-height: 38px;
+    padding: 0 16px;
+    border-radius: var(--pa-radius-sm, 6px);
+    border: 1px solid var(--cv-ai-ink);
+    background: var(--cv-ai-ink);
+    color: #fff;
+    font: inherit;
+    font-size: 13px;
+    font-weight: 650;
+    cursor: pointer;
+    transition: background-color var(--pa-transition, 150ms), opacity var(--pa-transition, 150ms);
+}
+.pa-convert-composer-send:hover:not(:disabled) { background: #134A86; }
+.pa-convert-composer-send:disabled { opacity: 0.45; cursor: default; }
+.pa-convert-composer-hint {
+    margin: 6px 0 0;
+    font-size: 11px;
+    line-height: 1.4;
+    color: var(--pa-ink-muted, #595959);
+}
+.pa-convert-composer-hint kbd {
+    font-family: inherit;
+    font-size: 10px;
+    padding: 0 4px;
+    border: 1px solid var(--cv-line-strong);
+    border-bottom-width: 2px;
+    border-radius: 3px;
+    background: var(--pa-control-bg, #FFFFFF);
+}
+
+.pa-convert-actions {
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid var(--cv-line);
+}
+.pa-convert-actions:empty { display: none; }
 
 .pa-convert-accept, .pa-convert-dismiss {
     min-height: 34px;
     padding: 8px 16px;
-    border-radius: 8px;
-    font: inherit; font-size: 13px; font-weight: 600;
+    border-radius: var(--pa-radius-sm, 6px);
+    font: inherit;
+    font-size: 13px;
+    font-weight: 600;
     cursor: pointer;
+    transition: background-color var(--pa-transition, 150ms), border-color var(--pa-transition, 150ms);
 }
-
-.pa-convert-accept {
-    border: 1px solid #306C30;
-    background: #3A843A;
-    color: #fff;
-}
+/* The accept is the app's own success green -- the same fill as Run
+   PaintOmics -- because it is the thing we want pressed. */
+.pa-convert-accept { border: 1px solid #306C30; background: #3A843A; color: #fff; }
 .pa-convert-accept:hover { background: #337533; }
-
 .pa-convert-dismiss {
     border: 1px solid var(--pa-ink-label, #52525B);
     background: var(--pa-control-bg, #FFFFFF);
     color: var(--pa-ink-control, #3F3F46);
     font-weight: 500;
 }
+.pa-convert-dismiss:hover { border-color: var(--cv-ai-ink); color: var(--cv-ai-ink); }
+.pa-convert-dismiss.is-quiet { border-color: transparent; background: transparent; }
 
 /* The sandbox does the work but shows nothing; it must not take layout. */
 .pa-convert-sandbox {
     position: absolute;
-    width: 1px; height: 1px;
-    left: -9999px; top: 0;
+    width: 1px;
+    height: 1px;
+    left: -9999px;
+    top: 0;
     border: 0;
-}
-
-/* ---- review: tables, previews, chips ------------------------------------ */
-
-.pa-convert-reviewhost { margin-top: 10px; }
-.pa-convert-summary {
-    margin: 0 0 12px;
-    font-size: 12.5px; line-height: 1.55;
-    color: var(--pa-ink-control, #3F3F46);
-}
-
-.pa-convert-card {
-    margin-bottom: 10px;
-    padding: 12px 12px 10px;
-    border-radius: 12px;
-    border: 1px solid rgba(24, 24, 27, 0.10);
-    background: var(--pa-surface, #FFFFFF);
-    transition: border-color 160ms ease, box-shadow 160ms ease;
-}
-.pa-convert-card-chosen {
-    border-color: var(--pa-accent-green, #247B21);
-    box-shadow: 0 0 0 3px rgba(36, 123, 33, 0.10);
-}
-
-.pa-convert-card-head { display: flex; align-items: flex-start; gap: 10px; }
-.pa-convert-pick { display: flex; gap: 10px; align-items: flex-start; flex: 1 1 auto; min-width: 0; cursor: pointer; }
-.pa-convert-pick input { margin: 3px 0 0; accent-color: var(--pa-accent-green, #247B21); }
-.pa-convert-card-titles { min-width: 0; }
-.pa-convert-card-title { font-size: 13px; font-weight: 650; overflow-wrap: anywhere; }
-.pa-convert-card-meta { margin-top: 2px; font-size: 11.5px; color: var(--pa-ink-muted, #595959); }
-
-.pa-convert-badge {
-    flex: 0 0 auto;
-    padding: 2px 8px;
-    border-radius: 99px;
-    background: #E9F3E8;
-    color: var(--pa-accent-green, #247B21);
-    font-size: 10.5px; font-weight: 700; letter-spacing: 0.02em; text-transform: uppercase;
-    align-self: center;
-}
-
-.pa-convert-iconbtn {
-    flex: 0 0 auto;
-    width: 28px; height: 28px;
-    border: 1px solid rgba(24, 24, 27, 0.12); border-radius: 7px;
-    background: var(--pa-control-bg, #FFFFFF);
-    color: var(--pa-ink-control, #3F3F46);
-    font-size: 14px; line-height: 1; cursor: pointer;
-}
-.pa-convert-iconbtn:hover { border-color: var(--pa-accent-blue, #19589E); color: var(--pa-accent-blue, #19589E); }
-
-.pa-convert-preview {
-    margin: 10px 0 8px;
-    border-radius: 8px;
-    border: 1px solid rgba(24, 24, 27, 0.08);
-    background: var(--pa-surface-sunken, #F5F4EF);
-    overflow-x: auto;         /* wide previews scroll here, never the drawer */
-}
-.pa-convert-preview table { border-collapse: collapse; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; }
-.pa-convert-preview th, .pa-convert-preview td {
-    padding: 4px 9px;
-    border-bottom: 1px solid rgba(24, 24, 27, 0.06);
-    white-space: nowrap; text-align: left;
-    max-width: 160px; overflow: hidden; text-overflow: ellipsis;
-}
-.pa-convert-preview th { font-weight: 650; color: var(--pa-ink-control, #3F3F46); background: rgba(24, 24, 27, 0.03); }
-.pa-convert-preview td { font-variant-numeric: tabular-nums; color: var(--pa-ink, #18181B); }
-.pa-convert-preview .pa-convert-id { font-weight: 600; }
-.pa-convert-preview .pa-convert-more { color: var(--pa-ink-muted, #595959); font-weight: 500; }
-
-.pa-convert-chips { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; margin-top: 6px; }
-.pa-convert-chips-label { font-size: 11px; font-weight: 650; color: var(--pa-ink-muted, #595959); margin-right: 2px; }
-.pa-convert-chip {
-    padding: 1px 7px; border-radius: 99px;
-    font-size: 10.5px; line-height: 1.6;
-    background: var(--pa-surface-quiet, #F3F2ED);
-    color: var(--pa-ink-control, #3F3F46);
-    max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
-.pa-convert-kept .pa-convert-chip { background: #E9F3E8; color: #1F5E1D; }
-.pa-convert-dropped .pa-convert-chip { text-decoration: line-through; opacity: 0.8; }
-.pa-convert-chip-more { text-decoration: none !important; opacity: 1 !important; }
-
-.pa-convert-card-note {
-    margin: 8px 0 0;
-    font-size: 11.5px; line-height: 1.5;
-    color: var(--pa-ink-muted, #595959);
-}
-
-.pa-convert-linked {
-    display: flex; align-items: center; gap: 8px;
-    margin-top: 8px; padding: 7px 9px;
-    border-radius: 8px;
-    background: #F4F9F3;
-    font-size: 11.5px; line-height: 1.45;
-    color: var(--pa-ink-control, #3F3F46);
-}
-.pa-convert-linked > span:nth-child(2) { flex: 1 1 auto; min-width: 0; overflow-wrap: anywhere; }
-.pa-convert-linked-icon { color: var(--pa-accent-green, #247B21); font-weight: 700; }
-
-.pa-convert-extras { margin-top: 12px; }
-.pa-convert-extras h4 { margin: 0 0 4px; font-size: 12px; font-weight: 650; color: var(--pa-ink-muted, #595959); }
-.pa-convert-extras .pa-convert-linked { background: var(--pa-surface-quiet, #F3F2ED); }
-
-.pa-convert-skipped { margin-top: 10px; font-size: 11.5px; color: var(--pa-ink-muted, #595959); }
-.pa-convert-skipped summary { cursor: pointer; font-weight: 600; }
-.pa-convert-skipped-row { padding: 3px 0 0 14px; }
-
-.pa-convert-addothers {
-    display: flex; gap: 9px; align-items: flex-start;
-    margin-top: 12px; padding: 10px 12px;
-    border-radius: 10px;
-    border: 1px dashed rgba(25, 88, 158, 0.45);
-    font-size: 12.5px; line-height: 1.45; cursor: pointer;
-}
-.pa-convert-addothers input { margin-top: 3px; accent-color: var(--pa-accent-blue, #19589E); }
-
-.pa-convert-review-failed h3 { color: #B3261E; }
-.pa-convert-answer { margin-top: 8px; font-size: 11.5px; color: var(--pa-accent-green, #247B21); font-weight: 600; }
-
-.pa-phase-user .pa-convert-icon { background: #E8EFF7; color: var(--pa-accent-blue, #19589E); }
-.pa-phase-finalising .pa-convert-icon { background: #E8EFF7; color: var(--pa-accent-blue, #19589E); }
-.pa-phase-user .pa-convert-step-detail { color: var(--pa-ink, #18181B); font-style: italic; }
-
-/* ---- composer ------------------------------------------------------------ */
-
-.pa-convert-composer {
-    display: flex; gap: 8px; align-items: flex-end;
-    padding: 10px 20px 0;
-    border-top: 1px solid rgba(24, 24, 27, 0.08);
-    background: var(--pa-surface, #FFFFFF);
-}
-.pa-convert-composer-input {
-    flex: 1 1 auto;
-    min-height: 38px; max-height: 120px;
-    padding: 9px 12px;
-    border-radius: 10px;
-    border: 1px solid rgba(24, 24, 27, 0.18);
-    background: var(--pa-control-bg, #FFFFFF);
-    color: var(--pa-ink, #18181B);
-    font: inherit; font-size: 12.5px; line-height: 1.4;
-    resize: vertical;
-}
-.pa-convert-composer-input:focus { outline: none; border-color: var(--pa-accent-blue, #19589E); box-shadow: 0 0 0 3px rgba(25, 88, 158, 0.12); }
-.pa-convert-composer-input:disabled { opacity: 0.55; }
-.pa-convert-composer-send {
-    flex: 0 0 auto;
-    min-height: 38px; padding: 0 14px;
-    border-radius: 10px;
-    border: 1px solid var(--pa-accent-blue, #19589E);
-    background: var(--pa-accent-blue, #19589E);
-    color: #fff;
-    font: inherit; font-size: 12.5px; font-weight: 650;
-    cursor: pointer;
-}
-.pa-convert-composer-send:disabled { opacity: 0.45; cursor: default; }
-.pa-convert-composer-hint {
-    padding: 5px 20px 8px;
-    font-size: 10.5px; line-height: 1.4;
-    color: var(--pa-ink-muted, #595959);
-    background: var(--pa-surface, #FFFFFF);
 }

--- a/PaintomicsClient/public_html/resources/css/inputformat.css
+++ b/PaintomicsClient/public_html/resources/css/inputformat.css
@@ -219,3 +219,159 @@ input[type="text"].pa-field-err {
     margin-right: 2px;
     vertical-align: -0.15em;
 }
+
+/* ------------------------------------------------------------------------
+   The standing offer.
+
+   Before a file is picked the strip carries the AI's one sentence -- any file
+   will do -- with no tint and no border, because a promise is not a verdict.
+   It turns into the checking / ok / convert states the moment a file lands.
+   ------------------------------------------------------------------------ */
+.pa-format-idle {
+    background: transparent;
+    border-color: transparent;
+    padding: 6px 14px 8px;
+    color: var(--pa-ink-muted, #595959);
+    font-size: 12px;
+    align-items: center;
+}
+.pa-format-idle .pa-format-icon-ai {
+    display: inline-flex;
+    color: var(--pa-ai-blue, #4A90D9);
+    font-size: 15px;
+    line-height: 1;
+}
+.pa-format-idle b {
+    font-weight: 600;
+    color: var(--pa-accent-blue, #19589E);
+}
+
+/* After the AI's table is accepted, the ok strip names where it came from
+   and offers the conversion again. */
+.pa-format-provenance {
+    display: flex;
+    align-items: flex-start;
+    gap: 7px;
+    margin-top: 6px;
+    color: var(--pa-ink-muted, #595959);
+}
+.pa-format-provenance-text { flex: 1 1 auto; min-width: 0; }
+.pa-format-provenance .pa-format-linkbtn { margin-left: 4px; }
+.pa-format-provenance-mark {
+    display: inline-flex;
+    color: var(--pa-ai-blue, #4A90D9);
+    font-size: 14px;
+    line-height: 1;
+}
+.pa-format-provenance b { font-weight: 600; color: var(--pa-ink-control, #3F3F46); }
+.pa-format-linkbtn {
+    padding: 0;
+    border: 0;
+    background: none;
+    font: inherit;
+    color: var(--pa-link, #0060BA);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    cursor: pointer;
+}
+.pa-format-linkbtn:hover { color: var(--pa-link-hover, #24785D); }
+.pa-format-linkbtn:focus-visible { outline: 2px solid var(--pa-focus-ring, #0A84FF); outline-offset: 2px; border-radius: 2px; }
+
+/* ------------------------------------------------------------------------
+   The Section 3 callout: "Bring your files as they are".
+
+   It borrows .po-ai-section-body from the Section 2 callout for its panel,
+   and lays out the same way: the explanation gets a reading measure, the
+   aside takes the space the prose cannot use and says what leaves the
+   machine. The AI mark on the heading is what Section 2's heading wears.
+   ------------------------------------------------------------------------ */
+.po-upload-ai-grid {
+    display: flex;
+    gap: 18px 32px;
+    align-items: flex-start;
+}
+.po-upload-ai-text {
+    flex: 1 1 auto;
+    min-width: 0;
+    max-width: var(--pa-measure-note, 78ch);
+}
+/* Pinned to the panel's right edge, where Section 2 keeps its controls, so
+   the two callouts' right columns stand on the same line. */
+.po-upload-ai-aside {
+    flex: 0 1 400px;
+    margin-left: auto;
+    min-width: 220px;
+    padding: 10px 14px 11px;
+    border-radius: var(--pa-radius-sm, 6px);
+    background: var(--pa-surface, #FFFFFF);
+    border: 1px solid #CFE0F0;
+}
+.po-upload-ai-icon {
+    display: inline-flex;
+    color: var(--pa-ai-blue, #4A90D9);
+    flex-shrink: 0;
+}
+/* Not the #4A90D9 the mark uses: bold body text needs 4.5:1, so the darker
+   accent blue, exactly as the Section 2 head does it. */
+.po-upload-ai .po-hero-ai-head strong {
+    color: var(--pa-accent-blue, #19589E);
+    font-size: 14.5px;
+    font-weight: 700;
+}
+/* `div.contentbox p` is (0,1,2) and adds the card inset to every paragraph
+   inside a card; two classes outrank it, the same trap the hero notes. */
+.po-ai-section-body.po-upload-ai p {
+    margin: 6px 0 0;
+    padding: 0;
+    font-size: 14px;
+    line-height: 1.5;
+    color: var(--pa-ink-body, #555);
+    max-width: none;
+}
+.po-ai-section-body.po-upload-ai p b { font-weight: 700; color: var(--pa-accent-blue, #19589E); }
+.po-upload-ai-does {
+    list-style: none;
+    margin: 8px 0 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 16px;
+}
+.po-ai-section-body.po-upload-ai .po-upload-ai-does li {
+    position: relative;
+    padding: 0 0 0 13px;
+    font-size: 12.5px;
+    line-height: 1.5;
+    color: var(--pa-ink-muted, #595959);
+    max-width: none;
+}
+.po-upload-ai-does li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0.55em;
+    width: 5px;
+    height: 5px;
+    border-radius: 1px;
+    background: var(--pa-ai-blue, #4A90D9);
+}
+.po-upload-ai-aside-title {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--pa-accent-blue, #19589E);
+}
+.po-ai-section-body.po-upload-ai .po-upload-ai-aside p {
+    margin: 5px 0 0;
+    font-size: 12.5px;
+    line-height: 1.5;
+    color: var(--pa-ink-muted, #595959);
+}
+.po-upload-ai-aside p span { color: var(--pa-ink-control, #3F3F46); font-weight: 600; }
+
+
+@media (max-width: 980px) {
+    .po-upload-ai-grid { flex-direction: column; }
+    .po-upload-ai-aside { max-width: none; }
+}

--- a/PaintomicsClient/public_html/resources/css/inputformat.css
+++ b/PaintomicsClient/public_html/resources/css/inputformat.css
@@ -338,7 +338,6 @@ input[type="text"].pa-field-err {
 }
 .po-upload-ai-consent input:focus-visible { outline: 2px solid var(--pa-focus-ring, #0A84FF); outline-offset: 2px; }
 .po-upload-ai-consent > label { flex: 1 1 auto; cursor: pointer; font-weight: 400; }
-.po-upload-ai-consent .ai-consent-warn span { font-weight: 600; }
 
 /* The right column: a label on top like "Experiment design (optional):",
    then the formats as pills -- scannable where a sentence listing them was

--- a/PaintomicsClient/public_html/resources/css/inputformat.css
+++ b/PaintomicsClient/public_html/resources/css/inputformat.css
@@ -336,25 +336,8 @@ input[type="text"].pa-field-err {
     margin: 0 0 8px;
     line-height: 18px;
 }
-.po-upload-ai-formats {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px;
-}
-.po-upload-ai .po-upload-ai-formats li {
-    padding: 3px 10px;
-    border-radius: 99px;
-    border: 1px solid #CFE0F0;
-    background: var(--pa-surface, #FFFFFF);
-    font-size: 12px;
-    line-height: 1.4;
-    color: var(--pa-ink-control, #3F3F46);
-    max-width: none;
-    white-space: nowrap;
-}
+/* The pills themselves are .po-pill-list in main.css, shared with the
+   interpretation panel's facts. */
 
 @media (max-width: 980px) {
     .po-upload-ai-grid { flex-direction: column; }

--- a/PaintomicsClient/public_html/resources/css/inputformat.css
+++ b/PaintomicsClient/public_html/resources/css/inputformat.css
@@ -283,19 +283,14 @@ input[type="text"].pa-field-err {
 .pa-format-linkbtn:focus-visible { outline: 2px solid var(--pa-focus-ring, #0A84FF); outline-offset: 2px; border-radius: 2px; }
 
 /* ------------------------------------------------------------------------
-   The Section 3 row: "Bring your files as they are".
+   The Section 3 panel: "Bring your files as they are".
 
-   A plain row on the same two columns as the Section 2 panel, not a second
-   panel: the blue panel is the form's one decision and a second one read as
-   that decision asked twice. It keeps the panel's inset so its sentence starts
-   on the same x as Section 2's (283px on a 1867px viewport), and its right
-   column is the page's one right column -- 400px wide, starting at 1185px,
-   where Section 2's experiment-design field and the Help panel start too.
+   The same .po-ai-section-body panel as Section 2 (it supplies the surface,
+   the border, the padding and the card inset), on the same two columns: the
+   sentence starts on the same x as Section 2's (283px on a 1867px viewport),
+   and the right column is the page's one right column -- 400px wide, starting
+   at 1185px, where the experiment-design field and the Help panel start too.
    ------------------------------------------------------------------------ */
-.po-upload-ai {
-    margin: 5px var(--pa-card-inset) 10px;
-    padding: 4px 22px 12px;
-}
 .po-upload-ai-grid {
     display: flex;
     align-items: flex-start;

--- a/PaintomicsClient/public_html/resources/css/inputformat.css
+++ b/PaintomicsClient/public_html/resources/css/inputformat.css
@@ -318,9 +318,9 @@ input[type="text"].pa-field-err {
 /* The lead on its own line, the sentence 2px under it: one block to the eye,
    two rows to the overlay. */
 .po-upload-ai p.po-upload-ai-lead { margin: 0 0 4px; }
-/* The lead at the size of the switch's title above, so the two sections
-   open with the same voice. */
-.po-upload-ai p.po-upload-ai-lead b { font-size: 15px; font-weight: 600; }
+/* The lead at the size of the consent title in the panel above, one step
+   under the section heading, so the two panels open with the same voice. */
+.po-upload-ai p.po-upload-ai-lead b { font-size: 14px; font-weight: 600; }
 
 /* The right column: a label on top like "Experiment design (optional):",
    then the formats as pills -- scannable where a sentence listing them was

--- a/PaintomicsClient/public_html/resources/css/inputformat.css
+++ b/PaintomicsClient/public_html/resources/css/inputformat.css
@@ -283,61 +283,44 @@ input[type="text"].pa-field-err {
 .pa-format-linkbtn:focus-visible { outline: 2px solid var(--pa-focus-ring, #0A84FF); outline-offset: 2px; border-radius: 2px; }
 
 /* ------------------------------------------------------------------------
-   The Section 3 callout: "Bring your files as they are".
+   The Section 3 row: "Bring your files as they are".
 
-   Same panel and the same skeleton as the Section 2 callout so the two read as
-   one feature: the prose column is 3/5 and the right column 2/5 with a 32px
-   gutter (measured off Section 2's hbox: its textarea starts at 1077px on a
-   1867px viewport, and so does this right column); the head, the sentence and
-   the consent control sit on the same three lines as their Section 2
-   counterparts. No box around the right column -- Section 2 has none, and a
-   bordered card there was the heaviest thing on the form.
+   A plain row on the same two columns as the Section 2 panel, not a second
+   panel: the blue panel is the form's one decision and a second one read as
+   that decision asked twice. It keeps the panel's inset so its sentence starts
+   on the same x as Section 2's (283px on a 1867px viewport), and its right
+   column is the page's one right column -- 400px wide, starting at 1185px,
+   where Section 2's experiment-design field and the Help panel start too.
    ------------------------------------------------------------------------ */
+.po-upload-ai {
+    margin: 5px var(--pa-card-inset) 10px;
+    padding: 4px 22px 12px;
+}
 .po-upload-ai-grid {
     display: flex;
     align-items: flex-start;
 }
 .po-upload-ai-text {
-    flex: 3 1 0;
+    flex: 1 1 auto;
     min-width: 0;
 }
 .po-upload-ai-aside {
-    flex: 2 1 0;
+    flex: 0 0 400px;
     min-width: 0;
     margin-left: 32px;
 }
 /* `div.contentbox p` is (0,1,2) and adds the card inset to every paragraph
    inside a card; two classes outrank it. The type itself is .ai-intro-copy,
-   the Section 2 sentence's own class, and it runs the same measure, so the
-   two sentences sit on the same lines. The lead-in is the bold the Section 2
-   sentence gives its subject. */
-.po-ai-section-body.po-upload-ai p.ai-intro-copy {
+   the Section 2 sentence's own class, so the two sentences match; the lead-in
+   is the bold the Section 2 sentence gives its subject. */
+.po-upload-ai p.ai-intro-copy {
     margin: 0;
     padding: 0;
 }
-.po-ai-section-body.po-upload-ai p.ai-intro-copy b { font-weight: 700; color: var(--pa-accent-blue, #19589E); }
-
-/* The consent row, shaped like Section 2's checkbox row: 16px box, 8px gap,
-   label that wraps with a hanging indent. */
-.po-upload-ai-consent {
-    display: flex;
-    align-items: flex-start;
-    gap: 8px;
-    margin: 10px 0 0;   /* Section 2: sentence bottom 87, box top 97 */
-    font-size: 13px;
-    line-height: 1.45;
-    color: var(--pa-ink, #18181B);
-}
-.po-upload-ai-consent input {
-    flex: 0 0 auto;
-    width: 16px;
-    height: 16px;
-    margin: 1px 0 0;
-    accent-color: var(--pa-accent-blue, #19589E);
-    cursor: pointer;
-}
-.po-upload-ai-consent input:focus-visible { outline: 2px solid var(--pa-focus-ring, #0A84FF); outline-offset: 2px; }
-.po-upload-ai-consent > label { flex: 1 1 auto; cursor: pointer; font-weight: 400; }
+.po-upload-ai p.ai-intro-copy b { font-weight: 700; color: var(--pa-accent-blue, #19589E); }
+/* The lead on its own line, the sentence 2px under it: one block to the eye,
+   two rows to the overlay. */
+.po-upload-ai p.po-upload-ai-lead { margin: 0 0 2px; }
 
 /* The right column: a label on top like "Experiment design (optional):",
    then the formats as pills -- scannable where a sentence listing them was
@@ -356,7 +339,7 @@ input[type="text"].pa-field-err {
     flex-wrap: wrap;
     gap: 6px;
 }
-.po-ai-section-body.po-upload-ai .po-upload-ai-formats li {
+.po-upload-ai .po-upload-ai-formats li {
     padding: 3px 10px;
     border-radius: 99px;
     border: 1px solid #CFE0F0;
@@ -370,5 +353,5 @@ input[type="text"].pa-field-err {
 
 @media (max-width: 980px) {
     .po-upload-ai-grid { flex-direction: column; }
-    .po-upload-ai-aside { margin: 12px 0 0; }
+    .po-upload-ai-aside { margin: 12px 0 0; flex-basis: auto; }
 }

--- a/PaintomicsClient/public_html/resources/css/inputformat.css
+++ b/PaintomicsClient/public_html/resources/css/inputformat.css
@@ -316,11 +316,16 @@ input[type="text"].pa-field-err {
 .po-upload-ai p.ai-intro-copy {
     margin: 0;
     padding: 0;
+    font-size: 14px;
+    line-height: 1.55;
 }
 .po-upload-ai p.ai-intro-copy b { font-weight: 700; color: var(--pa-accent-blue, #19589E); }
 /* The lead on its own line, the sentence 2px under it: one block to the eye,
    two rows to the overlay. */
-.po-upload-ai p.po-upload-ai-lead { margin: 0 0 2px; }
+.po-upload-ai p.po-upload-ai-lead { margin: 0 0 4px; }
+/* The lead at the size of the switch's title above, so the two sections
+   open with the same voice. */
+.po-upload-ai p.po-upload-ai-lead b { font-size: 15px; font-weight: 600; }
 
 /* The right column: a label on top like "Experiment design (optional):",
    then the formats as pills -- scannable where a sentence listing them was

--- a/PaintomicsClient/public_html/resources/css/inputformat.css
+++ b/PaintomicsClient/public_html/resources/css/inputformat.css
@@ -18,7 +18,9 @@
    setHeight() rather than by letting the DOM grow. */
 .pa-format-strip {
     margin: 0 10px 10px 10px;
-    padding: 12px 14px;
+    /* 10px of side padding plus the 10px margin puts the icon on the 20px
+       rail the card's own title text keeps (.omicboxTitle padding-left). */
+    padding: 12px 10px;
     border-radius: 4px;
     border: 1px solid transparent;
     font-family: var(--pa-font-sans);
@@ -230,7 +232,7 @@ input[type="text"].pa-field-err {
 .pa-format-idle {
     background: transparent;
     border-color: transparent;
-    padding: 6px 14px 8px;
+    padding: 4px 10px 8px;
     color: var(--pa-ink-muted, #595959);
     font-size: 12px;
     align-items: center;
@@ -240,6 +242,9 @@ input[type="text"].pa-field-err {
     color: var(--pa-ai-blue, #4A90D9);
     font-size: 15px;
     line-height: 1;
+    /* The mark's hexagon is drawn ~15% inside its viewBox, so at 15px its
+       ink starts 2px right of the box; the card title's ink does not. */
+    margin-left: -2px;
 }
 .pa-format-idle b {
     font-weight: 600;
@@ -280,98 +285,91 @@ input[type="text"].pa-field-err {
 /* ------------------------------------------------------------------------
    The Section 3 callout: "Bring your files as they are".
 
-   It borrows .po-ai-section-body from the Section 2 callout for its panel,
-   and lays out the same way: the explanation gets a reading measure, the
-   aside takes the space the prose cannot use and says what leaves the
-   machine. The AI mark on the heading is what Section 2's heading wears.
+   Same panel and the same skeleton as the Section 2 callout so the two read as
+   one feature: the prose column is 3/5 and the right column 2/5 with a 32px
+   gutter (measured off Section 2's hbox: its textarea starts at 1077px on a
+   1867px viewport, and so does this right column); the head, the sentence and
+   the consent control sit on the same three lines as their Section 2
+   counterparts. No box around the right column -- Section 2 has none, and a
+   bordered card there was the heaviest thing on the form.
    ------------------------------------------------------------------------ */
 .po-upload-ai-grid {
     display: flex;
-    gap: 18px 32px;
     align-items: flex-start;
 }
 .po-upload-ai-text {
-    flex: 1 1 auto;
+    flex: 3 1 0;
     min-width: 0;
-    max-width: var(--pa-measure-note, 78ch);
 }
-/* Pinned to the panel's right edge, where Section 2 keeps its controls, so
-   the two callouts' right columns stand on the same line. */
 .po-upload-ai-aside {
-    flex: 0 1 400px;
-    margin-left: auto;
-    min-width: 220px;
-    padding: 10px 14px 11px;
-    border-radius: var(--pa-radius-sm, 6px);
-    background: var(--pa-surface, #FFFFFF);
-    border: 1px solid #CFE0F0;
-}
-.po-upload-ai-icon {
-    display: inline-flex;
-    color: var(--pa-ai-blue, #4A90D9);
-    flex-shrink: 0;
-}
-/* Not the #4A90D9 the mark uses: bold body text needs 4.5:1, so the darker
-   accent blue, exactly as the Section 2 head does it. */
-.po-upload-ai .po-hero-ai-head strong {
-    color: var(--pa-accent-blue, #19589E);
-    font-size: 14.5px;
-    font-weight: 700;
+    flex: 2 1 0;
+    min-width: 0;
+    margin-left: 32px;
 }
 /* `div.contentbox p` is (0,1,2) and adds the card inset to every paragraph
-   inside a card; two classes outrank it, the same trap the hero notes. */
-.po-ai-section-body.po-upload-ai p {
-    margin: 6px 0 0;
+   inside a card; two classes outrank it. The type itself is .ai-intro-copy,
+   the Section 2 sentence's own class, and it runs the same measure, so the
+   two sentences sit on the same lines. The lead-in is the bold the Section 2
+   sentence gives its subject. */
+.po-ai-section-body.po-upload-ai p.ai-intro-copy {
+    margin: 0;
     padding: 0;
-    font-size: 14px;
-    line-height: 1.5;
-    color: var(--pa-ink-body, #555);
-    max-width: none;
 }
-.po-ai-section-body.po-upload-ai p b { font-weight: 700; color: var(--pa-accent-blue, #19589E); }
-.po-upload-ai-does {
+.po-ai-section-body.po-upload-ai p.ai-intro-copy b { font-weight: 700; color: var(--pa-accent-blue, #19589E); }
+
+/* The consent row, shaped like Section 2's checkbox row: 16px box, 8px gap,
+   label that wraps with a hanging indent. */
+.po-upload-ai-consent {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    margin: 10px 0 0;   /* Section 2: sentence bottom 87, box top 97 */
+    font-size: 13px;
+    line-height: 1.45;
+    color: var(--pa-ink, #18181B);
+}
+.po-upload-ai-consent input {
+    flex: 0 0 auto;
+    width: 16px;
+    height: 16px;
+    margin: 1px 0 0;
+    accent-color: var(--pa-accent-blue, #19589E);
+    cursor: pointer;
+}
+.po-upload-ai-consent input:focus-visible { outline: 2px solid var(--pa-focus-ring, #0A84FF); outline-offset: 2px; }
+.po-upload-ai-consent > label { flex: 1 1 auto; cursor: pointer; font-weight: 400; }
+.po-upload-ai-consent .ai-consent-warn span { font-weight: 600; }
+
+/* The right column: a label on top like "Experiment design (optional):",
+   then the formats as pills -- scannable where a sentence listing them was
+   not. */
+.po-upload-ai-aside-title {
+    font-size: 13px;
+    color: var(--pa-ink, #18181B);
+    margin: 0 0 8px;
+    line-height: 18px;
+}
+.po-upload-ai-formats {
     list-style: none;
-    margin: 8px 0 0;
+    margin: 0;
     padding: 0;
     display: flex;
     flex-wrap: wrap;
-    gap: 4px 16px;
+    gap: 6px;
 }
-.po-ai-section-body.po-upload-ai .po-upload-ai-does li {
-    position: relative;
-    padding: 0 0 0 13px;
-    font-size: 12.5px;
-    line-height: 1.5;
-    color: var(--pa-ink-muted, #595959);
+.po-ai-section-body.po-upload-ai .po-upload-ai-formats li {
+    padding: 3px 10px;
+    border-radius: 99px;
+    border: 1px solid #CFE0F0;
+    background: var(--pa-surface, #FFFFFF);
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--pa-ink-control, #3F3F46);
     max-width: none;
+    white-space: nowrap;
 }
-.po-upload-ai-does li::before {
-    content: "";
-    position: absolute;
-    left: 0;
-    top: 0.55em;
-    width: 5px;
-    height: 5px;
-    border-radius: 1px;
-    background: var(--pa-ai-blue, #4A90D9);
-}
-.po-upload-ai-aside-title {
-    font-size: 11px;
-    font-weight: 600;
-    letter-spacing: 0.07em;
-    text-transform: uppercase;
-    color: var(--pa-accent-blue, #19589E);
-}
-.po-ai-section-body.po-upload-ai .po-upload-ai-aside p {
-    margin: 5px 0 0;
-    font-size: 12.5px;
-    line-height: 1.5;
-    color: var(--pa-ink-muted, #595959);
-}
-.po-upload-ai-aside p span { color: var(--pa-ink-control, #3F3F46); font-weight: 600; }
-
 
 @media (max-width: 980px) {
     .po-upload-ai-grid { flex-direction: column; }
-    .po-upload-ai-aside { max-width: none; }
+    .po-upload-ai-aside { margin: 12px 0 0; }
 }

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -1640,56 +1640,13 @@ ul.menu li.loggedOption, ul.menu span.loggedOption {
 	margin-top: 1px;
 }
 
-/* The consent control as a switch, leading the panel.
-
-   A 16px box under a paragraph read as fine print; the decision this panel
-   exists for deserves to be the first thing in it and to look like the on/off
-   control every other AI product uses for the same question. Still the Ext
-   checkboxfield underneath -- same name, same value, same listeners -- only
-   drawn differently: a 36x20 track whose knob is a background image, because
-   the control is an <input type=button> and cannot carry a pseudo-element.
-   `background-position` is what moves the knob, and it animates. */
-.po-ai-section-body .x-form-cb-wrap > .x-form-checkbox {
-	width: 36px;
-	height: 20px;
-	margin-top: 0;
-	border: 0;
-	border-radius: 10px;
-	background-color: #C4C8CF;
-	background-image: radial-gradient(circle at center, #FFFFFF 0 6.5px, transparent 7px);
-	background-size: 16px 16px;
-	background-repeat: no-repeat;
-	background-position: 2px 2px;
-	box-shadow: inset 0 0 0 1px rgba(24, 24, 27, 0.06);
-	transition: background-color var(--pa-transition), background-position var(--pa-transition);
-	cursor: pointer;
-}
-.po-ai-section-body .x-form-cb-wrap > .x-form-checkbox:hover {
-	background-color: #B3B8C0;
-}
-.po-ai-section-body .x-form-cb-checked .x-form-cb-wrap > .x-form-checkbox,
-.po-ai-section-body .x-form-cb-checked .x-form-cb-wrap > .x-form-checkbox:hover {
-	background-color: var(--pa-accent-blue);
-	background-image: radial-gradient(circle at center, #FFFFFF 0 6.5px, transparent 7px);
-	background-position: 18px 2px;
-	box-shadow: none;
-}
-.po-ai-section-body .x-form-cb-wrap > .x-form-checkbox:focus-visible {
-	outline: 2px solid var(--pa-focus-ring);
-	outline-offset: 2px;
-}
-/* The field is a content-sized table (277px measured), so the label's
-   flex: 1 had nothing to grow into and the switch sat beside the words.
-   Full width puts the switch at the row's end, where a settings row keeps
-   it. */
-.po-ai-section-body table.x-form-type-checkbox {
-	width: 100%;
-}
-/* The switch's label is the panel's title now. */
+/* The consent box's label is the column's title: the one control on the
+   panel, named at title size. The box itself is the application's own
+   checkbox (the shared .x-form-checkbox rule), as on the Databases row. */
 .po-ai-section-body .x-form-cb-wrap > .x-form-cb-label {
 	font-size: 15px;
 	font-weight: 600;
-	line-height: 20px;
+	line-height: 18px;
 	color: var(--pa-ink-title, #1A1A18);
 }
 /* The explanation, under the switch: a step larger than the 13px the AI

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -1640,6 +1640,76 @@ ul.menu li.loggedOption, ul.menu span.loggedOption {
 	margin-top: 1px;
 }
 
+/* The consent control as a switch, leading the panel.
+
+   A 16px box under a paragraph read as fine print; the decision this panel
+   exists for deserves to be the first thing in it and to look like the on/off
+   control every other AI product uses for the same question. Still the Ext
+   checkboxfield underneath -- same name, same value, same listeners -- only
+   drawn differently: a 36x20 track whose knob is a background image, because
+   the control is an <input type=button> and cannot carry a pseudo-element.
+   `background-position` is what moves the knob, and it animates. */
+.po-ai-section-body .x-form-cb-wrap > .x-form-checkbox {
+	width: 36px;
+	height: 20px;
+	margin-top: 0;
+	border: 0;
+	border-radius: 10px;
+	background-color: #C4C8CF;
+	background-image: radial-gradient(circle at center, #FFFFFF 0 6.5px, transparent 7px);
+	background-size: 16px 16px;
+	background-repeat: no-repeat;
+	background-position: 2px 2px;
+	box-shadow: inset 0 0 0 1px rgba(24, 24, 27, 0.06);
+	transition: background-color var(--pa-transition), background-position var(--pa-transition);
+	cursor: pointer;
+}
+.po-ai-section-body .x-form-cb-wrap > .x-form-checkbox:hover {
+	background-color: #B3B8C0;
+}
+.po-ai-section-body .x-form-cb-checked .x-form-cb-wrap > .x-form-checkbox,
+.po-ai-section-body .x-form-cb-checked .x-form-cb-wrap > .x-form-checkbox:hover {
+	background-color: var(--pa-accent-blue);
+	background-image: radial-gradient(circle at center, #FFFFFF 0 6.5px, transparent 7px);
+	background-position: 18px 2px;
+	box-shadow: none;
+}
+.po-ai-section-body .x-form-cb-wrap > .x-form-checkbox:focus-visible {
+	outline: 2px solid var(--pa-focus-ring);
+	outline-offset: 2px;
+}
+/* The switch's label is the panel's title now. */
+.po-ai-section-body .x-form-cb-wrap > .x-form-cb-label {
+	font-size: 15px;
+	font-weight: 600;
+	line-height: 20px;
+	color: var(--pa-ink-title, #1A1A18);
+}
+/* The explanation, under the switch: a step larger than the 13px the AI
+   widget uses for chat, because this is a panel on a form, not a bubble. */
+.po-ai-section-body p.ai-intro-copy {
+	font-size: 14px;
+	line-height: 1.55;
+	margin: 10px 0 0;
+	max-width: var(--pa-measure-note, 78ch);
+}
+/* The privacy notice's link: quiet, at the end of the sentence, the way every
+   AI product links its data notice -- not a red (!) beside the consent. */
+.ai-gdpr-info-link {
+	color: var(--pa-ink-muted);
+	font-size: 12.5px;
+	white-space: nowrap;
+	text-decoration: none;
+}
+.ai-gdpr-info-link:hover {
+	color: var(--pa-accent-blue);
+	text-decoration: underline;
+}
+.ai-gdpr-info-link .fa {
+	margin-right: 2px;
+	font-size: 12px;
+}
+
 /* The experiment-design field on step 1 ---------------------------------------
    Free text describing an experiment, so it is sized to be written in rather
    than filled in: the label sits on top (see the note in PA_Step1Views.js) and
@@ -6942,7 +7012,10 @@ div.po-step-card p,
      because three of them read as unfinished. This is a panel, so it takes the
      surface radius like every other panel. */
   border-radius: var(--pa-radius);
-  padding: 18px 22px;
+  /* 22px of air above and below, not 18: the panel reads as a card now, with
+     a switch for a title, and the tighter padding made it look packed. The
+     sides stay 22 so the prose keeps its rail. */
+  padding: 22px 22px 20px;
   /* --pa-card-inset, not 20px: this callout sits directly under the
      "AI-Powered Pathway Interpretation" heading, so a 6px difference between
      the two left edges is visible as a step. ExtJS's box layout reads this

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -1644,10 +1644,26 @@ ul.menu li.loggedOption, ul.menu span.loggedOption {
    panel, named at title size. The box itself is the application's own
    checkbox (the shared .x-form-checkbox rule), as on the Databases row. */
 .po-ai-section-body .x-form-cb-wrap > .x-form-cb-label {
-	font-size: 15px;
+	/* 14px, one step under the 16px section heading above the panel; at 15px
+	   it out-sized the heading that owns it. */
+	font-size: 14px;
 	font-weight: 600;
 	line-height: 18px;
 	color: var(--pa-ink-title, #1A1A18);
+}
+
+/* The upload form's three section headings. div.contentbox h3 is 13.5px for
+   every card in the application; on this form the panels under the headings
+   carry 14px titles and 14px copy, so at 13.5px the headings were the smallest
+   type in their own sections. 16px is the design system's h3; the extra top
+   margin is the air each section needs to read as a block. Scoped to the
+   form so no other card moves. */
+.paStep1Form div.contentbox h3,
+div.contentbox .paStep1Form h3 {
+	font-size: 16px;
+	font-weight: 600;
+	color: var(--pa-ink-title, #1A1A18);
+	margin: 20px 0 6px;
 }
 /* The explanation, under the switch: a step larger than the 13px the AI
    widget uses for chat, because this is a panel on a form, not a bubble. */

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -1678,6 +1678,13 @@ ul.menu li.loggedOption, ul.menu span.loggedOption {
 	outline: 2px solid var(--pa-focus-ring);
 	outline-offset: 2px;
 }
+/* The field is a content-sized table (277px measured), so the label's
+   flex: 1 had nothing to grow into and the switch sat beside the words.
+   Full width puts the switch at the row's end, where a settings row keeps
+   it. */
+.po-ai-section-body table.x-form-type-checkbox {
+	width: 100%;
+}
 /* The switch's label is the panel's title now. */
 .po-ai-section-body .x-form-cb-wrap > .x-form-cb-label {
 	font-size: 15px;
@@ -1693,7 +1700,35 @@ ul.menu li.loggedOption, ul.menu span.loggedOption {
 	margin: 10px 0 0;
 	max-width: var(--pa-measure-note, 78ch);
 }
-/* The privacy notice's link: quiet, at the end of the sentence, the way every
+/* Pills: short tokens where a sentence would list things -- the formats the
+   converter handles under Section 3, the three facts about the interpretation
+   beside its switch. One rule for both so they are one shape. */
+.po-pill-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+}
+div.contentbox .po-pill-list li,
+.po-pill-list li {
+	padding: 3px 10px;
+	border-radius: 99px;
+	border: 1px solid #CFE0F0;
+	background: var(--pa-surface, #FFFFFF);
+	font-size: 12px;
+	line-height: 1.4;
+	color: var(--pa-ink-control, #3F3F46);
+	max-width: none;
+	white-space: nowrap;
+}
+/* The decision column's stack: switch row, one line, pills, privacy link. */
+.po-ai-section-body p.po-ai-oneliner { margin: 12px 0 0; }
+.po-ai-section-body .po-ai-facts { margin: 10px 0 0; }
+.po-ai-section-body p.po-ai-privacy { margin: 10px 0 0; padding: 0; line-height: 1.4; }
+
+/* The privacy notice's link: quiet, at the end of the stack, the way every
    AI product links its data notice -- not a red (!) beside the consent. */
 .ai-gdpr-info-link {
 	color: var(--pa-ink-muted);
@@ -1705,10 +1740,7 @@ ul.menu li.loggedOption, ul.menu span.loggedOption {
 	color: var(--pa-accent-blue);
 	text-decoration: underline;
 }
-.ai-gdpr-info-link .fa {
-	margin-right: 2px;
-	font-size: 12px;
-}
+
 
 /* The experiment-design field on step 1 ---------------------------------------
    Free text describing an experiment, so it is sized to be written in rather

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -1640,17 +1640,10 @@ ul.menu li.loggedOption, ul.menu span.loggedOption {
 	margin-top: 1px;
 }
 
-/* The consent box's label is the column's title: the one control on the
-   panel, named at title size. The box itself is the application's own
-   checkbox (the shared .x-form-checkbox rule), as on the Databases row. */
-.po-ai-section-body .x-form-cb-wrap > .x-form-cb-label {
-	/* 14px, one step under the 16px section heading above the panel; at 15px
-	   it out-sized the heading that owns it. */
-	font-size: 14px;
-	font-weight: 600;
-	line-height: 18px;
-	color: var(--pa-ink-title, #1A1A18);
-}
+/* The consent box's label keeps the application's checkbox-label type --
+   13px regular, the same as "KEGG (required)" on the Databases row above --
+   so the one control on this panel reads as a control, not a heading. A
+   title-sized label (15px, then 14px) was tried and read as too big. */
 
 /* The upload form's three section headings. div.contentbox h3 is 13.5px for
    every card in the application; on this form the panels under the headings

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -90,7 +90,7 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/format-repair.js": (
         "0.1", "944c929f1496258aba56f026e7c30e4affb7052dcbc127b06982eaadff205cd2"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-panel.js": (
-        "1.6", "34780e55d33b7a5ba322f303c50784b85a5ae55be635103ebd935a7f5c58b96c"),
+        "1.7", "6d492cfd7074ffa0d4250de99fff599cb7728323166375f003b514f9bda09532"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-roles.js": (
         "0.2", "4c5afdf4f9c59d167756516db823cc1fa01179f3cd7b967d137c38a78c0508dd"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js": (
@@ -98,7 +98,7 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js": (
         "0.6", "d884a0d8344fccf966aab1219c9c70f9e29ca93a4a42e7ddf8f0852189f5ecdd"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js": (
-        "0.5", "7bf6ca18c3444e955d82c7bbdec80c6123f23ca00889925719afedfb24098c0e"),
+        "0.6", "4ecdf2432832aba369df3d73483bdd5fd89969c9b2c86e597d030b15ff7e3844"),
     "app/view/common/Util.js": (
         "2.1", "12359b8bf746394f63a7e0a15513a4f9ac82de1a25bbaa0e91e6b2fdd7e0050e"),
     "app/view/common/ExtJS_extensions.js": (

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -90,7 +90,7 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/format-repair.js": (
         "0.1", "944c929f1496258aba56f026e7c30e4affb7052dcbc127b06982eaadff205cd2"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-panel.js": (
-        "1.7", "6d492cfd7074ffa0d4250de99fff599cb7728323166375f003b514f9bda09532"),
+        "1.8", "114dfabe8cc3c0281dac3a3bab2fd629f50c22ef186edf382af88c25c4455658"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-roles.js": (
         "0.2", "4c5afdf4f9c59d167756516db823cc1fa01179f3cd7b967d137c38a78c0508dd"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js": (

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -90,15 +90,15 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/format-repair.js": (
         "0.1", "944c929f1496258aba56f026e7c30e4affb7052dcbc127b06982eaadff205cd2"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-panel.js": (
-        "1.5", "cfd1cce44c8cb5a02edec4dfc3550bf2e933763a9d467a86ef0f1f201bb79db7"),
+        "1.6", "34780e55d33b7a5ba322f303c50784b85a5ae55be635103ebd935a7f5c58b96c"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-roles.js": (
         "0.2", "4c5afdf4f9c59d167756516db823cc1fa01179f3cd7b967d137c38a78c0508dd"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js": (
         "0.3", "d7f2846c58226fdfe334fefc68c8d6519cc4eae393265e15dd047e5babded4f3"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js": (
-        "0.5", "aba9f81cf637615a055d7259d7568a000b83af65c2e20cd413050928b8260478"),
+        "0.6", "d884a0d8344fccf966aab1219c9c70f9e29ca93a4a42e7ddf8f0852189f5ecdd"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js": (
-        "0.4", "b9d1aff2eb3830c5485f53443ed494847b168bf12372aab39b98b2c4faa75c3c"),
+        "0.5", "7bf6ca18c3444e955d82c7bbdec80c6123f23ca00889925719afedfb24098c0e"),
     "app/view/common/Util.js": (
         "2.1", "12359b8bf746394f63a7e0a15513a4f9ac82de1a25bbaa0e91e6b2fdd7e0050e"),
     "app/view/common/ExtJS_extensions.js": (

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -90,7 +90,7 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/format-repair.js": (
         "0.1", "944c929f1496258aba56f026e7c30e4affb7052dcbc127b06982eaadff205cd2"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-panel.js": (
-        "1.8", "114dfabe8cc3c0281dac3a3bab2fd629f50c22ef186edf382af88c25c4455658"),
+        "1.9", "7198efa3a416c7527ab58602339f97df0e81a9f532c65b19f81c23c42dc56b2f"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-roles.js": (
         "0.2", "4c5afdf4f9c59d167756516db823cc1fa01179f3cd7b967d137c38a78c0508dd"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js": (

--- a/docs/ai-input-converter.md
+++ b/docs/ai-input-converter.md
@@ -88,16 +88,18 @@ On **Use this table** the omic card's strip records the provenance —
 attached)* — with a **Convert again** link that reopens the sheet on the
 original upload.
 
-Section 3 of the upload form states the offer before any file is picked, in
-the same skeleton as the Section 2 callout: one sentence ("Bring your files as
-they are…"), a consent checkbox — *Convert with the PaintOmics AI agent when a
-file needs it (sends only the file's structure to …)* — ticked by default
-because ticking it sends nothing (a file goes to the model only when the user
-presses Convert on it), and a "Works with" column of formats where Section 2
-keeps its experiment-design field. Unticking the box withdraws the Convert
-offer from every card. A standing one-line note in every omic card and a
-sentence in the Help panel complete it. The actor is named the same way on
-every surface: *the PaintOmics AI agent*.
+Section 3 of the upload form states the offer before any file is picked, as a
+plain row on the same two columns as the Section 2 panel: a bold lead ("Bring
+your files as they are.") and one sentence on the left, a "Works with" column
+of format pills on the right. There is deliberately no checkbox: pressing
+**Convert it for me** on a file is the consent, nothing leaves the browser
+before that, and a second box under the interpretation's consent box read as
+the same decision asked twice. The page keeps one right column — the
+experiment-design field, the "Works with" pills and the Help panel all start
+on the same x. A standing one-line note in every omic card and a sentence in
+the Help panel complete it. The actor is named the same way on every surface:
+*the PaintOmics AI agent*. The job's name is taken from the experiment
+design's first line; there is no separate description field.
 
 ## 3. Letting the user steer with a prompt, and review the result
 

--- a/docs/ai-input-converter.md
+++ b/docs/ai-input-converter.md
@@ -56,6 +56,44 @@ building a matrix out of q-values is treated as an error.
 matrices **plus** an `FDR < 0.05` relevant list, with `logFC`, `logCPM`,
 `PValue` dropped from the matrices.
 
+## The conversion sheet — what the user watches
+
+The sheet that opens from **Convert it for me** is laid out as a notebook of
+the run rather than a spinner, so that every claim the feature makes is
+checkable on screen:
+
+- **Stage rail** — Read → Plan → Run → Check → Apply → Review, lit as the
+  agent's own state machine reaches each stage. A retry visibly drops back to
+  Plan; a failure marks the stage it failed in. The attempt count and the clock
+  sit beside it.
+- **What the AI sees** — the profile exactly as the model receives it: the
+  container (workbook / delimited text), every sheet with rows × columns, each
+  column as a chip kind-coded *identifier candidate / numeric / text*, repeated
+  identifiers flagged on the chip, column families, the example rows behind a
+  disclosure, the payload size in characters and the gateway it is sent to
+  (from `/ai_provider`). This is what makes "only the structure leaves your
+  computer" a statement the user can verify rather than trust.
+- **Timeline** — every step with the seconds it cost (the model turns are the
+  visible cost), attempt badges, the generated script and its printed output
+  one click away at the step that ran them (with Copy), the validator's verdict
+  quoted one failure per line, and the agent's questions as answer cards.
+- **Result tickets** — one per table: preview, kept / left-out columns, the
+  attached relevant list, a download; the chosen one wears the destination
+  omic's hue bar.
+- **Dock** — the composer (two lines tall, grows as you type; Enter sends) to
+  steer or answer in your own words, then the decision row.
+
+On **Use this table** the omic card's strip records the provenance —
+*Converted by PaintOmics AI from `<file>` (table "…", relevant-features list
+attached)* — with a **Convert again** link that reopens the sheet on the
+original upload.
+
+Section 3 of the upload form states the offer before any file is picked: an
+AI callout under the heading ("Bring your files as they are", with an aside
+naming what leaves the machine), a standing one-line note in every omic card,
+and a sentence in the Help panel. The conversion is therefore presented as how
+the upload step works, not as a fallback after a failed check.
+
 ## 3. Letting the user steer with a prompt, and review the result
 
 **Yes — the drawer is a conversation, not a one-shot.**

--- a/docs/ai-input-converter.md
+++ b/docs/ai-input-converter.md
@@ -66,7 +66,7 @@ checkable on screen:
   agent's own state machine reaches each stage. A retry visibly drops back to
   Plan; a failure marks the stage it failed in. The attempt count and the clock
   sit beside it.
-- **What the AI sees** — the profile exactly as the model receives it: the
+- **What the agent sees** — the profile exactly as the model receives it: the
   container (workbook / delimited text), every sheet with rows × columns, each
   column as a chip kind-coded *identifier candidate / numeric / text*, repeated
   identifiers flagged on the chip, column families, the example rows behind a
@@ -88,11 +88,16 @@ On **Use this table** the omic card's strip records the provenance —
 attached)* — with a **Convert again** link that reopens the sheet on the
 original upload.
 
-Section 3 of the upload form states the offer before any file is picked: an
-AI callout under the heading ("Bring your files as they are", with an aside
-naming what leaves the machine), a standing one-line note in every omic card,
-and a sentence in the Help panel. The conversion is therefore presented as how
-the upload step works, not as a fallback after a failed check.
+Section 3 of the upload form states the offer before any file is picked, in
+the same skeleton as the Section 2 callout: one sentence ("Bring your files as
+they are…"), a consent checkbox — *Convert with the PaintOmics AI agent when a
+file needs it (sends only the file's structure to …)* — ticked by default
+because ticking it sends nothing (a file goes to the model only when the user
+presses Convert on it), and a "Works with" column of formats where Section 2
+keeps its experiment-design field. Unticking the box withdraws the Convert
+offer from every card. A standing one-line note in every omic card and a
+sentence in the Help panel complete it. The actor is named the same way on
+every surface: *the PaintOmics AI agent*.
 
 ## 3. Letting the user steer with a prompt, and review the result
 


### PR DESCRIPTION
## Summary
Redesign of the AI input-format converter's front end and the Step 1 upload form around it.

**The conversion sheet** (`convert-drawer.js` + `inputconvert.css`, rewritten) is a notebook of the run, not a spinner: a stage rail wired to the agent's real state machine (Read → Plan → Run → Check → Apply → Review; retries visibly drop back to Plan), a **"What the agent sees"** card rendering the profiler payload exactly as the model receives it (kind-coded columns, repeated identifiers, example rows, payload size, the gateway it goes to), a timeline with per-step durations, attempt badges, the script and its output one click away, the validator's verdict quoted one failure per line, questions as answer cards; result tickets wearing the destination omic's hue; a two-line composer that grows. `convert-agent.js` emits two new events (`profile`, `output`); the loop is unchanged.

**Step 1 form**
- Section 2 and Section 3 share one blue panel and one right column (experiment-design field, "Works with" pills, Help panel all start on the same x). Section 2: the design field is the wide thing on the left; on the right the consent checkbox (the application's own checkbox, label at the form's checkbox-label size), one line, three pills, a plain "Data privacy" link (the red `!` is gone; the notice is unchanged).
- Section 3 "Bring your files as they are": lead + one sentence + the formats as pills; no second checkbox (pressing *Convert it for me* is the consent). Every omic card carries a standing one-line offer; after accept the card records provenance (*Converted by the PaintOmics AI agent from … · Convert again*).
- The "Enter a job description" field is folded into the experiment design (first line → job name, server's `setName()` unchanged; verified end to end through `form.getValues()` and the My data job list).
- Consent labels trimmed to their verb on the owner's call; the actor is named *the PaintOmics AI agent* on every surface.
- Type: section headings 16px (DS h3), panel copy 14px, pills 12px.

## Verification
- Real conversions through the sheet on the local worktree server (DESeq2 workbook, 9–13 s), Revise (5 honest rejections when a text column was requested), scripted question/failure states, accept path filling both file fields, dark theme.
- Alignment overlay (`paGuides.report`) on Step 1: **0 strays, 0 baseline strays** after every round; two rails in the sheet (boxes 24px, type 64px).
- Clean-archive import gate: 9/9 servlets import. Client tests 48/48. `test_versioned_assets_are_bumped` green against HEAD (markers + digests updated).
- No server runtime file changes (one test + docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
