### PR TITLE
Bound every AI conversion turn and name the gateway when it does not answer

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js
@@ -214,14 +214,28 @@
                 throw new Error(reason || "The conversion service refused the request.");
             }
             // Poll rather than hold a request open: the site has four request
-            // threads and the gateway takes about a minute.
+            // threads and the gateway takes about a minute. The server bounds
+            // its own turn (agent_turn.TURN_BUDGET_SECONDS, 150 s by default)
+            // well inside these 240 polls, so a gateway that does not answer
+            // comes back as `error` WITH its reason long before this loop
+            // gives up -- the bare "timed out" below is for a server that
+            // stopped answering the poll itself.
             for (var i = 0; i < 240; i++) {
                 await new Promise(function (r) { setTimeout(r, 1000); });
                 var poll = await fetch("input_convert/turn/" + encodeURIComponent(body.ticket),
                                        { credentials: "same-origin" });
                 var p = await poll.json();
                 if (p.state === "done") return p.action;
-                if (p.state === "error") throw new Error("The conversion service failed on that step.");
+                if (p.state === "error") {
+                    throw new Error(p.message || "The conversion service failed on that step.");
+                }
+                if (p.state === "unknown") {
+                    // The ticket is gone before it was answered: the server
+                    // restarted under it. Polling on would wait four minutes
+                    // for nothing.
+                    throw new Error("The server lost track of this conversion " +
+                                    "(it may have restarted). Please try again.");
+                }
             }
             throw new Error("The conversion timed out.");
         };

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -145,7 +145,7 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.6"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=0.6"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=0.7"></script>
 	<!--MORE REGULATOR–TARGET NETWORK VIEW -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js?v=0.7"></script>
 	<!--OMNIPATH PATHWAY NETWORK VIEW (OmniPath ships no diagram; its pathways render as graphs) -->

--- a/PaintomicsServer/src/classes/AIInterpret/llm_client.py
+++ b/PaintomicsServer/src/classes/AIInterpret/llm_client.py
@@ -174,13 +174,45 @@ class LLMClient:
             _SCHEMA_SUPPORT[self.api_base] = False
 
     def complete(self, messages, max_tokens=4096, temperature=0.3,
-                 response_format=None, timeout=None):
+                 response_format=None, timeout=None, stream=False,
+                 max_attempts=3, budget_seconds=None):
+        """One chat completion, returned as a string.
+
+        `stream=True` asks the gateway for server-sent events and folds the
+        deltas back into one string. On the CSIC gateway that is not an
+        optimisation but the difference between an answer and none: LiteLLM
+        gives a NON-streamed request about 120 s before it retries the backend
+        itself, so a long generation never completes that way, while a stream
+        is judged per read and runs for as long as tokens keep coming.
+
+        `budget_seconds` is a wall clock over the WHOLE call -- every attempt,
+        every backoff and the streamed body itself. A caller with someone
+        waiting on the other end (a browser polling a ticket) sets it so this
+        call gives up FIRST and says why; without it a stream that trickles a
+        token a minute holds a worker and a queue slot until the gateway
+        decides to stop. `max_attempts` bounds the retries the same way. Both
+        default to the behaviour every existing caller had.
+        """
         # Drop the schema up front on an endpoint already known to reject it,
         # so we pay the 400 once per process rather than once per call.
         if response_format is not None and not self.supports_schema():
             response_format = None
 
-        for attempt in range(3):  # 2 retries
+        attempts = max(1, int(max_attempts))
+        deadline = (time.monotonic() + budget_seconds) if budget_seconds else None
+
+        def _backoff(seconds, err):
+            # A retry that cannot finish inside the budget only delays an
+            # answer nobody will be there to read. Stop here instead.
+            if deadline is not None and time.monotonic() + seconds >= deadline:
+                raise err
+            time.sleep(seconds)
+
+        for attempt in range(attempts):
+            if deadline is not None and time.monotonic() >= deadline:
+                raise requests.exceptions.Timeout(
+                    "LLM call exceeded its %ss budget before attempt %d"
+                    % (budget_seconds, attempt + 1))
             try:
                 logger.info(f"LLM complete: model={self.model}, "
                             f"msgs={len(messages)}, max_tokens={max_tokens} "
@@ -189,6 +221,8 @@ class LLMClient:
                            "max_tokens": max_tokens, "temperature": temperature}
                 if response_format is not None:
                     payload["response_format"] = response_format
+                if stream:
+                    payload["stream"] = True
                 limiter = _limiter_for(self.api_base)
                 if limiter is not None:
                     limiter.acquire()
@@ -198,15 +232,19 @@ class LLMClient:
                              "Content-Type": "application/json"},
                     json=payload,
                     timeout=timeout or DEFAULT_TIMEOUT,
+                    stream=stream,
                 )
                 r.raise_for_status()
-                content = r.json()["choices"][0]["message"]["content"]
+                if stream:
+                    content = self._fold_stream(r, deadline)
+                else:
+                    content = r.json()["choices"][0]["message"]["content"]
                 logger.info(f"LLM complete: got {len(content)} chars")
                 return content
             except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
-                logger.warning(f"LLM request failed (attempt {attempt + 1}/3): {e}")
-                if attempt < 2:
-                    time.sleep(5 * (attempt + 1))  # 5s, 10s backoff
+                logger.warning(f"LLM request failed (attempt {attempt + 1}/{attempts}): {e}")
+                if attempt < attempts - 1:
+                    _backoff(5 * (attempt + 1), e)  # 5s, 10s backoff
                     continue
                 raise
             except requests.exceptions.HTTPError as e:
@@ -225,7 +263,7 @@ class LLMClient:
                 # job at the last phase. Back off and retry, honouring
                 # Retry-After when the server sends one.
                 if e.response is not None and e.response.status_code == 429:
-                    if attempt < 2:
+                    if attempt < attempts - 1:
                         wait = 5 * (attempt + 1)
                         try:
                             wait = max(wait, int(e.response.headers.get("Retry-After", 0)))
@@ -238,20 +276,70 @@ class LLMClient:
                         # a Retry-After the server explicitly asked for.
                         wait += random.uniform(0, 0.5 * wait)
                         logger.warning("LLM rate limited (429), retrying in %ss "
-                                       "(attempt %d/3)", wait, attempt + 1)
-                        time.sleep(wait)
+                                       "(attempt %d/%d)", wait, attempt + 1, attempts)
+                        _backoff(wait, e)
                         continue
-                    logger.error("LLM rate limited (429) after 3 attempts")
+                    logger.error("LLM rate limited (429) after %d attempts", attempts)
                     raise
                 # Don't retry other 4xx errors (auth, bad request) — they won't self-heal
                 if e.response is not None and 400 <= e.response.status_code < 500:
                     logger.error(f"LLM HTTP {e.response.status_code}: {e.response.text[:500]}")
                     raise
-                logger.warning(f"LLM server error (attempt {attempt + 1}/3): {e}")
-                if attempt < 2:
-                    time.sleep(5 * (attempt + 1))
+                logger.warning(f"LLM server error (attempt {attempt + 1}/{attempts}): {e}")
+                if attempt < attempts - 1:
+                    _backoff(5 * (attempt + 1), e)
                     continue
                 raise
+
+    @staticmethod
+    def _fold_stream(response, deadline):
+        """Concatenate the content deltas of a streamed chat completion.
+
+        `deadline` is a time.monotonic() value or None. It is checked between
+        events because the per-read timeout cannot see a gateway under load
+        that keeps the stream alive at a token a minute. The response is
+        closed on every path: a finished stream returns its connection to the
+        pool, a cut one is dropped rather than left half-read.
+        """
+        parts = []
+        try:
+            for line in response.iter_lines():
+                if deadline is not None and time.monotonic() > deadline:
+                    raise requests.exceptions.Timeout(
+                        "streamed completion exceeded its budget after %d chars"
+                        % sum(len(p) for p in parts))
+                if not line:
+                    continue
+                if isinstance(line, bytes):
+                    line = line.decode("utf-8", "replace")
+                if not line.startswith("data:"):
+                    continue
+                data = line[5:].strip()
+                if data == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(chunk, dict):
+                    continue
+                if chunk.get("error"):
+                    # LiteLLM reports a backend failure mid-stream as an event,
+                    # not a status code. It is as transient as a 503 would be.
+                    raise requests.exceptions.ConnectionError(
+                        "gateway error mid-stream: %s" % json.dumps(chunk["error"])[:300])
+                choices = chunk.get("choices") or []
+                if not choices:
+                    continue
+                delta = (choices[0].get("delta") or {}).get("content")
+                if delta:
+                    parts.append(delta)
+        finally:
+            try:
+                response.close()
+            except Exception:
+                pass
+        return "".join(parts)
 
     def complete_json(self, messages, schema_name, schema, fallback_parser,
                       max_tokens=4096, temperature=0.3, timeout=None):

--- a/PaintomicsServer/src/classes/AIInterpret/llm_client.py
+++ b/PaintomicsServer/src/classes/AIInterpret/llm_client.py
@@ -209,10 +209,19 @@ class LLMClient:
             time.sleep(seconds)
 
         for attempt in range(attempts):
-            if deadline is not None and time.monotonic() >= deadline:
-                raise requests.exceptions.Timeout(
-                    "LLM call exceeded its %ss budget before attempt %d"
-                    % (budget_seconds, attempt + 1))
+            attempt_timeout = timeout or DEFAULT_TIMEOUT
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise requests.exceptions.Timeout(
+                        "LLM call exceeded its %ss budget before attempt %d"
+                        % (budget_seconds, attempt + 1))
+                # A socket read that is blocked cannot see the deadline, so
+                # the last attempt must not be allowed a read longer than
+                # what is left -- or the budget is the budget plus one read
+                # timeout, and that attempt outlives the browser's patience.
+                connect, read = attempt_timeout
+                attempt_timeout = (min(connect, remaining), min(read, remaining))
             try:
                 logger.info(f"LLM complete: model={self.model}, "
                             f"msgs={len(messages)}, max_tokens={max_tokens} "
@@ -231,7 +240,7 @@ class LLMClient:
                     headers={"Authorization": f"Bearer {self.api_key}",
                              "Content-Type": "application/json"},
                     json=payload,
-                    timeout=timeout or DEFAULT_TIMEOUT,
+                    timeout=attempt_timeout,
                     stream=stream,
                 )
                 r.raise_for_status()

--- a/PaintomicsServer/src/classes/InputConvert/agent_turn.py
+++ b/PaintomicsServer/src/classes/InputConvert/agent_turn.py
@@ -22,6 +22,59 @@ logger = logging.getLogger(__name__)
 
 VALID_TYPES = ("code", "question", "done")
 
+# Budget for one turn -- wall clock, retries included. convert-drawer.js polls
+# a ticket 240 times a second apart (plus the round trip), so the server has
+# to give up FIRST, with a reason, or it keeps spending on an answer nobody is
+# waiting for while holding one of the two conversion slots. Measured on
+# paintomics.uv.es 2026-08-21, when the gateway hung for an hour: on the old
+# unbounded, non-streamed path every turn took 3 x 180 s, every browser gave
+# up at four minutes with a bare "timed out", and the next click found both
+# slots taken. Healthy turns take 1-11 s (same log, that morning).
+TURN_BUDGET_SECONDS = int(os.getenv("AI_CONVERT_TURN_SECONDS", "150"))
+
+# Per socket read. The answer is streamed, so this means "no token for N
+# seconds", not "the whole answer within N seconds"; the first token of a
+# healthy turn arrives in about a second.
+READ_TIMEOUT_SECONDS = int(os.getenv("AI_CONVERT_READ_TIMEOUT", "60"))
+
+
+class GatewayUnavailable(Exception):
+    """The model gateway did not deliver an answer for this turn.
+
+    Distinct from `None` (the gateway answered; the answer did not parse).
+    The agent loop retries a None -- the model may do better next time -- but
+    a gateway that is not answering will not answer the retry either, and the
+    browser stops listening after about four minutes. The servlet turns this
+    into a failed ticket carrying the message, so the user reads "the AI
+    service did not answer" inside the budget instead of "timed out" after it.
+
+    `fact` is the one-clause statement of what happened, kept separately so a
+    later refusal can quote it ("... did not answer a moment ago") without
+    repeating the advice.
+    """
+
+    def __init__(self, fact, advice="It may be busy or down; please try again in a few minutes."):
+        self.fact = str(fact).rstrip(".")
+        super().__init__((self.fact + ". " + advice).strip())
+
+
+def _describe_failure(exc):
+    """(fact, advice) for the user, from whatever the transport raised."""
+    import requests
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    if isinstance(exc, (requests.exceptions.Timeout, requests.exceptions.ConnectionError)):
+        return ("The AI service did not answer within %d seconds" % TURN_BUDGET_SECONDS,
+                "It may be busy or down; please try again in a few minutes.")
+    if status == 429:
+        return ("The AI service is rate-limiting requests",
+                "Please try again in a minute.")
+    if status:
+        return ("The AI service refused the request (HTTP %d)" % status,
+                "Please try again later.")
+    return ("The AI service failed: %s" % (str(exc)[:200] or type(exc).__name__),
+            "Please try again later.")
+
 
 def _extract_json(text):
     """Pull the action object out of whatever the model wrapped it in.
@@ -102,7 +155,14 @@ def normalise_action(raw):
 
 
 def next_action(state, client=None):
-    """Ask the model what to do next. Returns a normalised action, or None."""
+    """Ask the model what to do next.
+
+    Returns a normalised action, or None when the model answered with
+    something that is not one. Raises GatewayUnavailable when the gateway did
+    not answer inside TURN_BUDGET_SECONDS -- the two are different failures
+    and the loop must treat them differently (retry the first, stop on the
+    second).
+    """
     if client is None:
         try:
             from src.classes.AIInterpret.llm_client import LLMClient
@@ -118,16 +178,30 @@ def next_action(state, client=None):
     ]
 
     try:
-        reply = client.complete(messages, max_tokens=6000, temperature=0.1)
+        # Streamed and bounded, like every other long call to this gateway:
+        # see csic-gateway-120s-per-attempt-budget. A transient 503 or 429
+        # comes back at once and is retried inside the budget; a hang costs at
+        # most one read timeout per attempt and the budget cuts the rest.
+        reply = client.complete(messages, max_tokens=6000, temperature=0.1,
+                                stream=True, timeout=(15, READ_TIMEOUT_SECONDS),
+                                max_attempts=3, budget_seconds=TURN_BUDGET_SECONDS)
     except Exception as exc:
         logger.warning("input-convert turn failed: %s", exc)
-        return None
+        fact, advice = _describe_failure(exc)
+        raise GatewayUnavailable(fact, advice) from exc
 
     return normalise_action(_extract_json(reply))
 
 
 if __name__ == "__main__":
     # Used by the corpus harness: state JSON on stdin, action JSON on stdout.
+    # A gateway failure goes to stderr and is answered with null, so the
+    # harness keeps the contract it had; the servlet is the caller that turns
+    # GatewayUnavailable into a user-facing failure.
     payload = json.load(sys.stdin)
-    action = next_action(payload)
+    try:
+        action = next_action(payload)
+    except GatewayUnavailable as exc:
+        sys.stderr.write("input-convert: %s\n" % exc)
+        action = None
     sys.stdout.write(json.dumps(action) if action else "null")

--- a/PaintomicsServer/src/servlets/InputConvertServlet.py
+++ b/PaintomicsServer/src/servlets/InputConvertServlet.py
@@ -8,16 +8,24 @@ up when a user closes the tab.
 
 It does NOT wait for the model inline. paintomics4.ini runs processes=1,
 threads=4, so four threads serve every request on the site; the CSIC gateway
-takes ~120 s per attempt. An inline call would hold a quarter of the site's
-capacity per conversion and take the site down at four concurrent users. The
-work is enqueued and the browser polls, exactly as aiInterpretInitiate does.
+can take a minute or more per answer. An inline call would hold a quarter of
+the site's capacity per conversion and take the site down at four concurrent
+users. The work is enqueued and the browser polls, exactly as
+aiInterpretInitiate does.
+
+Each turn is bounded (agent_turn.TURN_BUDGET_SECONDS) and a gateway that does
+not answer fails the ticket with the reason, which the browser shows. For a
+short cooldown after that, new turns are refused at once rather than each
+spending the budget to find the same thing out.
 """
 
 import logging
+import math
 import os
 import threading
 import time
 
+from src.classes.InputConvert import agent_turn
 from src.common.ServerErrorManager import handleException
 from src.common.UserSessionManager import UserSessionManager
 
@@ -57,6 +65,45 @@ _inflight = threading.BoundedSemaphore(MAX_CONCURRENT_CONVERSIONS)
 MAX_TURNS_PER_USER_PER_DAY = 120
 _usage = {}
 _usage_lock = threading.Lock()
+
+# ---------------------------------------------------------------------------
+# Gateway cooldown
+# ---------------------------------------------------------------------------
+# When a turn has just found the gateway not answering, the next click must not
+# spend another TURN_BUDGET_SECONDS finding the same thing out. For this long
+# after such a failure new turns are refused at once, quoting the reason the
+# failed turn recorded. Short on purpose: a recovered gateway is back in use
+# within a couple of minutes, and a refused click costs the user a retry, not
+# a wait. The first turn that succeeds clears it early.
+GATEWAY_COOLDOWN_SECONDS = 90
+_gateway_lock = threading.Lock()
+_gateway_down_until = 0.0
+_gateway_last_error = ""
+
+
+def _mark_gateway_down(failure):
+    global _gateway_down_until, _gateway_last_error
+    with _gateway_lock:
+        _gateway_down_until = time.monotonic() + GATEWAY_COOLDOWN_SECONDS
+        _gateway_last_error = getattr(failure, "fact", None) or str(failure)
+
+
+def _mark_gateway_up():
+    global _gateway_down_until, _gateway_last_error
+    with _gateway_lock:
+        _gateway_down_until = 0.0
+        _gateway_last_error = ""
+
+
+def _gateway_cooldown_left():
+    """Seconds of cooldown remaining, 0 when turns may go out."""
+    with _gateway_lock:
+        return max(0.0, _gateway_down_until - time.monotonic())
+
+
+def _reset_gateway_state():
+    """Forget any recorded gateway failure (tests)."""
+    _mark_gateway_up()
 
 
 def _spend_turn(user_id):
@@ -101,6 +148,12 @@ def _reject_if_carrying_data(state):
 
 def inputConvertTurn(REQUEST, RESPONSE, QUEUE_INSTANCE, JOB_ID):
     """POST /input_convert/turn -> {ticket}. The browser then polls for it."""
+    # Whether THIS request holds a conversion slot that nobody else will
+    # release. It is handed to the queued work on enqueue; until then an error
+    # here must give it back, and before acquire an error must not touch the
+    # semaphore at all -- releasing a slot another conversion holds lets that
+    # conversion's own release overflow the bound and fail its job.
+    acquired = False
     try:
         userID = REQUEST.cookies.get("userID")
         sessionToken = REQUEST.cookies.get("sessionToken")
@@ -117,39 +170,50 @@ def inputConvertTurn(REQUEST, RESPONSE, QUEUE_INSTANCE, JOB_ID):
                 "The conversion request carried a %r field that looks like raw data. "
                 "Only the file's structure is sent." % offending)
 
+        cooldown = _gateway_cooldown_left()
+        if cooldown:
+            raise Exception(
+                "%s a moment ago; conversions are paused for another %d seconds "
+                "while it recovers. Please try again then."
+                % (_gateway_last_error, math.ceil(cooldown)))
+
         if not _spend_turn(userID):
             raise Exception("Daily conversion limit reached for this account.")
 
         if not _inflight.acquire(blocking=False):
             raise Exception("The server is converting other files right now. "
                             "Please try again in a moment.")
+        acquired = True
 
         def work(payload):
+            # Runs on a queue worker, which now owns the slot: released here on
+            # every path. A gateway failure propagates so the ticket fails with
+            # its message, and starts the cooldown for the next click.
             try:
-                from src.classes.InputConvert.agent_turn import next_action
-                return next_action(payload)
+                action = agent_turn.next_action(payload)
+            except agent_turn.GatewayUnavailable as failure:
+                _mark_gateway_down(failure)
+                raise
             finally:
                 _inflight.release()
+            _mark_gateway_up()
+            return action
 
         # PySiQ takes (fn, args) -- the callable and a tuple, not a closure.
-        QUEUE_INSTANCE.enqueue(fn=work, args=(state,), job_id=JOB_ID, timeout=300)
+        QUEUE_INSTANCE.enqueue(fn=work, args=(state,), job_id=JOB_ID,
+                               timeout=agent_turn.TURN_BUDGET_SECONDS + 30)
+        acquired = False                      # the worker owns it from here
         RESPONSE.setContent({"success": True, "ticket": JOB_ID})
     except Exception as ex:
-        _release_quietly()
+        if acquired:
+            _inflight.release()
         handleException(RESPONSE, ex, __file__, "inputConvertTurn")
     finally:
         return RESPONSE
 
 
-def _release_quietly():
-    try:
-        _inflight.release()
-    except ValueError:
-        pass  # was never acquired on this path
-
-
 def inputConvertResult(REQUEST, RESPONSE, QUEUE_INSTANCE, ticket):
-    """GET /input_convert/turn/<ticket> -> {state, action}."""
+    """GET /input_convert/turn/<ticket> -> {state, action | message}."""
     try:
         userID = REQUEST.cookies.get("userID")
         sessionToken = REQUEST.cookies.get("sessionToken")
@@ -165,7 +229,13 @@ def inputConvertResult(REQUEST, RESPONSE, QUEUE_INSTANCE, ticket):
             action = QUEUE_INSTANCE.get_result(ticket, remove=True)
             RESPONSE.setContent({"success": True, "state": "done", "action": action})
         elif "FAILED" in status.upper():
-            RESPONSE.setContent({"success": True, "state": "error"})
+            # Carry the reason, and consume the entry like a finished one:
+            # PySiQ removes nothing by itself, so a failed ticket would
+            # otherwise sit in its table until the next restart.
+            message = (QUEUE_INSTANCE.get_error_message(ticket)
+                       or "The conversion service failed on that step.")
+            QUEUE_INSTANCE.get_result(ticket, remove=True)
+            RESPONSE.setContent({"success": True, "state": "error", "message": message})
         else:
             RESPONSE.setContent({"success": True, "state": "running"})
     except Exception as ex:

--- a/PaintomicsServer/src/tests/test_input_convert_gateway_timeout.py
+++ b/PaintomicsServer/src/tests/test_input_convert_gateway_timeout.py
@@ -247,6 +247,25 @@ class StreamedCompletion(unittest.TestCase):
                         max_attempts=3, budget_seconds=150)
             self.assertEqual(len(p.calls), 1,
                              "past the deadline, the retry loop must stop")
+
+            # A retry that does fit gets only the budget that is left: a
+            # blocked read cannot see the deadline, so the read timeout is
+            # what bounds the final attempt.
+            fake_clock["now"] = 0.0
+
+            def eat_seventy(payload, stream):
+                fake_clock["now"] += 70.0
+                raise requests.exceptions.ReadTimeout("no token")
+
+            with _Patched(eat_seventy) as p:
+                with self.assertRaises(requests.exceptions.Timeout):
+                    lc.LLMClient(PROVIDER).complete(
+                        [{"role": "user", "content": "x"}], stream=True,
+                        timeout=(15, 60), max_attempts=3, budget_seconds=100)
+            self.assertEqual(p.calls[0]["timeout"], (15, 60))
+            self.assertEqual(p.calls[1]["timeout"], (15, 30),
+                             "the second attempt may only read for what is left")
+            self.assertEqual(len(p.calls), 2, "no third attempt fits the budget")
         finally:
             lc.time.monotonic = real
 

--- a/PaintomicsServer/src/tests/test_input_convert_gateway_timeout.py
+++ b/PaintomicsServer/src/tests/test_input_convert_gateway_timeout.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""A hung model gateway must fail a conversion turn fast, and say so.
+
+Why this exists
+---------------
+On 2026-08-21 the CSIC gateway (llm.iiia.es) stopped answering for about an
+hour: TCP and TLS completed, then not one byte came back. Every conversion
+started in that window looked, to the user, like the feature being broken:
+
+  * the server turn called the gateway NON-streamed with a 180 s read timeout
+    and three attempts, so one turn took ~9 minutes to fail;
+  * the browser polls a ticket for ~4 minutes and then reports the generic
+    "The conversion timed out." -- nothing named the gateway;
+  * the failed turn came back as `state: done, action: null`, which the agent
+    loop treats as "the model wrote garbage" and RETRIES, five times;
+  * each zombie turn held one of the two conversion slots, so the next click
+    was refused with "the server is converting other files".
+
+The interpreter had already moved every long call to a streamed, bounded
+transport for exactly this gateway behaviour (see
+csic-gateway-120s-per-attempt-budget); the converter was written later and
+took the unbounded path.
+
+What is pinned here
+-------------------
+  * `LLMClient.complete(stream=True)` folds a server-sent-event stream into
+    one string, and a `budget_seconds` wall clock bounds the WHOLE call,
+    retries included -- a stream that trickles forever is cut, and no retry
+    starts past the deadline.
+  * `agent_turn.next_action` asks for a streamed, bounded turn whose budget
+    ends before the browser stops listening, and raises `GatewayUnavailable`
+    (never returns None) when the gateway does not answer. None stays
+    reserved for an answer that arrived but did not parse -- that IS worth
+    another attempt; a dead gateway is not.
+  * The servlet reports a failed turn as `state: "error"` WITH the reason,
+    consumes the failed ticket, refuses the next turn immediately while the
+    gateway is cooling down, and never over-releases the concurrency
+    semaphore on an error path.
+
+Usage:
+    cd PaintomicsServer
+    PYTHONPATH=. python src/tests/test_input_convert_gateway_timeout.py
+"""
+import json
+import os
+import sys
+import threading
+import time
+import unittest
+
+SERVER_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, SERVER_ROOT)
+
+import requests
+
+from src.classes.AIInterpret import llm_client as lc
+from src.classes.InputConvert import agent_turn
+from src.common.PySiQ import Queue, JobStatus
+from src.servlets import InputConvertServlet as servlet
+
+PROVIDER = {"api_base": "https://gateway.example/v1", "api_key": "k", "model": "m"}
+
+
+# ---------------------------------------------------------------------------
+# Doubles
+# ---------------------------------------------------------------------------
+def _sse(text_parts, done=True):
+    """The byte lines an OpenAI-compatible gateway streams for `text_parts`."""
+    lines = []
+    for part in text_parts:
+        lines.append(("data: " + json.dumps(
+            {"choices": [{"delta": {"content": part}}]})).encode("utf-8"))
+        lines.append(b"")                      # SSE records are blank-line separated
+    if done:
+        lines.append(b"data: [DONE]")
+    return lines
+
+
+class _StreamResp:
+    """requests.Response double for stream=True: iter_lines() + close()."""
+    headers = {}
+
+    def __init__(self, lines, delay=0.0, status=200):
+        self._lines = lines
+        self._delay = delay
+        self.status_code = status
+        self.closed = False
+        self.text = ""
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            err = requests.exceptions.HTTPError("HTTP %d" % self.status_code)
+            err.response = self
+            raise err
+
+    def iter_lines(self):
+        for line in self._lines:
+            if self._delay:
+                time.sleep(self._delay)
+            yield line
+
+    def close(self):
+        self.closed = True
+
+    def json(self):                            # only the non-stream path uses this
+        raise AssertionError("a streamed response must not be read with .json()")
+
+
+class _Patched:
+    """Swap requests.post and time.sleep inside llm_client for one test."""
+
+    def __init__(self, handler):
+        self.handler = handler
+        self.calls = []
+        self.sleeps = []
+
+    def __enter__(self):
+        self._post, self._sleep = lc.requests.post, lc.time.sleep
+
+        def fake_post(url, headers=None, json=None, timeout=None, stream=False):
+            self.calls.append({"payload": json, "timeout": timeout, "stream": stream})
+            return self.handler(json, stream)
+
+        lc.requests.post = fake_post
+        # `time` is one shared module, so this stub is global: keep real
+        # sub-second sleeps (the trickling stream below relies on them) and
+        # only swallow the 5 s / 10 s retry backoffs.
+        real_sleep = self._sleep
+        lc.time.sleep = lambda s: real_sleep(s) if s < 1 else self.sleeps.append(s)
+        return self
+
+    def __exit__(self, *exc):
+        lc.requests.post, lc.time.sleep = self._post, self._sleep
+
+
+class _Request:
+    def __init__(self, state=None, cookies=None):
+        self.cookies = cookies or {}
+        self._state = state or {}
+
+    def get_json(self, force=True, silent=True):
+        return self._state
+
+
+class _Response:
+    def __init__(self):
+        self.content = None
+        self.status = None
+
+    def setContent(self, content):
+        self.content = content
+
+    def setStatus(self, status):
+        self.status = status
+
+    def getResponse(self):
+        return self.content
+
+
+class _AnySession:
+    def isValidUser(self, userID, sessionToken):
+        return True
+
+
+def _wait_until(predicate, seconds=5.0):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return predicate()
+
+
+# ---------------------------------------------------------------------------
+# LLMClient.complete(stream=True, budget_seconds=...)
+# ---------------------------------------------------------------------------
+class StreamedCompletion(unittest.TestCase):
+
+    def test_stream_is_folded_into_one_string(self):
+        parts = ['{"type": "code", ', '"python": "print(1)", ', '"summary": "ok"}']
+        with _Patched(lambda payload, stream: _StreamResp(_sse(parts))) as p:
+            out = lc.LLMClient(PROVIDER).complete(
+                [{"role": "user", "content": "x"}], stream=True)
+        self.assertEqual(out, "".join(parts))
+        self.assertEqual(len(p.calls), 1)
+        self.assertTrue(p.calls[0]["payload"].get("stream"),
+                        "the payload must ask the gateway to stream")
+        self.assertTrue(p.calls[0]["stream"],
+                        "requests.post must be told to stream the body")
+
+    def test_default_call_is_unchanged(self):
+        """stream defaults off: the interpreter's callers see no difference."""
+        class _Plain:
+            headers = {}
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"choices": [{"message": {"content": "plain"}}]}
+
+        with _Patched(lambda payload, stream: _Plain()) as p:
+            out = lc.LLMClient(PROVIDER).complete([{"role": "user", "content": "x"}])
+        self.assertEqual(out, "plain")
+        self.assertNotIn("stream", p.calls[0]["payload"])
+        self.assertFalse(p.calls[0]["stream"])
+
+    def test_a_trickling_stream_is_cut_at_the_budget(self):
+        # 200 chunks, 50 ms apart = 10 s of "alive but useless" streaming.
+        slow = _StreamResp(_sse(["x"] * 200), delay=0.05)
+        started = time.monotonic()
+        with _Patched(lambda payload, stream: slow) as p:
+            with self.assertRaises(requests.exceptions.Timeout):
+                lc.LLMClient(PROVIDER).complete(
+                    [{"role": "user", "content": "x"}], stream=True,
+                    budget_seconds=0.4, max_attempts=3)
+        elapsed = time.monotonic() - started
+        self.assertLess(elapsed, 2.0, "the budget must cut the stream, not wait it out")
+        self.assertTrue(slow.closed, "the cut stream must be closed")
+        self.assertEqual(len(p.calls), 1, "no retry may start once the budget is spent")
+
+    def test_read_timeouts_retry_within_the_budget_only(self):
+        def handler(payload, stream):
+            raise requests.exceptions.ReadTimeout("no token for 60 s")
+
+        with _Patched(handler) as p:
+            with self.assertRaises(requests.exceptions.Timeout):
+                lc.LLMClient(PROVIDER).complete(
+                    [{"role": "user", "content": "x"}], stream=True,
+                    max_attempts=2, budget_seconds=1000)
+        self.assertEqual(len(p.calls), 2, "max_attempts bounds the retries")
+
+        # A budget that the first attempt already exhausted: no second attempt.
+        fake_clock = {"now": 0.0}
+        real = lc.time.monotonic
+        lc.time.monotonic = lambda: fake_clock["now"]
+        try:
+            def slow_fail(payload, stream):
+                fake_clock["now"] += 200.0        # the attempt ate 200 "seconds"
+                raise requests.exceptions.ReadTimeout("no token")
+
+            with _Patched(slow_fail) as p:
+                with self.assertRaises(requests.exceptions.Timeout):
+                    lc.LLMClient(PROVIDER).complete(
+                        [{"role": "user", "content": "x"}], stream=True,
+                        max_attempts=3, budget_seconds=150)
+            self.assertEqual(len(p.calls), 1,
+                             "past the deadline, the retry loop must stop")
+        finally:
+            lc.time.monotonic = real
+
+
+# ---------------------------------------------------------------------------
+# agent_turn.next_action
+# ---------------------------------------------------------------------------
+class _RecordingClient:
+    def __init__(self, reply=None, error=None):
+        self.reply, self.error, self.kwargs = reply, error, None
+
+    def complete(self, messages, **kwargs):
+        self.kwargs = kwargs
+        if self.error:
+            raise self.error
+        return self.reply
+
+
+STATE = {"goal": "convert", "fileName": "x.tsv", "profile": {"tables": []},
+         "history": [], "answers": {}, "instructions": []}
+
+
+class TurnContract(unittest.TestCase):
+
+    def test_turn_is_streamed_and_bounded_inside_the_browsers_patience(self):
+        client = _RecordingClient(reply='{"type": "done"}')
+        agent_turn.next_action(dict(STATE), client=client)
+        self.assertTrue(client.kwargs.get("stream"), "the turn must stream")
+        budget = client.kwargs.get("budget_seconds")
+        self.assertIsNotNone(budget, "the turn must carry a wall-clock budget")
+        # convert-drawer.js polls 240 times, a second apart plus the round
+        # trip: the server must give up first, with a reason, or the browser
+        # reports a bare "timed out" while the turn keeps spending.
+        self.assertLessEqual(budget, 200)
+        self.assertEqual(budget, agent_turn.TURN_BUDGET_SECONDS)
+
+    def test_a_hung_gateway_raises_not_none(self):
+        client = _RecordingClient(
+            error=requests.exceptions.ReadTimeout("Read timed out. (read timeout=60)"))
+        with self.assertRaises(agent_turn.GatewayUnavailable) as ctx:
+            agent_turn.next_action(dict(STATE), client=client)
+        message = str(ctx.exception)
+        self.assertIn("AI service", message)
+        self.assertIn(str(agent_turn.TURN_BUDGET_SECONDS), message,
+                      "the message should say how long it waited")
+
+    def test_a_refusal_names_the_status(self):
+        resp = _StreamResp([], status=503)
+        err = requests.exceptions.HTTPError("HTTP 503")
+        err.response = resp
+        client = _RecordingClient(error=err)
+        with self.assertRaises(agent_turn.GatewayUnavailable) as ctx:
+            agent_turn.next_action(dict(STATE), client=client)
+        self.assertIn("503", str(ctx.exception))
+
+    def test_garbage_from_a_live_gateway_is_still_none(self):
+        """An answer that does not parse is the MODEL's failure: retry it."""
+        client = _RecordingClient(reply="I cannot help with that.")
+        self.assertIsNone(agent_turn.next_action(dict(STATE), client=client))
+
+
+# ---------------------------------------------------------------------------
+# InputConvertServlet
+# ---------------------------------------------------------------------------
+class ServletFailurePath(unittest.TestCase):
+
+    def setUp(self):
+        self._session = servlet.UserSessionManager
+        self._enabled = servlet._converter_enabled
+        self._next = agent_turn.next_action
+        servlet.UserSessionManager = _AnySession
+        servlet._converter_enabled = lambda: True
+        servlet._reset_gateway_state()
+        # A fresh per-test usage table so the daily limit never leaks between tests.
+        servlet._usage.clear()
+
+    def tearDown(self):
+        servlet.UserSessionManager = self._session
+        servlet._converter_enabled = self._enabled
+        agent_turn.next_action = self._next
+        servlet._reset_gateway_state()
+
+    def _turn(self, queue, state=None, cookies=None, ticket="convert_t1"):
+        request = _Request(state or {"goal": "g"}, cookies or {"userID": "u1", "sessionToken": "s"})
+        return servlet.inputConvertTurn(request, _Response(), queue, ticket).content
+
+    def _result(self, queue, ticket):
+        request = _Request(cookies={"userID": "u1", "sessionToken": "s"})
+        return servlet.inputConvertResult(request, _Response(), queue, ticket).content
+
+    def test_failed_turn_reports_error_with_the_reason_and_is_consumed(self):
+        agent_turn.next_action = lambda payload: (_ for _ in ()).throw(
+            agent_turn.GatewayUnavailable("The AI service did not answer within 5 seconds."))
+        queue = Queue()
+        queue.start_worker(1)
+        try:
+            body = self._turn(queue)
+            self.assertTrue(body.get("success"), body)
+            ticket = body["ticket"]
+            self.assertTrue(_wait_until(
+                lambda: queue.check_status(ticket) == JobStatus.FAILED))
+            polled = self._result(queue, ticket)
+            self.assertEqual(polled.get("state"), "error")
+            self.assertIn("did not answer", polled.get("message", ""))
+            # Consumed: the next poll finds nothing rather than re-reporting it.
+            self.assertEqual(self._result(queue, ticket).get("state"), "unknown")
+        finally:
+            queue.stop_worker()
+
+    def test_next_turn_is_refused_immediately_while_the_gateway_cools_down(self):
+        agent_turn.next_action = lambda payload: (_ for _ in ()).throw(
+            agent_turn.GatewayUnavailable("The AI service did not answer within 5 seconds."))
+        queue = Queue()
+        queue.start_worker(1)
+        try:
+            ticket = self._turn(queue)["ticket"]
+            self.assertTrue(_wait_until(
+                lambda: queue.check_status(ticket) == JobStatus.FAILED))
+            self.assertTrue(servlet._gateway_cooldown_left() > 0,
+                            "a failed turn must start the cooldown")
+            refused = self._turn(queue, ticket="convert_t2")
+            self.assertFalse(refused.get("success"), refused)
+            text = json.dumps(refused)
+            self.assertIn("did not answer", text)
+            self.assertIn("try again", text.lower())
+            # Nothing was enqueued for the refused click.
+            self.assertEqual(queue.check_status("convert_t2"), JobStatus.NOT_QUEUED)
+        finally:
+            queue.stop_worker()
+
+    def test_cooldown_expires(self):
+        servlet._mark_gateway_down("The AI service did not answer within 5 seconds.")
+        self.assertGreater(servlet._gateway_cooldown_left(), 0)
+        servlet._gateway_down_until = time.monotonic() - 1
+        self.assertEqual(servlet._gateway_cooldown_left(), 0)
+        queue = Queue()                                 # no worker: the job just sits
+        body = self._turn(queue, ticket="convert_t3")
+        self.assertTrue(body.get("success"), body)
+
+    def test_a_successful_turn_clears_the_cooldown(self):
+        servlet._mark_gateway_down("The AI service did not answer within 5 seconds.")
+        agent_turn.next_action = lambda payload: {"type": "done"}
+        servlet._gateway_down_until = time.monotonic() - 1
+        queue = Queue()
+        queue.start_worker(1)
+        try:
+            ticket = self._turn(queue, ticket="convert_t4")["ticket"]
+            self.assertTrue(_wait_until(
+                lambda: queue.check_status(ticket) == JobStatus.FINISHED))
+            self.assertEqual(self._result(queue, ticket).get("action"), {"type": "done"})
+        finally:
+            queue.stop_worker()
+
+    def test_an_error_before_the_slot_is_taken_does_not_free_someone_elses(self):
+        queue = Queue()
+        servlet._inflight.acquire()                     # another conversion in flight
+        try:
+            before = servlet._inflight._value
+            # Exhaust this user's daily budget so the route refuses BEFORE acquire.
+            day = int(time.time() // 86400)
+            servlet._usage["u9"] = (day, servlet.MAX_TURNS_PER_USER_PER_DAY)
+            refused = self._turn(queue, cookies={"userID": "u9", "sessionToken": "s"},
+                                 ticket="convert_t5")
+            self.assertFalse(refused.get("success"), refused)
+            self.assertEqual(servlet._inflight._value, before,
+                             "a pre-acquire failure must not release a slot it never held")
+        finally:
+            servlet._inflight.release()
+
+    def test_the_worker_releases_the_slot_it_was_handed(self):
+        agent_turn.next_action = lambda payload: {"type": "done"}
+        queue = Queue()
+        queue.start_worker(1)
+        try:
+            free = servlet._inflight._value
+            ticket = self._turn(queue, ticket="convert_t6")["ticket"]
+            self.assertTrue(_wait_until(
+                lambda: queue.check_status(ticket) == JobStatus.FINISHED))
+            self.assertTrue(_wait_until(lambda: servlet._inflight._value == free),
+                            "the slot must come back once the turn is over")
+        finally:
+            queue.stop_worker()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -98,7 +98,7 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js": (
         "0.6", "d884a0d8344fccf966aab1219c9c70f9e29ca93a4a42e7ddf8f0852189f5ecdd"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js": (
-        "0.6", "4ecdf2432832aba369df3d73483bdd5fd89969c9b2c86e597d030b15ff7e3844"),
+        "0.7", "241e9a48b99f6ca40f3f9d3b5dd29f27513ca38c181fb902075a0149af9ca4b3"),
     "app/view/common/Util.js": (
         "2.1", "12359b8bf746394f63a7e0a15513a4f9ac82de1a25bbaa0e91e6b2fdd7e0050e"),
     "app/view/common/OrganismSearch.js": (

--- a/docs/ai-input-converter.md
+++ b/docs/ai-input-converter.md
@@ -147,6 +147,32 @@ The acceptance gate is always PaintOmics' own validator — the agent never grad
 its own work — extended to reject a values matrix that silently repeats an
 identifier or leaves an identifier cell empty.
 
+## When the AI service does not answer
+
+The gateway behind the converter is shared and can stall: on 2026-08-21 it
+accepted connections for about an hour without returning a byte. What the user
+sees then is decided here, not by the gateway:
+
+- **Every turn is bounded.** `agent_turn.next_action` streams the completion
+  (the only call shape this gateway finishes for long answers) under a wall
+  clock of `AI_CONVERT_TURN_SECONDS` (150 s, retries included) with a per-read
+  timeout of `AI_CONVERT_READ_TIMEOUT` (60 s). The browser polls a ticket for
+  about four minutes, so the server always gives up first, with a reason.
+- **A gateway failure is not a model failure.** The turn raises
+  `GatewayUnavailable`, the ticket fails with that message, and the sheet shows
+  it ("The AI service did not answer within 150 seconds. It may be busy or
+  down; please try again in a few minutes."). A `null` action — the model
+  answered but not with an action — is still retried, because that one can
+  succeed on the next try.
+- **A short cooldown.** For 90 s after such a failure, new turns are refused at
+  once with the recorded reason instead of each spending the budget to learn
+  the same thing. The first turn that succeeds clears it.
+- **Slots are returned.** The two concurrency slots are released by the worker
+  that ran the turn, and an error before a slot was taken never releases one
+  that another conversion holds.
+
+`src/tests/test_input_convert_gateway_timeout.py` pins all four.
+
 ## Privacy and isolation (unchanged)
 
 The generated Python runs in an opaque-origin Pyodide sandbox


### PR DESCRIPTION
## Why

"The automatic file conversion is not working" on paintomics.uv.es, 2026-08-21 afternoon.

UV's uwsgi log shows every converter turn since 16:36 UTC dying the same way:

```
16:48:15 NEW JOB convert_a244019d… ADDED TO QUEUE
16:48:15 LLM complete: model=deepseek-ai/DeepSeek-V4-Flash-0731, msgs=2, max_tokens=6000 (attempt 1)
16:51:15 LLM request failed (attempt 1/3): … Read timed out. (read timeout=180)
16:54:20 LLM request failed (attempt 2/3): … Read timed out. (read timeout=180)
…        input-convert turn failed: … Read timed out. (read timeout=180)
```

while the browser polled the ticket every second from 16:49:17 to 16:51:08 and then gave up.

The immediate cause is **external**: the CSIC gateway (`llm.iiia.es`) stopped answering around 16:10 UTC — TCP and TLS complete in ~40 ms and then not one byte comes back, from UV, from a laptop and from garnatxa alike (`/health/readiness` hangs). The interpreter's agent loop hit its 450 s backstop at 16:18 for the same reason. Turns that morning took 0.7–11 s each, so the converter is fine whenever the gateway answers.

What is **ours** is how the converter behaves when the gateway hangs:

- `agent_turn.next_action` called the gateway **non-streamed** with the default 180 s read timeout and three attempts — ~9.4 minutes per turn. The interpreter already moved every long call to a streamed, bounded transport for exactly this gateway (LiteLLM gives a non-streamed request ~120 s; a stream is judged per read).
- `convert-drawer.js` polls a ticket for ~4 minutes and then throws a bare *"The conversion timed out."* — nothing named the gateway.
- The failed turn returned `None` → `state: done, action: null`, which `convert-agent.js` counts as *"unparseable action"* (the model wrote garbage) and **retries**, up to five times.
- Each zombie turn held one of the two `_inflight` slots, so the next click was refused with *"The server is converting other files right now."* — visible in the log as a second worker starting while the first was still stuck.
- `_release_quietly()` on an error **before** `acquire` released a slot another conversion held; that conversion's own `finally: release()` then overflowed the `BoundedSemaphore` and failed its job.

## What changes

- **`LLMClient.complete`** gains `stream`, `max_attempts` and `budget_seconds`. The SSE stream is folded into one string; the budget is a wall clock over attempts, backoff and body, each attempt's read timeout is capped at what is left (a blocked socket read cannot see a deadline — without the cap a 150 s budget measured 195 s), and no retry starts past it. Defaults leave every existing caller unchanged (`test_llm_schema_json` 12/12, `test_ai_missing_key_fails_fast` 12/12).
- **`agent_turn.next_action`** streams under `AI_CONVERT_TURN_SECONDS` (150 s) with `AI_CONVERT_READ_TIMEOUT` (60 s) per read, and raises `GatewayUnavailable(fact, advice)` — never `None` — when the gateway does not answer. `None` stays reserved for an answer that did not parse, which is the case worth another attempt.
- **`InputConvertServlet`** reports a failed ticket as `state: "error"` with the reason and consumes it; refuses new turns for 90 s after a gateway failure, at once, quoting the recorded reason instead of letting each click spend the budget to learn the same thing (the first successful turn clears it); releases only the slot it actually holds.
- **`convert-drawer.js` 0.7** shows the server's message and stops on a ticket the server has lost.
- `docs/ai-input-converter.md`: "When the AI service does not answer".

## Verified

- `test_input_convert_gateway_timeout.py` 14/14 (stream folding, budget cut, retry cap, `GatewayUnavailable` vs `None`, failed-ticket message, cooldown, semaphore accounting).
- Existing: `test_llm_schema_json` 12/12, `test_ai_missing_key_fails_fast` 12/12, PySiQ suites, `test_module_imports`, `test_versioned_assets_are_bumped`, client tests 48/48, servlet import gate.
- In Chrome against a worktree server, with the gateway actually down: the sheet shows *"The conversion could not finish — The AI service did not answer within 150 seconds. It may be busy or down; please try again in a few minutes."* The server turn ran 19:25:57 → 19:28:27 (**150.07 s**, third attempt's read timeout capped at 14.8 s) while the browser was still polling. A second *Convert it for me* 68 s later was refused in 1 ms (`POST /input_convert/turn` → 400) and the sheet reads *"The AI service did not answer within 150 seconds a moment ago; conversions are paused for another 23 seconds while it recovers. Please try again then."*
- The real-world harness (`run_realworld_corpus.js --only GSE103722 --attempts 1`) runs the identical `agent_turn.py` headlessly: 151.5 s, same message, harness reports the file as failed and stays intact.
- Full server sweep in the worktree: 227 passing; the 6 failures (`test_ai_agent_endtoend`, `test_dependencies_declared`, `test_more_servlet_step1`, `test_pathway_universe_database_filter`, `test_relevance_file_shape_and_conditions`, `test_retention_matches_the_promise`) fail identically on a clean archive of `origin/master` — local-environment artifacts, not regressions.
- **Pending:** the happy path against the live gateway (real conversions of the `~/Desktop/test-fails-check` corpus through the streamed path). The gateway had been silent for ~2 h at merge time, so this is merged and deployed on the strength of the failure-path verification above plus the unit tests; the streamed parser mirrors the interpreter's `_stream_to_completion`, which has run against this gateway since PR #30. The corpus result will be posted as a comment here as soon as the gateway answers; rollback is `~/deploy_backups/pre_pr77` on UV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
