### PR TITLE
Let the bridge-set guard know about ncbi_geneid

### DIFF
--- a/PaintomicsServer/src/tests/test_uniprot_two_hop_mapping.py
+++ b/PaintomicsServer/src/tests/test_uniprot_two_hop_mapping.py
@@ -157,8 +157,14 @@ class TwoHopMappingTest(unittest.TestCase):
         test asserts -- and `ensembl_peptide` must not be in the bridge set.
         """
         self.assertNotIn("ensembl_peptide", mapper.GENE_LEVEL_BRIDGE_DATABASES)
+        # `ncbi_geneid` is the other name the installers give the SAME NCBI gene
+        # space as `entrezgene`, so it is gene-level by construction and joined
+        # the set in #85. The list is pinned rather than filtered because the
+        # property under test is membership, not shape: a peptide- or
+        # transcript-level database appearing here is the bug this catches, and
+        # only an explicit list makes that visible when someone adds one.
         self.assertEqual(tuple(mapper.GENE_LEVEL_BRIDGE_DATABASES),
-                         ("entrezgene", "ensembl_gene", "kegg_id"))
+                         ("entrezgene", "ncbi_geneid", "ensembl_gene", "kegg_id"))
 
     def testFirstHopAnswerIsNotDisturbed(self):
         """A name the first hop resolves must not be re-resolved or re-ordered."""


### PR DESCRIPTION
`master` is currently red on `test_uniprot_two_hop_mapping.testPeptideIsNeverUsedAsABridge`.

#85 added `ncbi_geneid` to `GENE_LEVEL_BRIDGE_DATABASES` — the fix that stopped every gene-based job crashing on dme, bta, ptr and acs — but the guard pins the tuple exactly:

```
AssertionError: Tuples differ:
  ('entrezgene', 'ncbi_geneid', 'ensembl_gene', 'kegg_id')  # the code
!=('entrezgene', 'ensembl_gene', 'kegg_id')                 # the test
```

Verified against a clean `git archive origin/master` checkout, so it is master's state and not a local artefact.

The property the test protects — that no peptide- or transcript-level database is ever used as a bridge — is unaffected; `ncbi_geneid` is the other name the installers give the same NCBI gene space as `entrezgene`, so it is gene-level by construction. The list stays explicit rather than becoming a membership check, because an identifier space quietly joining this set is the bug the assertion exists to surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)