### PR TITLE
Give four more species a KEGG table that speaks their identifiers

### DIFF
--- a/PaintomicsServer/src/AdminTools/checkIdentifierMapping.py
+++ b/PaintomicsServer/src/AdminTools/checkIdentifierMapping.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Can each installed species actually translate its own pathway identifiers?
+
+Why this exists
+---------------
+`conf/organismDB.py` names the xref table each pathway database translates
+INTO. Nothing has ever checked that the named table exists, holds anything, or
+holds the identifiers the pathway documents actually reference -- and all three
+have failed in production, each in a way no offline test can see:
+
+  * **absent** -- `dme` and `dre` named tables their build never produced.
+    `resolveDatabaseIds` did `find_one(...).get("_id")` on a None, and every
+    gene-based job on the species died at step 1 with "Oops..Internal error!".
+    One user hit it 7 times in 20 minutes before reporting it.
+  * **empty** -- `dosa` named `ensembl_transcript`, which its build *registers*
+    before reading the input file it never received. The table exists with 0
+    documents, resolves without error, and maps nothing. Every rice job
+    reported success having translated not one gene.
+  * **wrong identifier space** -- `cel` named `entrezgene` (numeric NCBI ids)
+    while KEGG keys C. elegans on `CELE_C17G1.7`. The table is present and
+    populated and matched 0 of 500 sampled pathway genes. Also silent.
+  * **partially covering** -- `sly` named `entrezgene`, which held 68% of the
+    gene ids its KEGG pathways reference; the rest could never be painted.
+
+The last three are worse than the crash: a job that maps nothing still reaches
+step 3 and reports success, so the failure reaches the user as an empty result
+they will read as biology.
+
+What it checks
+--------------
+For every installed species, for every pathway database whose pathways are
+loaded, that the configured identifier and gene-symbol tables (a) exist,
+(b) are non-empty, and (c) contain the gene ids the species' own pathway
+documents reference. The pathway documents are the authority: they are what
+mapping has to produce to paint anything.
+
+Read-only -- it opens no cursor it does not close and writes nothing.
+
+Usage:
+    python3 checkIdentifierMapping.py                 # every installed species
+    python3 checkIdentifierMapping.py --species=cel,dre
+    python3 checkIdentifierMapping.py --verbose       # show the passes too
+
+Exits 1 if any ERROR was found, so it can gate a deploy or an install.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from src.conf.organismDB import dicDatabases
+
+#: How many of a database's pathway gene ids to test the configured table
+#: against. The question is "does this table speak the same identifier space",
+#: which a few hundred ids answer as well as fifty thousand, and the query is
+#: one indexed `$in` per table.
+PATHWAY_GENE_SAMPLE = 500
+
+#: Below this share of pathway gene ids the table is not merely incomplete, it
+#: is the wrong table: no plausible annotation gap loses half a gene space.
+#: `sly` sat at 68% with a 100% table installed alongside it, `hsa` sits at 90%
+#: on the right one, so the two populations are well separated.
+COVERAGE_FLOOR = 0.80
+
+#: `getDatabasesByOrganismCode`'s fallback for a species absent from
+#: dicDatabases -- checked here too, since that is how two broken species
+#: (ptr, acs) went unnoticed.
+FALLBACK = [{"KEGG": "kegg_id"}, {"KEGG": "kegg_gene_symbol"}]
+
+#: KEGG is unioned into every job by PathwayAcquisitionServlet whatever the user
+#: submitted, so a KEGG finding cannot be dodged by picking another database.
+MANDATORY_DATABASE = "KEGG"
+
+ERROR, WARNING, INFO = "ERROR", "WARNING", "INFO"
+
+
+class Finding(object):
+    """One thing wrong with one species' mapping configuration."""
+
+    def __init__(self, severity, organism, database, message, table=None):
+        self.severity = severity
+        self.organism = organism
+        self.database = database
+        self.table = table
+        self.message = message
+
+    def __str__(self):
+        return "%-7s %-6s %-9s %s" % (self.severity, self.organism,
+                                      self.database, self.message)
+
+
+def _configuredTables(organism, configuration=None):
+    """(identifier table, gene-symbol table) per pathway database.
+
+    `configuration` overrides what organismDB.py says, so a caller -- a test,
+    or an operator asking "what would this species do if I pointed it there?"
+    -- can check a configuration that is not the installed one.
+    """
+    variants = configuration if configuration is not None else dicDatabases.get(organism, FALLBACK)
+    identifiers = variants[0] if len(variants) > 0 else {}
+    symbols = variants[1] if len(variants) > 1 else {}
+    return identifiers, symbols
+
+
+def _installedSources(db):
+    """Pathway databases whose pathways are loaded, KEGG for an absent `source`.
+
+    `source` was added when Reactome was, so a document without one predates
+    there being anything but KEGG -- the same reading `DatabaseAvailability`
+    takes.
+    """
+    return sorted({source or MANDATORY_DATABASE for source in db.kegg.distinct("source")})
+
+
+def _pathwayGeneIDs(db, source, limit=PATHWAY_GENE_SAMPLE):
+    """A sample of the gene ids this database's pathway documents reference.
+
+    Spread evenly across the sorted gene space rather than taken from the front
+    of it. Stopping at the first `limit` ids collected instead measured a few
+    early pathways, and taking the first `limit` sorted ones measured a single
+    prefix: on `sly` -- numeric NCBI ids -- that sampled almost only ids
+    beginning "1", which happen to be the well-annotated ones, and reported 87%
+    coverage for a table that holds 68% of the real space. A stride sample of
+    the whole set puts both back at the true figure and stays deterministic, so
+    two runs a week apart are comparable.
+    """
+    query = ({"$or": [{"source": MANDATORY_DATABASE}, {"source": {"$exists": False}}]}
+             if source == MANDATORY_DATABASE else {"source": source})
+    identifiers = set()
+    for pathway in db.kegg.find(query, {"genes": 1}):
+        for gene in (pathway.get("genes") or []):
+            geneID = gene.get("id") if isinstance(gene, dict) else gene
+            if geneID:
+                identifiers.add(str(geneID))
+    ordered = sorted(identifiers)
+    if len(ordered) <= limit:
+        return ordered
+    stride = len(ordered) / float(limit)
+    return [ordered[int(index * stride)] for index in range(limit)][:limit]
+
+
+def _covers(db, tableID, geneIDs):
+    """How many of `geneIDs` the table holds. One indexed $in, no cursor kept."""
+    if not geneIDs:
+        return 0
+    return len(db.xref.distinct("display_id",
+                                {"dbname_id": tableID, "display_id": {"$in": geneIDs}}))
+
+
+def _bestAlternative(db, tables, geneIDs, exclude=None):
+    """The installed table that covers these gene ids best, so a finding can
+    name the fix instead of only the fault."""
+    best = (None, 0)
+    for name, tableID in tables.items():
+        if name == exclude:
+            continue
+        hits = _covers(db, tableID, geneIDs)
+        if hits > best[1]:
+            best = (name, hits)
+    return best
+
+
+def checkOrganism(db, organism, configuration=None):
+    """Every mapping fault this species' installed data can show. Read-only."""
+    findings = []
+    tables = {row["dbname"]: row["_id"] for row in db.dbname.find({}, {"dbname": 1})}
+    identifierTables, symbolTables = _configuredTables(organism, configuration)
+
+    for source in _installedSources(db):
+        configuredIdentifier = identifierTables.get(source)
+        if configuredIdentifier is None:
+            # Not a crash: DatabaseAvailability will not offer a database it
+            # cannot map, and the servlet intersects the selection with this
+            # same config. The data is installed and unreachable, which is
+            # worth saying out loud but is not a broken job.
+            findings.append(Finding(
+                INFO, organism, source,
+                "pathways are installed but organismDB.py names no identifier "
+                "table, so the database is never offered"))
+            continue
+
+        geneIDs = _pathwayGeneIDs(db, source)
+
+        for role, configured in (("identifier", configuredIdentifier),
+                                 ("gene-symbol", symbolTables.get(source))):
+            if configured is None:
+                findings.append(Finding(
+                    ERROR, organism, source,
+                    "no %s table is configured, so resolveDatabaseIds raises "
+                    "and every job on this species fails%s"
+                    % (role, " (KEGG cannot be deselected)"
+                       if source == MANDATORY_DATABASE else "")))
+                continue
+            if configured not in tables:
+                findings.append(Finding(
+                    ERROR, organism, source,
+                    "configured %s table '%s' does not exist -- it was never "
+                    "built, so every job on this species fails at step 1%s"
+                    % (role, configured,
+                       " (KEGG cannot be deselected)"
+                       if source == MANDATORY_DATABASE else ""),
+                    table=configured))
+                continue
+
+            total = db.xref.count_documents({"dbname_id": tables[configured]})
+            if total == 0:
+                # The two roles fail differently. The identifier table is what
+                # a feature must reach to be painted at all, so an empty one is
+                # a job that maps nothing and still reports success. The symbol
+                # table only feeds a separate display pass
+                # (FeatureNamesToKeggIDsMapper.mapFeatureIdentifiers), so an
+                # empty one costs gene symbols and nothing else -- which is the
+                # ordinary state of the ~18 bacteria and fungi for which KEGG
+                # publishes no symbols, not a misconfiguration.
+                findings.append(Finding(
+                    ERROR if role == "identifier" else WARNING, organism, source,
+                    ("configured identifier table '%s' is registered but EMPTY, "
+                     "so jobs map nothing and still report success" % configured)
+                    if role == "identifier" else
+                    ("configured gene-symbol table '%s' is registered but empty, "
+                     "so features are shown by identifier and cannot be matched "
+                     "by symbol" % configured),
+                    table=configured))
+                continue
+
+            # Coverage is only meaningful for the identifier table: the symbol
+            # table names genes for display and is not what pathway documents
+            # are keyed on.
+            if role != "identifier" or not geneIDs:
+                continue
+
+            hits = _covers(db, tables[configured], geneIDs)
+            share = float(hits) / len(geneIDs)
+            if share >= COVERAGE_FLOOR:
+                continue
+            bestName, bestHits = _bestAlternative(db, tables, geneIDs, exclude=configured)
+            advice = ""
+            if bestHits > hits:
+                advice = ("; '%s' holds %d of them (%.0f%%) and is installed"
+                          % (bestName, bestHits, 100.0 * bestHits / len(geneIDs)))
+            findings.append(Finding(
+                ERROR if hits == 0 else WARNING, organism, source,
+                "configured identifier table '%s' holds %d of %d gene ids this "
+                "database's pathways reference (%.0f%%)%s"
+                % (configured, hits, len(geneIDs), 100.0 * share, advice),
+                table=configured))
+    return findings
+
+
+def checkAll(client, organisms=None, suffix="-paintomics", progress=None):
+    """Findings for every installed species, or just the ones named."""
+    names = sorted(name for name in client.list_database_names()
+                   if name.endswith(suffix) and name != "global" + suffix)
+    findings = []
+    for name in names:
+        organism = name[:-len(suffix)]
+        if organisms and organism not in organisms:
+            continue
+        if progress:
+            progress(organism)
+        findings.extend(checkOrganism(client[name], organism))
+    return findings
+
+
+def main(argv):
+    organisms = None
+    verbose = False
+    for argument in argv[1:]:
+        if argument.startswith("--species="):
+            organisms = [code.strip() for code in argument.split("=", 1)[1].split(",") if code.strip()]
+        elif argument in ("--verbose", "-v"):
+            verbose = True
+        elif argument in ("--help", "-h"):
+            print(__doc__)
+            return 0
+        else:
+            sys.stderr.write("Unknown argument: %s\n" % argument)
+            return 2
+
+    from pymongo import MongoClient
+    from src.conf.serverconf import MONGODB_HOST, MONGODB_PORT
+
+    client = MongoClient(MONGODB_HOST, MONGODB_PORT)
+    try:
+        checked = []
+        findings = checkAll(client, organisms, progress=checked.append)
+    finally:
+        client.close()
+
+    errors = [f for f in findings if f.severity == ERROR]
+    warnings = [f for f in findings if f.severity == WARNING]
+    for finding in findings:
+        if finding.severity == INFO and not verbose:
+            continue
+        print(finding)
+
+    print("\n%d species checked, %d error(s), %d warning(s)"
+          % (len(checked), len(errors), len(warnings)))
+    if not errors and not warnings:
+        print("Every installed species can translate the identifiers its own "
+              "pathway documents use.")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/PaintomicsServer/src/AdminTools/scripts/cel_resources/build_database.py
+++ b/PaintomicsServer/src/AdminTools/scripts/cel_resources/build_database.py
@@ -38,7 +38,13 @@ try:
     COMMON_BUILD_DB_TOOLS.processUniProtData()
     COMMON_BUILD_DB_TOOLS.processRefSeqGeneSymbolData()
     # COMMON_BUILD_DB_TOOLS.processVegaData()
-    #COMMON_BUILD_DB_TOOLS.processKEGGMappingData()
+    # KEGG keys C. elegans on its own identifier space (CELE_C17G1.7), which
+    # no other source here produces: with this call commented out the species
+    # had ensembl/refseq/uniprot tables and nothing that matched a single one of
+    # its KEGG pathway genes, so every worm job mapped 0 features and reported
+    # success. This builds kegg_id (plus ncbi_geneid, which bridges it to the
+    # Ensembl-side identifiers users actually upload).
+    COMMON_BUILD_DB_TOOLS.processKEGGMappingData()
 
 
     #**************************************************************************

--- a/PaintomicsServer/src/AdminTools/scripts/dre_resources/build_database.py
+++ b/PaintomicsServer/src/AdminTools/scripts/dre_resources/build_database.py
@@ -35,7 +35,13 @@ try:
     COMMON_BUILD_DB_TOOLS.processUniProtData()
     COMMON_BUILD_DB_TOOLS.processRefSeqGeneSymbolData()
     # COMMON_BUILD_DB_TOOLS.processVegaData()
-    #COMMON_BUILD_DB_TOOLS.processKEGGMappingData()
+    # Zebrafish never received mapping/ensembl_mapping.list, so the Ensembl,
+    # RefSeq and UniProt steps above all produced nothing and dre shipped with
+    # no gene identifier table at all -- resolveDatabaseIds then raised on the
+    # configured `entrezgene` and every dre job failed at step 1. The KEGG
+    # mapping files ARE present, and this call turns them into kegg_id /
+    # ncbi_geneid / uniprot_acc / kegg_gene_symbol.
+    COMMON_BUILD_DB_TOOLS.processKEGGMappingData()
 
 
     #**************************************************************************

--- a/PaintomicsServer/src/conf/organismDB.py
+++ b/PaintomicsServer/src/conf/organismDB.py
@@ -1,7 +1,17 @@
 dicDatabases = {
         'mmu'   :   [{'KEGG': 'entrezgene', 'Reactome': 'reactome_gene_id', 'OmniPath': 'uniprot_acc'}, {'KEGG': 'refseq_gene_symbol', 'Reactome': 'reactome_gene_id', 'OmniPath': 'refseq_gene_symbol'}],
         'hsa'   :   [{'KEGG': 'entrezgene', 'Reactome': 'reactome_gene_id', 'OmniPath': 'uniprot_acc'}, {'KEGG': 'refseq_gene_symbol', 'Reactome': 'reactome_gene_id', 'OmniPath': 'refseq_gene_symbol'}],
-        'dre'   :   [{'KEGG': 'entrezgene', 'Reactome': 'reactome_gene_id'}, {'KEGG': 'refseq_gene_symbol', 'Reactome': 'reactome_gene_id'}],
+        # Zebrafish. Named `entrezgene`, which its build produces from
+        # `mapping/ensembl_mapping.list` -- a file that was never downloaded for
+        # dre, so the table does not exist and EVERY dre job died in
+        # resolveDatabaseIds (KEGG is mandatory, so no submission could avoid
+        # it). The KEGG mapping files ARE on disk, so `processKEGGMappingData()`
+        # was enabled in its build script and dre rebuilt; `kegg_id` then holds
+        # the numeric NCBI gene ids its pathway documents reference (measured:
+        # 500/500 of them). `refseq_gene_symbol` is likewise absent and cannot
+        # be built without the RefSeq downloads, so the symbol slot moves to
+        # `kegg_gene_symbol`, which the same KEGG mapping produces.
+        'dre'   :   [{'KEGG': 'kegg_id', 'Reactome': 'reactome_gene_id'}, {'KEGG': 'kegg_gene_symbol', 'Reactome': 'reactome_gene_id'}],
         'dme'   :   [{'KEGG': 'kegg_id', 'Reactome': 'reactome_gene_id'}, {'KEGG': 'kegg_gene_symbol', 'Reactome': 'reactome_gene_id'}],
         # bta/ptr/acs declared kegg_id, which only processKEGGMappingData() builds
         # and none of their build scripts calls -- so `resolveDatabaseIds` found no
@@ -16,8 +26,24 @@ dicDatabases = {
         'bta'   :   [{'KEGG': 'entrezgene', 'Reactome': 'reactome_gene_id'}, {'KEGG': 'refseq_gene_symbol', 'Reactome': 'reactome_gene_id'}],
         'ptr'   :   [{'KEGG': 'entrezgene'}, {'KEGG': 'refseq_gene_symbol'}],
         'acs'   :   [{'KEGG': 'entrezgene'}, {'KEGG': 'refseq_gene_symbol'}],
-        'dosa'  :   [{'KEGG': 'ensembl_transcript'}, {'KEGG': 'kegg_gene_symbol'}],
-        'sly'   :   [{'KEGG': 'entrezgene', 'MapMan': 'mapman_gene_id'}, {'KEGG': 'kegg_gene_symbol', 'MapMan': 'mapman_gene_id'}],
+        # Rice (RAP-DB). `ensembl_transcript` is registered by dosa's own
+        # processEnsemblData -- insertDatabase runs before the file read, so a
+        # missing input leaves the table declared and EMPTY (0 documents), which
+        # resolves without error and maps nothing: every dosa job reported
+        # success having translated no gene at all. Its KEGG pathway documents
+        # reference RAP-DB gene ids (`Os01g0147900`) and only `kegg_id` holds
+        # them -- measured 500/500, and 100% reachable from uniprot_acc and
+        # kegg_gene_symbol, the species' other populated tables.
+        'dosa'  :   [{'KEGG': 'kegg_id'}, {'KEGG': 'kegg_gene_symbol'}],
+        # Tomato. `entrezgene` (16,173 entries, from Ensembl) holds only part
+        # of the NCBI gene space KEGG references: it matched 340 of 500 sampled
+        # pathway gene ids, so ~1 gene in 3 could never be painted whatever the
+        # user uploaded. `kegg_id` (35,181) matched 500/500 and measured
+        # better-or-equal from EVERY installed table -- Solyc ids stay at
+        # 150/150, while uniprot_acc and kegg_gene_symbol go from 0% to 100%
+        # because the target no longer sits on the far side of the
+        # Ensembl/KEGG mate split.
+        'sly'   :   [{'KEGG': 'kegg_id', 'MapMan': 'mapman_gene_id'}, {'KEGG': 'kegg_gene_symbol', 'MapMan': 'mapman_gene_id'}],
         'rno'   :   [{'KEGG': 'entrezgene', 'Reactome': 'reactome_gene_id', 'OmniPath': 'uniprot_acc'}, {'KEGG': 'refseq_gene_symbol', 'Reactome': 'reactome_gene_id', 'OmniPath': 'refseq_gene_symbol'}],
         'sot'   :   [{'KEGG': 'kegg_id', 'MapMan': 'mapman_gene_id'}, {'KEGG': 'kegg_gene_symbol', 'MapMan': 'mapman_gene_id'}],
         # Rice. The KEGG half repeats the default this species already got
@@ -39,7 +65,15 @@ dicDatabases = {
         # refseq symbols where its build produced them (mmu-style), kegg_id +
         # kegg symbols otherwise (sce-style). cfa's build yields no gene
         # symbols, so its name slot degrades to entrezgene.
-        'cel'   :   [{'KEGG': 'entrezgene', 'Reactome': 'reactome_gene_id'}, {'KEGG': 'refseq_gene_symbol', 'Reactome': 'reactome_gene_id'}],
+        # C. elegans. Same shape as dme: KEGG keys it on its OWN identifier
+        # space (`CELE_C17G1.7`), so the configured `entrezgene` -- numeric NCBI
+        # ids -- matched 0 of 500 sampled pathway gene ids and no other installed
+        # table matched one either. Every worm job mapped nothing and reported
+        # success. `processKEGGMappingData()` was enabled in its build script so
+        # `kegg_id` carries the CELE_ ids. The symbol slot keeps
+        # `refseq_gene_symbol` (44,150 entries against kegg_gene_symbol's fewer,
+        # and reachable from what worm users upload).
+        'cel'   :   [{'KEGG': 'kegg_id', 'Reactome': 'reactome_gene_id'}, {'KEGG': 'refseq_gene_symbol', 'Reactome': 'reactome_gene_id'}],
         'cfa'   :   [{'KEGG': 'entrezgene', 'Reactome': 'reactome_gene_id'}, {'KEGG': 'entrezgene', 'Reactome': 'reactome_gene_id'}],
         'ddi'   :   [{'KEGG': 'kegg_id', 'Reactome': 'reactome_gene_id'}, {'KEGG': 'kegg_gene_symbol', 'Reactome': 'reactome_gene_id'}],
         'gga'   :   [{'KEGG': 'entrezgene', 'Reactome': 'reactome_gene_id'}, {'KEGG': 'refseq_gene_symbol', 'Reactome': 'reactome_gene_id'}],

--- a/PaintomicsServer/src/tests/test_identifier_mapping_check.py
+++ b/PaintomicsServer/src/tests/test_identifier_mapping_check.py
@@ -1,0 +1,205 @@
+"""The mapping checker must recognise every shape this fault has taken.
+
+Four species have shipped with a KEGG mapping that could not work, and only one
+of them crashed. The other three reported success while translating nothing,
+which is the reason this check exists at all -- an empty result reads to a user
+as biology, not as a bug:
+
+    dme/dre   the configured table was never built        -> AttributeError
+    dosa      the table is registered and EMPTY           -> silent, 0 features
+    cel       the table is populated with the WRONG space -> silent, 0 features
+    sly       the table holds only part of the space      -> silent, 32% lost
+
+Each is reproduced below against a fake MongoDB, so the check is proven to
+catch the fault it was written for rather than assumed to.
+
+Run:
+    PYTHONPATH=PaintomicsServer python PaintomicsServer/src/tests/test_identifier_mapping_check.py
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from src.AdminTools.checkIdentifierMapping import (
+    ERROR, INFO, WARNING, checkOrganism)
+
+#: Every check below states the configuration it is checking rather than
+#: reading organismDB.py. A test that depends on the live config fails the day
+#: someone fixes the species it names -- which is exactly what these fixes do.
+KEGG_BY_ID = [{"KEGG": "kegg_id"}, {"KEGG": "kegg_gene_symbol"}]
+KEGG_BY_ENTREZ = [{"KEGG": "entrezgene"}, {"KEGG": "refseq_gene_symbol"}]
+
+
+class FakeCollection(object):
+    def __init__(self, documents):
+        self.documents = documents
+
+    def find(self, query=None, projection=None):
+        return iter(self._matching(query or {}))
+
+    def distinct(self, field, query=None):
+        return sorted({document[field] for document in self._matching(query or {})
+                       if field in document})
+
+    def count_documents(self, query):
+        return len(self._matching(query))
+
+    def _matching(self, query):
+        matched = []
+        for document in self.documents:
+            if self._matches(document, query):
+                matched.append(document)
+        return matched
+
+    @staticmethod
+    def _matches(document, query):
+        for field, condition in query.items():
+            if field == "$or":
+                if not any(FakeCollection._matches(document, sub) for sub in condition):
+                    return False
+            elif isinstance(condition, dict):
+                if "$in" in condition and document.get(field) not in condition["$in"]:
+                    return False
+                if "$exists" in condition and (field in document) != condition["$exists"]:
+                    return False
+            elif document.get(field) != condition:
+                return False
+        return True
+
+
+class FakeDatabase(object):
+    """A species database built from table -> [identifiers] and its pathways."""
+
+    def __init__(self, tables, pathways):
+        self.dbname = FakeCollection(
+            [{"_id": index, "dbname": name} for index, name in enumerate(sorted(tables))])
+        tableIDs = {name: index for index, name in enumerate(sorted(tables))}
+        self.xref = FakeCollection(
+            [{"_id": "%s:%s" % (name, value), "dbname_id": tableIDs[name],
+              "display_id": value}
+             for name, values in tables.items() for value in values])
+        self.kegg = FakeCollection(pathways)
+
+
+def keggPathways(geneIDs, source="KEGG"):
+    return [{"source": source, "genes": [{"id": geneID} for geneID in geneIDs]}]
+
+
+def severitiesFor(findings, severity):
+    return [finding for finding in findings if finding.severity == severity]
+
+
+class TestIdentifierMappingCheck(unittest.TestCase):
+
+    def test_a_configured_table_that_was_never_built_is_an_error(self):
+        """dme/dre: find_one returns None and every job dies at step 1."""
+        db = FakeDatabase({"reactome_gene_id": ["MYCA"]},
+                          keggPathways(["323107", "327165"]))
+        findings = checkOrganism(db, "dre", KEGG_BY_ID)
+        errors = severitiesFor(findings, ERROR)
+        self.assertTrue(errors, "a missing configured table must be an error")
+        self.assertIn("does not exist", errors[0].message)
+        self.assertIn("kegg_id", errors[0].message)
+
+    def test_a_registered_but_empty_table_is_an_error(self):
+        """dosa: resolves fine, maps nothing, reports success -- the worst shape."""
+        db = FakeDatabase({"kegg_id": [], "kegg_gene_symbol": ["OsX"]},
+                          keggPathways(["Os01g0147900", "Os01g0841600"]))
+        findings = checkOrganism(db, "dosa", [{"KEGG": "kegg_id"},
+                                              {"KEGG": "kegg_gene_symbol"}])
+        errors = severitiesFor(findings, ERROR)
+        self.assertTrue(errors, "an empty identifier table must be an error")
+        self.assertIn("EMPTY", errors[0].message)
+
+    def test_a_table_in_the_wrong_identifier_space_is_an_error(self):
+        """cel: populated, resolves, and matches none of the pathway genes."""
+        db = FakeDatabase(
+            {"kegg_id": ["13222292", "179427"],          # numeric NCBI ids
+             "kegg_gene_symbol": ["set-10"]},
+            keggPathways(["CELE_C17G1.7", "CELE_F59A7.9"]))   # KEGG's own space
+        findings = checkOrganism(db, "cel", KEGG_BY_ID)
+        errors = severitiesFor(findings, ERROR)
+        self.assertTrue(errors, "0% coverage must be an error, not a warning")
+        self.assertIn("0 of 2", errors[0].message)
+
+    def test_a_partially_covering_table_is_reported_with_the_better_one(self):
+        """sly: 68% is not an annotation gap, and the fix is already installed."""
+        pathwayGenes = ["1", "2", "3", "4", "5"]
+        db = FakeDatabase(
+            {"entrezgene": ["1", "2"],                    # covers 40%
+             "kegg_id": pathwayGenes,                     # covers 100%
+             "refseq_gene_symbol": ["symA"]},
+            keggPathways(pathwayGenes))
+        # `ptr` still names entrezgene, and correctly so -- KEGG really does key
+        # chimpanzee on NCBI gene ids. It stands in here for the shape sly had.
+        findings = checkOrganism(db, "ptr", KEGG_BY_ENTREZ)
+        flagged = severitiesFor(findings, WARNING) + severitiesFor(findings, ERROR)
+        self.assertTrue(flagged, "40% coverage must be reported")
+        self.assertIn("kegg_id", flagged[0].message,
+                      "the finding must name the better table that is installed")
+
+    def test_an_empty_gene_symbol_table_is_a_warning_not_an_error(self):
+        """18 installed bacteria and fungi are in this state and work fine.
+
+        KEGG publishes no gene symbols for them. Identifiers still map; only
+        the display pass has nothing to say. Grading it as an error would bury
+        the four species that really are broken under eighteen that are not.
+        """
+        db = FakeDatabase({"kegg_id": ["a", "b"], "kegg_gene_symbol": []},
+                          keggPathways(["a", "b"]))
+        findings = checkOrganism(db, "afm", KEGG_BY_ID)
+        self.assertEqual([], severitiesFor(findings, ERROR),
+                         "an empty symbol table does not stop a job mapping")
+        warnings = severitiesFor(findings, WARNING)
+        self.assertTrue(warnings)
+        self.assertIn("cannot be matched by symbol", warnings[0].message)
+
+    def test_a_missing_gene_symbol_table_is_still_an_error(self):
+        """Absent is not the same as empty: resolveDatabaseIds raises on absent."""
+        db = FakeDatabase({"kegg_id": ["a"]}, keggPathways(["a"]))
+        findings = checkOrganism(db, "dre", KEGG_BY_ID)
+        errors = severitiesFor(findings, ERROR)
+        self.assertTrue(errors, "a missing symbol table crashes the job")
+        self.assertIn("kegg_gene_symbol", errors[0].message)
+
+    def test_a_correct_species_produces_no_error_or_warning(self):
+        """The check has to stay quiet on the 129 species that are fine."""
+        genes = ["Os01g0147900", "Os02g0171100"]
+        db = FakeDatabase({"kegg_id": genes, "kegg_gene_symbol": ["symA"]},
+                          keggPathways(genes))
+        findings = checkOrganism(db, "dosa", KEGG_BY_ID)
+        self.assertEqual([], severitiesFor(findings, ERROR))
+        self.assertEqual([], severitiesFor(findings, WARNING))
+
+    def test_installed_pathways_with_no_configured_mapping_are_information(self):
+        """bvu's MapMan: unreachable, but never offered, so not a broken job."""
+        db = FakeDatabase({"kegg_id": ["a"], "kegg_gene_symbol": ["s"],
+                           "mapman_gene_id": ["1.1"]},
+                          keggPathways(["a"]) + keggPathways(["1.1"], source="MapMan"))
+        findings = checkOrganism(db, "bvu", KEGG_BY_ID)
+        self.assertEqual([], severitiesFor(findings, ERROR))
+        infos = severitiesFor(findings, INFO)
+        self.assertTrue(infos)
+        self.assertEqual("MapMan", infos[0].database)
+
+    def test_a_species_absent_from_the_config_is_checked_on_the_fallback(self):
+        """ptr and acs were broken precisely because nobody checked the fallback."""
+        db = FakeDatabase({"entrezgene": ["1"]}, keggPathways(["1"]))
+        findings = checkOrganism(db, "no-such-species")   # falls back to kegg_id
+        errors = severitiesFor(findings, ERROR)
+        self.assertTrue(errors, "the fallback tables must be checked too")
+        self.assertIn("kegg_id", errors[0].message)
+
+    def test_the_mandatory_database_says_it_cannot_be_deselected(self):
+        """A KEGG fault is unavoidable; the report should say so."""
+        db = FakeDatabase({"reactome_gene_id": ["X"]}, keggPathways(["1"]))
+        findings = checkOrganism(db, "dre", KEGG_BY_ID)
+        self.assertIn("KEGG cannot be deselected",
+                      severitiesFor(findings, ERROR)[0].message)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Sweeping all 133 installed species for the fault that killed every Drosophila job (#85) found four more. Only one of them crashed; the other three mapped **nothing** and reported success, which reaches a user as an empty result they will read as biology.

| species | fault | before | after |
|---|---|---|---|
| `dre` zebrafish | named `entrezgene`, built from a mapping file dre never received — table absent | **every job died at step 1** | 150/150 (100%), 230 pathways |
| `cel` C. elegans | named `entrezgene` (numeric NCBI) while KEGG keys worm on `CELE_C17G1.7` — populated, matched **0 of 500** pathway genes | 0 mapped, "success" | 150/150 (100%), 263 pathways |
| `dosa` rice RAP-DB | named `ensembl_transcript`, which its build *registers before* reading an input it never received — table exists with **0 documents** | 0 mapped, "success" | 150/150 (100%), 82 pathways |
| `sly` tomato | named `entrezgene`, holding **169 of 500** gene ids its KEGG pathways reference | ~1 gene in 3 unpaintable | 150/150 (100%), MapMan unchanged at 96% |

KEGG is unioned into every job by `PathwayAcquisitionServlet`, so none of these could be dodged by picking another database.

## What each needed

`dre` and `cel` needed **data**: `processKEGGMappingData()` was commented out in both build scripts — as it was for `dme` — while their KEGG mapping files sat on disk untouched. Both rebuilt on production with `DBManager.py reinstall` (reads `current/` only, promotes nothing); Reactome preserved on both, verified byte-for-byte identical on identical inputs.

`dosa` and `sly` needed only the right table named. No data install.

## Measured before changing anything

Pointing `sly` at `kegg_id` is better-or-equal from **every** installed table — Solyc ids stay at 150/150, while `uniprot_acc` and `kegg_gene_symbol` go 0% → 100%, because the target no longer sits across the Ensembl/KEGG mate split.

`cel`'s WBGene→KEGG rate is 40%, and that is correct biology: the misses are `21ur-*` piRNAs, which KEGG does not cover. From KEGG's own side **97%** of its worm genes reach a WBGene id.

## The guard

None of the three silent failures can be caught offline — one table is empty, one is populated with the wrong identifier space, one is merely incomplete. So `checkIdentifierMapping.py` reads the installed data and asks whether the configured table actually contains the gene ids the species' own pathway documents reference.

Run against production it reproduced all four faults and nothing else:

```
133 species checked, 4 error(s)   <- before
133 species checked, 0 error(s)   <- after
```

The 18 remaining warnings are 17 bacteria/fungi whose empty *gene-symbol* table is simply what KEGG publishes (identifiers still map; only the display pass is affected) and one pre-existing rno/OmniPath gap.

10 unit tests reproduce each fault shape against a fake MongoDB, plus the 4 existing tests from #85.

## Verified in Chrome on the live site

Four jobs on paintomics.uv.es with files built from each species' own identifiers: `u7705JBW3n` (dre), `q144M0K2Cu` (cel), `0BIy0uCor3` (dosa), `4h1USIp7oi` (sly). Step 1 completes, step 2 reports the figures above, step 3 lists real per-pathway gene counts (zebrafish: Lysine degradation 11, Oxidative phosphorylation 7), and a pathway diagram opens and paints. One unrelated pre-existing console error (`JobController.js` IndexedDB job-list cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
