### PR TITLE
Find an organism by what the user means, not what they spelt

### DIFF
--- a/PaintomicsClient/public_html/app/controller/DataManagementController.js
+++ b/PaintomicsClient/public_html/app/controller/DataManagementController.js
@@ -287,7 +287,7 @@ this.requestNewSpecieHandler = function(){
 				"</div>"
 			},
 			{
-				xtype: 'combo',fieldLabel: 'Organism', name: 'specie',
+				xtype: 'organismcombo', fieldLabel: 'Organism', name: 'specie',
 				width: 500, itemId: "speciesCombobox",
 				allowBlank: false, forceSelection: false,
 				emptyText: 'Please choose an organism',

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -1529,7 +1529,7 @@ function PA_Step1JobView() {
 						{
 							xtype: "container", layout: { type: "vbox", align: "stretch" }, flex: 0.4, items: [
 							{
-								xtype: 'combo',fieldLabel: 'Organism', name: 'specie',
+								xtype: 'organismcombo', fieldLabel: 'Organism', name: 'specie',
 								/* 26px is --pa-card-inset: this field sits directly under
 								   "1. Organism selection", so it has to start on the same
 								   left edge as that heading. */

--- a/PaintomicsClient/public_html/app/view/common/OrganismSearch.js
+++ b/PaintomicsClient/public_html/app/view/common/OrganismSearch.js
@@ -318,6 +318,10 @@
     function rank(query, organisms) {
         var tokens = tokenize(query), out = [], i, entry, scored, item;
         organisms = organisms || [];
+        /* "(" or "-" or a script the names are not written in: nothing can
+           match, and it must not fall through to the browse-everything branch
+           below -- in the request dialog that is 11,550 rows for a stray key. */
+        if (!tokens.length && /\S/.test(String(query == null ? "" : query))) return out;
         for (i = 0; i < organisms.length; i++) {
             item = organisms[i];
             if (!item || item.name == null) continue;
@@ -375,11 +379,17 @@
      * <mark>. The name is escaped, so a name is never markup.
      */
     function highlight(name, query, value) {
-        var entry = index({name: name, value: value == null ? "" : value}),
-            tokens = tokenize(query), scored;
-        if (!tokens.length) return escapeHtml(name == null ? "" : name);
+        var organism = name !== null && typeof name === "object" ? name : {name: name, value: value == null ? "" : value},
+            tokens, entry, scored;
+        if (organism.name == null) return "";
+        tokens = tokenize(query);
+        if (!tokens.length) return escapeHtml(organism.name);
+        /* The list template hands over the row's own data object, the one
+           rank() already indexed, so a full-list render does not re-index
+           every name; a bare string is indexed on the spot. */
+        entry = organism === name ? indexOf(organism) : index(organism);
         scored = scoreOrganism(tokens, entry);
-        if (!scored || !scored.ranges.length) return escapeHtml(name);
+        if (!scored || !scored.ranges.length) return escapeHtml(organism.name);
         return markRanges(entry.name, scored.ranges);
     }
 
@@ -417,7 +427,7 @@
                     var combo = Ext.getCmp(comboId), query = (combo && combo.lastQuery) || "",
                         code = values.value != null && values.value !== values.name ? String(values.value) : "";
                     return '<span class="po-organism-row"><span class="po-organism-name">' +
-                        highlight(values.name, query, values.value) + "</span>" +
+                        highlight(values, query) + "</span>" +
                         (code ? '<span class="po-organism-code">' + highlightCode(code, query) + "</span>" : "") +
                         "</span>";
                 }
@@ -490,6 +500,19 @@
 
             organismKey: function (data) {
                 return String(data.value) + "\u0001" + String(data.name);
+            },
+
+            /* The stock lookup searches the store's filtered rows only, so
+               setValue("mmu") fails while the user's last query is still
+               narrowing the list -- which is exactly when example mode sets
+               the organism programmatically. Every row is still in the
+               snapshot, so look there. */
+            findRecord: function (field, value) {
+                var items = (this.store.snapshot || this.store.data).items, i;
+                for (i = 0; i < items.length; i++) {
+                    if (items[i].get(field) === value) return items[i];
+                }
+                return false;
             }
         });
     }

--- a/PaintomicsClient/public_html/app/view/common/OrganismSearch.js
+++ b/PaintomicsClient/public_html/app/view/common/OrganismSearch.js
@@ -1,0 +1,507 @@
+/*
+ * Ranks organisms by how well a typed query names them.
+ *
+ * Both organism pickers -- Step 1's combo and the "Request a new organism"
+ * dialog's -- used the stock ExtJS local query, which keeps a row only when its
+ * display name STARTS with the typed text. KEGG names organisms
+ * "Genus species (common name)", so "mouse" found nothing (the row is
+ * "Mus musculus (house mouse)"), "hsa" found nothing, and one typo emptied the
+ * list. People type the common name, the code, the genus, a strain, or a
+ * misspelling of any of those; this module scores every row for all of them
+ * and the combo below lists the rows in that order, with the matched parts
+ * marked.
+ *
+ * The ranking half has no DOM or ExtJS dependency and is exported for node, so
+ * test_organism_search runs the shipped file against the production organism
+ * list. The ExtJS half is defined only when Ext is present.
+ *
+ * How a query is scored
+ * ---------------------
+ * The query is split into words. Every word must match the organism somewhere
+ * (so "e coli" narrows rather than widens), and the organism's score is the
+ * sum of each word's best match, where a match is one of, from strongest to
+ * weakest:
+ *
+ *   a whole common name              "rat", "human"
+ *   the head word of a common name   "mouse" in "house mouse"
+ *   the KEGG code exactly            "mmu", "hsa"
+ *   a whole word                     "sapiens", "mus"
+ *   the start of a word              "arab", "homo"
+ *   the start of the KEGG code       "hs"
+ *   a fragment of a word             "rice" in "licorice"
+ *   a misspelling of a word          "mosue", "humna", "arabadopsos"
+ *
+ * A common-name match edges out the same match in the scientific name, the
+ * head word of a common name ("mouse" in "house mouse") edges out another
+ * word of it, and the genus edges out the species epithet. A single letter
+ * is a genus initial ("e coli", "c elegans"), not a word. Misspellings are
+ * accepted only for words of four letters or more (one edit; two from eight
+ * letters), so "cat" never becomes "rat". Ties go to the classic model
+ * organisms, then to the name: with all 11,550 KEGG organisms in the list,
+ * "mouse" has six whole-word hits and Mus musculus is the one meant.
+ */
+(function (root, factory) {
+    var api = factory();
+    if (typeof module === "object" && module.exports) module.exports = api;
+    root.PaintomicsOrganismSearch = api;
+    if (root.Ext && root.Ext.define) api.defineCombo(root.Ext);
+})(typeof self !== "undefined" ? self : this, function () {
+    "use strict";
+
+    /* Scores for one query word. The gaps are what the ordering above relies
+       on: a field bonus (+2) or a position bonus (+3/+4) must never lift a
+       weaker kind of match over a stronger one.
+
+       The code sits BELOW a whole common name (96) and the head word of one
+       (88 + 2 + 4 = 94), and above everything else. 253 of KEGG's 11,550 codes
+       spell a word of some other organism's name -- "fly" is a Flavobacterium,
+       "dog" a Desulfobulbus, "cow", "cat", "bat", "fox", "rat" and "pig" are
+       all bacteria -- and the animal is what was meant. A code nothing else
+       spells, "hsa", still lands first. */
+    var SCORE = {
+        phrase: 96,
+        code: 93,
+        word: 88, prefix: 78, codePrefix: 70, fragment: 58, fuzzy: 48,
+        fuzzyPrefix: 42,
+        common: 2,      // the match is in a common name rather than the scientific one
+        head: 4,        // a whole-word match on the head word of a common name, or the genus
+        lead: 3,        // a prefix match on the first word of a common name, or the genus
+        editCost: 12,   // per edit of a misspelling
+        wholePhrase: 10 // the whole query is a whole common name
+    };
+
+    /* KEGG codes of the classic model organisms. Only a tie-breaker: with the
+       full KEGG list loaded, "mouse" is a whole-word hit on six organisms and
+       "yeast" on a dozen, and alphabetical order would put Acomys and
+       Candida first. A better match always beats a model organism. */
+    var MODEL_ORGANISMS = {
+        hsa: 1, mmu: 1, rno: 1, dre: 1, dme: 1, cel: 1, sce: 1, spo: 1, ath: 1,
+        eco: 1, bsu: 1, osa: 1, zma: 1, gga: 1, xtr: 1, xla: 1, bta: 1, ssc: 1,
+        cfa: 1, ptr: 1, mcc: 1, ddi: 1, pfa: 1, cre: 1, gmx: 1, sly: 1, sot: 1,
+        vvi: 1, tae: 1
+    };
+
+    var COMBINING_MARKS = /[\u0300-\u036f]/g;
+
+    /*
+     * Lower-cases and strips accents, keeping a map from every character of
+     * the result back to the character of `text` it came from, so a match
+     * found in the normalised string can be marked in the original.
+     */
+    function analyse(text) {
+        var norm = "", map = [], i, j, c, n;
+        text = String(text == null ? "" : text);
+        for (i = 0; i < text.length; i++) {
+            c = text.charAt(i).toLowerCase();
+            n = c.normalize ? c.normalize("NFD").replace(COMBINING_MARKS, "") : c;
+            for (j = 0; j < n.length; j++) {
+                norm += n.charAt(j);
+                map.push(i);
+            }
+        }
+        map.push(text.length);
+        return {text: text, norm: norm, map: map};
+    }
+
+    function normalize(text) {
+        return analyse(text).norm;
+    }
+
+    /*
+     * The words of a normalised string, with their positions. A run joined by
+     * hyphens or underscores ("K-12", "USA300_FPR3757") yields its parts and
+     * the joined form, so "k12" and "K-12" both find E. coli.
+     */
+    function words(norm) {
+        var out = [], run = /[a-z0-9]+(?:[-_][a-z0-9]+)*/g, part = /[a-z0-9]+/g, m, p, joined;
+        while ((m = run.exec(norm)) !== null) {
+            if (m[0].indexOf("-") < 0 && m[0].indexOf("_") < 0) {
+                out.push({text: m[0], start: m.index, end: m.index + m[0].length});
+                continue;
+            }
+            joined = m[0].replace(/[-_]/g, "");
+            out.push({text: joined, start: m.index, end: m.index + m[0].length});
+            part.lastIndex = 0;
+            while ((p = part.exec(m[0])) !== null) {
+                out.push({text: p[0], start: m.index + p.index, end: m.index + p.index + p[0].length});
+            }
+        }
+        return out;
+    }
+
+    /* The query's words: split on whitespace and punctuation, hyphens and
+       underscores removed rather than split on, so "K-12" is the word "k12". */
+    function tokenize(query) {
+        var norm = normalize(query), out = [], run = /[a-z0-9]+(?:[-_][a-z0-9]+)*/g, m;
+        while ((m = run.exec(norm)) !== null) out.push(m[0].replace(/[-_]/g, ""));
+        return out;
+    }
+
+    /*
+     * Everything the scorer needs to know about one organism, computed once.
+     * KEGG writes "Genus species strain (common name)"; any parenthesised
+     * group is treated as a common-name phrase ("(Japanese rice) (RAPDB)" gives
+     * two), and the text before the first parenthesis is the scientific name.
+     */
+    function index(organism) {
+        var name = analyse(organism.name), norm = name.norm, code = normalize(organism.value),
+            phrases = [], groups = [], depth = 0, open = -1, i, c, w, list, k, phrase;
+        for (i = 0; i < norm.length; i++) {
+            c = norm.charAt(i);
+            if (c === "(") { if (depth++ === 0) open = i; }
+            else if (c === ")" && depth > 0 && --depth === 0) { groups.push({start: open + 1, end: i}); }
+        }
+        if (depth > 0 && open >= 0) groups.push({start: open + 1, end: norm.length});
+        list = words(norm);
+        for (k = 0; k < groups.length; k++) {
+            phrase = {text: norm.slice(groups[k].start, groups[k].end).replace(/\s+/g, " ").replace(/^ | $/g, ""),
+                      common: true, words: []};
+            for (i = 0; i < list.length; i++) {
+                w = list[i];
+                if (w.start >= groups[k].start && w.end <= groups[k].end) { w.common = true; phrase.words.push(w); }
+            }
+            phrases.push(phrase);
+        }
+        phrase = {text: "", common: false, words: []};
+        for (i = 0; i < list.length; i++) {
+            if (!list[i].common) phrase.words.push(list[i]);
+        }
+        phrases.unshift(phrase);
+        for (k = 0; k < phrases.length; k++) {
+            for (i = 0; i < phrases[k].words.length; i++) {
+                w = phrases[k].words[i];
+                w.first = i === 0;
+                w.last = i === phrases[k].words.length - 1;
+            }
+        }
+        return {name: name, code: code, words: list, phrases: phrases,
+                model: MODEL_ORGANISMS.hasOwnProperty(code)};
+    }
+
+    var cache = typeof WeakMap === "function" ? new WeakMap() : null;
+
+    function indexOf(organism) {
+        var entry;
+        if (cache && organism && typeof organism === "object") {
+            entry = cache.get(organism);
+            if (!entry) { entry = index(organism); cache.set(organism, entry); }
+            return entry;
+        }
+        return index(organism);
+    }
+
+    /*
+     * Restricted Damerau-Levenshtein distance (insert, delete, substitute,
+     * transpose adjacent), capped: returns max + 1 as soon as no row can come
+     * back under the cap. Words are short, so the table is a few dozen cells.
+     */
+    function editDistance(a, b, max) {
+        var la = a.length, lb = b.length, prev2 = null, prev = [], cur, i, j, cost, v, rowMin;
+        if (Math.abs(la - lb) > max) return max + 1;
+        for (j = 0; j <= lb; j++) prev[j] = j;
+        for (i = 1; i <= la; i++) {
+            cur = [i];
+            rowMin = i;
+            for (j = 1; j <= lb; j++) {
+                cost = a.charAt(i - 1) === b.charAt(j - 1) ? 0 : 1;
+                v = Math.min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + cost);
+                if (i > 1 && j > 1 && a.charAt(i - 1) === b.charAt(j - 2) && a.charAt(i - 2) === b.charAt(j - 1)) {
+                    v = Math.min(v, prev2[j - 2] + 1);
+                }
+                cur[j] = v;
+                if (v < rowMin) rowMin = v;
+            }
+            if (rowMin > max) return max + 1;
+            prev2 = prev;
+            prev = cur;
+        }
+        return prev[lb];
+    }
+
+    function allowedEdits(token) {
+        return token.length >= 8 ? 2 : (token.length >= 4 ? 1 : 0);
+    }
+
+    /*
+     * The best match of one query word against one organism: its score and,
+     * when the match is in the name, the range of the name it covers. Null
+     * when the word matches nothing.
+     */
+    function matchToken(token, entry) {
+        var best = null, i, k, w, at, score, edits, maxEdits, list = entry.words, phrases = entry.phrases;
+
+        function consider(s, start, end) {
+            if (!best || s > best.score) best = {score: s, start: start, end: end};
+        }
+
+        /* One letter is an initial: "e coli", "h sapiens". As a word it would
+           match a fragment of nearly every name and the "x" of a hybrid. */
+        if (token.length === 1) {
+            w = phrases[0].words[0];
+            if (w && w.text.charAt(0) === token) consider(SCORE.prefix + SCORE.lead, w.start, w.start + 1);
+            return best;
+        }
+
+        if (token === entry.code) consider(SCORE.code, -1, -1);
+        for (k = 1; k < phrases.length; k++) {
+            if (phrases[k].text === token) {
+                w = phrases[k].words;
+                consider(SCORE.phrase, w[0].start, w[w.length - 1].end);
+            }
+        }
+        for (i = 0; i < list.length; i++) {
+            w = list[i];
+            if (w.text === token) {
+                score = SCORE.word + (w.common ? SCORE.common : 0) + ((w.common ? w.last : w.first) ? SCORE.head : 0);
+                consider(score, w.start, w.end);
+            } else if (w.text.indexOf(token) === 0) {
+                score = SCORE.prefix + (w.common ? SCORE.common : 0) + (w.first ? SCORE.lead : 0);
+                consider(score, w.start, w.start + token.length);
+            } else if ((at = w.text.indexOf(token)) > 0) {
+                consider(SCORE.fragment + (w.common ? SCORE.common : 0), w.start + at, w.start + at + token.length);
+            }
+        }
+        if (best && best.score >= SCORE.codePrefix) return best;
+        if (token.length >= 2 && entry.code.indexOf(token) === 0) consider(SCORE.codePrefix, -1, -1);
+        if (best && best.score >= SCORE.fragment) return best;
+
+        maxEdits = allowedEdits(token);
+        if (maxEdits === 0) return best;
+        for (i = 0; i < list.length; i++) {
+            w = list[i];
+            if (w.text.length < 4) continue;
+            edits = editDistance(token, w.text, maxEdits);
+            if (edits <= maxEdits) {
+                consider(SCORE.fuzzy - SCORE.editCost * edits + (w.common ? SCORE.common : 0), w.start, w.end);
+            } else if (w.text.length > token.length + maxEdits) {
+                /* A misspelt start of a longer word: "arabidpo" for arabidopsis. */
+                edits = editDistance(token, w.text.slice(0, token.length), maxEdits);
+                if (edits <= maxEdits) {
+                    consider(SCORE.fuzzyPrefix - SCORE.editCost * edits + (w.common ? SCORE.common : 0), w.start, w.end);
+                }
+            }
+        }
+        return best;
+    }
+
+    /*
+     * Scores one organism for a tokenised query. Null when any word of the
+     * query matches nothing. `ranges` are the parts of the name to mark.
+     */
+    function scoreOrganism(tokens, entry) {
+        var total = 0, ranges = [], i, k, m, phrase = tokens.join(" ");
+        for (i = 0; i < tokens.length; i++) {
+            m = matchToken(tokens[i], entry);
+            if (!m) return null;
+            total += m.score;
+            if (m.start >= 0) ranges.push([m.start, m.end]);
+        }
+        for (k = 1; k < entry.phrases.length; k++) {
+            if (entry.phrases[k].text === phrase) { total += SCORE.wholePhrase; break; }
+        }
+        return {score: total, ranges: ranges};
+    }
+
+    function byName(a, b) {
+        var an = a.key, bn = b.key;
+        if (an !== bn) return an < bn ? -1 : 1;
+        return a.value < b.value ? -1 : (a.value > b.value ? 1 : 0);
+    }
+
+    /*
+     * The organisms that match `query`, best first. Each result carries the
+     * organism's name and value and its score. An empty query lists every
+     * organism by name.
+     *
+     * organisms: [{name, value}], as the species endpoint serves them.
+     */
+    function rank(query, organisms) {
+        var tokens = tokenize(query), out = [], i, entry, scored, item;
+        organisms = organisms || [];
+        for (i = 0; i < organisms.length; i++) {
+            item = organisms[i];
+            if (!item || item.name == null) continue;
+            entry = indexOf(item);
+            if (tokens.length) {
+                scored = scoreOrganism(tokens, entry);
+                if (!scored) continue;
+            } else {
+                scored = {score: 0};
+            }
+            out.push({name: item.name, value: item.value, score: scored.score,
+                      key: entry.name.norm, model: entry.model});
+        }
+        out.sort(function (a, b) {
+            if (a.score !== b.score) return b.score - a.score;
+            /* The model-organism prior breaks ties between MATCHES. A blank
+               query is a browse, and a browse is alphabetical. */
+            if (tokens.length && a.model !== b.model) return a.model ? -1 : 1;
+            return byName(a, b);
+        });
+        for (i = 0; i < out.length; i++) {
+            delete out[i].key;
+            delete out[i].model;
+        }
+        return out;
+    }
+
+    function escapeHtml(text) {
+        return String(text).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+    }
+
+    /* Marks the given (normalised-index) ranges of an analysed string. */
+    function markRanges(analysed, ranges) {
+        var merged = [], i, r, out = "", at = 0, start, end;
+        ranges = ranges.slice().sort(function (a, b) { return a[0] - b[0]; });
+        for (i = 0; i < ranges.length; i++) {
+            r = ranges[i];
+            if (merged.length && r[0] <= merged[merged.length - 1][1]) {
+                merged[merged.length - 1][1] = Math.max(merged[merged.length - 1][1], r[1]);
+            } else {
+                merged.push([r[0], r[1]]);
+            }
+        }
+        for (i = 0; i < merged.length; i++) {
+            start = analysed.map[merged[i][0]];
+            end = analysed.map[merged[i][1]];
+            out += escapeHtml(analysed.text.slice(at, start)) + "<mark>" + escapeHtml(analysed.text.slice(start, end)) + "</mark>";
+            at = end;
+        }
+        return out + escapeHtml(analysed.text.slice(at));
+    }
+
+    /*
+     * The organism's name as HTML, with the parts `query` matched wrapped in
+     * <mark>. The name is escaped, so a name is never markup.
+     */
+    function highlight(name, query, value) {
+        var entry = index({name: name, value: value == null ? "" : value}),
+            tokens = tokenize(query), scored;
+        if (!tokens.length) return escapeHtml(name == null ? "" : name);
+        scored = scoreOrganism(tokens, entry);
+        if (!scored || !scored.ranges.length) return escapeHtml(name);
+        return markRanges(entry.name, scored.ranges);
+    }
+
+    /* The KEGG code as HTML, marked when a word of the query is (the start of) it. */
+    function highlightCode(code, query) {
+        var norm = normalize(code), tokens = tokenize(query), i;
+        if (code == null) return "";
+        for (i = 0; i < tokens.length; i++) {
+            if (tokens[i].length >= 2 && norm.indexOf(tokens[i]) === 0) {
+                return "<mark>" + escapeHtml(String(code).slice(0, tokens[i].length)) + "</mark>" +
+                    escapeHtml(String(code).slice(tokens[i].length));
+            }
+        }
+        return escapeHtml(code);
+    }
+
+    /*
+     * xtype 'organismcombo': an Ext.form.field.ComboBox whose local query is
+     * the ranking above instead of the display-name prefix filter. Everything
+     * else about the combo -- the store, valueField, forceSelection, the
+     * change event -- is untouched, so the two pickers keep their contracts.
+     */
+    function defineCombo(Ext) {
+        if (Ext.ClassManager.get("Paintomics.form.OrganismCombo")) return;
+        Ext.define("Paintomics.form.OrganismCombo", {
+            extend: "Ext.form.field.ComboBox",
+            alias: "widget.organismcombo",
+            queryMode: "local",
+
+            statics: {
+                /* Called from the list template with the row's data. The query
+                   is read from the combo rather than closed over because the
+                   template is built once and the query changes per keystroke. */
+                renderItem: function (values, comboId) {
+                    var combo = Ext.getCmp(comboId), query = (combo && combo.lastQuery) || "",
+                        code = values.value != null && values.value !== values.name ? String(values.value) : "";
+                    return '<span class="po-organism-row"><span class="po-organism-name">' +
+                        highlight(values.name, query, values.value) + "</span>" +
+                        (code ? '<span class="po-organism-code">' + highlightCode(code, query) + "</span>" : "") +
+                        "</span>";
+                }
+            },
+
+            initComponent: function () {
+                var me = this;
+                me.listConfig = Ext.apply({
+                    getInnerTpl: function () {
+                        return '{[Paintomics.form.OrganismCombo.renderItem(values, "' + me.id + '")]}';
+                    }
+                }, me.listConfig);
+                /* Not the usual ExtJS parent call: ExtJS 4 implements that with
+                   Function.caller, which this strict-mode file does not have,
+                   and the failure ("Cannot read properties of null (reading
+                   'apply')") takes the whole Step 1 view down with it. */
+                Ext.form.field.ComboBox.prototype.initComponent.apply(me, arguments);
+            },
+
+            /* Replaces ComboBox.doLocalQuery. Same shape: install the query
+               filter once, enable it for a query and disable it for the
+               trigger's show-all, then filter, expand or collapse, afterQuery.
+               The differences are that the filter keeps the rows rank() kept,
+               and the store is sorted by rank for as long as there is a query
+               -- its own sorters come back when the query is cleared. */
+            doLocalQuery: function (queryPlan) {
+                var me = this, store = me.store, query = (queryPlan.query || "").replace(/^\s+|\s+$/g, ""),
+                    records, ranked, order, i;
+
+                if (!me.organismSorters) me.organismSorters = store.sorters.getRange();
+                if (!me.queryFilter) {
+                    me.organismOrder = {};
+                    me.queryFilter = new Ext.util.Filter({
+                        id: me.id + "-query-filter",
+                        filterFn: function (record) {
+                            return me.organismOrder.hasOwnProperty(me.organismKey(record.data));
+                        }
+                    });
+                    store.addFilter(me.queryFilter, false);
+                }
+
+                if (query) {
+                    records = (store.snapshot || store.data).items;
+                    ranked = rank(query, Ext.Array.map(records, function (record) { return record.data; }));
+                    order = {};
+                    for (i = 0; i < ranked.length; i++) order[me.organismKey(ranked[i])] = i;
+                    me.organismOrder = order;
+                    me.queryFilter.disabled = false;
+                    store.sorters.clear();
+                    store.sorters.add(new Ext.util.Sorter({
+                        sorterFn: function (a, b) {
+                            return order[me.organismKey(a.data)] - order[me.organismKey(b.data)];
+                        }
+                    }));
+                } else {
+                    me.queryFilter.disabled = true;
+                    store.sorters.clear();
+                    store.sorters.addAll(me.organismSorters);
+                }
+
+                store.filter();
+
+                if (store.getCount()) {
+                    me.expand();
+                } else {
+                    me.collapse();
+                }
+                me.afterQuery(queryPlan);
+            },
+
+            organismKey: function (data) {
+                return String(data.value) + "\u0001" + String(data.name);
+            }
+        });
+    }
+
+    return {
+        normalize: normalize,
+        tokenize: tokenize,
+        editDistance: editDistance,
+        rank: rank,
+        highlight: highlight,
+        highlightCode: highlightCode,
+        defineCombo: defineCombo,
+        SCORE: SCORE
+    };
+});

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.13" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.14" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.3" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.3" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.2" />
@@ -129,6 +129,7 @@
 	<!--CUSTOM SENCHA EXTENSIONS-->
 	<script type="text/javascript" src="app/view/common/Util.js?v=2.1"></script>
 	<script type="text/javascript" src="app/view/common/ExtJS_extensions.js?v=0.7"></script>
+	<script type="text/javascript" src="app/view/common/OrganismSearch.js?v=1.0"></script>
 	<script type="text/javascript" src="app/view/common/upload/Panel.js?v=0.2"></script>
 	<!--LAYOUT DEBUG OVERLAY - inert until ctrl+alt+G or ?guides=1 -->
 	<script type="text/javascript" src="app/view/common/AlignmentGuides.js?v=4.2"></script>

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -8218,3 +8218,38 @@ div.repDetectionCard h3 {
   .po-hero-viz .po-viz-agent-ring,
   .po-hero-viz .po-viz-pulse { opacity: 0; animation: none; }
 }
+
+/* ---------------------------------------------------------------------------
+   Organism picker rows (xtype organismcombo, app/view/common/OrganismSearch.js)
+   The list marks the parts of a name the query matched and shows the KEGG code
+   at the row's right edge. <mark> is bold rather than a highlighter fill: the
+   row already has hover and selection fills, and a third one under a few
+   letters read as a rendering fault. Colour is inherited, so the dark theme's
+   row ink (dark.css, .x-boundlist-item) carries through with nothing to restate.
+   --------------------------------------------------------------------------- */
+.po-organism-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75em;
+  min-width: 0;
+}
+.po-organism-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.po-organism-code {
+  flex: none;
+  font-family: "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--pa-ink-muted);
+}
+.po-organism-name mark,
+.po-organism-code mark {
+  background: transparent;
+  color: inherit;
+  font-weight: 700;
+}

--- a/PaintomicsServer/src/tests/organisms_paintomics_uv.json
+++ b/PaintomicsServer/src/tests/organisms_paintomics_uv.json
@@ -1,0 +1,538 @@
+{
+ "_comment": "GET https://paintomics.uv.es/kegg_data/species.json as served on 2026-08-21: the organisms installed on the production server, the list the Step 1 organism picker searches. A fixture for test_organism_search; refresh it from the same URL, not by hand.",
+ "success": true,
+ "species": [
+  {
+   "name": "'Nostoc azollae' 0708",
+   "value": "naz"
+  },
+  {
+   "name": "Abrus precatorius (Indian licorice)",
+   "value": "aprc"
+  },
+  {
+   "name": "Abyssalbus ytuae",
+   "value": "fbm"
+  },
+  {
+   "name": "Acanthopagrus latus (yellowfin seabream)",
+   "value": "alat"
+  },
+  {
+   "name": "Acinonyx jubatus (cheetah)",
+   "value": "aju"
+  },
+  {
+   "name": "Acropora digitifera (stony coral)",
+   "value": "adf"
+  },
+  {
+   "name": "Aeromicrobium erythreum",
+   "value": "aer"
+  },
+  {
+   "name": "Aeromonas hydrophila ML09-119",
+   "value": "ahy"
+  },
+  {
+   "name": "Amphimedon queenslandica (sponge)",
+   "value": "aqu"
+  },
+  {
+   "name": "Anopheles gambiae (malaria mosquito)",
+   "value": "aga"
+  },
+  {
+   "name": "Apis mellifera (honey bee)",
+   "value": "ame"
+  },
+  {
+   "name": "Arabidopsis thaliana (thale cress)",
+   "value": "ath"
+  },
+  {
+   "name": "Arachis hypogaea (peanut)",
+   "value": "ahf"
+  },
+  {
+   "name": "Aspergillus flavus",
+   "value": "afv"
+  },
+  {
+   "name": "Aspergillus fumigatus",
+   "value": "afm"
+  },
+  {
+   "name": "Aspergillus niger (black aspergilli)",
+   "value": "ang"
+  },
+  {
+   "name": "Aspergillus oryzae",
+   "value": "aor"
+  },
+  {
+   "name": "Azospirillum brasilense Sp 7",
+   "value": "abf"
+  },
+  {
+   "name": "Bacillus cereus ATCC 14579",
+   "value": "bce"
+  },
+  {
+   "name": "Bacillus subtilis subsp. subtilis 168",
+   "value": "bsu"
+  },
+  {
+   "name": "Bacillus tropicus",
+   "value": "btro"
+  },
+  {
+   "name": "Bacillus zhangzhouensis",
+   "value": "bzh"
+  },
+  {
+   "name": "Bifidobacterium animalis subsp. lactis BB-12",
+   "value": "bbb"
+  },
+  {
+   "name": "Bombyx mori (domestic silkworm)",
+   "value": "bmor"
+  },
+  {
+   "name": "Bos taurus (cow)",
+   "value": "bta"
+  },
+  {
+   "name": "Brassica oleracea (wild cabbage)",
+   "value": "boe"
+  },
+  {
+   "name": "Bufo bufo (common toad)",
+   "value": "bbuf"
+  },
+  {
+   "name": "Caenorhabditis elegans (nematode)",
+   "value": "cel"
+  },
+  {
+   "name": "Candida albicans",
+   "value": "cal"
+  },
+  {
+   "name": "Canis lupus familiaris (dog)",
+   "value": "cfa"
+  },
+  {
+   "name": "Capilliphycus salinus",
+   "value": "csau"
+  },
+  {
+   "name": "Carica papaya (papaya)",
+   "value": "cpap"
+  },
+  {
+   "name": "Chelonia mydas (green sea turtle)",
+   "value": "cmy"
+  },
+  {
+   "name": "Chlamydomonas reinhardtii",
+   "value": "cre"
+  },
+  {
+   "name": "Citrus sinensis (Valencia orange)",
+   "value": "cit"
+  },
+  {
+   "name": "Citrus x clementina (clementine)",
+   "value": "cic"
+  },
+  {
+   "name": "Clostridium butyricum",
+   "value": "cbut"
+  },
+  {
+   "name": "Coprinopsis cinerea (gray shag)",
+   "value": "cci"
+  },
+  {
+   "name": "Cricetulus griseus (Chinese hamster)",
+   "value": "cge"
+  },
+  {
+   "name": "Crocodylus porosus (Australian saltwater crocodile)",
+   "value": "cpoo"
+  },
+  {
+   "name": "Cryptococcus deneoformans B-3501A",
+   "value": "cnb"
+  },
+  {
+   "name": "Cryptococcus deneoformans JEC21",
+   "value": "cne"
+  },
+  {
+   "name": "Cryptococcus gattii",
+   "value": "cgi"
+  },
+  {
+   "name": "Cyclopterus lumpus (lumpfish)",
+   "value": "clum"
+  },
+  {
+   "name": "Danio rerio (zebrafish)",
+   "value": "dre"
+  },
+  {
+   "name": "Dichomitus squalens",
+   "value": "dsq"
+  },
+  {
+   "name": "Dictyostelium discoideum (cellular slime mold)",
+   "value": "ddi"
+  },
+  {
+   "name": "Drosophila melanogaster (fruit fly)",
+   "value": "dme"
+  },
+  {
+   "name": "Enterobacter cloacae subsp. cloacae ATCC 13047",
+   "value": "enc"
+  },
+  {
+   "name": "Equus caballus (horse)",
+   "value": "ecb"
+  },
+  {
+   "name": "Escherichia coli K-12 MG1655",
+   "value": "eco"
+  },
+  {
+   "name": "Faecalibacterium duncaniae A2165",
+   "value": "fpra"
+  },
+  {
+   "name": "Fomitiporia mediterranea",
+   "value": "fme"
+  },
+  {
+   "name": "Fragaria vesca (woodland strawberry)",
+   "value": "fve"
+  },
+  {
+   "name": "Fusarium graminearum",
+   "value": "fgr"
+  },
+  {
+   "name": "Fusarium oxysporum",
+   "value": "fox"
+  },
+  {
+   "name": "Gallus gallus (chicken)",
+   "value": "gga"
+  },
+  {
+   "name": "Gloeophyllum trabeum",
+   "value": "gtr"
+  },
+  {
+   "name": "Glycine max (soybean)",
+   "value": "gmx"
+  },
+  {
+   "name": "Haemophilus parainfluenzae",
+   "value": "hpr"
+  },
+  {
+   "name": "Heterobasidion irregulare",
+   "value": "hir"
+  },
+  {
+   "name": "Homo sapiens (human)",
+   "value": "hsa"
+  },
+  {
+   "name": "Hydra vulgaris (swiftwater hydra)",
+   "value": "hmg"
+  },
+  {
+   "name": "Klebsiella pneumoniae subsp. pneumoniae HS11286",
+   "value": "kpm"
+  },
+  {
+   "name": "Laccaria bicolor",
+   "value": "lbc"
+  },
+  {
+   "name": "Lactuca sativa (garden lettuce)",
+   "value": "lsv"
+  },
+  {
+   "name": "Leishmania major",
+   "value": "lma"
+  },
+  {
+   "name": "Magallana gigas (Pacific oyster)",
+   "value": "crg"
+  },
+  {
+   "name": "Manihot esculenta (cassava)",
+   "value": "mesc"
+  },
+  {
+   "name": "Manis javanica (Malayan pangolin)",
+   "value": "mjv"
+  },
+  {
+   "name": "Mus musculus (house mouse)",
+   "value": "mmu"
+  },
+  {
+   "name": "Mycobacterium tuberculosis H37Rv",
+   "value": "mtu"
+  },
+  {
+   "name": "Neofusicoccum parvum",
+   "value": "npa"
+  },
+  {
+   "name": "Neurospora crassa",
+   "value": "ncr"
+  },
+  {
+   "name": "Nicotiana benthamiana",
+   "value": "nben"
+  },
+  {
+   "name": "Nostoc cf. commune",
+   "value": "ncf"
+  },
+  {
+   "name": "Oryctolagus cuniculus (rabbit)",
+   "value": "ocu"
+  },
+  {
+   "name": "Oryza glaberrima (African rice)",
+   "value": "ogl"
+  },
+  {
+   "name": "Oryza sativa japonica (Japanese rice)",
+   "value": "osa"
+  },
+  {
+   "name": "Oryza sativa japonica (Japanese rice) (RAPDB)",
+   "value": "dosa"
+  },
+  {
+   "name": "Ovis aries (sheep)",
+   "value": "oas"
+  },
+  {
+   "name": "Pan troglodytes (chimpanzee)",
+   "value": "ptr"
+  },
+  {
+   "name": "Paracoccus denitrificans",
+   "value": "pde"
+  },
+  {
+   "name": "Parasteatoda tepidariorum (common house spider)",
+   "value": "ptep"
+  },
+  {
+   "name": "Penicillium rubens",
+   "value": "pcs"
+  },
+  {
+   "name": "Phanerochaete carnosa",
+   "value": "pco"
+  },
+  {
+   "name": "Phocaeicola vulgatus",
+   "value": "bvu"
+  },
+  {
+   "name": "Photobacterium profundum",
+   "value": "ppr"
+  },
+  {
+   "name": "Physcomitrium patens (spreading earthmoss)",
+   "value": "ppp"
+  },
+  {
+   "name": "Plasmodium falciparum 3D7",
+   "value": "pfa"
+  },
+  {
+   "name": "Populus trichocarpa (black cottonwood)",
+   "value": "pop"
+  },
+  {
+   "name": "Prevotella melaninogenica",
+   "value": "pmz"
+  },
+  {
+   "name": "Prunus dulcis (almond)",
+   "value": "pdul"
+  },
+  {
+   "name": "Prunus mume (Japanese apricot)",
+   "value": "pmum"
+  },
+  {
+   "name": "Prunus persica (peach)",
+   "value": "pper"
+  },
+  {
+   "name": "Pseudomonas aeruginosa PAO1",
+   "value": "pae"
+  },
+  {
+   "name": "Pseudomonas putida KT2440",
+   "value": "ppu"
+  },
+  {
+   "name": "Pseudomonas syringae pv. tomato DC3000",
+   "value": "pst"
+  },
+  {
+   "name": "Punctularia strigosozonata",
+   "value": "psq"
+  },
+  {
+   "name": "Raphanus sativus (radish)",
+   "value": "rsz"
+  },
+  {
+   "name": "Rattus norvegicus (rat)",
+   "value": "rno"
+  },
+  {
+   "name": "Rhodanobacter denitrificans",
+   "value": "rhd"
+  },
+  {
+   "name": "Saccharomyces cerevisiae (budding yeast)",
+   "value": "sce"
+  },
+  {
+   "name": "Salmonella enterica subsp. enterica serovar Typhimurium SL1344",
+   "value": "sey"
+  },
+  {
+   "name": "Schaalia odontolytica",
+   "value": "soo"
+  },
+  {
+   "name": "Schizophyllum commune",
+   "value": "scm"
+  },
+  {
+   "name": "Schizosaccharomyces pombe (fission yeast)",
+   "value": "spo"
+  },
+  {
+   "name": "Sclerotinia sclerotiorum",
+   "value": "ssl"
+  },
+  {
+   "name": "Shewanella algae",
+   "value": "salg"
+  },
+  {
+   "name": "Sneathia vaginalis",
+   "value": "sns"
+  },
+  {
+   "name": "Solanum lycopersicum (tomato)",
+   "value": "sly"
+  },
+  {
+   "name": "Solanum tuberosum (potato)",
+   "value": "sot"
+  },
+  {
+   "name": "Sorghum bicolor (sorghum)",
+   "value": "sbi"
+  },
+  {
+   "name": "Staphylococcus aureus subsp. aureus MRSA252 (MRSA)",
+   "value": "sar"
+  },
+  {
+   "name": "Staphylococcus aureus subsp. aureus USA300_FPR3757 (CA-MRSA)",
+   "value": "saa"
+  },
+  {
+   "name": "Stereum hirsutum",
+   "value": "shs"
+  },
+  {
+   "name": "Streptococcus gordonii",
+   "value": "sgo"
+  },
+  {
+   "name": "Streptococcus mutans UA159 (serotype c)",
+   "value": "smu"
+  },
+  {
+   "name": "Streptomyces lividans",
+   "value": "slv"
+  },
+  {
+   "name": "Sus scrofa (pig)",
+   "value": "ssc"
+  },
+  {
+   "name": "Taeniopygia guttata (zebra finch)",
+   "value": "tgu"
+  },
+  {
+   "name": "Trametes versicolor",
+   "value": "tvs"
+  },
+  {
+   "name": "Tremella mesenterica",
+   "value": "tms"
+  },
+  {
+   "name": "Trichoderma reesei QM6a",
+   "value": "tre"
+  },
+  {
+   "name": "Triticum aestivum (bread wheat)",
+   "value": "taes"
+  },
+  {
+   "name": "Varroa destructor (honeybee mite)",
+   "value": "vde"
+  },
+  {
+   "name": "Vibrio cholerae O1 El Tor N16961",
+   "value": "vch"
+  },
+  {
+   "name": "Vigna radiata (mung bean)",
+   "value": "vra"
+  },
+  {
+   "name": "Vitis vinifera (wine grape)",
+   "value": "vvi"
+  },
+  {
+   "name": "Xenopus tropicalis (tropical clawed frog)",
+   "value": "xtr"
+  },
+  {
+   "name": "Yarrowia lipolytica",
+   "value": "yli"
+  },
+  {
+   "name": "Zea mays (maize)",
+   "value": "zma"
+  },
+  {
+   "name": "Zygosaccharomyces rouxii",
+   "value": "zro"
+  }
+ ]
+}

--- a/PaintomicsServer/src/tests/test_organism_search.py
+++ b/PaintomicsServer/src/tests/test_organism_search.py
@@ -51,6 +51,9 @@ INDEX_HTML = os.path.join(CLIENT_ROOT, "index.html")
 
 NODE = shutil.which("node")
 
+with io.open(FIXTURE, encoding="utf-8") as _handle:
+    FIXTURE_SIZE = len(json.load(_handle)["species"])
+
 
 def read(path):
     with io.open(path, encoding="utf-8") as handle:
@@ -191,11 +194,18 @@ class EmptyQueryAndOrder(unittest.TestCase):
     def test_empty_query_lists_every_organism_alphabetically(self):
         listed = codes("")
         names = node("S.rank('', L).map(r => r.name)")
-        self.assertEqual(133, len(listed))
+        self.assertEqual(FIXTURE_SIZE, len(listed))
         self.assertEqual(sorted(names, key=lambda n: n.lower()), names)
 
     def test_whitespace_only_is_empty(self):
-        self.assertEqual(133, len(codes("   ")))
+        self.assertEqual(FIXTURE_SIZE, len(codes("   ")))
+
+    def test_a_query_with_no_word_in_it_finds_nothing(self):
+        # "(" or "-" or a script the names are not written in has nothing to
+        # match; it must not fall through to the browse-everything branch
+        # (11,550 rows rendered for a stray character, in the request dialog).
+        for query in ["(", "-", "'", "小鼠", "мышь", " ( ) "]:
+            self.assertEqual([], codes(query), repr(query))
 
     def test_results_carry_name_value_and_score(self):
         top = node("S.rank('mouse', L)[0]")
@@ -240,6 +250,10 @@ class Highlighting(unittest.TestCase):
         self.assertEqual("Mus musculus (house mouse)",
                          self.highlight("Mus musculus (house mouse)", ""))
 
+    def test_a_missing_name_is_empty_not_the_word_null(self):
+        self.assertEqual("", node("S.highlight(null, 'x')"))
+        self.assertEqual("", node("S.highlight(null, '')"))
+
 
 @unittest.skipIf(NODE is None, "node is not available")
 class RequestDialogScale(unittest.TestCase):
@@ -271,6 +285,110 @@ class RequestDialogScale(unittest.TestCase):
     def test_fuzzy_query_over_the_full_list_finds_the_mouse(self):
         ranked = node("S.rank('mosue', L).map(r => r.value)", listPath=ALL_SPECIES)
         self.assertEqual("mmu", ranked[0])
+
+
+# A stand-in for the slice of ExtJS 4.2.1 the combo touches, just enough to run
+# doLocalQuery / renderItem / findRecord under node. The store mimics what was
+# checked in ext-all-debug.js: filter() re-filters from `snapshot` skipping
+# disabled filters, then re-sorts `data` with the current sorters.
+STUB_EXT = r"""
+const organisms = L.map(d => ({data: d, get: f => d[f]}));
+function collection(items) {
+  return {items: items.slice(), getRange() { return this.items.slice(); }, clear() { this.items = []; },
+          add(x) { this.items.push(x); }, addAll(xs) { this.items = this.items.concat(xs); }, get length() { return this.items.length; }};
+}
+const store = {
+  snapshot: null, data: {items: organisms.slice()}, filters: [],
+  sorters: collection([{property: 'name', sorterFn: (a, b) => a.data.name < b.data.name ? -1 : 1}]),
+  addFilter(f) { this.filters.push(f); },
+  filter() {
+    this.snapshot = this.snapshot || {items: organisms.slice()};
+    const live = this.filters.filter(f => !f.disabled);
+    this.data = {items: this.snapshot.items.filter(r => live.every(f => f.filterFn(r)))};
+    const sorter = this.sorters.items[0];
+    if (sorter) this.data.items.sort(sorter.sorterFn);
+  },
+  getCount() { return this.data.items.length; }
+};
+let body = null;
+const Ext = {
+  ClassManager: {get: () => undefined},
+  define: (name, b) => { body = b; },
+  apply: Object.assign,
+  Array: {map: (xs, fn) => xs.map(fn)},
+  util: {Filter: function (c) { Object.assign(this, c); this.disabled = false; },
+         Sorter: function (c) { Object.assign(this, c); }},
+  form: {field: {ComboBox: {prototype: {initComponent() { this.parentInit = true; }, findRecord() { return 'stock'; }}}}},
+  getCmp: id => combo
+};
+S.defineCombo(Ext);
+const combo = Object.assign(Object.create(body), {
+  id: 'c1', store, lastQuery: undefined, events: [],
+  expand() { this.events.push('expand'); }, collapse() { this.events.push('collapse'); },
+  afterQuery() { this.events.push('afterQuery'); }
+});
+combo.initComponent();
+function query(q) { combo.lastQuery = q; combo.events = []; combo.doLocalQuery({query: q, forceAll: q === ''}); }
+const rows = () => store.data.items.map(r => r.data.value);
+"""
+
+
+@unittest.skipIf(NODE is None, "node is not available")
+class ComboIntegration(unittest.TestCase):
+    """What xtype organismcombo does to its store, per query, under a stub Ext."""
+
+    def run_js(self, expression):
+        return node("(() => {" + STUB_EXT + "return " + expression + ";})()")
+
+    def test_a_query_keeps_and_orders_the_ranked_rows(self):
+        out = self.run_js("(query('mouse'), {rows: rows(), events: combo.events, "
+                          "filterOn: !combo.queryFilter.disabled})")
+        self.assertEqual("mmu", out["rows"][0])
+        self.assertTrue(out["filterOn"])
+        self.assertEqual(["expand", "afterQuery"], out["events"])
+
+    def test_a_typo_is_ranked_the_same_way_through_the_combo(self):
+        self.assertEqual("hsa", self.run_js("(query('humna'), rows())")[0])
+
+    def test_the_empty_query_restores_the_store_and_lists_everything(self):
+        out = self.run_js("(query('mouse'), query(''), {count: store.getCount(), "
+                          "sorter: store.sorters.items[0].property, filterOff: combo.queryFilter.disabled, "
+                          "first: rows()[0]})")
+        self.assertEqual(FIXTURE_SIZE, out["count"])
+        self.assertEqual("name", out["sorter"])
+        self.assertTrue(out["filterOff"])
+        self.assertEqual("naz", out["first"])
+
+    def test_a_query_with_no_word_collapses_an_empty_list(self):
+        out = self.run_js("(query('('), {count: store.getCount(), events: combo.events})")
+        self.assertEqual(0, out["count"])
+        self.assertEqual(["collapse", "afterQuery"], out["events"])
+
+    def test_narrowing_then_widening_brings_rows_back(self):
+        out = self.run_js("(query('mouse'), query('mo'), rows().length)")
+        self.assertGreater(out, 1)
+
+    def test_find_record_looks_past_the_active_filter(self):
+        # Example mode calls setValue('mmu') whatever the user typed before; the
+        # stock lookup searches only the filtered rows and fails to find it.
+        out = self.run_js("(query('human'), {found: combo.findRecord('value', 'mmu').data.value, "
+                          "missing: combo.findRecord('value', 'nope')})")
+        self.assertEqual("mmu", out["found"])
+        self.assertFalse(out["missing"])
+
+    def test_render_item_marks_the_hit_and_shows_the_code(self):
+        html = self.run_js("(query('mouse'), body.statics.renderItem({name: 'Mus musculus (house mouse)', value: 'mmu'}, 'c1'))")
+        self.assertIn("house <mark>mouse</mark>)", html)
+        self.assertIn('<span class="po-organism-code">mmu</span>', html)
+
+    def test_render_item_escapes_the_name_and_omits_a_code_equal_to_it(self):
+        html = self.run_js("(query('a'), body.statics.renderItem({name: 'a <b> & c', value: 'a <b> & c'}, 'c1'))")
+        self.assertIn("&lt;b&gt; &amp; c", html)
+        self.assertNotIn("<b>", html)
+        self.assertNotIn("po-organism-code", html)
+
+    def test_the_superclass_init_still_runs(self):
+        self.assertTrue(self.run_js("combo.parentInit"))
 
 
 class Wiring(unittest.TestCase):

--- a/PaintomicsServer/src/tests/test_organism_search.py
+++ b/PaintomicsServer/src/tests/test_organism_search.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""The organism picker must find what the user means, not what they spelt.
+
+What this guards
+----------------
+Step 1's organism combo (and the "Request a new organism" dialog's) used the
+stock ExtJS local query, which keeps a row only when the display name STARTS
+with the typed text. So "mouse" found nothing -- the row is "Mus musculus
+(house mouse)" -- and a single typo emptied the list. Users type the common
+name, the KEGG code, a genus, a strain, or a misspelling of any of those, and
+the picker has to rank the organism they mean first for all of them.
+
+The ranking lives in app/view/common/OrganismSearch.js, a module with no
+DOM or ExtJS dependency so node can run it exactly as the browser does. The
+list it is run against here is the one paintomics.uv.es served on 2026-08-21
+(organisms_paintomics_uv.json): 133 real organisms, the population the picker
+actually searches in production, with the collisions that matter -- two
+yeasts, three rices, "licorice" hiding "rice", "Streptococcus mutans" hiding
+"mus", two Nostocs and a quoted name.
+
+Why a Python file runs a JavaScript module
+------------------------------------------
+The client has no test harness of its own; every client contract in this
+directory is checked from here (see test_validator_agrees_with_server for the
+same pattern). The module is loaded with node's require, so what is tested is
+the file as shipped, not an extract.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_organism_search
+"""
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CLIENT_ROOT = os.path.abspath(os.path.join(HERE, "../../../PaintomicsClient/public_html"))
+MODULE = os.path.join(CLIENT_ROOT, "app/view/common/OrganismSearch.js")
+FIXTURE = os.path.join(HERE, "organisms_paintomics_uv.json")
+ALL_SPECIES = os.path.join(CLIENT_ROOT, "resources/data/all_species.json")
+STEP1_VIEWS = os.path.join(CLIENT_ROOT, "app/view/PathwayAcquisitionViews/PA_Step1Views.js")
+DATA_MANAGEMENT = os.path.join(CLIENT_ROOT, "app/controller/DataManagementController.js")
+INDEX_HTML = os.path.join(CLIENT_ROOT, "index.html")
+
+NODE = shutil.which("node")
+
+
+def read(path):
+    with io.open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def node(expression, listPath=FIXTURE):
+    """Evaluates `expression` with the module as S and the organism list as L."""
+    script = (
+        "const S = require(%s);"
+        "const L = require(%s).species;"
+        "process.stdout.write(JSON.stringify(%s));"
+    ) % (json.dumps(MODULE), json.dumps(listPath), expression)
+    result = subprocess.run([NODE, "-e", script], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if result.returncode != 0:
+        raise AssertionError("node failed: " + result.stderr.decode("utf-8", "replace"))
+    return json.loads(result.stdout.decode("utf-8"))
+
+
+def codes(query):
+    """KEGG codes in the order the picker would list them for `query`."""
+    return node("S.rank(%s, L).map(r => r.value)" % json.dumps(query))
+
+
+@unittest.skipIf(NODE is None, "node is not available")
+class CommonNamesAndCodes(unittest.TestCase):
+    """The ways people actually refer to an organism all have to land first."""
+
+    def test_common_name_word_finds_house_mouse_first(self):
+        # The report that started this: "mouse" found nothing.
+        self.assertEqual("mmu", codes("mouse")[0])
+        self.assertEqual("mmu", codes("Mouse")[0])
+        self.assertEqual("mmu", codes("  MOUSE ")[0])
+
+    def test_kegg_code_is_an_exact_hit(self):
+        self.assertEqual("hsa", codes("hsa")[0])
+        self.assertEqual("mmu", codes("mmu")[0])
+        self.assertEqual("rno", codes("rno")[0])
+
+    def test_genus_word_beats_a_prefix_elsewhere(self):
+        # "pan" is the chimpanzee's genus and the start of the pangolin's name.
+        ranked = codes("pan")
+        self.assertEqual("ptr", ranked[0])
+        self.assertIn("mjv", ranked)
+        self.assertEqual("mmu", codes("mus")[0])
+
+    def test_the_whole_common_name_beats_a_word_of_one(self):
+        # "rat" is all of the rat's common name, and a word of no other.
+        self.assertEqual("rno", codes("rat")[0])
+
+    def test_scientific_name_prefix(self):
+        self.assertEqual("ath", codes("arab")[0])
+        self.assertEqual("hsa", codes("homo")[0])
+        self.assertEqual("hsa", codes("sapiens")[0])
+
+    def test_every_match_for_a_shared_common_name_is_kept(self):
+        ranked = codes("rice")
+        # The three rices first (two share a name), licorice after them.
+        self.assertEqual({"osa", "dosa", "ogl"}, set(ranked[:3]))
+        self.assertIn("aprc", ranked[3:])
+
+    def test_two_yeasts_both_listed(self):
+        ranked = codes("yeast")
+        self.assertEqual({"sce", "spo"}, set(ranked[:2]))
+        self.assertEqual("sce", ranked[0])
+
+
+@unittest.skipIf(NODE is None, "node is not available")
+class Typos(unittest.TestCase):
+    """One slip in a word of four or more letters still finds the organism."""
+
+    def test_transposed_letters(self):
+        self.assertEqual("mmu", codes("mosue")[0])
+        self.assertEqual("mmu", codes("muose")[0])
+
+    def test_one_wrong_letter(self):
+        self.assertEqual("hsa", codes("humna")[0])
+        self.assertEqual("hsa", codes("hunan")[0])
+        self.assertEqual("ath", codes("arabidpsis")[0])
+
+    def test_a_missing_letter(self):
+        self.assertEqual("dre", codes("zebrfish")[0])
+        self.assertEqual("sly", codes("tomto")[0])
+
+    def test_two_slips_in_a_long_word(self):
+        self.assertEqual("ath", codes("arabadopsos")[0])
+        self.assertEqual("dme", codes("drosofila")[0])
+
+    def test_short_tokens_are_not_fuzzed(self):
+        # Three letters is too short to guess at: "cat" must not become "rat".
+        self.assertNotIn("rno", codes("cat"))
+        self.assertEqual([], codes("qzx"))
+
+    def test_nonsense_finds_nothing(self):
+        self.assertEqual([], codes("qzxvwy"))
+        self.assertEqual([], codes("xxxxxxxxxxxx"))
+
+
+@unittest.skipIf(NODE is None, "node is not available")
+class MultiWordQueries(unittest.TestCase):
+    """Every word of the query has to match; the words may be in any order."""
+
+    def test_initial_plus_species(self):
+        self.assertEqual("eco", codes("e coli")[0])
+        self.assertEqual("cel", codes("c elegans")[0])
+        self.assertEqual("sce", codes("s cerevisiae")[0])
+
+    def test_split_common_name(self):
+        self.assertEqual("dre", codes("zebra fish")[0])
+        self.assertEqual("dme", codes("fruit fly")[0])
+        self.assertEqual("mmu", codes("house mouse")[0])
+
+    def test_word_order_does_not_matter(self):
+        self.assertEqual("mmu", codes("mouse house")[0])
+        self.assertEqual("hsa", codes("sapiens homo")[0])
+
+    def test_a_word_that_matches_nothing_empties_the_list(self):
+        self.assertEqual([], codes("mouse qzxvwy"))
+
+    def test_joined_and_hyphenated_strains(self):
+        self.assertEqual("eco", codes("k12")[0])
+        self.assertEqual("eco", codes("K-12")[0])
+        self.assertEqual("eco", codes("ecoli")[0])
+
+    def test_a_single_letter_is_a_genus_initial(self):
+        # "x" is a whole word of "Citrus x clementina"; an initial is not a word.
+        self.assertEqual(["xtr"], codes("x"))
+        self.assertEqual("hsa", codes("h sapiens")[0])
+
+    def test_quoted_names_search_by_their_words(self):
+        self.assertEqual("naz", codes("azollae")[0])
+        self.assertEqual({"naz", "ncf"}, set(codes("nostoc")[:2]))
+
+
+@unittest.skipIf(NODE is None, "node is not available")
+class EmptyQueryAndOrder(unittest.TestCase):
+
+    def test_empty_query_lists_every_organism_alphabetically(self):
+        listed = codes("")
+        names = node("S.rank('', L).map(r => r.name)")
+        self.assertEqual(133, len(listed))
+        self.assertEqual(sorted(names, key=lambda n: n.lower()), names)
+
+    def test_whitespace_only_is_empty(self):
+        self.assertEqual(133, len(codes("   ")))
+
+    def test_results_carry_name_value_and_score(self):
+        top = node("S.rank('mouse', L)[0]")
+        self.assertEqual({"name": "Mus musculus (house mouse)", "value": "mmu"},
+                         {"name": top["name"], "value": top["value"]})
+        self.assertGreater(top["score"], 0)
+
+    def test_ties_are_broken_by_name(self):
+        # Both Oryza sativa rows match "japanese rice" identically.
+        ranked = codes("japanese rice")
+        self.assertEqual(["osa", "dosa"], ranked[:2])
+
+
+@unittest.skipIf(NODE is None, "node is not available")
+class Highlighting(unittest.TestCase):
+    """The dropdown marks what matched, and never injects markup from a name."""
+
+    def highlight(self, name, query):
+        return node("S.highlight(%s, %s)" % (json.dumps(name), json.dumps(query)))
+
+    def test_marks_the_matched_word(self):
+        self.assertEqual("Mus musculus (house <mark>mouse</mark>)",
+                         self.highlight("Mus musculus (house mouse)", "mouse"))
+
+    def test_marks_a_prefix(self):
+        self.assertEqual("Mus musculus (<mark>hous</mark>e mouse)",
+                         self.highlight("Mus musculus (house mouse)", "hous"))
+
+    def test_marks_the_whole_word_a_typo_matched(self):
+        self.assertEqual("Mus musculus (house <mark>mouse</mark>)",
+                         self.highlight("Mus musculus (house mouse)", "mosue"))
+
+    def test_marks_every_query_word(self):
+        self.assertEqual("<mark>Homo</mark> <mark>sapiens</mark> (human)",
+                         self.highlight("Homo sapiens (human)", "sapiens homo"))
+
+    def test_escapes_html_in_the_name(self):
+        self.assertEqual("a &lt;b&gt; &amp; c", self.highlight("a <b> & c", ""))
+        self.assertEqual("<mark>a</mark> &lt;b&gt; &amp; c", self.highlight("a <b> & c", "a"))
+
+    def test_no_query_returns_the_escaped_name(self):
+        self.assertEqual("Mus musculus (house mouse)",
+                         self.highlight("Mus musculus (house mouse)", ""))
+
+
+@unittest.skipIf(NODE is None, "node is not available")
+class RequestDialogScale(unittest.TestCase):
+    """The request dialog searches every KEGG organism (11,550), per keystroke."""
+
+    def test_ranks_eleven_thousand_organisms_in_well_under_a_keystroke(self):
+        millis = node(
+            "(() => { S.rank('mo', L); const t = process.hrtime.bigint();"
+            " for (const q of ['m', 'mo', 'mou', 'mous', 'mouse']) S.rank(q, L);"
+            " return Number(process.hrtime.bigint() - t) / 5e6; })()",
+            listPath=ALL_SPECIES)
+        self.assertLess(millis, 150, "%.1f ms per query" % millis)
+
+    def test_an_english_word_beats_a_code_that_spells_it(self):
+        # 253 KEGG codes spell a word of another organism's name: "fly" is a
+        # Flavobacterium, "dog" a Desulfobulbus. The animal is what was meant.
+        full = lambda q: node("S.rank(%s, L).map(r => r.value)" % json.dumps(q), listPath=ALL_SPECIES)
+        self.assertEqual("dme", full("fly")[0])
+        self.assertEqual("cfa", full("dog")[0])
+        self.assertEqual("bta", full("cow")[0])
+        # ...while a code nothing else spells is still an exact hit.
+        self.assertEqual("hsa", full("hsa")[0])
+
+    def test_initial_plus_species_over_the_full_list_finds_the_model_strain(self):
+        # 286 E. coli strains; K-12 MG1655 is the one the initial means.
+        full = lambda q: node("S.rank(%s, L).map(r => r.value)" % json.dumps(q), listPath=ALL_SPECIES)
+        self.assertEqual("eco", full("e coli")[0])
+
+    def test_fuzzy_query_over_the_full_list_finds_the_mouse(self):
+        ranked = node("S.rank('mosue', L).map(r => r.value)", listPath=ALL_SPECIES)
+        self.assertEqual("mmu", ranked[0])
+
+
+class Wiring(unittest.TestCase):
+    """Both organism combos use the ranked picker, and the page loads it."""
+
+    def combo(self, source):
+        start = source.index('itemId: "speciesCombobox"')
+        return source[source.rindex("xtype:", 0, start):start]
+
+    def test_step1_combo_is_the_organism_picker(self):
+        self.assertIn("xtype: 'organismcombo'", self.combo(read(STEP1_VIEWS)))
+
+    def test_request_dialog_combo_is_the_organism_picker(self):
+        self.assertIn("xtype: 'organismcombo'", self.combo(read(DATA_MANAGEMENT)))
+
+    def test_index_html_loads_the_module_before_the_app(self):
+        html = read(INDEX_HTML)
+        module = re.search(r'src="app/view/common/OrganismSearch\.js\?v=[0-9.]+"', html)
+        self.assertIsNotNone(module, "OrganismSearch.js is not loaded with a ?v= marker")
+        self.assertLess(module.start(), html.index('src="app.js'))
+
+    def test_the_combo_never_uses_callparent(self):
+        # The module is strict so node runs it as the browser does, and ExtJS
+        # 4's callParent reads Function.caller, which strict mode removes. The
+        # failure is "Cannot read properties of null (reading 'apply')" in
+        # initComponent, the Step 1 view never builds, and the app shows its
+        # generic boot-failure dialog. Superclass calls go through the
+        # prototype instead.
+        source = read(MODULE)
+        self.assertEqual(-1, source.find("callParent"), "callParent in OrganismSearch.js")
+        self.assertIn('"use strict"', source)
+
+    def test_module_is_loadable_without_extjs(self):
+        # node has no Ext; the ranking half must not need it.
+        self.assertIsNotNone(NODE)
+        result = subprocess.run([NODE, "-e", "require(%s)" % json.dumps(MODULE)],
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        self.assertEqual(0, result.returncode, result.stderr.decode("utf-8", "replace"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -102,7 +102,7 @@ PUBLISHED = {
     "app/view/common/Util.js": (
         "2.1", "12359b8bf746394f63a7e0a15513a4f9ac82de1a25bbaa0e91e6b2fdd7e0050e"),
     "app/view/common/OrganismSearch.js": (
-        "1.0", "304dd14fcd77bde92cda9d5cbffaeae994e0f6a3da1a74da76d8f0e028ea6a9a"),
+        "1.0", "7903626835e7703bdb6a1e31b78e3ca00539eee23b8fa67a37524cd9cc4d2e7f"),
     "app/view/common/ExtJS_extensions.js": (
         "0.7", "f1e68f670cc56064fc15649d259004ccbd96f49181ced049cffbe62c29bf1d80"),
     "app/view/common/CookieConsent.js": (

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -101,6 +101,8 @@ PUBLISHED = {
         "0.6", "4ecdf2432832aba369df3d73483bdd5fd89969c9b2c86e597d030b15ff7e3844"),
     "app/view/common/Util.js": (
         "2.1", "12359b8bf746394f63a7e0a15513a4f9ac82de1a25bbaa0e91e6b2fdd7e0050e"),
+    "app/view/common/OrganismSearch.js": (
+        "1.0", "304dd14fcd77bde92cda9d5cbffaeae994e0f6a3da1a74da76d8f0e028ea6a9a"),
     "app/view/common/ExtJS_extensions.js": (
         "0.7", "f1e68f670cc56064fc15649d259004ccbd96f49181ced049cffbe62c29bf1d80"),
     "app/view/common/CookieConsent.js": (


### PR DESCRIPTION
## Summary

Both organism pickers — Step 1's combo and the *Request a new organism* dialog's — used the stock ExtJS local query, which keeps a row only when its display name **starts with** the typed text. KEGG names organisms "Genus species (common name)", so typing `mouse` found nothing (the row is *Mus musculus (house mouse)*), `hsa` found nothing, and a single typo emptied the list.

This PR replaces that with a ranked, typo-tolerant search:

- **`app/view/common/OrganismSearch.js`** (new, dependency-free, node-loadable) scores every row for a query: a whole common name, the head word of one (`mouse` in *house mouse*), the KEGG code, a whole word, the start of a word, the start of the code, a fragment, and finally a misspelling (Damerau-Levenshtein; one edit from four letters, two from eight, so `cat` never becomes `rat`). Every word of a multi-word query must match (`e coli`, `zebra fish`, `humna sapeins`); a single letter is a genus initial; hyphenated strains match joined (`k12` → K-12); accents and quotes are ignored; ties go to the classic model organisms before the name.
- The KEGG code deliberately scores *below* an exact common name: 253 of KEGG's 11,550 codes spell a word of some other organism (`fly` is a Flavobacterium, `dog` a Desulfobulbus; `cat`, `cow`, `bat`, `fox`, `rat`, `pig` are all bacteria) and the animal is what was meant. A code nothing else spells (`hsa`) still lands first.
- The same file defines **`xtype: 'organismcombo'`**, an `Ext.form.field.ComboBox` whose `doLocalQuery` filters and sorts the store by that ranking (the store's own sorters return when the query is cleared) and whose list rows mark the matched parts in bold with the code at the right edge. Both combos switch to it; store, `valueField`, `forceSelection` and the `change` event are untouched, so the database checkboxes still follow the selection.
- `main.css` gets the row styles (`?v=1.14`); the module is loaded from `index.html` with `?v=1.0` and recorded in the versioned-assets table.

## Test plan

- [x] `python -m src.tests.test_organism_search` — 50 tests: runs the shipped module under node against the list paintomics.uv.es served on 2026-08-21 (133 organisms, committed as `organisms_paintomics_uv.json`) and the full 11,550-organism KEGG list — common names, codes, typos, initials, strains, ties, highlighting/escaping, per-keystroke timing (< 150 ms over 11,550), and the source wiring of both combos and the page include.
- [x] `test_versioned_assets_are_bumped`, `test_index_html_revalidates`, `test_database_checkboxes_follow_the_server`, `test_example_mode_client_wiring` still pass.
- [x] Chrome, against a worktree server with the production organism list loaded: `mouse` → *Mus musculus (house **mouse**)* first and pre-highlighted; Enter sets `mmu` and the database boxes update; `mosue`, `humna sapeins`, `e coli`, `K-12`, `hsa`, `rat`, `yeast`, `rice`, and the empty query (alphabetical, 132 rows) all behave; light and dark themes; the request dialog ranks all 11,550 organisms at 5–70 ms per keystroke.

## Notes from review

- The request dialog's combo had no `queryMode`, so it was in ExtJS *remote* mode: every keystroke re-issued `store.load()` for `all_species.json` and never filtered. The class default `queryMode: 'local'` fixes that as a side effect.
- `findRecord` is overridden to search the store snapshot: the stock lookup searches only the currently filtered rows, so `setValue('mmu')` failed while the user's last query was still narrowing the list — which is exactly when example mode sets the organism programmatically. Same behaviour as stock otherwise.
- A query with no word in it (`(`, `-`, a name in another script) lists nothing rather than everything (second commit, from review).
- The ExtJS half (`doLocalQuery`, `renderItem`, `findRecord`) is now covered under a stub Ext in `test_organism_search` (50 tests total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
