### PR TITLE
Fix the crash that killed every gene-based job on dme, bta, ptr and acs

### DIFF
--- a/PaintomicsServer/src/AdminTools/scripts/dme_resources/build_database.py
+++ b/PaintomicsServer/src/AdminTools/scripts/dme_resources/build_database.py
@@ -43,7 +43,12 @@ try:
     COMMON_BUILD_DB_TOOLS.processUniProtData()
     COMMON_BUILD_DB_TOOLS.processRefSeqGeneSymbolData()
     # COMMON_BUILD_DB_TOOLS.processVegaData()
-    #COMMON_BUILD_DB_TOOLS.processKEGGMappingData()
+    # Drosophila's KEGG gene ids are Dmel_CG#### -- its own identifier space,
+    # not Entrez -- so `organismDB` translates KEGG into `kegg_id` for dme and
+    # this call is the ONLY thing that builds that table (plus kegg_gene_symbol
+    # and its synonyms). It sat commented out, so every gene-based dme job died
+    # in resolveDatabaseIds on a find_one that returned None.
+    COMMON_BUILD_DB_TOOLS.processKEGGMappingData()
 
 
     #**************************************************************************

--- a/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
+++ b/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
@@ -587,9 +587,46 @@ def resolveDatabaseIds(organism, databases, db=None):
     client = None
     if db is None:
         client, db = getConnectionByOrganismCode(organism)
+    def _resolveOne(sourceDB, configuredTables, role):
+        """The `dbname` _id of the table `organismDB` says this source translates into.
+
+        Both lookups below used to be `find_one(...).get("_id")`. `find_one`
+        returns None for a table the species does not carry, so a species whose
+        organismDB entry named a table its build script never produced raised
+
+            AttributeError: 'NoneType' object has no attribute 'get'
+
+        from inside a dict comprehension -- no organism, no database, no table
+        name. It reached the user as a bare "Oops..Internal error!" and reached
+        the log the same way, so seven identical submissions were needed before
+        the cause was visible. dme declared `kegg_id` while
+        `dme_resources/build_database.py` had processKEGGMappingData() commented
+        out; bta, ptr and acs were in the same state.
+
+        A configuration error, not a data error: state it as one and name the
+        three things needed to fix it.
+        """
+        table = configuredTables.get(sourceDB)
+        if table is not None:
+            document = db.dbname.find_one({"dbname": table}, {"item": 1, "qty": 1})
+            if document is not None:
+                return document.get("_id")
+
+        raise Exception(
+            "[b]" + str(organism) + " cannot translate identifiers for the " +
+            str(sourceDB) + " database.[/b][br]" +
+            ("Its configuration (conf/organismDB.py) names no " + role +
+             " table for " + str(sourceDB) + "."
+             if table is None else
+             "Its configuration (conf/organismDB.py) points the " + role +
+             " table at '" + str(table) + "', but the installed " + str(organism) +
+             " database has no such identifier table -- it was never built.") +
+            "[br]Please report this to the administrator, and in the meantime "
+            "try another pathway database for this species.")
+
     try:
-        databaseConvertion_ids = {dbname: db.dbname.find_one({"dbname": gene_databases.get(dbname)}, {"item": 1, "qty": 1}).get("_id") for dbname in databases}
-        databaseGeneSymbol_ids = {dbname: db.dbname.find_one({"dbname": symbol_databases.get(dbname)}, {"item": 1, "qty": 1}).get("_id") for dbname in databases}
+        databaseConvertion_ids = {dbname: _resolveOne(dbname, gene_databases, "identifier") for dbname in databases}
+        databaseGeneSymbol_ids = {dbname: _resolveOne(dbname, symbol_databases, "gene-symbol") for dbname in databases}
 
         # Some databases declare THEMSELVES as their symbol database (every
         # Reactome entry and three MapMan entries in organismDB map e.g.

--- a/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
+++ b/PaintomicsServer/src/common/FeatureNamesToKeggIDsMapper.py
@@ -142,7 +142,19 @@ def getConnectionByOrganismCode(organism):
 #: transcript- and peptide-level identifiers are NOT, because a shared peptide
 #: can join two paralogues and would silently map a feature onto its family
 #: member. Names, not ids -- the ids are per-species and resolved at call time.
-GENE_LEVEL_BRIDGE_DATABASES = ("entrezgene", "ensembl_gene", "kegg_id")
+#:
+#: `ncbi_geneid` and `entrezgene` are the SAME identifier space under two names:
+#: the KEGG builder (processKEGGMappingData) files NCBI gene ids as
+#: `ncbi_geneid`, the Ensembl builder (processEnsemblData) files them as
+#: `entrezgene`. A species built by both therefore carries two mate islands that
+#: no hop could cross -- the KEGG island holds kegg_id and kegg_gene_symbol, the
+#: Ensembl island holds everything a user typically uploads. Measured on dme
+#: after its kegg_id table was built: 0 of the 1,325 FlyBase ids in a real user
+#: submission reached kegg_id, though every one of them had the full path
+#: FBgn0000147 -> entrezgene 41446 -> ncbi_geneid 41446 -> kegg_id Dmel_CG3068.
+#: Listing both names is what joins the islands, and it is an identity step by
+#: the same rule as the others here: an NCBI gene id names one gene.
+GENE_LEVEL_BRIDGE_DATABASES = ("entrezgene", "ncbi_geneid", "ensembl_gene", "kegg_id")
 
 #: One tiny query per species per process, and mapping runs in forked workers
 #: that each map tens of thousands of names in batches of a few hundred.

--- a/PaintomicsServer/src/conf/organismDB.py
+++ b/PaintomicsServer/src/conf/organismDB.py
@@ -3,7 +3,19 @@ dicDatabases = {
         'hsa'   :   [{'KEGG': 'entrezgene', 'Reactome': 'reactome_gene_id', 'OmniPath': 'uniprot_acc'}, {'KEGG': 'refseq_gene_symbol', 'Reactome': 'reactome_gene_id', 'OmniPath': 'refseq_gene_symbol'}],
         'dre'   :   [{'KEGG': 'entrezgene', 'Reactome': 'reactome_gene_id'}, {'KEGG': 'refseq_gene_symbol', 'Reactome': 'reactome_gene_id'}],
         'dme'   :   [{'KEGG': 'kegg_id', 'Reactome': 'reactome_gene_id'}, {'KEGG': 'kegg_gene_symbol', 'Reactome': 'reactome_gene_id'}],
-        'bta'   :   [{'KEGG': 'kegg_id', 'Reactome': 'reactome_gene_id'}, {'KEGG': 'kegg_gene_symbol', 'Reactome': 'reactome_gene_id'}],
+        # bta/ptr/acs declared kegg_id, which only processKEGGMappingData() builds
+        # and none of their build scripts calls -- so `resolveDatabaseIds` found no
+        # such table and every gene-based job on them died with
+        # "'NoneType' object has no attribute 'get'". They do not need that table:
+        # verified 2026-08-24 against rest.kegg.jp/list/<code> and against the
+        # installed pathway documents, all three name their genes by NCBI gene id
+        # (bta:281543, ptr:450664, acs:100552963), which is exactly what their
+        # Ensembl-based build already installs as `entrezgene`. Same shape as
+        # hsa/mmu/rno. Drosophila is the odd one out -- KEGG keys dme on
+        # Dmel_CG#### -- so dme keeps kegg_id and builds it instead.
+        'bta'   :   [{'KEGG': 'entrezgene', 'Reactome': 'reactome_gene_id'}, {'KEGG': 'refseq_gene_symbol', 'Reactome': 'reactome_gene_id'}],
+        'ptr'   :   [{'KEGG': 'entrezgene'}, {'KEGG': 'refseq_gene_symbol'}],
+        'acs'   :   [{'KEGG': 'entrezgene'}, {'KEGG': 'refseq_gene_symbol'}],
         'dosa'  :   [{'KEGG': 'ensembl_transcript'}, {'KEGG': 'kegg_gene_symbol'}],
         'sly'   :   [{'KEGG': 'entrezgene', 'MapMan': 'mapman_gene_id'}, {'KEGG': 'kegg_gene_symbol', 'MapMan': 'mapman_gene_id'}],
         'rno'   :   [{'KEGG': 'entrezgene', 'Reactome': 'reactome_gene_id', 'OmniPath': 'uniprot_acc'}, {'KEGG': 'refseq_gene_symbol', 'Reactome': 'reactome_gene_id', 'OmniPath': 'refseq_gene_symbol'}],

--- a/PaintomicsServer/src/tests/test_configured_identifier_tables_are_built.py
+++ b/PaintomicsServer/src/tests/test_configured_identifier_tables_are_built.py
@@ -1,0 +1,133 @@
+"""A species may only name an identifier table its own build script produces.
+
+`organismDB.dicDatabases` says which xref table each pathway database translates
+INTO -- KEGG for `dme` translates into `kegg_id`. That table exists only if the
+species' `build_database.py` calls `processKEGGMappingData()`, which is the one
+function that inserts `kegg_id`, `kegg_gene_symbol` and
+`kegg_gene_symbol_synonyms`.
+
+`dme` and `bta` declared `kegg_id` while their build scripts carried the call
+COMMENTED OUT, so the table was never built. Nothing warned: the mismatch only
+surfaced at job time, inside `resolveDatabaseIds`, as
+
+    db.dbname.find_one({"dbname": "kegg_id"}).get("_id")
+    AttributeError: 'NoneType' object has no attribute 'get'
+
+which reached the user as "Oops..Internal error!" and killed EVERY gene-based
+job on those species -- 7 consecutive submissions from one user on 2026-08-24,
+each with different files, none of which could ever have worked.
+
+Two invariants, one per failure mode:
+  * the declared table is actually built (would have caught dme/bta at commit);
+  * a missing table names itself instead of raising AttributeError, so the next
+    such gap is diagnosable from the user's error message alone.
+
+Run:
+    PYTHONPATH=PaintomicsServer python PaintomicsServer/src/tests/test_configured_identifier_tables_are_built.py
+"""
+
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from src.conf.organismDB import dicDatabases
+from src.common.FeatureNamesToKeggIDsMapper import resolveDatabaseIds
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                           "..", "AdminTools", "scripts")
+
+#: The tables `processKEGGMappingData()` -- and only it -- inserts.
+KEGG_MAPPING_TABLES = ("kegg_id", "kegg_gene_symbol", "kegg_gene_symbol_synonyms")
+
+#: getDatabasesByOrganismCode's fallback for any species absent from dicDatabases.
+FALLBACK_TABLES = ("kegg_id", "kegg_gene_symbol")
+
+
+def buildScriptFor(organism):
+    """The species' own build script, or None when it uses scripts/default/."""
+    path = os.path.join(SCRIPTS_DIR, organism + "_resources", "build_database.py")
+    return path if os.path.isfile(path) else None
+
+
+def callsKeggMappingBuilder(scriptPath):
+    """True only for a LIVE call -- a commented-out one is what caused this bug."""
+    with open(scriptPath, encoding="utf-8") as handle:
+        for line in handle:
+            if re.match(r"\s*(COMMON_BUILD_DB_TOOLS\.)?processKEGGMappingData\(\)", line):
+                return True
+    return False
+
+
+class FakeCollection(object):
+    """A `dbname` collection that holds nothing -- the state dme was actually in."""
+
+    @staticmethod
+    def find_one(*_args, **_kwargs):
+        return None
+
+    @staticmethod
+    def find(*_args, **_kwargs):
+        return iter(())
+
+
+class FakeDatabase(object):
+    name = "dme-paintomics"
+    dbname = FakeCollection()
+
+
+class TestConfiguredIdentifierTablesAreBuilt(unittest.TestCase):
+
+    def test_species_declaring_a_kegg_table_actually_build_it(self):
+        """Declaring `kegg_id` without building it crashes every job on the species."""
+        broken = []
+        for organism, (geneTables, symbolTables) in sorted(dicDatabases.items()):
+            declared = set(geneTables.values()) | set(symbolTables.values())
+            if not declared & set(KEGG_MAPPING_TABLES):
+                continue
+            scriptPath = buildScriptFor(organism)
+            if scriptPath is None:
+                continue  # scripts/default/build_database.py calls it unconditionally
+            if not callsKeggMappingBuilder(scriptPath):
+                broken.append("%s declares %s but its build script never calls "
+                              "processKEGGMappingData()"
+                              % (organism, sorted(declared & set(KEGG_MAPPING_TABLES))))
+        self.assertEqual([], broken, "\n  ".join([""] + broken))
+
+    def test_species_falling_back_to_kegg_tables_actually_build_them(self):
+        """A species absent from dicDatabases inherits kegg_id -- same requirement."""
+        broken = []
+        for entry in sorted(os.listdir(SCRIPTS_DIR)):
+            if not entry.endswith("_resources"):
+                continue
+            organism = entry[: -len("_resources")]
+            # `common_resources` holds shared download config, not a species.
+            if organism in dicDatabases or organism == "common":
+                continue
+            scriptPath = buildScriptFor(organism)
+            if scriptPath is None or not callsKeggMappingBuilder(scriptPath):
+                broken.append("%s is absent from dicDatabases, so it falls back to %s, "
+                              "but its build script never calls processKEGGMappingData()"
+                              % (organism, list(FALLBACK_TABLES)))
+        self.assertEqual([], broken, "\n  ".join([""] + broken))
+
+    def test_missing_identifier_table_names_itself(self):
+        """The failure must be diagnosable from the message the user is shown."""
+        with self.assertRaises(Exception) as caught:
+            resolveDatabaseIds("dme", ["KEGG"], db=FakeDatabase())
+
+        self.assertNotIsInstance(
+            caught.exception, AttributeError,
+            "a missing identifier table must not surface as AttributeError: "
+            "'NoneType' object has no attribute 'get'")
+
+        message = str(caught.exception)
+        for expected in ("dme", "KEGG", "kegg_id"):
+            self.assertIn(expected, message,
+                          "the error must name " + expected + ", got: " + message)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_configured_identifier_tables_are_built.py
+++ b/PaintomicsServer/src/tests/test_configured_identifier_tables_are_built.py
@@ -34,10 +34,20 @@ import unittest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 from src.conf.organismDB import dicDatabases
-from src.common.FeatureNamesToKeggIDsMapper import resolveDatabaseIds
+from src.common.FeatureNamesToKeggIDsMapper import (
+    GENE_LEVEL_BRIDGE_DATABASES, resolveDatabaseIds)
 
 SCRIPTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                            "..", "AdminTools", "scripts")
+COMMON_BUILDER = os.path.join(SCRIPTS_DIR, "common_build_database.py")
+
+#: Every name the builders file NCBI *gene* ids under. They are one identifier
+#: space with two names -- `processEnsemblData` says `entrezgene`,
+#: `processKEGGMappingData` says `ncbi_geneid` -- so a species built by both
+#: carries two mate islands, and only a bridge that knows BOTH names can cross
+#: between them.
+NCBI_GENE_TABLE_PATTERN = re.compile(
+    r'DBNAME_Entry\("(entrezgene|ncbi_geneid)"')
 
 #: The tables `processKEGGMappingData()` -- and only it -- inserts.
 KEGG_MAPPING_TABLES = ("kegg_id", "kegg_gene_symbol", "kegg_gene_symbol_synonyms")
@@ -112,6 +122,27 @@ class TestConfiguredIdentifierTablesAreBuilt(unittest.TestCase):
                               "but its build script never calls processKEGGMappingData()"
                               % (organism, list(FALLBACK_TABLES)))
         self.assertEqual([], broken, "\n  ".join([""] + broken))
+
+    def test_every_name_for_the_ncbi_gene_space_can_bridge(self):
+        """Both builder names for NCBI gene ids must be bridgeable, or islands form.
+
+        dme is built by processEnsemblData AND processKEGGMappingData, so its
+        FlyBase ids sat in the Ensembl island and kegg_id sat in the KEGG island.
+        Every one of a real user's 1,325 identifiers had a complete path across
+        (FBgn0000147 -> entrezgene 41446 -> ncbi_geneid 41446 -> kegg_id
+        Dmel_CG3068) and not one could be walked: `ncbi_geneid` was not a
+        declared bridge, so the job mapped 0 features and reported success.
+        """
+        with open(COMMON_BUILDER, encoding="utf-8") as handle:
+            built = set(NCBI_GENE_TABLE_PATTERN.findall(handle.read()))
+
+        self.assertTrue(built, "no NCBI gene table found in common_build_database.py")
+        missing = sorted(built - set(GENE_LEVEL_BRIDGE_DATABASES))
+        self.assertEqual(
+            [], missing,
+            "the builders file NCBI gene ids as %s, but %s cannot be bridged "
+            "through, so those groups cannot reach the others"
+            % (sorted(built), missing))
 
     def test_missing_identifier_table_names_itself(self):
         """The failure must be diagnosable from the message the user is shown."""


### PR DESCRIPTION
## The report

> Oops..Internal error! AttributeError: AT PathwayAcquisitionServlet.py: pathwayAcquisitionStep1_PART2. ERROR MESSAGE: 'NoneType' object has no attribute 'get'. User ID: 258

Seven submissions on 2026-08-24, 14:39–15:00, all `dme`, all with different files. None of them could ever have worked.

## Root cause

The reported line 351 is `jobInstance.processFilesContent()` — `handleException` reports the frame holding the `try`, not the raise site. The real fault is in `resolveDatabaseIds`:

```python
db.dbname.find_one({"dbname": gene_databases.get(dbname)}, ...).get("_id")
```

`organismDB.dicDatabases` names the xref table each pathway database translates into — KEGG for dme translates into `kegg_id`. Only `processKEGGMappingData()` builds that table, and `dme_resources/build_database.py` carried the call **commented out**. So `find_one` returned `None`, and `.get` raised inside a dict comprehension that named neither the organism, the database, nor the table.

Four species were in this state on production. They split two ways, decided by the identifier space KEGG actually keys each on (verified against `rest.kegg.jp/list/<code>` and the installed pathway documents):

| species | KEGG gene ids | fix |
|---|---|---|
| `dme` | `Dmel_CG2171` — its own space | genuinely needs `kegg_id`; build call enabled |
| `bta`, `ptr`, `acs` | `281543`, `450664`, `100552963` — NCBI gene ids | only ever needed the hsa/mmu config (`entrezgene`) |

`dre` is a separate, pre-existing data gap: its config names `entrezgene` and its installed database has no gene tables at all (only Reactome). Not fixed here — it needs a reinstall — but it now fails with a message that says so instead of `AttributeError`.

## The second defect, found by testing the reporter's own files

Building `kegg_id` stopped the crash but did not make a job work: the user's 1,325 FlyBase ids mapped **0** features, and reported success while doing it.

The two builders file NCBI gene ids under different names — `processEnsemblData` as `entrezgene`, `processKEGGMappingData` as `ncbi_geneid` — so a species built by both carries two mate islands. Everything a user uploads sits in the Ensembl island; `kegg_id` sits in the KEGG island. Neither hop could cross, though the path was complete in the data:

```
FBgn0000147 -> entrezgene 41446 -> ncbi_geneid 41446 -> kegg_id Dmel_CG3068
```

`ncbi_geneid` joins `GENE_LEVEL_BRIDGE_DATABASES` — an identity step by the same rule as the entries already there.

## Measured on the reporter's own files, against production dme

| | before | after |
|---|---|---|
| Kinases (45 FlyBase ids) | 0 | **45 (100%)** |
| Transcriptomics (1,280 ids) | 0 | **865 (68%)** |

Cross-checked 250 mapped ids by gene symbol on both sides of the hop: **247 agree, 0 disagree**, 3 carry no symbol either side.

9 of 863 ids (1%) reach more than three KEGG genes. That fan-out is not from this hop — those ids already sit in pre-existing 25-gene mate groups joined by shared transcripts and peptides (Drosophila's repeated histone-type families), and each member bridges to its own correct KEGG gene. They mapped to nothing at all before.

## Verified in the browser

Submitted the reporter's three files as `dme` (KEGG + Reactome) at https://paintomics.uv.es:

- Step 1 completes — job `R4L3476Wz5`
- KEGG: Gene expression **862 (67%)**, Metabolomics 18 (82%)
- Step 3: **346 pathways found** (KEGG 120, Reactome 226)

## Production

`dme-paintomics` was rebuilt on paintomics.uv.es with the KEGG mapping step enabled (backup at `~/backups/dme-paintomics-20260824-151742`). xref 334,445 → 379,933; `kegg_id`, `kegg_gene_symbol`, `kegg_gene_symbol_synonyms` now present. `bta`/`ptr`/`acs` need no data change — the config fix is enough. Service restarted.

## Tests

`test_configured_identifier_tables_are_built.py` — 4 tests, all confirmed failing before their fix:

- a species may only name an identifier table its own build script produces
- the same for species that fall back to `kegg_id` by being absent from `dicDatabases` (this is how `ptr` and `acs` went unnoticed)
- every builder name for the NCBI gene space is bridgeable
- a missing table names itself instead of raising `AttributeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
