### PR TITLE
Let step 2 choose the compound a metabolite name meant

### DIFF
--- a/PaintomicsClient/public_html/app/controller/JobController.js
+++ b/PaintomicsClient/public_html/app/controller/JobController.js
@@ -602,6 +602,7 @@ function JobController() {
 		var me = this;
 		var jobID = jobView.getModel().getJobID();
 		var attempts = 0;
+		var failures = 0;
 
 		var fail = function (message) {
 			jobView.setAIButtonState("idle");
@@ -657,8 +658,16 @@ function JobController() {
 				error: function (xhr) {
 					// One dropped request must not end the poll: the AI status
 					// poll shipped with exactly that bug and died on a single
-					// blip. Only a run of them gives up, via the attempt ceiling.
-					if (attempts <= AI_SUGGEST_MAX_POLLS) {
+					// blip. Only a run of them gives up.
+					//
+					// Counted separately from `attempts`. Guarded on that, the
+					// branch below was unreachable -- poll() returns early once
+					// `attempts` passes the ceiling, so inside a running poll
+					// the test was always true and a server that was down for
+					// the whole window reported "taking longer than expected"
+					// instead of the transport error it actually hit.
+					failures++;
+					if (failures <= AI_SUGGEST_MAX_TRANSPORT_FAILURES) {
 						setTimeout(poll, AI_POLL_INTERVAL);
 						return;
 					}

--- a/PaintomicsClient/public_html/app/controller/JobController.js
+++ b/PaintomicsClient/public_html/app/controller/JobController.js
@@ -510,6 +510,13 @@ function JobController() {
 
 
 
+						// Carried from step 1 so step 2 knows whether this job may use
+						// the AI at all. The other two responses that send it
+						// (step 3, pa_recover_job) arrive too late for step 2.
+						if (response.aiConsent === true || response.aiConsent === "true") {
+							jobModel.aiConsent = true;
+						}
+
 						//TODO: IF IS THE SECOND TIME THAT THE PREVIOUS STEP WAS EXECUTED AND NOTHING CHANGES, AVOID RESENDING?
 						jobModel.setFoundCompounds([]);
 						var matchedMetabolites = response.matchedMetabolites;
@@ -577,6 +584,107 @@ function JobController() {
 	* @param {type} jobView
 	* @returns {undefined}
 	************************************************************/
+	/**
+	* "Choose for me": ask the server which KEGG compound each ambiguous name
+	* meant, then apply the answer to the cards.
+	*
+	* Enqueue-and-poll, not one request: the server puts the work on its job
+	* queue because a route that blocked on the LLM gateway would hold one of
+	* the four uWSGI threads that serve the whole site.
+	*
+	* Nothing is saved by this. The suggestions move checkboxes in the browser's
+	* own model; the analysis only changes if the user then presses Next step,
+	* and Undo puts every tick back.
+	*
+	* @param {PA_Step2JobView} jobView
+	*/
+	this.step2SuggestCompoundsHandler = function (jobView) {
+		var me = this;
+		var jobID = jobView.getModel().getJobID();
+		var attempts = 0;
+
+		var fail = function (message) {
+			jobView.setAIButtonState("idle");
+			showErrorMessage(message || "The AI could not choose the compounds.", {
+				height: 200, width: 420
+			});
+		};
+
+		var poll = function () {
+			attempts++;
+			// Ceiling rather than a timeout on the request: the server's own
+			// budget stops the gateway call, and this only has to outlast it.
+			if (attempts > AI_SUGGEST_MAX_POLLS) {
+				fail("The AI is taking longer than expected. Your selection has "
+					+ "not been changed \u2014 please choose the compounds yourself, "
+					+ "or try again.");
+				return;
+			}
+
+			$.ajax({
+				type: "POST", url: SERVER_URL_PA_SUGGEST_COMPOUNDS_STATUS,
+				data: {jobID: jobID}, dataType: "json",
+				success: function (response) {
+					if (!response || response.success !== true) {
+						fail(response && (response.errorMessage || response.message));
+						return;
+					}
+					if (response.status === "running" || response.status === "queued") {
+						setTimeout(poll, AI_POLL_INTERVAL);
+						return;
+					}
+					if (response.status !== "finished") {
+						fail("The AI compound selection did not finish.");
+						return;
+					}
+
+					// applyAISuggestions re-renders the panel, and the panel is
+					// where the buttons live now -- Undo appears with it.
+					var counts = jobView.applyAISuggestions(response);
+					jobView.setAIButtonState("done");
+
+					// Same verb as the banner it appears over. "Selected" would
+					// also overstate it: these are the cards that CHANGED, not
+					// every card the run decided.
+					var changed = counts.byRule + counts.byAI;
+					showSuccessMessage(
+						changed > 0
+							? "Changed " + changed + " compound selection" + (changed === 1 ? "" : "s")
+							  + (counts.unsure > 0 ? ", " + counts.unsure + " left for you" : "")
+							: "Your selection already matched \u2014 nothing changed",
+						{showTimeout: 1, closeTimeout: 3});
+				},
+				error: function (xhr) {
+					// One dropped request must not end the poll: the AI status
+					// poll shipped with exactly that bug and died on a single
+					// blip. Only a run of them gives up, via the attempt ceiling.
+					if (attempts <= AI_SUGGEST_MAX_POLLS) {
+						setTimeout(poll, AI_POLL_INTERVAL);
+						return;
+					}
+					ajaxErrorHandler(xhr);
+					jobView.setAIButtonState("idle");
+				}
+			});
+		};
+
+		$.ajax({
+			type: "POST", url: SERVER_URL_PA_SUGGEST_COMPOUNDS,
+			data: {jobID: jobID}, dataType: "json",
+			success: function (response) {
+				if (!response || response.success !== true) {
+					fail(response && (response.errorMessage || response.message));
+					return;
+				}
+				setTimeout(poll, AI_POLL_INTERVAL);
+			},
+			error: function (xhr) {
+				ajaxErrorHandler(xhr);
+				jobView.setAIButtonState("idle");
+			}
+		});
+	};
+
 	this.step2OnFormSubmitHandler = function (jobView) {
 		if (jobView.checkForm() === true) {
 			var me = this;

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
@@ -512,20 +512,28 @@ function PA_Step2JobView() {
 	this.renderAIActions = function() {
 		var hidden = this.aiAvailable ? "" : ' style="display:none;"';
 		var undo = this.aiSnapshot
-			? '<a href="javascript:void(0)" class="button btn-default" id="aiUndoButton">' +
-			  '<i class="fa fa-undo"></i> Undo</a>'
+			? '<a href="javascript:void(0)" class="button btn-ai-quiet" id="aiUndoButton" ' +
+			  'title="Put every tick back as it was">' +
+			  '<i class="fa fa-undo"></i></a>'
 			: "";
 
 		var mark = (typeof getAIMark === "function") ? getAIMark() : "";
 
 		return '' +
 		'<div class="aiSuggestActions"' + hidden + '>' +
-		'  <h3 class="aiSuggestActionsTitle">' + mark + ' Let PaintOmics AI choose</h3>' +
-		'  <p class="aiSuggestHint">It reads your organism and experiment design, and ' +
-		'only ever picks a candidate already on a card.</p>' +
+		'  <div class="aiSuggestActionsBody">' +
+		// data-guides="ignore": the alignment overlay measures where TYPE starts,
+		// and an icon-led label starts its type one icon in. The mark is on the
+		// panel's rail, which is the edge a reader sees; the offset is the icon,
+		// and it is declared here rather than left for the HUD to rediscover.
+		'    <h3 class="aiSuggestActionsTitle" data-guides="ignore">' +
+		       mark + '<span>PaintOmics AI</span></h3>' +
+		'    <p class="aiSuggestHint">Picks the most likely compound for each name, from ' +
+		'your organism and experiment design.</p>' +
+		'  </div>' +
 		'  <div class="aiSuggestActionsRow">' +
-		'    <a href="javascript:void(0)" class="button btn-info" id="aiSuggestButton">' +
-		       mark + ' Choose for me</a>' +
+		'    <a href="javascript:void(0)" class="button btn-ai" id="aiSuggestButton">' +
+		       mark + '<span>Choose for me</span></a>' +
 		     undo +
 		'  </div>' +
 		'</div>';
@@ -542,15 +550,17 @@ function PA_Step2JobView() {
 		if (button.length === 0) {
 			return;
 		}
+		var mark = (typeof getAIMark === "function") ? getAIMark() : "";
+
 		if (state === "working") {
 			button.addClass("aiWorking")
-				.html('<i class="fa fa-circle-o-notch fa-spin"></i> Choosing\u2026');
+				.html('<i class="fa fa-circle-o-notch fa-spin"></i><span>Choosing\u2026</span>');
 		} else if (state === "done") {
 			button.removeClass("aiWorking")
-				.html('<i class="fa fa-magic"></i> ' + (label || "Choose again"));
+				.html(mark + '<span>' + (label || "Choose again") + '</span>');
 		} else {
 			button.removeClass("aiWorking")
-				.html('<i class="fa fa-magic"></i> Choose for me');
+				.html(mark + '<span>Choose for me</span>');
 		}
 	};
 
@@ -586,11 +596,18 @@ function PA_Step2JobView() {
 		// `compoundsIntroBox` takes this card out of the 49%-wide odd/even
 		// float grid the metabolite cards use. As one of those it was a
 		// half-width block of prose with an empty half-row beside it.
+		//
+		// Two columns inside it: what the user has to do, and the offer to do
+		// it for them. A lone button under a line of prose in a 1360px card
+		// read as an afterthought -- it had no surface of its own and nothing
+		// to balance against.
 		'<div class="contentbox omicSummaryBox compoundsIntroBox">' +
-		'  <div id="about">' +
-		'    <h2>Compounds disambiguation</h2>' +
-		'    <p>Some names matched more than one KEGG compound. Pick the one you ' +
-		'measured on each card.</p>' +
+		'  <div id="about" class="compoundsIntroLayout">' +
+		'    <div class="compoundsIntroText">' +
+		'      <h2>Compounds disambiguation</h2>' +
+		'      <p><b>' + me.items.length + '</b> of your compound names matched more than ' +
+		'one KEGG compound. Pick the one you measured on each card below.</p>' +
+		'    </div>' +
 		     me.renderAIActions() +
 		'  </div>' +
 		'</div>' +
@@ -1474,6 +1491,67 @@ function mappingSummaryCaption(mappedFeatures, unmappedFeatures) {
 		'</div>';
 }
 
+/**
+* The mapped/unmapped ring, drawn the same way for every omic.
+*
+* Extracted because the compound omics were not getting one. The old code drew
+* this only for gene-based omics and gave a compound omic
+* `<b>See Compounds disambiguation</b>`, 60px down an otherwise empty 327x195
+* box -- a slot that looked broken beside four cards that all had a chart, and
+* a line that looked like a link and was not one.
+*
+* The reason given was that a compound omic has no per-database breakdown, and
+* that is true -- but the breakdown was only ever the tooltip's `note`. The
+* ring itself is mapped against unmapped, which every omic has.
+*
+* @param {String} divName the panel's id prefix
+* @param {String} omicName series name, shown in the tooltip
+* @param {Number} mapped features that resolved to an identifier
+* @param {Number} unmapped features that did not
+* @param {String} note per-database detail for the tooltip, "" when there is none
+*/
+function renderMappingDonut(divName, omicName, mapped, unmapped, note) {
+	$('#' + divName + 'mapping_summary_plot').highcharts({
+		chart: {type: 'pie', height: 195},
+		title: {
+			text: "Mapped/Unmapped features",
+			style: {"fontSize": "13px"}
+		},
+		credits: {enabled: false},
+		tooltip: {
+			pointFormat: '{series.name}: <b>{point.y}</b><br/><br/>{point.options.note}<br/>'
+		},
+		plotOptions: {
+			pie: {
+				// Off on purpose: see mappingSummaryCaption. At this size
+				// Highcharts hid the "Mapped features" label on every omic and
+				// clipped the other one, so the ring is now the proportion and
+				// the caption underneath carries the numbers. With no labels to
+				// leave room for, the ring can sit in the middle of its box.
+				dataLabels: {enabled: false},
+				center: ['50%', '45%']
+			}
+		},
+		series: [{
+			type: 'pie',
+			name: omicName,
+			size: 100,
+			innerSize: '30%',
+			data: [{
+				name: 'Unmapped features',
+				y: Number.parseFloat(unmapped),
+				color: "rgb(250, 112, 112)",
+				note: ""
+			}, {
+				name: 'Mapped features',
+				y: Number.parseFloat(mapped),
+				color: "rgb(106, 208, 150)",
+				note: note
+			}]
+		}]
+	});
+}
+
 function PA_OmicSummaryPanel(omicName, dataDistribution, isCompoundOmic) {
 	/***********************************************************************
 	* ATTRIBUTES
@@ -1534,59 +1612,37 @@ function PA_OmicSummaryPanel(omicName, dataDistribution, isCompoundOmic) {
 							}
 						}
 
-						//WHEN THE BOX IS READY, CALL HIGHCHARTS AND CREATE THE PIE WITH MAPPING SUMMARY AND THE BOXPLOT FOR DATA DISTRIBUTION
-						$('#' + divName + 'mapping_summary_plot').highcharts({
-							chart: {type: 'pie',height: 195},
-							title: {
-								text: "Mapped/Unmapped features",
-								style: {"fontSize": "13px"}
-							},
-							credits: {enabled: false},
-							tooltip: {
-									pointFormat: '{series.name}: <b>{point.y}</b><br/><br/>{point.options.note}<br/>'
-							},
-							plotOptions: {
-								pie: {
-									// Off on purpose: see mappingSummaryCaption. At
-									// this size Highcharts hid the "Mapped features"
-									// label on every omic and clipped the other one,
-									// so the ring is now the proportion and the
-									// caption underneath carries the numbers. With
-									// no labels to leave room for, the ring can sit
-									// in the middle of its box.
-									dataLabels: {enabled: false},
-									center: ['50%', '45%']
-								}
-							},
-							series: [{
-								type: 'pie',
-								name: me.omicName,
-								size: 100,
-								innerSize: '30%',
-								data: [{
-									name: 'Unmapped features',
-									y: Number.parseFloat(me.dataDistribution[1]),
-									color: "rgb(250, 112, 112)",
-									note: ""
-								}, {
-									name: 'Mapped features',
-									y: Number.parseFloat(mappedFeatures),
-									color: "rgb(106, 208, 150)",
-									note: added_info
-								}]
-							}]
-						});
+						renderMappingDonut(divName, me.omicName, mappedFeatures,
+							me.dataDistribution[1], added_info);
 					} else {
-						// A compound omic is matched once against KEGG compound
-						// IDs, so there is no per-database breakdown to draw - but
-						// its mapped/unmapped counts matter just as much, and until
-						// now the panel reported neither.
+						// A compound omic is matched once against KEGG compound ids, so
+						// there is no per-database breakdown for the TOOLTIP -- and that
+						// is all that is missing. The mapped and unmapped counts it does
+						// have are the same two numbers every other omic's ring is drawn
+						// from. They were being discarded, and the slot printed a bold
+						// line 60px down an otherwise empty 327x195 box.
 						mappedFeatures = me.dataDistribution[0];
-						$('#' + divName + 'mapping_summary_plot').html('<div style="text-align:center; padding-top:60px;"><b>See Compounds disambiguation</b></div>');
+						added_info = "";
+						renderMappingDonut(divName, me.omicName, mappedFeatures,
+							me.dataDistribution[1], added_info);
 					}
 
+					// A real control now. It used to be a bare <b> styled like a
+					// link: it looked clickable and did nothing when clicked.
 					$('#' + divName + 'mapping_summary_caption')
-						.html(mappingSummaryCaption(mappedFeatures, me.dataDistribution[1]));
+						.html(mappingSummaryCaption(mappedFeatures, me.dataDistribution[1]) +
+							(isCompoundOmic
+								? '<div class="mappingSummaryJump">' +
+								  '<a href="javascript:void(0)" class="compoundsJumpLink">' +
+								  'See compounds disambiguation</a></div>'
+								: ''))
+						.off("click.paJump")
+						.on("click.paJump", ".compoundsJumpLink", function() {
+							var target = document.querySelector(".compoundsIntroBox");
+							if (target) {
+								target.scrollIntoView({block: "start", behavior: "smooth"});
+							}
+						});
 
 					//   0        1       2    3    4    5     6,   7   8      9        10
 					//[MAPPED, UNMAPPED, MIN, P10, Q1, MEDIAN, Q3, P90, MAX, MIN_IR, Max_IR]

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
@@ -408,29 +408,7 @@ function PA_Step2JobView() {
 		}
 
 		if (me.items.length > 0) {
-			// The whole disambiguation panel is one string of HTML inside a
-			// single component. It used to be a column layout holding one
-			// container per matched name, each holding one Ext box per candidate
-			// plus an Ext.tip.ToolTip per candidate; a job with 6592 matched
-			// names built tens of thousands of components and froze the tab for
-			// minutes before the first paint. The markup below reproduces the
-			// same DOM (the cards are laid out by .metaboliteBox:nth-child in
-			// main.css, not by the column layout) at a fraction of the cost.
-			compoundsPanelHTML =
-			'<div class="contentbox omicSummaryBox">' +
-			'  <div id="about">' +
-			'    <h2>Compounds disambiguation</h2>' +
-			'    <p>Some compounds names need to be disambiguated.</p>' +
-			'    <p>Please check the list below and choose the compounds in which you are interested.</p> ' +
-			'  </div>' +
-			'</div>' +
-			me.items.map(function(compoundSetView, index) {
-				return compoundSetView.renderCard(index);
-			}).join("") +
-			// The cards are floated; the column layout used to supply the
-			// clearfix, so without this the panel would collapse to no height
-			// and the cards would spill out of the step-2 form.
-			'<div style="clear: both;"></div>';
+			compoundsPanelHTML = me.renderCompoundsPanel();
 		}
 
 		this.component = Ext.widget({
@@ -477,6 +455,7 @@ function PA_Step2JobView() {
 					$('#download_mapping_file').click(function() {
 						application.getController("DataManagementController").downloadFilesHandler(me, "mapping_results_" + me.getModel().getJobID() + ".zip", "job_result", me.getModel().getJobID());
 					});
+					me.initAISuggestButton();
 					initializeTooltips(".helpTip");
 					me.initCompoundsPanelHandlers(this.queryById("compoundsPanelsContainer"));
 				},
@@ -488,6 +467,305 @@ function PA_Step2JobView() {
 
 		return this.component;
 	};
+	/**
+	* Show the button only where it can actually do something.
+	*
+	* Three conditions, all of which have to hold: this deployment has AI
+	* switched on AND has a token (`/ai_provider` answers both), the job carries
+	* consent, and there is at least one card to decide. A button that appears
+	* and then reports that the server has no API key is worse than no button.
+	*/
+	this.initAISuggestButton = function() {
+		var me = this;
+		if (me.items.length === 0) {
+			return;
+		}
+		if (me.getModel().aiConsent !== true) {
+			return;
+		}
+		if (typeof withAIProviderInfo !== "function") {
+			return;
+		}
+		withAIProviderInfo(function(info) {
+			if (!info || info.enabled !== true || info.configured !== true) {
+				return;
+			}
+			// Kept on the view rather than only in the DOM: the panel is
+			// re-rendered whenever picks are applied or undone, and the answer
+			// to "may this job use the AI" must survive that.
+			me.aiAvailable = true;
+			$(".aiSuggestActions").show();
+		});
+	};
+
+	/**
+	* The AI controls, inside the card that introduces the section.
+	*
+	* Deliberately here rather than in the step's toolbar. The toolbar's buttons
+	* act on the whole step - go back, run the next step, reset everything - and
+	* this one acts on the compound cards immediately below it. Next to them it
+	* can also say what it does and what it costs the user, which a toolbar
+	* button has no room for.
+	*
+	* @returns {String}
+	*/
+	this.renderAIActions = function() {
+		var hidden = this.aiAvailable ? "" : ' style="display:none;"';
+		var undo = this.aiSnapshot
+			? '<a href="javascript:void(0)" class="button btn-default" id="aiUndoButton">' +
+			  '<i class="fa fa-undo"></i> Undo</a>'
+			: "";
+
+		return '' +
+		'<div class="aiSuggestActions"' + hidden + '>' +
+		'  <div class="aiSuggestActionsText">' +
+		'    <h3 class="aiSuggestActionsTitle">Not sure which one?</h3>' +
+		'    <p class="aiSuggestHint">PaintOmics picks the most likely KEGG compound ' +
+		'for each ambiguous name, from the organism and your experiment design. It ' +
+		'chooses only from the candidates already on a card, leaves anything genuinely ' +
+		'ambiguous to you, and saves nothing until you press <b>Next step</b>.</p>' +
+		'  </div>' +
+		'  <div class="aiSuggestActionsRow">' +
+		'    <a href="javascript:void(0)" class="button btn-info" id="aiSuggestButton">' +
+		'      <i class="fa fa-magic"></i> Choose for me</a>' +
+		     undo +
+		'  </div>' +
+		'</div>';
+	};
+
+	/**
+	* The button's four states, in one place so none of them can be half-applied.
+	*
+	* @param {String} state one of "idle", "working", "done"
+	* @param {String} label optional text for the "done" state
+	*/
+	this.setAIButtonState = function(state, label) {
+		var button = $("#aiSuggestButton");
+		if (button.length === 0) {
+			return;
+		}
+		if (state === "working") {
+			button.addClass("aiWorking")
+				.html('<i class="fa fa-circle-o-notch fa-spin"></i> Choosing\u2026');
+		} else if (state === "done") {
+			button.removeClass("aiWorking")
+				.html('<i class="fa fa-magic"></i> ' + (label || "Choose again"));
+		} else {
+			button.removeClass("aiWorking")
+				.html('<i class="fa fa-magic"></i> Choose for me');
+		}
+	};
+
+	this.aiSuggestHandler = function() {
+		if ($("#aiSuggestButton").hasClass("aiWorking")) {
+			return;
+		}
+		this.setAIButtonState("working");
+		this.controller.step2SuggestCompoundsHandler(this);
+	};
+
+	/**
+	* The whole disambiguation panel as one string of HTML.
+	*
+	* It used to be a column layout holding one container per matched name, each
+	* holding one Ext box per candidate plus an Ext.tip.ToolTip per candidate; a
+	* job with 6592 matched names built tens of thousands of components and froze
+	* the tab for minutes before the first paint. This markup reproduces the same
+	* DOM (the cards are laid out by .metaboliteBox:nth-child in main.css, not by
+	* the column layout) at a fraction of the cost.
+	*
+	* Extracted from the component definition so that accepting the AI's picks
+	* can rebuild it. Re-rendering rather than patching checkboxes in place is
+	* deliberate: a collapsed card's alternatives are not in the document at all,
+	* so a DOM-only update would silently miss exactly the candidates the AI is
+	* most likely to have turned OFF.
+	*
+	* @returns {String}
+	*/
+	this.renderCompoundsPanel = function() {
+		var me = this;
+		return '' +
+		// `compoundsIntroBox` takes this card out of the 49%-wide odd/even
+		// float grid the metabolite cards use. As one of those it was a
+		// half-width block of prose with an empty half-row beside it.
+		'<div class="contentbox omicSummaryBox compoundsIntroBox">' +
+		'  <div id="about">' +
+		'    <h2>Compounds disambiguation</h2>' +
+		'    <p>Some compound names matched more than one KEGG compound. Choose the one ' +
+		'you measured on each card below \u2014 or let PaintOmics propose them.</p>' +
+		     me.renderAIActions() +
+		'  </div>' +
+		'</div>' +
+		me.renderAISummary() +
+		me.items.map(function(compoundSetView, index) {
+			return compoundSetView.renderCard(index);
+		}).join("") +
+		// The cards are floated; the column layout used to supply the clearfix,
+		// so without this the panel would collapse to no height and the cards
+		// would spill out of the step-2 form.
+		'<div style="clear: both;"></div>';
+	};
+
+	/**
+	* The banner that says what the AI did, or nothing at all before it has run.
+	*
+	* The counts are of cards actually CHANGED, not of decisions received: the
+	* server ranks every compound set it has, including ones this view draws no
+	* card for, and reporting those would credit the feature with work the user
+	* cannot see.
+	*
+	* @returns {String}
+	*/
+	this.renderAISummary = function() {
+		var summary = this.aiSummary;
+		if (!summary) {
+			return "";
+		}
+
+		var parts = [];
+		if (summary.byRule > 0) {
+			parts.push('<b>' + summary.byRule + '</b> by name matching');
+		}
+		if (summary.byAI > 0) {
+			parts.push('<b>' + summary.byAI + '</b> by the AI');
+		}
+
+		// The count is of cards CHANGED. Saying "selected" would claim the ones
+		// that were already right, which is most of them on a typical job.
+		var headline = parts.length
+			? 'Changed ' + parts.join(' and ') + '.'
+			: 'Nothing needed changing \u2014 your selection already matched.';
+
+		var tail = summary.unsure > 0
+			? ' <b>' + summary.unsure + '</b> left for you, marked <i>AI unsure</i> below.'
+			: ' Nothing was left undecided.';
+
+		var model = summary.model
+			? '<div class="aiSuggestModel">Answered by ' + Ext.String.htmlEncode(summary.model) +
+			  '. Every choice was checked against the candidates on its own card; ' +
+			  'anything outside them was discarded.</div>'
+			: '';
+
+		return '' +
+		'<div class="contentbox aiSuggestSummary">' +
+		'  <div class="aiSuggestSummaryHead">' +
+		'    <i class="fa fa-magic aiSuggestSummaryMark"></i>' +
+		'    <span>' + headline + tail + '</span>' +
+		'  </div>' +
+		model +
+		'</div>';
+	};
+
+	/**
+	* Accept a suggestion payload: tick what it chose, untick its rivals.
+	*
+	* Only ever touches candidates INSIDE a set the server named, and only sets
+	* this view actually drew a card for. A decision for an input name this view
+	* has no card for is dropped rather than applied blind - the server's idea of
+	* which sets need a decision is deliberately more permissive than this one
+	* (`selected` does not exist server-side), and the cards are what the user
+	* consented to by pressing the button.
+	*
+	* @param {Object} payload as returned by /pa_suggest_compounds_status
+	* @returns {Object} {byRule, byAI, unsure} counts of cards actually changed
+	*/
+	this.applyAISuggestions = function(payload) {
+		var me = this;
+		var byTitle = {};
+		me.items.forEach(function(compoundSetView) {
+			byTitle[compoundSetView.getModel().getTitle()] = compoundSetView;
+		});
+
+		// One snapshot of every tick before anything moves, so Undo is exact
+		// rather than an attempt to invert the decisions one at a time.
+		me.aiSnapshot = me.items.map(function(compoundSetView) {
+			var model = compoundSetView.getModel();
+			return {
+				view: compoundSetView,
+				state: model.getMainCompounds().concat(model.getOtherCompounds())
+					.map(function(compound) { return compound.selected === true; }),
+				aiState: compoundSetView.aiState || null
+			};
+		});
+
+		var counts = {byRule: 0, byAI: 0, unsure: 0};
+
+		(payload.decisions || []).forEach(function(decision) {
+			var compoundSetView = byTitle[decision.title];
+			if (!compoundSetView || !decision.keggID) {
+				return;
+			}
+
+			// Only a card whose ticks actually MOVED gets marked. The server
+			// decides every set it has, and on a typical job most of those
+			// decisions agree with what was already selected -- badging those
+			// too put a chip on 52 of 47 cards, at which point the chip stops
+			// meaning anything and the eye cannot find the changes.
+			if (!compoundSetView.selectOnly(decision.keggID)) {
+				return;
+			}
+
+			if (decision.tier === "ai") { counts.byAI++; } else { counts.byRule++; }
+			compoundSetView.aiState = {
+				status: "picked", keggID: decision.keggID, tier: decision.tier,
+				confidence: decision.confidence || "", reason: decision.reason || ""
+			};
+		});
+
+		(payload.unresolved || []).forEach(function(entry) {
+			var compoundSetView = byTitle[entry.title];
+			if (!compoundSetView) {
+				return;
+			}
+			counts.unsure++;
+			compoundSetView.aiState = {
+				status: "unsure", keggID: null, tier: "ai", confidence: "",
+				reason: entry.reason || entry.detail || ""
+			};
+		});
+
+		me.aiSummary = {byRule: counts.byRule, byAI: counts.byAI,
+		                unsure: counts.unsure, model: payload.model || ""};
+		me.refreshCompoundsPanel();
+		return counts;
+	};
+
+	/**
+	* Put every tick back exactly as it was before the button was pressed.
+	*/
+	this.undoAISuggestions = function() {
+		var snapshot = this.aiSnapshot;
+		if (!snapshot) {
+			return;
+		}
+		snapshot.forEach(function(entry) {
+			var model = entry.view.getModel();
+			var compounds = model.getMainCompounds().concat(model.getOtherCompounds());
+			compounds.forEach(function(compound, index) {
+				compound.selected = entry.state[index];
+			});
+			entry.view.aiState = entry.aiState;
+		});
+		this.aiSnapshot = null;
+		this.aiSummary = null;
+		this.refreshCompoundsPanel();
+	};
+
+	/**
+	* Rebuild the cards and rebind the delegated handlers they depend on.
+	*/
+	this.refreshCompoundsPanel = function() {
+		var container = this.component && this.component.queryById
+			? this.component.queryById("compoundsPanelsContainer") : null;
+		if (!container) {
+			return;
+		}
+		container.update(this.renderCompoundsPanel());
+		// update() replaces the element's children, so the delegated handlers
+		// bound to the OLD element are gone with it.
+		this.initCompoundsPanelHandlers(container);
+	};
+
 	this.submitFormHandler = function() {
 		this.controller.step2OnFormSubmitHandler(this);
 	};
@@ -526,6 +804,20 @@ function PA_Step2JobView() {
 
 		panel.on("click", ".showOtherCompoundsButton", function() {
 			me.showOtherCompoundsHandler($(this));
+		});
+
+		// Delegated, like everything else bound here: the AI controls live
+		// inside this panel now, and the panel's HTML is replaced wholesale
+		// each time picks are applied or undone. A handler bound straight to
+		// the button would be thrown away with the element it was bound to,
+		// and Undo would stop responding after the first use.
+		panel.on("click", "#aiSuggestButton", function() {
+			me.aiSuggestHandler();
+		});
+
+		panel.on("click", "#aiUndoButton", function() {
+			me.undoAISuggestions();
+			me.setAIButtonState("idle");
 		});
 
 		Ext.create('Ext.tip.ToolTip', {
@@ -962,13 +1254,16 @@ function foundCountLabel(count, noun) {
 * @param {Number} columnWidth width in px of the cell, as the old view had it
 * @returns {String}
 */
-function renderCompoundCandidate(compound, columnWidth) {
+function renderCompoundCandidate(compound, columnWidth, aiPickedID) {
 	var compoundID = compound.getID();
 	var safeID = Ext.String.htmlEncode(compoundID);
 	var safeName = Ext.String.htmlEncode(compound.getName());
+	// Marks the one candidate the AI chose, so a card with four ticked-looking
+	// rows still says WHICH row the machine is responsible for.
+	var picked = (aiPickedID && compoundID === aiPickedID) ? " aiPickedCandidate" : "";
 
 	return '' +
-	'<div class="metaboliteCompound" data-compound-id="' + safeID + '" data-compound-name="' + safeName + '"' +
+	'<div class="metaboliteCompound' + picked + '" data-compound-id="' + safeID + '" data-compound-name="' + safeName + '"' +
 	' style="float:left; width:' + columnWidth + 'px; max-width:' + columnWidth + 'px; margin-top:5px;' +
 	' white-space:nowrap; overflow:hidden; text-overflow:ellipsis;">' +
 	'  <input type="checkbox"' + (compound.isSelected() ? " checked" : "") + ' name="metabolite" value="' + safeID + '">' +
@@ -1032,17 +1327,86 @@ function PA_Step2CompoundSetView() {
 	* @param {Number} index
 	* @returns {String}
 	*/
+	/**
+	* Tick exactly one candidate in this set and untick every other.
+	*
+	* The only mutation the AI path performs on the model. It is scoped to this
+	* one compound set by construction, so a suggestion can never reach across
+	* to another input name's candidates.
+	*
+	* @param {String} keggID the candidate to keep
+	* @returns {Boolean} whether anything actually changed
+	*/
+	this.selectOnly = function(keggID) {
+		var compounds = this.model.getMainCompounds().concat(this.model.getOtherCompounds());
+
+		// Membership is decided BEFORE anything moves. Written the other way -
+		// untick as you scan, check afterwards - an id this set does not
+		// contain clears every tick in it on the way to returning false, which
+		// is the worst outcome available: the user loses a selection they made,
+		// to an answer that was never valid for this card.
+		var found = compounds.some(function(compound) {
+			return compound.getID() === keggID;
+		});
+		if (!found) {
+			return false;
+		}
+
+		var changed = false;
+		compounds.forEach(function(compound) {
+			var wanted = (compound.getID() === keggID);
+			if (compound.selected !== wanted) {
+				compound.selected = wanted;
+				changed = true;
+			}
+		});
+		return changed;
+	};
+
+	/**
+	* The "AI" / "AI unsure" chip on a card, with its reason as the tooltip.
+	*
+	* @returns {String}
+	*/
+	this.renderAIBadge = function() {
+		var state = this.aiState;
+		if (!state) {
+			return "";
+		}
+		// Three states, three colours, and the deterministic one is NOT the
+		// AI colour. A rule that matched a name did not consult a model, and
+		// dressing it in the AI blue would claim credit the feature has not
+		// earned -- the point of the chip is to say what touched this card.
+		var kind = state.status === "unsure" ? "unsure"
+			: (state.tier === "ai" ? "ai" : "auto");
+		var label = {unsure: "AI unsure", ai: "AI", auto: "Auto"}[kind];
+		var icon = {unsure: "fa-question-circle", ai: "fa-magic", auto: "fa-check"}[kind];
+		var reason = Ext.String.htmlEncode(state.reason || "");
+
+		return '<span class="aiBadge aiBadge-' + kind + '"' +
+		       (reason ? ' title="' + reason + '"' : "") + '>' +
+		       '<i class="fa ' + icon + '"></i> ' + label + '</span>';
+	};
+
 	this.renderCard = function(index) {
 		var mainCompounds = this.model.getMainCompounds();
 		var otherCompounds = this.model.getOtherCompounds();
 
+		var aiPickedID = (this.aiState && this.aiState.keggID) || null;
+		var cardClass = "contentbox metaboliteBox";
+		if (this.aiState) {
+			cardClass += this.aiState.status === "unsure" ? " aiBox-unsure"
+				: (this.aiState.tier === "ai" ? " aiBox-ai" : " aiBox-auto");
+		}
+
 		var html =
-		'<div class="contentbox metaboliteBox" data-compoundset="' + index + '">' +
-		'  <h3 class="metaboliteTitle">' + Ext.String.htmlEncode(this.model.getTitle()) + '</h3>' +
+		'<div class="' + cardClass + '" data-compoundset="' + index + '">' +
+		'  <h3 class="metaboliteTitle">' + Ext.String.htmlEncode(this.model.getTitle()) +
+		     this.renderAIBadge() + '</h3>' +
 		'  <h4 style="padding-left: var(--pa-card-inset);">' + foundCountLabel(mainCompounds.length, "compound") + '</h4>' +
 		'  <div class="mainCompoundsPanel" style="padding: 3px 15px; overflow: hidden;">' +
 		mainCompounds.map(function(compound) {
-			return renderCompoundCandidate(compound, 200);
+			return renderCompoundCandidate(compound, 200, aiPickedID);
 		}).join("") +
 		'  </div>';
 
@@ -1066,8 +1430,9 @@ function PA_Step2CompoundSetView() {
 	* @returns {String}
 	*/
 	this.renderOtherCompounds = function() {
+		var aiPickedID = (this.aiState && this.aiState.keggID) || null;
 		return this.model.getOtherCompounds().map(function(compound) {
-			return renderCompoundCandidate(compound, 250);
+			return renderCompoundCandidate(compound, 250, aiPickedID);
 		}).join("");
 	};
 

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
@@ -136,20 +136,18 @@ function PA_Step2JobView() {
 			xtype: 'box',
 			cls: "contentbox omicSummaryBox", minHeight: 240,
 			html: '<div id="about">' +
-			'  <h2 >Feature ID/name translation summary <span class="helpTip" title="The percentage of your input features (names or identifiers) that could be translated into the identifier each database is keyed on - for example an NCBI Gene ID for KEGG, or a UniProt accession for OmniPath. It does not say whether the feature belongs to any pathway."></h2>' +
+			// The heading's tip carries the long form. The body used to repeat
+			// most of it across four lines -- an overview sentence that only said
+			// "below is an overview", a rule of thumb, an instruction, and a
+			// paragraph on comparing databases that restated this tip almost
+			// word for word. Two lines say the same things once.
+			'  <h2 >Feature ID/name translation summary <span class="helpTip" title="The percentage of your input features (names or identifiers) that could be translated into the identifier each database is keyed on - for example an NCBI Gene ID for KEGG, or a UniProt accession for OmniPath. A feature counts as soon as its name resolves, even if it belongs to no pathway in that database, so these figures are not a ranking - Step 3 reports pathway coverage."></h2>' +
 			'  <p>' +
-			'    Below you will find an overview of the results after matching the input files against the PaintOmics databases.<br>' +
-			'    As a general rule, the bigger the percentage of mapped features, the better the results obtained in later stages.<br>' +
-			'    If the mapping percentage was low, manually check your results and input data.<br>' +
-			// These percentages are pure identifier translation -- a feature counts
-			// here as soon as its name resolves into the database's identifier
-			// space, whether or not it belongs to any pathway there. Read as a
-			// league table they mislead: each database is keyed on a different
-			// identifier type (NCBI Gene for KEGG, UniProt for OmniPath), and the
-			// databases differ in scope by design, a whole-organism atlas against a
-			// curated signalling network. Saying so here is cheaper than the wrong
-			// conclusion it prevents.
-			'    <b>Comparing databases:</b> each percentage is identifier translation only &mdash; a feature counts as soon as its name resolves into that database\'s identifier space, even if it belongs to no pathway there. Databases are keyed on different identifier types and differ in scope by design, so these figures are not a ranking. Pathway coverage is what Step 3 reports.<br><br>' +
+			'    How many of your features resolved into each database\'s identifiers. ' +
+			'The more that map, the more there is to work with later &mdash; if one ' +
+			'looks low, check that file\'s identifiers.<br>' +
+			'    <b>Not a ranking:</b> the databases use different identifier types ' +
+			'and differ in scope by design. Step 3 reports pathway coverage.<br><br>' +
 			((Object.keys(dataDistribution).length > 0) ? '  <a href="javascript:void(0)" id="download_mapping_file"><i class="fa fa-download"></i> Download ID/Name mapping results.</a>' : "") +
 			'  </p>' +
 			'</div>'
@@ -158,7 +156,9 @@ function PA_Step2JobView() {
 			xtype: 'box',
 			cls: "contentbox omicSummaryBox", minHeight: 240,
 			html: '<div id="about">' +
-			'  <h2 >Data distribution summary <span class="helpTip" title=" "></h2>' +
+			// Was title=" ": the icon rendered, invited a hover, and showed an
+			// empty tooltip.
+			'  <h2 >Data distribution summary <span class="helpTip" title="How each omic\'s values are spread across your samples. The box is the interquartile range, the red line the median, and the whiskers reach the 10th and 90th percentiles - the same two percentiles the heatmap colour scale uses by default."></h2>' +
 			'  <p>' +
 			'    By default, percentiles 10 and 90 set the reference range for the heatmap colours. You can change this in the pathway view: open <b>Settings</b> in the toolbar and edit <b>Reference values</b>.<br>' +
 			// This figure replaces settingsbutton.png, a 2022 screenshot of the

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
@@ -516,18 +516,16 @@ function PA_Step2JobView() {
 			  '<i class="fa fa-undo"></i> Undo</a>'
 			: "";
 
+		var mark = (typeof getAIMark === "function") ? getAIMark() : "";
+
 		return '' +
 		'<div class="aiSuggestActions"' + hidden + '>' +
-		'  <div class="aiSuggestActionsText">' +
-		'    <h3 class="aiSuggestActionsTitle">Not sure which one?</h3>' +
-		'    <p class="aiSuggestHint">PaintOmics picks the most likely KEGG compound ' +
-		'for each ambiguous name, from the organism and your experiment design. It ' +
-		'chooses only from the candidates already on a card, leaves anything genuinely ' +
-		'ambiguous to you, and saves nothing until you press <b>Next step</b>.</p>' +
-		'  </div>' +
+		'  <h3 class="aiSuggestActionsTitle">' + mark + ' Let PaintOmics AI choose</h3>' +
+		'  <p class="aiSuggestHint">It reads your organism and experiment design, and ' +
+		'only ever picks a candidate already on a card.</p>' +
 		'  <div class="aiSuggestActionsRow">' +
 		'    <a href="javascript:void(0)" class="button btn-info" id="aiSuggestButton">' +
-		'      <i class="fa fa-magic"></i> Choose for me</a>' +
+		       mark + ' Choose for me</a>' +
 		     undo +
 		'  </div>' +
 		'</div>';
@@ -591,8 +589,8 @@ function PA_Step2JobView() {
 		'<div class="contentbox omicSummaryBox compoundsIntroBox">' +
 		'  <div id="about">' +
 		'    <h2>Compounds disambiguation</h2>' +
-		'    <p>Some compound names matched more than one KEGG compound. Choose the one ' +
-		'you measured on each card below \u2014 or let PaintOmics propose them.</p>' +
+		'    <p>Some names matched more than one KEGG compound. Pick the one you ' +
+		'measured on each card.</p>' +
 		     me.renderAIActions() +
 		'  </div>' +
 		'</div>' +
@@ -624,32 +622,32 @@ function PA_Step2JobView() {
 
 		var parts = [];
 		if (summary.byRule > 0) {
-			parts.push('<b>' + summary.byRule + '</b> by name matching');
+			parts.push('<b>' + summary.byRule + '</b> by name');
 		}
 		if (summary.byAI > 0) {
-			parts.push('<b>' + summary.byAI + '</b> by the AI');
+			parts.push('<b>' + summary.byAI + '</b> by PaintOmics AI');
 		}
 
 		// The count is of cards CHANGED. Saying "selected" would claim the ones
 		// that were already right, which is most of them on a typical job.
 		var headline = parts.length
 			? 'Changed ' + parts.join(' and ') + '.'
-			: 'Nothing needed changing \u2014 your selection already matched.';
+			: 'Nothing needed changing.';
 
 		var tail = summary.unsure > 0
-			? ' <b>' + summary.unsure + '</b> left for you, marked <i>AI unsure</i> below.'
-			: ' Nothing was left undecided.';
+			? ' <b>' + summary.unsure + '</b> left for you.'
+			: '';
 
 		var model = summary.model
-			? '<div class="aiSuggestModel">Answered by ' + Ext.String.htmlEncode(summary.model) +
-			  '. Every choice was checked against the candidates on its own card; ' +
-			  'anything outside them was discarded.</div>'
+			? '<div class="aiSuggestModel">' + Ext.String.htmlEncode(summary.model) +
+			  ' \u00b7 every choice checked against its own card</div>'
 			: '';
 
 		return '' +
 		'<div class="contentbox aiSuggestSummary">' +
 		'  <div class="aiSuggestSummaryHead">' +
-		'    <i class="fa fa-magic aiSuggestSummaryMark"></i>' +
+		'    <span class="aiSuggestSummaryMark">' +
+		       ((typeof getAIMark === "function") ? getAIMark() : "") + '</span>' +
 		'    <span>' + headline + tail + '</span>' +
 		'  </div>' +
 		model +

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
@@ -655,10 +655,14 @@ function PA_Step2JobView() {
 			? ' <b>' + summary.unsure + '</b> left for you.'
 			: '';
 
-		var model = summary.model
-			? '<div class="aiSuggestModel">' + Ext.String.htmlEncode(summary.model) +
-			  ' \u00b7 every choice checked against its own card</div>'
-			: '';
+		// The model identifier is deliberately not shown, here or anywhere else
+		// in the interface -- the same rule PA_Step1Views states for the consent
+		// copy. Naming a specific build invites the reader to evaluate the model
+		// rather than the decision in front of them, and the string goes stale
+		// the moment the gateway is repointed. What matters to a reader is that
+		// the answers were checked, which is what this says.
+		var model = '<div class="aiSuggestModel">' +
+			'Every choice was checked against the candidates on its own card.</div>';
 
 		return '' +
 		'<div class="contentbox aiSuggestSummary">' +
@@ -693,7 +697,13 @@ function PA_Step2JobView() {
 
 		// One snapshot of every tick before anything moves, so Undo is exact
 		// rather than an attempt to invert the decisions one at a time.
-		me.aiSnapshot = me.items.map(function(compoundSetView) {
+		//
+		// Taken ONCE. Overwriting it on "Choose again" replaced the user's own
+		// selection with the previous run's output, so Undo restored the AI's
+		// first answer while the button still promised "put every tick back as
+		// it was". The snapshot is cleared by undoAISuggestions, so the next
+		// run after an Undo takes a fresh one.
+		me.aiSnapshot = me.aiSnapshot || me.items.map(function(compoundSetView) {
 			var model = compoundSetView.getModel();
 			return {
 				view: compoundSetView,
@@ -705,9 +715,41 @@ function PA_Step2JobView() {
 
 		var counts = {byRule: 0, byAI: 0, unsure: 0};
 
+		// Which KEGG compound is already spoken for, and by which input name.
+		// Step 1 de-duplicates across boxes on purpose (JobController unselects
+		// the losing copy when two names propose the same id), and the warning
+		// on the checkbox exists for the same reason -- but that warning only
+		// fires on a real `change` event, so applying picks set by set would
+		// have re-created exactly the duplicates both guards prevent, silently,
+		// and posted the same compound twice to step 3.
+		var claimedBy = {};
+		me.items.forEach(function(compoundSetView) {
+			var model = compoundSetView.getModel();
+			model.getMainCompounds().concat(model.getOtherCompounds())
+				.forEach(function(compound) {
+					if (compound.selected === true) {
+						claimedBy[compound.getID()] = model.getTitle();
+					}
+				});
+		});
+
 		(payload.decisions || []).forEach(function(decision) {
 			var compoundSetView = byTitle[decision.title];
 			if (!compoundSetView || !decision.keggID) {
+				return;
+			}
+
+			// Already selected under a DIFFERENT input name: leave this set
+			// alone and say so, rather than duplicate the compound.
+			var owner = claimedBy[decision.keggID];
+			if (owner !== undefined && owner !== decision.title) {
+				counts.unsure++;
+				compoundSetView.aiState = {
+					status: "unsure", keggID: null, tier: decision.tier,
+					confidence: "",
+					reason: "\u201c" + owner + "\u201d already uses this compound, " +
+						"so it was left for you to decide"
+				};
 				return;
 			}
 
@@ -717,8 +759,21 @@ function PA_Step2JobView() {
 			// too put a chip on 52 of 47 cards, at which point the chip stops
 			// meaning anything and the eye cannot find the changes.
 			if (!compoundSetView.selectOnly(decision.keggID)) {
+				claimedBy[decision.keggID] = decision.title;
 				return;
 			}
+
+			// selectOnly cleared this set's other ticks; release their claims so
+			// a later decision can legitimately take one of them.
+			var model = compoundSetView.getModel();
+			model.getMainCompounds().concat(model.getOtherCompounds())
+				.forEach(function(compound) {
+					if (claimedBy[compound.getID()] === decision.title &&
+						compound.getID() !== decision.keggID) {
+						delete claimedBy[compound.getID()];
+					}
+				});
+			claimedBy[decision.keggID] = decision.title;
 
 			if (decision.tier === "ai") { counts.byAI++; } else { counts.byRule++; }
 			compoundSetView.aiState = {
@@ -740,7 +795,7 @@ function PA_Step2JobView() {
 		});
 
 		me.aiSummary = {byRule: counts.byRule, byAI: counts.byAI,
-		                unsure: counts.unsure, model: payload.model || ""};
+		                unsure: counts.unsure};
 		me.refreshCompoundsPanel();
 		return counts;
 	};
@@ -813,29 +868,48 @@ function PA_Step2JobView() {
 		// different items array.
 		var panel = $(panelComponent.el.dom);
 
-		panel.on("change", "input[type=checkbox][name=metabolite]", function() {
+		// Every binding below is namespaced and cleared first, because this
+		// function runs again on each apply and undo.
+		//
+		// The assumption that made that safe was wrong. Ext's Component.update()
+		// resolves to `getTargetEl().update(html)` -> `dom.innerHTML = html`, so
+		// the panel ELEMENT survives and only its children are replaced --
+		// delegated handlers bound to it survive with it. Re-binding therefore
+		// added a second copy of each: measured after one "Choose for me", the
+		// panel carried six click handlers instead of three, so
+		// showOtherCompoundsHandler ran twice per click -- the first call opened
+		// the alternatives and the second read `hasClass('visible')` as true and
+		// closed them again. "Show" became a dead button, and every checkbox
+		// fired its duplicate-compound warning twice.
+		panel.off(".paStep2");
+
+		panel.on("change.paStep2", "input[type=checkbox][name=metabolite]", function() {
 			me.compoundSelectionHandler($(this));
 		});
 
-		panel.on("click", ".showOtherCompoundsButton", function() {
+		panel.on("click.paStep2", ".showOtherCompoundsButton", function() {
 			me.showOtherCompoundsHandler($(this));
 		});
 
-		// Delegated, like everything else bound here: the AI controls live
-		// inside this panel now, and the panel's HTML is replaced wholesale
-		// each time picks are applied or undone. A handler bound straight to
-		// the button would be thrown away with the element it was bound to,
-		// and Undo would stop responding after the first use.
-		panel.on("click", "#aiSuggestButton", function() {
+		// Delegated rather than bound to the buttons themselves: the AI controls
+		// live inside this panel, and its HTML is replaced wholesale on every
+		// apply and undo, so a handler bound to the button would go with it.
+		panel.on("click.paStep2", "#aiSuggestButton", function() {
 			me.aiSuggestHandler();
 		});
 
-		panel.on("click", "#aiUndoButton", function() {
+		panel.on("click.paStep2", "#aiUndoButton", function() {
 			me.undoAISuggestions();
 			me.setAIButtonState("idle");
 		});
 
-		Ext.create('Ext.tip.ToolTip', {
+		// Same story: one tooltip per panel, not one per refresh. Each call used
+		// to leak another Ext.tip.ToolTip bound to the same target, which is the
+		// per-candidate tooltip cost this panel was rewritten to avoid.
+		if (me.compoundTooltip) {
+			me.compoundTooltip.destroy();
+		}
+		me.compoundTooltip = Ext.create('Ext.tip.ToolTip', {
 			target: panel[0],
 			delegate: '.metaboliteCompound',
 			listeners: {

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.51" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.60" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.14" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.4" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.7" />

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.49" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.51" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.14" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.4" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.7" />

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.44" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.49" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.14" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.4" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.7" />
@@ -125,7 +125,7 @@
 	<script type="text/javascript" src="js/libs/svgjs/jquery.svg.pan.zoom.min.js"></script>
 
 	<!--SCRIPTS FOR SERVER CONNECTION CONFIGURATION-->
-	<script type="text/javascript" src="resources/ServerConfiguration.js?v=1.0"></script>
+	<script type="text/javascript" src="resources/ServerConfiguration.js?v=1.1"></script>
 	<!--CUSTOM SENCHA EXTENSIONS-->
 	<script type="text/javascript" src="app/view/common/Util.js?v=2.1"></script>
 	<script type="text/javascript" src="app/view/common/ExtJS_extensions.js?v=0.7"></script>

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -125,7 +125,7 @@
 	<script type="text/javascript" src="js/libs/svgjs/jquery.svg.pan.zoom.min.js"></script>
 
 	<!--SCRIPTS FOR SERVER CONNECTION CONFIGURATION-->
-	<script type="text/javascript" src="resources/ServerConfiguration.js?v=1.1"></script>
+	<script type="text/javascript" src="resources/ServerConfiguration.js?v=1.2"></script>
 	<!--CUSTOM SENCHA EXTENSIONS-->
 	<script type="text/javascript" src="app/view/common/Util.js?v=2.1"></script>
 	<script type="text/javascript" src="app/view/common/ExtJS_extensions.js?v=0.7"></script>

--- a/PaintomicsClient/public_html/resources/ServerConfiguration.js
+++ b/PaintomicsClient/public_html/resources/ServerConfiguration.js
@@ -43,6 +43,12 @@ SERVER_URL_PA_STEP1 = SERVER_URL + "pa_step1";
 SERVER_URL_PA_EXAMPLE_STEP1 = "pa_step1/example";
 SERVER_URL_PA_STEP2 = SERVER_URL + "pa_step2";
 SERVER_URL_PA_STEP3 = SERVER_URL + "pa_step3";
+/* Step 2's "Choose for me". Two URLs because the work goes on the server's job
+   queue rather than into the request: uWSGI serves this site on four threads,
+   so a route that waited on the LLM gateway would be an outage rather than a
+   slow response. See CompoundSuggestionServlet.py. */
+SERVER_URL_PA_SUGGEST_COMPOUNDS = SERVER_URL + "pa_suggest_compounds";
+SERVER_URL_PA_SUGGEST_COMPOUNDS_STATUS = SERVER_URL + "pa_suggest_compounds_status";
 SERVER_URL_PA_SAVE_IMAGE = SERVER_URL + "pa_save_image";
 SERVER_URL_PA_SAVE_VISUAL_OPTIONS = SERVER_URL + "pa_save_visual_options";
 SERVER_URL_PA_PATHWAY_EVIDENCE = SERVER_URL + "pa_pathway_evidence";
@@ -72,6 +78,10 @@ SERVER_URL_AI_GENERATE_EXP_DESIGN = SERVER_URL + "ai_generate_exp_design";
    is a false statement. See getAIProviderInfo() in AIInterpretServlet.py. */
 SERVER_URL_AI_PROVIDER = SERVER_URL + "ai_provider";
 AI_POLL_INTERVAL = 3000;
+/* Polls before "Choose for me" gives up. The server caps one gateway batch at
+   180s (DEFAULT_BATCH_BUDGET_SECONDS) and a large job can run several, so this
+   has to outlast the server's own budget rather than race it. 100 x 3s = 5 min. */
+AI_SUGGEST_MAX_POLLS = 100;
 // How many consecutive unhandled refusals from /ai_interpret_status before the
 // widget gives up and says so. A refusal it recognises as permanent -- the job
 // no longer exists -- stops immediately and does not consume these; this is the

--- a/PaintomicsClient/public_html/resources/ServerConfiguration.js
+++ b/PaintomicsClient/public_html/resources/ServerConfiguration.js
@@ -79,9 +79,18 @@ SERVER_URL_AI_GENERATE_EXP_DESIGN = SERVER_URL + "ai_generate_exp_design";
 SERVER_URL_AI_PROVIDER = SERVER_URL + "ai_provider";
 AI_POLL_INTERVAL = 3000;
 /* Polls before "Choose for me" gives up. The server caps one gateway batch at
-   180s (DEFAULT_BATCH_BUDGET_SECONDS) and a large job can run several, so this
-   has to outlast the server's own budget rather than race it. 100 x 3s = 5 min. */
-AI_SUGGEST_MAX_POLLS = 100;
+   180s (DEFAULT_BATCH_BUDGET_SECONDS) and nothing caps the number of batches --
+   a job with more than 30 residual names runs two or more, so 100 x 3s = 5 min
+   was SHORTER than the server's own worst case and the browser abandoned runs
+   that were still executing. PySiQ never enforces the timeout passed to
+   enqueue, so the worker would keep going with nobody left to collect. 400 x 3s
+   = 20 min covers six slow batches. */
+AI_SUGGEST_MAX_POLLS = 400;
+
+/* Consecutive dropped requests before the poll reports the transport error
+   rather than a timeout. Separate from the ceiling above: one blip must not end
+   a run, but a server that is down should say so. */
+AI_SUGGEST_MAX_TRANSPORT_FAILURES = 5;
 // How many consecutive unhandled refusals from /ai_interpret_status before the
 // widget gives up and says so. A refusal it recognises as permanent -- the job
 // no longer exists -- stops immediately and does not consume these; this is the

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -8798,7 +8798,7 @@ div.repDetectionCard h3 {
    chip on nearly every card, and a chip on everything is a chip on nothing.
    ========================================================================== */
 
-/* ---- The section header, and the control inside it ----------------------- */
+/* ---- The section header, and the AI offer beside it ---------------------- */
 
 /* The metabolite cards are laid out by `width: 49%` plus odd/even floats (see
    `.omicSummaryBox, .metaboliteBox` above). The card that INTRODUCES them was
@@ -8815,74 +8815,175 @@ div.repDetectionCard h3 {
 	margin-bottom: 14px;
 }
 
-/* Deliberately not in the step toolbar: those buttons act on the whole step
-   (go back, run, reset) and this one acts on the cards directly below it.
-
-   One left-aligned column, not two. Spread across the full width the button
-   sat about a thousand pixels from the sentence explaining it, on the far side
-   of a card whose middle was empty -- the two read as unrelated controls. A
-   button belongs next to its own words. */
-.aiSuggestActions {
-	margin: 18px var(--pa-card-inset) 4px var(--pa-card-inset);
-	padding-top: 16px;
-	border-top: 1px solid var(--pa-surface-quiet);
-}
-/* This block carries the card's inset on itself (the margin above), so its
-   children must not add it a second time -- `div.contentbox h3` and
-   `div.contentbox p` both pad by --pa-card-inset, which put this heading and
-   its line 26px right of the paragraph above them. The file already has this
-   category: "Blocks that supply their own inset ... opt out below."
-
-   The mark keeps hanging in the gutter through the existing
-   `div.contentbox h3 > svg.po-ai-mark:first-child` rule, so the heading's TEXT
-   lands on the same rail as the prose rather than 1em right of it. */
-.aiSuggestActions > .aiSuggestActionsTitle,
-.aiSuggestActions > .aiSuggestHint {
-	padding-left: 0;
-	padding-right: 0;
-}
-.aiSuggestActionsTitle {
-	margin: 0 0 2px 0;
-	font-size: 14px;
-	font-weight: 600;
-	color: var(--pa-ink-title, #222);
-}
-.aiSuggestHint {
-	margin: 0;
-	font-size: 13px;
-	line-height: 1.55;
-	color: var(--pa-ink-muted);
-	/* A measure, not a width: prose set the full width of this card runs to
-	   about 140 characters a line, roughly twice a readable line. */
-	max-width: 70ch;
-}
-/* dark.css sets every `p` inside a contentbox to body ink through
-   `[data-theme="dark"] #mainViewCenterPanel .contentbox div > p`, which
-   outranks a single class -- so in the dark theme this hint was rendering at
-   the same weight as the heading above it and the hierarchy collapsed.
-
-   Matched on specificity rather than forced with !important: this is secondary
-   text in both themes, and the token already knows what "secondary" means in
-   each of them. */
-#mainViewCenterPanel .contentbox .aiSuggestActions .aiSuggestHint {
-	color: var(--pa-ink-muted);
-}
-
-.aiSuggestActionsRow {
+/* Two columns: what the user has to do, and the offer to do it for them.
+   Neither half works alone at this width -- prose across 1360px runs to about
+   140 characters a line, and a lone button under it had no surface of its own
+   and nothing to balance against. */
+.compoundsIntroLayout {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 8px;
 	align-items: center;
-	margin-top: 12px;
+	justify-content: space-between;
+	/* No column gap. The two halves are 49% each and the gutter is the 2%
+	   `space-between` distributes -- which is exactly how the floated cards
+	   below make theirs. A 28px gap on top of 98% overflows the row and wraps
+	   the panel under the text. */
+	gap: 10px 0;
 }
-.aiSuggestActionsRow .button {
+/* 49%, which is exactly the column the metabolite cards below use (see
+   `.omicSummaryBox, .metaboliteBox`). The header then sits ON the grid it
+   introduces rather than beside it -- the alternative, letting these two size
+   themselves, gave either a 944px line of prose or a 528px pool of dead space
+   between the halves, both of which read as a layout accident. */
+.compoundsIntroText {
+	flex: 0 1 49%;
+	min-width: 0;
+}
+
+/* ---- The AI offer ------------------------------------------------------- */
+
+/* Its own surface, tinted with the application's AI colour. A control that
+   costs a gateway call and changes what the analysis is about should look
+   like a thing you decide to use, not like a link someone left in a paragraph.
+
+   color-mix keeps the tint honest in both themes: it is always the CURRENT
+   --pa-ai-blue over the CURRENT surface, so dark.css's lighter blue on its
+   near-black panel comes out at the same weight the light theme has. The plain
+   declarations before each one are the fallback for a browser without it. */
+.aiSuggestActions {
+	flex: 0 0 49%;
+	/* Its own two columns: what it is on the left, the control on the right.
+	   Inside a 49% panel they sit about 300px apart -- close enough to read as
+	   one offer, where the same split across the whole 1360px card had put a
+	   thousand pixels between a sentence and the button it describes. */
+	display: flex;
+	align-items: center;
+	gap: 18px;
+	margin: 2px 0;
+	padding: 15px 17px;
+	border-radius: var(--pa-radius);
+	background: var(--pa-surface-subtle);
+	background: color-mix(in srgb, var(--pa-ai-blue) 7%, var(--pa-surface));
+	border: 1px solid var(--pa-border);
+	border: 1px solid color-mix(in srgb, var(--pa-ai-blue) 26%, transparent);
+}
+
+/* A small-caps label rather than a sentence: the panel's job is to be
+   recognised, and the line under it does the explaining. Opted out of
+   `div.contentbox h3`'s padding, which would inset it from its own panel. */
+/* The `.aiSuggestActionsBody >` prefix is load bearing twice over. `div.contentbox
+   h3` is one class and two elements, which outranks a bare class, so `padding: 0`
+   lost and the label carried the CARD's 26px inset inside its own panel. And the
+   parent has to be named correctly: written as `.aiSuggestActions >` it matched
+   nothing at all once the panel gained its body wrapper, and the label silently
+   fell all the way back to the card's h3 -- dark grey, 13.5px, not the AI colour
+   and not small caps. */
+.aiSuggestActionsBody > .aiSuggestActionsTitle {
+	display: flex;
+	align-items: center;
+	gap: 7px;
+	margin: 0 0 7px 0;
+	padding: 0;
+	font-size: 11.5px;
+	font-weight: 700;
+	letter-spacing: 0.07em;
+	text-transform: uppercase;
+	color: var(--pa-ai-blue);
+}
+/* `:first-child` is here to outscore `div.contentbox h3 > svg.po-ai-mark:first-child`,
+   which hangs the mark a full em into the gutter. That is right for a heading
+   inside a card, whose gutter is the card's 26px inset -- and wrong here, where
+   the gutter is this panel's 17px padding and the mark would hang past its own
+   border. Without it the mark sat outside the tinted surface. */
+.aiSuggestActionsBody > .aiSuggestActionsTitle > svg.po-ai-mark:first-child {
+	width: 15px;
+	height: 15px;
+	margin-left: 0;
+}
+.aiSuggestActionsBody > .aiSuggestHint {
 	margin: 0;
+	padding: 0;
+	font-size: 12.5px;
+	line-height: 1.5;
+	color: var(--pa-ink-muted);
+}
+
+.aiSuggestActionsBody {
+	flex: 1 1 auto;
+	min-width: 0;
+}
+.aiSuggestActionsRow {
+	display: flex;
+	align-items: stretch;
+	gap: 8px;
+	flex: 0 0 auto;
+}
+/* `.button` floats right and carries side margins, which inside a flex row
+   would put the primary and its Undo in the wrong order with a gap nobody
+   asked for. */
+.aiSuggestActionsRow > .button {
+	float: none;
+	margin: 0;
+}
+
+/* The primary. Fills the panel it lives in, so it reads as the panel's action
+   rather than as a button that happens to be nearby. --pa-ai-action-bg is the
+   fill the rest of the application already uses for an AI call to action, and
+   is deliberately NOT re-themed: it carries white text. */
+#aiSuggestButton {
+	flex: 0 0 auto;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 8px;
+	padding: 11px 20px;
+	/* Fits the longest label this button takes ("Choosing...") without
+	   resizing. Left to size itself it grew and shrank between the three
+	   states, and the paragraph beside it reflowed from two lines to one and
+	   back on every click. */
+	min-width: 172px;
+	font-size: 13.5px;
+	font-weight: 600;
+	color: #FFFFFF;
+	background-color: var(--pa-ai-action-bg);
+	border-color: var(--pa-ai-action-bg);
+	box-shadow: var(--pa-shadow);
+}
+#aiSuggestButton:hover {
+	color: #FFFFFF;
+	background-color: var(--pa-ai-action-bg-hover);
+	border-color: var(--pa-ai-action-bg-hover);
+}
+#aiSuggestButton svg.po-ai-mark {
+	width: 16px;
+	height: 16px;
+	color: inherit;
 }
 /* Anchors, so `disabled` does nothing; pointer-events is what stops a second
    click while the gateway is answering. */
 #aiSuggestButton.aiWorking {
 	opacity: 0.72;
 	pointer-events: none;
+}
+
+/* Undo is an escape hatch, not a second offer: icon only, quiet, and it keeps
+   its meaning through the tooltip. Giving it equal weight would ask the user
+   to choose between two buttons when only one of them is the point. */
+#aiUndoButton {
+	flex: 0 0 auto;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	min-width: 38px;
+	padding: 10px 12px;
+	color: var(--pa-ink-control, #3F3F46);
+	background-color: transparent;
+	border-color: var(--pa-border);
+}
+#aiUndoButton:hover {
+	color: var(--pa-ink-title, #222);
+	background-color: var(--pa-surface);
+	border-color: var(--pa-ink-muted);
 }
 
 /* ---- What happened, once it has run ------------------------------------- */
@@ -8974,4 +9075,21 @@ div.repDetectionCard h3 {
 	.contentbox.metaboliteBox.aiBox-unsure {
 		animation: none;
 	}
+}
+
+/* The jump from an omic's mapping summary down to the compound cards. Sits
+   under the mapped/unmapped caption, on the caption's own centre line. */
+.mappingSummaryJump {
+	text-align: center;
+	font-size: 12px;
+	padding-bottom: 6px;
+}
+.mappingSummaryJump > a {
+	color: var(--pa-link);
+	text-decoration: none;
+	border-bottom: 1px solid transparent;
+}
+.mappingSummaryJump > a:hover {
+	color: var(--pa-link-hover);
+	border-bottom-color: currentColor;
 }

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -8817,28 +8817,33 @@ div.repDetectionCard h3 {
 
 /* Deliberately not in the step toolbar: those buttons act on the whole step
    (go back, run, reset) and this one acts on the cards directly below it.
-   Here there is also room to say what it does before it is pressed.
 
-   Two columns at full width: what it does on the left, the control on the
-   right, sharing one baseline band. It wraps to a stack below 720px, where two
-   columns would leave the text at about 30 characters a line. */
+   One left-aligned column, not two. Spread across the full width the button
+   sat about a thousand pixels from the sentence explaining it, on the far side
+   of a card whose middle was empty -- the two read as unrelated controls. A
+   button belongs next to its own words. */
 .aiSuggestActions {
-	display: flex;
-	flex-wrap: wrap;
-	align-items: center;
-	justify-content: space-between;
-	gap: 12px 32px;
 	margin: 18px var(--pa-card-inset) 4px var(--pa-card-inset);
 	padding-top: 16px;
 	border-top: 1px solid var(--pa-surface-quiet);
 }
-.aiSuggestActionsText {
-	flex: 1 1 26rem;
-	min-width: 0;
+/* This block carries the card's inset on itself (the margin above), so its
+   children must not add it a second time -- `div.contentbox h3` and
+   `div.contentbox p` both pad by --pa-card-inset, which put this heading and
+   its line 26px right of the paragraph above them. The file already has this
+   category: "Blocks that supply their own inset ... opt out below."
+
+   The mark keeps hanging in the gutter through the existing
+   `div.contentbox h3 > svg.po-ai-mark:first-child` rule, so the heading's TEXT
+   lands on the same rail as the prose rather than 1em right of it. */
+.aiSuggestActions > .aiSuggestActionsTitle,
+.aiSuggestActions > .aiSuggestHint {
+	padding-left: 0;
+	padding-right: 0;
 }
 .aiSuggestActionsTitle {
-	margin: 0 0 5px 0;
-	font-size: 15px;
+	margin: 0 0 2px 0;
+	font-size: 14px;
 	font-weight: 600;
 	color: var(--pa-ink-title, #222);
 }
@@ -8848,8 +8853,8 @@ div.repDetectionCard h3 {
 	line-height: 1.55;
 	color: var(--pa-ink-muted);
 	/* A measure, not a width: prose set the full width of this card runs to
-	   about 140 characters a line, which is roughly twice a readable line. */
-	max-width: 78ch;
+	   about 140 characters a line, roughly twice a readable line. */
+	max-width: 70ch;
 }
 /* dark.css sets every `p` inside a contentbox to body ink through
    `[data-theme="dark"] #mainViewCenterPanel .contentbox div > p`, which
@@ -8868,7 +8873,7 @@ div.repDetectionCard h3 {
 	flex-wrap: wrap;
 	gap: 8px;
 	align-items: center;
-	flex: 0 0 auto;
+	margin-top: 12px;
 }
 .aiSuggestActionsRow .button {
 	margin: 0;
@@ -8898,10 +8903,11 @@ div.repDetectionCard h3 {
 	color: var(--pa-ink-body, #333);
 }
 .aiSuggestSummaryMark {
+	display: inline-flex;
 	color: var(--pa-ai-blue);
-	/* Baseline alignment puts an icon slightly high against 15px text. */
+	/* Baseline alignment puts the mark slightly high against 15px text. */
 	position: relative;
-	top: 1px;
+	top: 2px;
 }
 /* Which model answered, and that its answers were checked. Available to a
    reader who wants it rather than announced to one who does not. */

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -8777,3 +8777,195 @@ div.repDetectionCard h3 {
   color: inherit;
   font-weight: 700;
 }
+
+/* ==========================================================================
+   Step 2 - "Choose for me" (AI compound disambiguation)
+
+   Built entirely from tokens dark.css already redefines, so the theme follows
+   without a single [data-theme] rule here.
+
+   The one idea this styling has to carry: after the button runs, you should be
+   able to tell at a glance WHAT touched each card. Three states, three colours,
+   and they are not interchangeable --
+
+     Auto       --pa-ink-muted     a name-matching rule; no model was involved,
+                                   so it must not wear the AI colour
+     AI         --pa-ai-blue       the application's one AI colour, shared with
+                                   the mark, the consent block and the widget
+     AI unsure  --pa-accent-orange the model declined; this one is still yours
+
+   Cards the run did not change carry no mark at all. Badging those too put a
+   chip on nearly every card, and a chip on everything is a chip on nothing.
+   ========================================================================== */
+
+/* ---- The section header, and the control inside it ----------------------- */
+
+/* The metabolite cards are laid out by `width: 49%` plus odd/even floats (see
+   `.omicSummaryBox, .metaboliteBox` above). The card that INTRODUCES them was
+   picking that up as well, so the section opened with a half-width block of
+   prose and an empty half-row beside it. It is a header, not a card in the
+   grid: it takes the row.
+
+   `min-height` is reset for the same reason -- 230px is a floor that keeps two
+   side-by-side cards even, and this one has nothing beside it. */
+.contentbox.omicSummaryBox.compoundsIntroBox {
+	float: none;
+	width: 100%;
+	min-height: 0;
+	margin-bottom: 14px;
+}
+
+/* Deliberately not in the step toolbar: those buttons act on the whole step
+   (go back, run, reset) and this one acts on the cards directly below it.
+   Here there is also room to say what it does before it is pressed.
+
+   Two columns at full width: what it does on the left, the control on the
+   right, sharing one baseline band. It wraps to a stack below 720px, where two
+   columns would leave the text at about 30 characters a line. */
+.aiSuggestActions {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px 32px;
+	margin: 18px var(--pa-card-inset) 4px var(--pa-card-inset);
+	padding-top: 16px;
+	border-top: 1px solid var(--pa-surface-quiet);
+}
+.aiSuggestActionsText {
+	flex: 1 1 26rem;
+	min-width: 0;
+}
+.aiSuggestActionsTitle {
+	margin: 0 0 5px 0;
+	font-size: 15px;
+	font-weight: 600;
+	color: var(--pa-ink-title, #222);
+}
+.aiSuggestHint {
+	margin: 0;
+	font-size: 13px;
+	line-height: 1.55;
+	color: var(--pa-ink-muted);
+	/* A measure, not a width: prose set the full width of this card runs to
+	   about 140 characters a line, which is roughly twice a readable line. */
+	max-width: 78ch;
+}
+/* dark.css sets every `p` inside a contentbox to body ink through
+   `[data-theme="dark"] #mainViewCenterPanel .contentbox div > p`, which
+   outranks a single class -- so in the dark theme this hint was rendering at
+   the same weight as the heading above it and the hierarchy collapsed.
+
+   Matched on specificity rather than forced with !important: this is secondary
+   text in both themes, and the token already knows what "secondary" means in
+   each of them. */
+#mainViewCenterPanel .contentbox .aiSuggestActions .aiSuggestHint {
+	color: var(--pa-ink-muted);
+}
+
+.aiSuggestActionsRow {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	align-items: center;
+	flex: 0 0 auto;
+}
+.aiSuggestActionsRow .button {
+	margin: 0;
+}
+/* Anchors, so `disabled` does nothing; pointer-events is what stops a second
+   click while the gateway is answering. */
+#aiSuggestButton.aiWorking {
+	opacity: 0.72;
+	pointer-events: none;
+}
+
+/* ---- What happened, once it has run ------------------------------------- */
+
+.contentbox.aiSuggestSummary {
+	margin: 5px 0 14px 0;
+	padding: 15px var(--pa-card-inset);
+	border-left: 3px solid var(--pa-ai-blue);
+	background: var(--pa-surface-subtle);
+	clear: both;
+}
+.aiSuggestSummaryHead {
+	display: flex;
+	align-items: baseline;
+	gap: 9px;
+	font-size: 15px;
+	line-height: 1.5;
+	color: var(--pa-ink-body, #333);
+}
+.aiSuggestSummaryMark {
+	color: var(--pa-ai-blue);
+	/* Baseline alignment puts an icon slightly high against 15px text. */
+	position: relative;
+	top: 1px;
+}
+/* Which model answered, and that its answers were checked. Available to a
+   reader who wants it rather than announced to one who does not. */
+.aiSuggestModel {
+	margin-top: 7px;
+	font-size: 12px;
+	line-height: 1.5;
+	color: var(--pa-ink-muted);
+}
+
+/* ---- Per-card provenance ------------------------------------------------- */
+
+.aiBadge {
+	display: inline-block;
+	margin-left: 8px;
+	padding: 1px 8px;
+	border: 1px solid currentColor;
+	border-radius: 10px;
+	font-size: 11px;
+	font-weight: normal;
+	/* Fixed line-height and inline-block so a metabolite name wrapping to two
+	   lines cannot stretch the chip with it. */
+	line-height: 16px;
+	white-space: nowrap;
+	vertical-align: middle;
+	cursor: help;
+}
+.aiBadge .fa {
+	font-size: 10px;
+	margin-right: 3px;
+}
+.aiBadge-auto   { color: var(--pa-ink-muted); }
+.aiBadge-ai     { color: var(--pa-ai-blue); }
+.aiBadge-unsure { color: var(--pa-accent-orange); }
+
+/* A 3px rail, so the state is readable while scanning a column of cards and
+   not only when reading one. */
+.contentbox.metaboliteBox.aiBox-auto   { border-left: 3px solid var(--pa-ink-muted); }
+.contentbox.metaboliteBox.aiBox-ai     { border-left: 3px solid var(--pa-ai-blue); }
+.contentbox.metaboliteBox.aiBox-unsure { border-left: 3px solid var(--pa-accent-orange); }
+
+/* The one candidate the machine is responsible for. A card can show several
+   ticked-looking rows, so "which row" is said rather than left to the box. */
+.metaboliteCompound.aiPickedCandidate > a {
+	font-weight: 600;
+	color: var(--pa-ai-blue);
+}
+
+/* One quiet reveal on the cards that moved. The panel is rebuilt wholesale, so
+   this runs once per apply and never on the cards left alone -- which is the
+   point: the motion is the answer to "what just changed?". */
+@keyframes aiCardSettle {
+	from { background-color: var(--pa-surface-subtle); }
+	to   { background-color: transparent; }
+}
+.contentbox.metaboliteBox.aiBox-auto,
+.contentbox.metaboliteBox.aiBox-ai,
+.contentbox.metaboliteBox.aiBox-unsure {
+	animation: aiCardSettle 900ms ease-out 1;
+}
+@media (prefers-reduced-motion: reduce) {
+	.contentbox.metaboliteBox.aiBox-auto,
+	.contentbox.metaboliteBox.aiBox-ai,
+	.contentbox.metaboliteBox.aiBox-unsure {
+		animation: none;
+	}
+}

--- a/PaintomicsServer/src/classes/CompoundDisambiguation/__init__.py
+++ b/PaintomicsServer/src/classes/CompoundDisambiguation/__init__.py
@@ -1,0 +1,36 @@
+#***************************************************************
+#  This file is part of Paintomics v4
+#
+#  Paintomics is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as
+#  published by the Free Software Foundation, either version 3 of
+#  the License, or (at your option) any later version.
+#
+#  Paintomics is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  More info http://bioinfo.cipf.es/paintomics
+#  Technical contact paintomicsai@gmail.com
+#**************************************************************
+"""Deciding which KEGG compound a metabolite name in a user's file meant.
+
+Step 1 maps a metabolite name to KEGG by case-insensitive SUBSTRING match, so
+"Glucose" arrives at step 2 carrying 113 candidates and "Alanine" carrying 105.
+Step 2 asks the user to tick the right ones. This package answers that question
+for them, in two tiers:
+
+  * :mod:`.ranker` -- deterministic. Reproducible, needs no network, and on the
+    STATegra metabolomics example it settles 31 of the 46 ambiguous names.
+  * :mod:`.resolver` -- the residual, put to an LLM as a CLOSED-SET choice: the
+    model may only answer with one of the KEGG ids it was shown, and an answer
+    outside that set is rejected rather than applied.
+
+Neither tier writes to the job. Both return advice; the user confirms it, and
+``pathwayAcquisitionStep2`` remains the only thing that ever stores a
+selection.
+"""

--- a/PaintomicsServer/src/classes/CompoundDisambiguation/prompts.py
+++ b/PaintomicsServer/src/classes/CompoundDisambiguation/prompts.py
@@ -1,0 +1,183 @@
+#***************************************************************
+#  This file is part of Paintomics v4
+#
+#  Paintomics is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as
+#  published by the Free Software Foundation, either version 3 of
+#  the License, or (at your option) any later version.
+#
+#  Paintomics is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  More info http://bioinfo.cipf.es/paintomics
+#  Technical contact paintomicsai@gmail.com
+#**************************************************************
+"""What the model is shown, and the shape it must answer in.
+
+The task is a CLOSED-SET choice. Each set arrives with its candidate KEGG ids
+listed, and the only legal answers are one of those ids or an abstention. The
+prompt says so, the schema says so, and :func:`resolver.validateChoice` enforces
+it -- an id outside the set is dropped, not applied. That is deliberate
+belt-and-braces: a prompt is a request, and the analysis a user publishes should
+not depend on a model having honoured one.
+"""
+
+#: Cap on how many of the file's other metabolite names go into the context.
+#: The panel is the single most informative thing available when no experiment
+#: design was written -- 58 amino acids and TCA intermediates identify
+#: themselves as primary metabolism without anyone saying so -- but a 6,592-name
+#: job would otherwise fill the whole prompt with it.
+MAX_PANEL_NAMES = 120
+
+#: Free-text the user wrote. Trimmed rather than trusted: it is theirs, it is
+#: unbounded, and it is not worth a truncated candidate list.
+MAX_DESIGN_CHARS = 1200
+
+
+SYSTEM_PROMPT = (
+    "You are a metabolomics data curator mapping the compound names in an "
+    "uploaded table to KEGG COMPOUND identifiers.\n"
+    "\n"
+    "For each input name you are given the candidate KEGG compounds it matched. "
+    "Choose the one the experiment most likely measured, or abstain.\n"
+    "\n"
+    "Rules:\n"
+    "1. Answer only with a kegg_id that appears in that input name's own "
+    "candidate list. Never invent one, and never borrow one from another "
+    "input name.\n"
+    "2. Use the organism. L-amino acids are the proteinogenic forms in "
+    "animals, plants and fungi. D-amino acids are largely bacterial "
+    "(peptidoglycan D-Ala and D-Glu) or confined to specific pathways, so in a "
+    "mammalian or plant sample an unqualified amino-acid name means the L- "
+    "form.\n"
+    "3. Prefer a specific form over an unspecified generic entry when the "
+    "biology is not in doubt: for a mouse sample, 'Alanine' is L-Alanine, not "
+    "the generic 'Alanine' entry.\n"
+    "4. Never choose between alpha and beta anomers unless the input name "
+    "states one. If a sugar's candidates differ only by anomer, abstain.\n"
+    "5. Abstain whenever more than one candidate is genuinely plausible for "
+    "this organism and this experiment. Abstaining is correct and expected; a "
+    "confident wrong compound silently changes which pathways the user's "
+    "analysis reports.\n"
+    "\n"
+    "To abstain, set kegg_id to \"ABSTAIN\". Give one short reason for every "
+    "answer, naming the organism or the evidence you used. Return one entry "
+    "per input name you were given, in the same order."
+)
+
+
+#: Strict JSON schema for the batch answer. `confidence` is an enum rather than
+#: a number because a model asked for 0-1 returns 0.9 for everything, and a
+#: threshold on that is a threshold on nothing.
+CHOICE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "choices": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "input_name": {"type": "string"},
+                    "kegg_id": {"type": "string"},
+                    "confidence": {"type": "string",
+                                   "enum": ["high", "medium", "low"]},
+                    "reason": {"type": "string"},
+                },
+                "required": ["input_name", "kegg_id", "confidence", "reason"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["choices"],
+    "additionalProperties": False,
+}
+
+
+def _trim(text, limit):
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + " [...]"
+
+
+def buildContextBlock(context):
+    """What is known about the experiment, in the order it is worth reading.
+
+    Everything here is already on the job -- nothing new is asked of the user.
+    When no experiment design was written, the metabolite panel carries most of
+    the signal on its own.
+
+    @param {Dict} context, keys: organism, organismLabel, jobDescription,
+           experimentDesign, omics, panel
+    @returns {String}
+    """
+    lines = []
+
+    label = (context.get("organismLabel") or "").strip()
+    code = (context.get("organism") or "").strip()
+    if label and code and label.lower() != code.lower():
+        lines.append("Organism: %s (KEGG code %s)" % (label, code))
+    elif code:
+        # No display name is available server-side (organism names live in the
+        # browser's KEGG organism list, not in any collection this process
+        # reads), so the code is labelled as what it is rather than dropped in
+        # bare -- "mmu" alone reads like a column header.
+        lines.append("Organism: KEGG organism code %s" % code)
+    elif label:
+        lines.append("Organism: %s" % label)
+
+    omics = [o for o in (context.get("omics") or []) if o]
+    if omics:
+        lines.append("Omics uploaded: %s" % ", ".join(omics))
+
+    description = _trim(context.get("jobDescription"), 200)
+    if description:
+        lines.append("Job title: %s" % description)
+
+    design = _trim(context.get("experimentDesign"), MAX_DESIGN_CHARS)
+    if design:
+        lines.append("Experiment design, as the user described it:\n%s" % design)
+    else:
+        lines.append("Experiment design: not provided. Infer what you can from "
+                     "the organism and from the panel of metabolites below.")
+
+    panel = [name for name in (context.get("panel") or []) if name]
+    if panel:
+        shown = panel[:MAX_PANEL_NAMES]
+        suffix = "" if len(panel) <= MAX_PANEL_NAMES else \
+            " (and %d more)" % (len(panel) - MAX_PANEL_NAMES)
+        lines.append("All metabolite names in this file%s: %s"
+                     % (suffix, ", ".join(shown)))
+
+    return "\n".join(lines)
+
+
+def renderCandidates(decision):
+    """One residual set as the model sees it: the name, then its candidates."""
+    lines = ["Input name: %s" % decision["title"]]
+    for candidate in decision["candidates"]:
+        names = ", ".join(candidate["names"])
+        lines.append("  - %s: %s" % (candidate["keggID"], names))
+    return "\n".join(lines)
+
+
+def buildBatchPrompt(decisions, context):
+    """The user turn for one batch of residual compound sets.
+
+    @param {List} decisions, residual decisions from the ranker
+    @param {Dict} context, as accepted by :func:`buildContextBlock`
+    @returns {String}
+    """
+    header = buildContextBlock(context)
+    body = "\n\n".join(renderCandidates(decision) for decision in decisions)
+    return (
+        "%s\n\n"
+        "Choose one KEGG compound for each of the %d input names below, or "
+        "abstain. Only the ids listed under an input name are legal answers "
+        "for that name.\n\n"
+        "%s" % (header, len(decisions), body))

--- a/PaintomicsServer/src/classes/CompoundDisambiguation/ranker.py
+++ b/PaintomicsServer/src/classes/CompoundDisambiguation/ranker.py
@@ -1,0 +1,440 @@
+#***************************************************************
+#  This file is part of Paintomics v4
+#
+#  Paintomics is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as
+#  published by the Free Software Foundation, either version 3 of
+#  the License, or (at your option) any later version.
+#
+#  Paintomics is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  More info http://bioinfo.cipf.es/paintomics
+#  Technical contact paintomicsai@gmail.com
+#**************************************************************
+"""Tier 1: what can be settled about a compound set without asking a model.
+
+Measured on the STATegra metabolomics example (58 named metabolites, mmu), the
+rules below settle 29 of the 49 sets that draw a card and hand 20 to the model.
+They are ordered so that each one only fires when it leaves exactly one answer.
+
+One rule that looks obvious is deliberately absent: **exact name wins**. It is
+wrong, and quietly so. Measured against ``global-paintomics.kegg_compounds``:
+
+    "Alanine"     -> C01401  (the unspecified form), NOT C00041 L-Alanine
+    "Serine"      -> C00716 AND C00065, two ids with that literal name
+    "Malic acid"  -> C00149 AND C00711
+    "Lactic acid" -> C01432, not the L- form every animal pathway draws
+
+For three of those the species filter below rescues the answer, because the
+unspecified form is drawn on no mouse pathway. For "Alanine" it does not:
+C01401 *is* on mouse maps, so that name stays ambiguous and is escalated. A
+rule that had "resolved" it to C01401 would have produced a wrong compound with
+no symptom at all -- the analysis would simply have been about a different
+metabolite than the user measured.
+"""
+
+import logging
+
+from src.classes.FoundFeature import FoundFeature
+from src.common.CompoundNameSimilarity import nameSimilarity
+
+#: Upper bound on how many candidates one residual set carries into a prompt.
+#: "Glucose" reaches step 2 with 113; the ones that matter are always the main
+#: candidates the organism actually draws, and a longer list is prompt weight
+#: rather than information.
+MAX_CANDIDATES_IN_PROMPT = 12
+
+#: Cap on the ids one synonym lookup will fetch, so a pathological job cannot
+#: turn tier 1 into a full scan of a 92,974-document collection.
+MAX_SYNONYM_LOOKUP = 4000
+
+#: How many synonyms one candidate carries into a card or a prompt. C00031 has
+#: sixteen; the first few closest to what the user typed are what identify it,
+#: and the rest are prompt weight.
+MAX_NAMES_PER_CANDIDATE = 6
+
+
+def _isUninformativeName(name):
+    """Names in ``kegg_compounds`` that carry no chemistry.
+
+    The collection stores one document per (id, synonym) and includes the KEGG
+    accession repeated as its own name, plus ChEBI cross-references as
+    "chebi:4167" and as a bare "4167". Shown to a user or to a model these are
+    noise. They are dropped only when something else survives, because a
+    candidate must never end up with no name at all.
+    """
+    text = (name or "").strip()
+    if not text:
+        return True
+    if text.lower().startswith("chebi:"):
+        return True
+    if text.isdigit():
+        return True
+    # "C00031" stored as its own name.
+    return len(text) == 6 and text[0] in "CDG" and text[1:].isdigit()
+
+
+def _namesFor(compound, synonymsByID):
+    """Every name to score and show this candidate under.
+
+    Deliberately NOT split on commas. 6,581 names in ``kegg_compounds`` contain
+    one -- "1D-myo-Inositol 1,4-bisphosphate", and C04137 is stored as
+    "Arginine, N2-(1-carboxyethyl)-, L-". Splitting that last one produced a
+    synonym "Arginine", which then scored as a direct hit for an input of
+    "L-arginine" and pulled an unrelated compound into the choice.
+
+    ``mapCompoundsIdentifiers`` does join merged duplicates with ", ", so a
+    stored name genuinely can be two synonyms in one string. That ambiguity
+    cannot be resolved from the string, which is why the authoritative list is
+    fetched by KEGG id instead -- see :func:`loadCompoundSynonyms`.
+    """
+    names = []
+    for name in list(synonymsByID.get(compound.getID(), ())) + [compound.getName()]:
+        text = (name or "").strip()
+        if text and text not in names:
+            names.append(text)
+    return names
+
+
+def candidatesByKeggID(compoundSet, synonymsByID=None):
+    """Collapse a step-2 compound set into one entry per KEGG id.
+
+    The same KEGG id routinely appears several times inside one set -- once per
+    synonym that matched the input substring -- and the user is choosing
+    between COMPOUNDS, not between spellings.
+
+    ``isMain`` is taken from the bucket the mapper put the candidate in, not
+    from rescoring the name here. That is the load-bearing choice in this
+    module: ``mainCompounds`` is what step 2 pre-ticks and draws, so a ranker
+    that recomputed "main" and disagreed would offer to resolve a set the user
+    is not looking at. Recomputed similarity is used only to order the
+    candidates a residual set carries into the prompt.
+
+    @param compoundSet, a FoundFeature: getTitle/getMainCompounds/getOtherCompounds
+    @param {Dict} synonymsByID, optional keggID -> [names] taken from KEGG
+    @returns {Dict} keggID -> {"keggID", "names", "similarity", "isMain"}
+    """
+    title = compoundSet.getTitle() or ""
+    synonymsByID = synonymsByID or {}
+    byID = {}
+
+    buckets = ([(c, True) for c in compoundSet.getMainCompounds()] +
+               [(c, False) for c in compoundSet.getOtherCompounds()])
+
+    for compound, isMain in buckets:
+        keggID = (compound.getID() or "").strip()
+        if not keggID:
+            continue
+
+        entry = byID.setdefault(keggID, {"keggID": keggID, "names": [],
+                                         "similarity": 0.0, "isMain": False})
+        # A candidate landing in BOTH buckets (the same id matched under a
+        # close synonym and a distant one) counts as main: that is the bucket
+        # whose checkbox the user sees ticked.
+        entry["isMain"] = entry["isMain"] or isMain
+
+        for name in _namesFor(compound, synonymsByID):
+            if name not in entry["names"]:
+                entry["names"].append(name)
+            score = nameSimilarity(name, title)
+            if score > entry["similarity"]:
+                entry["similarity"] = score
+
+    for entry in byID.values():
+        informative = [n for n in entry["names"] if not _isUninformativeName(n)]
+        names = informative or entry["names"][:1]
+        # Closest spelling first. KEGG returns synonyms in insertion order, so
+        # without this C00065 introduces itself to the user as
+        # "L-2-Amino-3-hydroxypropionic acid" and C00077 as
+        # "(S)-2,5-Diaminovaleric acid" -- both correct, both useless next to a
+        # checkbox for an input that said "Serine" and "Ornithine".
+        entry["names"] = sorted(names, key=lambda n: -nameSimilarity(n, title))[:MAX_NAMES_PER_CANDIDATE]
+
+    return byID
+
+
+def _isSelected(compound):
+    """``selected`` as the model and the DAO each spell it."""
+    getter = getattr(compound, "isSelected", None)
+    if callable(getter):
+        return bool(getter())
+    return bool(getattr(compound, "selected", False))
+
+
+def needsDisambiguation(compoundSet):
+    """Whether step 2 draws a card for this set.
+
+    Mirrors ``PA_Step2CompoundSetView.needsDisambiguation`` in PA_Step2Views.js,
+    and has to: a set with no card is one the user cannot see, and changing its
+    ticks would move the analysis under them. Anything this returns False for is
+    left exactly as the mapper left it.
+    """
+    mainCompounds = compoundSet.getMainCompounds()
+    otherCompounds = compoundSet.getOtherCompounds()
+
+    if len(mainCompounds) + len(otherCompounds) == 0:
+        return False
+    if len(otherCompounds) > 0:
+        return True
+    return not (len(mainCompounds) == 1 and _isSelected(mainCompounds[0]))
+
+
+def _promptPool(byID, preferred):
+    """The candidates a set carries forward, best match first."""
+    ordered = sorted(preferred, key=lambda keggID: (-byID[keggID]["similarity"], keggID))
+    return [byID[keggID] for keggID in ordered[:MAX_CANDIDATES_IN_PROMPT]]
+
+
+def rankCompoundSet(compoundSet, onMapIDs, organismLabel="", synonymsByID=None):
+    """Decide one compound set, or report that it needs a model.
+
+    @param compoundSet, a FoundFeature carrying one input name's candidates
+    @param {Set} onMapIDs, KEGG compound ids drawn on any pathway of the job's
+           organism. Empty means "unknown", and the filter is then skipped
+           rather than applied as though nothing were on the map.
+    @param {String} organismLabel, for the human-readable reason string
+    @param {Dict} synonymsByID, optional keggID -> [names]
+    @returns {Dict} with "status" in {"skip", "resolved", "residual"}
+    """
+    title = compoundSet.getTitle() or ""
+
+    if not needsDisambiguation(compoundSet):
+        return {"title": title, "status": "skip",
+                "reason": "step 2 draws no card for this name"}
+
+    byID = candidatesByKeggID(compoundSet, synonymsByID)
+    if len(byID) == 0:
+        return {"title": title, "status": "skip", "reason": "nothing matched"}
+
+    if len(byID) == 1:
+        keggID = next(iter(byID))
+        return {"title": title, "status": "resolved", "keggID": keggID,
+                "tier": "deterministic", "candidates": _promptPool(byID, byID.keys()),
+                "reason": "the only KEGG compound this name matched"}
+
+    mainIDs = {k for k, v in byID.items() if v["isMain"]}
+
+    # Rule 1 -- exactly one main candidate. The rest are substring hits on a
+    # different compound ("UDP-glucose" for "Glucose") and were never ticked.
+    if len(mainIDs) == 1:
+        keggID = next(iter(mainIDs))
+        return {"title": title, "status": "resolved", "keggID": keggID,
+                "tier": "deterministic", "candidates": _promptPool(byID, byID.keys()),
+                "reason": "the only candidate whose name matches the one you uploaded"}
+
+    # Rule 2 -- exactly one main candidate this organism actually draws. A
+    # compound on no pathway of the species contributes nothing downstream, so
+    # dropping it cannot change a result except by removing a false positive.
+    if onMapIDs and mainIDs:
+        onMap = mainIDs & set(onMapIDs)
+        if len(onMap) == 1:
+            keggID = next(iter(onMap))
+            where = ("a %s pathway" % organismLabel) if organismLabel else "a pathway of this organism"
+            return {"title": title, "status": "resolved", "keggID": keggID,
+                    "tier": "deterministic", "candidates": _promptPool(byID, mainIDs),
+                    "reason": "the only matching candidate drawn on " + where}
+        if len(onMap) > 1:
+            mainIDs = onMap  # narrow what the model is asked to choose between
+
+    # What is left is a real judgement: L- against D-, an anomer, or a generic
+    # form competing with a specific one. That goes to the model.
+    preferred = mainIDs or set(byID.keys())
+    return {"title": title, "status": "residual", "tier": "residual",
+            "candidates": _promptPool(byID, preferred),
+            "reason": "%d candidates remain after the deterministic rules" % len(preferred)}
+
+
+def partitionCompoundSets(compoundSets, onMapIDs, organismLabel="", synonymsByID=None):
+    """Rank every set and split it into settled, needs-a-model, and no-card.
+
+    @returns {Tuple} (resolved, residual, skipped) lists of decision dicts
+    """
+    resolved, residual, skipped = [], [], []
+    for compoundSet in compoundSets:
+        decision = rankCompoundSet(compoundSet, onMapIDs, organismLabel, synonymsByID)
+        if decision["status"] == "resolved":
+            resolved.append(decision)
+        elif decision["status"] == "residual":
+            residual.append(decision)
+        else:
+            skipped.append(decision)
+    return resolved, residual, skipped
+
+
+def coerceCompoundSets(rawSets):
+    """Give every compound set the accessors this module expects.
+
+    A job carries its compound sets in two different shapes depending on how it
+    was reached, and only one of them has methods:
+
+      * straight from step 1, ``processFilesContent`` leaves real FoundFeature
+        objects in memory, with getTitle/getMainCompounds/getOtherCompounds;
+      * reopened from MongoDB, ``PathwayAcquisitionJobDAO.findByID`` loads them
+        through ``FoundFeatureDAO.findAll`` -- which is ``FeatureDAO.findAll``,
+        and that constructs a plain ``Feature("")`` regardless of subclass.
+        ``Feature.parseBSON`` then setattrs the stored document onto it, so the
+        object HAS ``title`` and ``mainCompounds``, but ``mainCompounds`` is a
+        list of raw dicts and ``getMainCompounds()`` does not exist at all.
+
+    The recover-job response survives that because it only ever calls toBSON()
+    on them, which round-trips the dicts untouched. Anything that actually reads
+    the candidates does not, which is how this surfaced: pressing "Choose for
+    me" on a job opened by its ?jobID= URL failed with
+
+        'Feature' object has no attribute 'getMainCompounds'
+
+    Normalising here rather than fixing the DAO is deliberate. FeatureDAO.findAll
+    is shared by every feature the application loads, and changing what it
+    returns to make one button work would be a change to the job-loading path
+    of the whole product for the sake of a feature that can adapt in nine lines.
+
+    @param {List} rawSets, whatever ``getFoundCompounds()`` returned
+    @returns {List} FoundFeature instances
+    """
+    coerced = []
+    for rawSet in (rawSets or []):
+        if hasattr(rawSet, "getMainCompounds"):
+            coerced.append(rawSet)
+            continue
+        coerced.append(_foundFeatureFromRecord(rawSet))
+    return coerced
+
+
+def _candidateFromRecord(record):
+    """One stored candidate as a Compound, tolerating a dict or an object."""
+    from src.classes.Feature import Compound
+
+    get = record.get if isinstance(record, dict) else (lambda key, default=None:
+                                                       getattr(record, key, default))
+    candidate = Compound(get("ID", "") or "")
+    candidate.setName(get("name", "") or "")
+    # `similarity` is persisted, and `selected` is not (it exists only in the
+    # browser). Carry what is there and let the ranker default the rest.
+    candidate.similarity = get("similarity", 0) or 0
+    selected = get("selected", None)
+    if selected is not None:
+        candidate.selected = bool(selected)
+    return candidate
+
+
+def _foundFeatureFromRecord(record):
+    """Rebuild a FoundFeature from the flat record a reopened job carries."""
+    get = record.get if isinstance(record, dict) else (lambda key, default=None:
+                                                       getattr(record, key, default))
+    found = FoundFeature(get("ID", "") or "")
+    found.setTitle(get("title", "") or "")
+    for candidate in (get("mainCompounds", None) or []):
+        found.addMainCompound(_candidateFromRecord(candidate))
+    for candidate in (get("otherCompounds", None) or []):
+        found.addOtherCompound(_candidateFromRecord(candidate))
+    return found
+
+
+def collectKeggIDs(compoundSets):
+    """Every KEGG id mentioned by these sets, for one batched synonym lookup."""
+    ids = set()
+    for compoundSet in compoundSets:
+        for compound in (list(compoundSet.getMainCompounds()) +
+                         list(compoundSet.getOtherCompounds())):
+            keggID = (compound.getID() or "").strip()
+            if keggID:
+                ids.add(keggID)
+    return ids
+
+
+def loadCompoundSynonyms(keggIDs):
+    """KEGG's own names for these compound ids, one query for all of them.
+
+    The stored candidate name is whichever synonym matched the user's substring,
+    which is rarely the clearest one -- C00031 can arrive named "Grape sugar".
+    This is what lets a card say "D-Glucose" and what gives the model the
+    synonym list it needs to tell an anomer from its parent.
+
+    Returns ``{}`` on any failure: the ranker then falls back to stored names,
+    which degrades wording and ordering but never correctness, because
+    ``isMain`` does not depend on this.
+
+    @param {Iterable} keggIDs
+    @returns {Dict} keggID -> [names]
+    """
+    keggIDs = list(keggIDs or ())[:MAX_SYNONYM_LOOKUP]
+    if not keggIDs:
+        return {}
+
+    handle = None
+    try:
+        from src.conf.serverconf import MONGODB_HOST, MONGODB_PORT
+        from src.common.DBmanager import getSharedClient, SharedClientHandle
+
+        client = getSharedClient(MONGODB_HOST, MONGODB_PORT)
+        handle = SharedClientHandle(client)
+        collection = client["global-paintomics"]["kegg_compounds"]
+
+        synonyms = {}
+        for document in collection.find({"id": {"$in": keggIDs}}, {"id": 1, "name": 1}):
+            name = (document.get("name") or "").strip()
+            if not name or _isUninformativeName(name):
+                continue
+            names = synonyms.setdefault(document["id"], [])
+            if name not in names:
+                names.append(name)
+        return synonyms
+    except Exception as ex:
+        logging.warning("COMPOUND DISAMBIGUATION - could not load KEGG synonyms "
+                        "(%s); falling back to the names stored on the job", ex)
+        return {}
+    finally:
+        if handle is not None:
+            try:
+                handle.close()
+            except Exception:
+                pass
+
+
+def loadOrganismCompoundIDs(organism):
+    """KEGG compound ids drawn on at least one pathway of ``organism``.
+
+    Read from the organism's own ``kegg`` collection, which stores one document
+    per pathway with a ``compounds`` list of ``{id, x, y, ...}`` entries. On any
+    failure this returns an empty set, and every caller treats empty as "no
+    species information" and skips the filter -- a missing organism database
+    must weaken the ranking, never silently narrow it to nothing.
+
+    @param {String} organism, a KEGG organism code such as "mmu"
+    @returns {FrozenSet} compound ids, possibly empty
+    """
+    if not organism:
+        return frozenset()
+
+    handle = None
+    try:
+        from src.common.KeggInformationManager import KeggInformationManager
+        handle, db = KeggInformationManager().getConnectionByOrganismCode(organism)
+
+        ids = set()
+        # Projected to the one field that is read: the compounds list also
+        # carries per-pathway pixel geometry, and a 1008-pathway organism would
+        # otherwise pull all of it across for nothing.
+        for pathway in db.kegg.find({}, {"compounds.id": 1}):
+            for compound in (pathway.get("compounds") or []):
+                keggID = compound.get("id")
+                if keggID:
+                    ids.add(keggID)
+        return frozenset(ids)
+    except Exception as ex:
+        logging.warning("COMPOUND DISAMBIGUATION - could not read the pathway "
+                        "compounds for organism %r (%s); the species filter is "
+                        "skipped for this request", organism, ex)
+        return frozenset()
+    finally:
+        if handle is not None:
+            try:
+                handle.close()
+            except Exception:
+                pass

--- a/PaintomicsServer/src/classes/CompoundDisambiguation/ranker.py
+++ b/PaintomicsServer/src/classes/CompoundDisambiguation/ranker.py
@@ -231,23 +231,27 @@ def rankCompoundSet(compoundSet, onMapIDs, organismLabel="", synonymsByID=None):
     # Rule 2 -- exactly one main candidate this organism actually draws. A
     # compound on no pathway of the species contributes nothing downstream, so
     # dropping it cannot change a result except by removing a false positive.
-    if onMapIDs and mainIDs:
-        onMap = mainIDs & set(onMapIDs)
-        if len(onMap) == 1:
+    # Applied to whichever pool this set actually has. Guarded on `mainIDs` it
+    # skipped the sets that need it MOST: a name where nothing scores 0.9 has
+    # only fuzzy substring hits, and those went to the model unfiltered --
+    # including compounds drawn on no pathway of the organism at all.
+    pool = mainIDs or set(byID.keys())
+    if onMapIDs:
+        onMap = pool & set(onMapIDs)
+        if len(onMap) == 1 and mainIDs:
             keggID = next(iter(onMap))
             where = ("a %s pathway" % organismLabel) if organismLabel else "a pathway of this organism"
             return {"title": title, "status": "resolved", "keggID": keggID,
-                    "tier": "deterministic", "candidates": _promptPool(byID, mainIDs),
+                    "tier": "deterministic", "candidates": _promptPool(byID, pool),
                     "reason": "the only matching candidate drawn on " + where}
         if len(onMap) > 1:
-            mainIDs = onMap  # narrow what the model is asked to choose between
+            pool = onMap  # narrow what the model is asked to choose between
 
     # What is left is a real judgement: L- against D-, an anomer, or a generic
     # form competing with a specific one. That goes to the model.
-    preferred = mainIDs or set(byID.keys())
     return {"title": title, "status": "residual", "tier": "residual",
-            "candidates": _promptPool(byID, preferred),
-            "reason": "%d candidates remain after the deterministic rules" % len(preferred)}
+            "candidates": _promptPool(byID, pool),
+            "reason": "%d candidates remain after the deterministic rules" % len(pool)}
 
 
 def partitionCompoundSets(compoundSets, onMapIDs, organismLabel="", synonymsByID=None):
@@ -363,7 +367,11 @@ def loadCompoundSynonyms(keggIDs):
     @param {Iterable} keggIDs
     @returns {Dict} keggID -> [names]
     """
-    keggIDs = list(keggIDs or ())[:MAX_SYNONYM_LOOKUP]
+    # Sorted before slicing: `collectKeggIDs` returns a set, and slicing one
+    # takes whatever order it happened to iterate in. Past the cap that gave a
+    # different subset of candidates their real names on every run, and so a
+    # different prompt -- which is the determinism TEMPERATURE = 0.0 is set for.
+    keggIDs = sorted(keggIDs or ())[:MAX_SYNONYM_LOOKUP]
     if not keggIDs:
         return {}
 

--- a/PaintomicsServer/src/classes/CompoundDisambiguation/resolver.py
+++ b/PaintomicsServer/src/classes/CompoundDisambiguation/resolver.py
@@ -121,6 +121,14 @@ def validateChoice(choice, decision):
         return {"outcome": "abstained", "keggID": None, "confidence": confidence,
                 "reason": reason, "detail": "the model abstained"}
 
+    # Matched case-insensitively. The ABSTAIN token already was, and a gateway
+    # that dropped response_format answers in free text, where "c00041" for
+    # C00041 is a formatting difference -- not the invented id this check is
+    # for. Rejecting it logged a real closed-set violation that never happened.
+    canonical = {cid.upper(): cid for cid in candidateIDs}
+    if keggID.upper() in canonical:
+        keggID = canonical[keggID.upper()]
+
     if keggID not in candidateIDs:
         # Either invented, or lifted from another input name in the same batch.
         # Both are the same failure from here: an id this name never matched.
@@ -229,7 +237,25 @@ def suggestCompounds(decisions, context, client=None, batchSize=DEFAULT_BATCH_SI
         return {"accepted": [], "abstained": [], "rejected": [], "model": "", "batches": 0}
 
     if client is None:
-        client = buildClient()
+        try:
+            client = buildClient()
+        except Exception as ex:
+            # A missing or malformed key, or a provider entry without an
+            # api_base: nothing here can run. That must not cost the caller the
+            # tier-1 decisions it already has, which needed no gateway at all --
+            # raising from here failed the whole queued job and the browser was
+            # told "AI compound selection failed" for a run that had already
+            # settled most of the sets by rule.
+            logging.warning("COMPOUND DISAMBIGUATION - job %s: no usable AI client "
+                            "(%s); leaving %d set(s) to the user", jobID, ex,
+                            len(decisions))
+            return {"accepted": [], "rejected": [],
+                    "abstained": [{"title": d["title"], "keggID": None,
+                                   "confidence": "", "reason": "",
+                                   "detail": "the AI service is not available",
+                                   "tier": "ai", "candidates": d.get("candidates", [])}
+                                  for d in decisions],
+                    "model": "", "batches": 0}
 
     from src.classes.AIInterpret.llm_client import json_schema_format
 
@@ -272,6 +298,16 @@ def suggestCompounds(decisions, context, client=None, batchSize=DEFAULT_BATCH_SI
     # The audit trail. Nothing about these choices is written to the job, so
     # the log is where "which compound did the model pick for job X, and what
     # did it refuse" is recoverable afterwards.
+    #
+    # The model identifier is named HERE and only here. It is deliberately kept
+    # out of the browser payload (the interface never names a build), which is
+    # exactly why it has to be recorded on this side -- otherwise "which model
+    # chose C00041 for job X" is answerable from nowhere at all.
+    logging.info("COMPOUND DISAMBIGUATION - job %s: %d batch(es) answered by %s "
+                 "(%d accepted, %d abstained, %d rejected)",
+                 jobID, batches, getattr(client, "model", "") or "unknown",
+                 len(accepted), len(abstained), len(rejected))
+
     for entry in accepted:
         logging.info("COMPOUND DISAMBIGUATION - job %s: %r -> %s (%s) %s",
                      jobID, entry["title"], entry["keggID"], entry["confidence"],

--- a/PaintomicsServer/src/classes/CompoundDisambiguation/resolver.py
+++ b/PaintomicsServer/src/classes/CompoundDisambiguation/resolver.py
@@ -1,0 +1,284 @@
+#***************************************************************
+#  This file is part of Paintomics v4
+#
+#  Paintomics is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as
+#  published by the Free Software Foundation, either version 3 of
+#  the License, or (at your option) any later version.
+#
+#  Paintomics is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  More info http://bioinfo.cipf.es/paintomics
+#  Technical contact paintomicsai@gmail.com
+#**************************************************************
+"""Tier 2: put the residual sets to a model as a closed-set choice.
+
+The contract, and the whole reason this module is separate from the prompt that
+states it:
+
+    An answer is applied only if it names a KEGG id that was in that input
+    name's own candidate list.
+
+:func:`validateChoice` is where that is enforced. It is a pure function over
+one answer and one decision, so the guarantee can be tested without a gateway,
+a job or a network. Everything it turns down -- an invented id, an id borrowed
+from a different input name in the same batch, a name that was never asked
+about, a low-confidence guess -- becomes an abstention, and an abstention leaves
+the user's existing ticks exactly as they were.
+
+Nothing here writes to the job. The return value is advice; the user confirms
+it, and ``pathwayAcquisitionStep2`` remains the only writer of a selection.
+"""
+
+import json
+import logging
+import re
+
+from src.classes.CompoundDisambiguation import prompts
+
+#: Residual sets per gateway call. Sets are independent, so this trades prompt
+#: size against round trips: the STATegra example's 18 residuals are one call,
+#: and a job whose residual list runs to hundreds is still a handful.
+DEFAULT_BATCH_SIZE = 30
+
+#: Wall clock for one batch, across every attempt and backoff. Someone is
+#: watching a spinner; this call must give up and say so rather than hold a
+#: queue slot until the gateway decides to.
+DEFAULT_BATCH_BUDGET_SECONDS = 180
+
+#: A selection that changes which pathways a user publishes should not change
+#: between two runs of the same job if it can be helped.
+TEMPERATURE = 0.0
+
+#: The literal the prompt tells the model to use when it will not choose.
+ABSTAIN_TOKEN = "ABSTAIN"
+
+
+def parseChoices(text):
+    """Pull the choices array out of a model reply.
+
+    The gateway honours ``response_format`` when it can and falls back to free
+    text when it cannot (``LLMClient.supports_schema``), so both shapes have to
+    parse. Anything unparseable yields an empty list, which the caller reports
+    as a batch that abstained rather than as a batch that succeeded.
+    """
+    body = (text or "").strip()
+    if not body:
+        return []
+
+    if body.startswith("```"):
+        body = "\n".join(line for line in body.split("\n")
+                         if not line.strip().startswith("```")).strip()
+
+    payload = None
+    try:
+        payload = json.loads(body)
+    except (ValueError, TypeError):
+        # A model that wrapped the object in prose. Take the outermost braces.
+        match = re.search(r"\{.*\}", body, re.DOTALL)
+        if match:
+            try:
+                payload = json.loads(match.group())
+            except (ValueError, TypeError):
+                payload = None
+
+    if isinstance(payload, list):
+        choices = payload
+    elif isinstance(payload, dict):
+        choices = payload.get("choices")
+    else:
+        choices = None
+
+    if not isinstance(choices, list):
+        return []
+    return [choice for choice in choices if isinstance(choice, dict)]
+
+
+def validateChoice(choice, decision):
+    """Decide whether one model answer may be applied to one compound set.
+
+    This is the closed-set gate. It never trusts ``kegg_id`` further than
+    membership of ``decision["candidates"]``.
+
+    @param {Dict} choice, one entry of the model's ``choices`` array
+    @param {Dict} decision, the residual decision the choice claims to answer
+    @returns {Dict} {"outcome": "accepted"|"abstained"|"rejected",
+                     "keggID", "confidence", "reason", "detail"}
+    """
+    candidateIDs = {candidate["keggID"] for candidate in decision.get("candidates", [])}
+
+    keggID = str(choice.get("kegg_id") or "").strip()
+    confidence = str(choice.get("confidence") or "").strip().lower()
+    reason = str(choice.get("reason") or "").strip()
+
+    if not keggID or keggID.upper() == ABSTAIN_TOKEN:
+        return {"outcome": "abstained", "keggID": None, "confidence": confidence,
+                "reason": reason, "detail": "the model abstained"}
+
+    if keggID not in candidateIDs:
+        # Either invented, or lifted from another input name in the same batch.
+        # Both are the same failure from here: an id this name never matched.
+        return {"outcome": "rejected", "keggID": None, "confidence": confidence,
+                "reason": reason,
+                "detail": "%s was not one of the candidates for %r"
+                          % (keggID, decision.get("title", ""))}
+
+    if confidence == "low":
+        return {"outcome": "abstained", "keggID": None, "confidence": confidence,
+                "reason": reason, "detail": "the model was not confident"}
+
+    return {"outcome": "accepted", "keggID": keggID, "confidence": confidence or "medium",
+            "reason": reason, "detail": ""}
+
+
+def _indexByTitle(decisions):
+    """Titles to decisions, so a reply can be matched by name rather than order."""
+    exact, lowered = {}, {}
+    for decision in decisions:
+        title = decision.get("title", "")
+        exact.setdefault(title, decision)
+        lowered.setdefault(title.strip().lower(), decision)
+    return exact, lowered
+
+
+def applyChoices(decisions, choices):
+    """Match a batch's answers to its questions and validate each one.
+
+    Answers are matched on ``input_name``, never on position: a model that
+    drops or reorders an entry would otherwise shift every later answer onto
+    the wrong metabolite -- the one failure mode in this whole feature that
+    produces confident, plausible, uniformly wrong output.
+
+    @returns {Tuple} (accepted, abstained, rejected) lists
+    """
+    exact, lowered = _indexByTitle(decisions)
+    answered = set()
+    accepted, abstained, rejected = [], [], []
+
+    for choice in choices:
+        name = str(choice.get("input_name") or "").strip()
+        decision = exact.get(name) or lowered.get(name.lower())
+        if decision is None:
+            rejected.append({"title": name, "detail": "no such input name in this batch"})
+            continue
+
+        title = decision["title"]
+        if title in answered:
+            rejected.append({"title": title, "detail": "answered twice in one batch"})
+            continue
+        answered.add(title)
+
+        verdict = validateChoice(choice, decision)
+        entry = {"title": title, "keggID": verdict["keggID"],
+                 "confidence": verdict["confidence"], "reason": verdict["reason"],
+                 "detail": verdict["detail"], "tier": "ai",
+                 "candidates": decision.get("candidates", [])}
+
+        if verdict["outcome"] == "accepted":
+            accepted.append(entry)
+        elif verdict["outcome"] == "rejected":
+            rejected.append(entry)
+        else:
+            abstained.append(entry)
+
+    # A set the model simply did not mention is an abstention, not a silent
+    # drop: it still needs to appear in the count the user is shown.
+    for decision in decisions:
+        if decision["title"] not in answered:
+            abstained.append({"title": decision["title"], "keggID": None,
+                              "confidence": "", "reason": "",
+                              "detail": "the model did not answer for this name",
+                              "tier": "ai", "candidates": decision.get("candidates", [])})
+
+    return accepted, abstained, rejected
+
+
+def _chunk(items, size):
+    for start in range(0, len(items), max(1, size)):
+        yield items[start:start + size]
+
+
+def buildClient():
+    """An LLMClient for the configured provider.
+
+    Raises ``MissingAPIKeyError`` when this deployment has no token, which the
+    servlet turns into "the button is unavailable" rather than into a failure
+    the user is asked to interpret.
+    """
+    from src.conf.serverconf import AI_LLM_PROVIDER, AI_PROVIDERS
+    from src.classes.AIInterpret.llm_client import LLMClient
+    return LLMClient(AI_PROVIDERS.get(AI_LLM_PROVIDER, {}), AI_LLM_PROVIDER)
+
+
+def suggestCompounds(decisions, context, client=None, batchSize=DEFAULT_BATCH_SIZE,
+                     budgetSeconds=DEFAULT_BATCH_BUDGET_SECONDS, jobID=""):
+    """Ask the model to choose for every residual set, batched.
+
+    @param {List} decisions, residual decisions from the ranker
+    @param {Dict} context, as accepted by :func:`prompts.buildContextBlock`
+    @param client, an LLMClient; built from configuration when omitted
+    @returns {Dict} {"accepted", "abstained", "rejected", "model", "batches"}
+    """
+    if not decisions:
+        return {"accepted": [], "abstained": [], "rejected": [], "model": "", "batches": 0}
+
+    if client is None:
+        client = buildClient()
+
+    from src.classes.AIInterpret.llm_client import json_schema_format
+
+    accepted, abstained, rejected = [], [], []
+    batches = 0
+
+    for batch in _chunk(decisions, batchSize):
+        batches += 1
+        messages = [
+            {"role": "system", "content": prompts.SYSTEM_PROMPT},
+            {"role": "user", "content": prompts.buildBatchPrompt(batch, context)},
+        ]
+        try:
+            # Streamed: a non-streamed request to the CSIC gateway is given
+            # about 120s before LiteLLM retries the backend itself, and a
+            # 30-set batch can outrun that.
+            reply = client.complete(
+                messages,
+                max_tokens=4096,
+                temperature=TEMPERATURE,
+                response_format=json_schema_format("compound_choices", prompts.CHOICE_SCHEMA),
+                stream=True,
+                budget_seconds=budgetSeconds)
+        except Exception as ex:
+            logging.warning("COMPOUND DISAMBIGUATION - batch of %d failed for job "
+                            "%s (%s); those names are left to the user",
+                            len(batch), jobID, ex)
+            for decision in batch:
+                abstained.append({"title": decision["title"], "keggID": None,
+                                  "confidence": "", "reason": "",
+                                  "detail": "the AI service could not be reached",
+                                  "tier": "ai", "candidates": decision.get("candidates", [])})
+            continue
+
+        batchAccepted, batchAbstained, batchRejected = applyChoices(batch, parseChoices(reply))
+        accepted.extend(batchAccepted)
+        abstained.extend(batchAbstained)
+        rejected.extend(batchRejected)
+
+    # The audit trail. Nothing about these choices is written to the job, so
+    # the log is where "which compound did the model pick for job X, and what
+    # did it refuse" is recoverable afterwards.
+    for entry in accepted:
+        logging.info("COMPOUND DISAMBIGUATION - job %s: %r -> %s (%s) %s",
+                     jobID, entry["title"], entry["keggID"], entry["confidence"],
+                     entry["reason"])
+    for entry in rejected:
+        logging.warning("COMPOUND DISAMBIGUATION - job %s: REJECTED an answer for "
+                        "%r: %s", jobID, entry.get("title", ""), entry.get("detail", ""))
+
+    return {"accepted": accepted, "abstained": abstained, "rejected": rejected,
+            "model": getattr(client, "model", ""), "batches": batches}

--- a/PaintomicsServer/src/classes/Feature.py
+++ b/PaintomicsServer/src/classes/Feature.py
@@ -19,7 +19,7 @@
 #**************************************************************
 
 from src.common.Util import Model
-from difflib import SequenceMatcher
+from src.common.CompoundNameSimilarity import nameSimilarity
 
 #**************************************************************
 # CLASS Feature
@@ -248,11 +248,14 @@ class Compound(Feature):
         self.similarity= 0
 
     def calculateSimilarity(self, other_name):
-        mainPrefixes = {"", "cis-","trans-","d-","l-","(s)-","alpha-","beta-","alpha-d-","beta-d-","alpha-l-","beta-l-"}
-        if self.getName().lower() == other_name.lower():
-            self.similarity = 1
-        elif self.getName().lower().replace(other_name.lower(), "") in mainPrefixes:
-            self.similarity = 0.9
-        else:
-            self.similarity = SequenceMatcher(a=self.getName().lower(), b=other_name.lower()).ratio()
+        """Score this candidate against the name the user uploaded, and keep it.
+
+        The arithmetic lives in :mod:`src.common.CompoundNameSimilarity` so
+        that the step-2 ranker, which rescores candidates read back out of
+        MongoDB, cannot disagree with the mapper about which candidates are
+        "main" ones. Setting ``self.similarity`` stays here: it is this
+        object's state, and JobController reads it off the wire to break ties
+        when two input names propose the same KEGG compound.
+        """
+        self.similarity = nameSimilarity(self.getName(), other_name)
         return self.similarity

--- a/PaintomicsServer/src/common/CompoundNameSimilarity.py
+++ b/PaintomicsServer/src/common/CompoundNameSimilarity.py
@@ -74,7 +74,3 @@ def nameSimilarity(candidateName, inputName):
         return MAIN_SIMILARITY_THRESHOLD
     return SequenceMatcher(a=candidate, b=query).ratio()
 
-
-def isMainCandidate(candidateName, inputName):
-    """Whether ``candidateName`` belongs in the main bucket for ``inputName``."""
-    return nameSimilarity(candidateName, inputName) >= MAIN_SIMILARITY_THRESHOLD

--- a/PaintomicsServer/src/common/CompoundNameSimilarity.py
+++ b/PaintomicsServer/src/common/CompoundNameSimilarity.py
@@ -1,0 +1,80 @@
+#***************************************************************
+#  This file is part of Paintomics v4
+#
+#  Paintomics is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as
+#  published by the Free Software Foundation, either version 3 of
+#  the License, or (at your option) any later version.
+#
+#  Paintomics is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  More info http://bioinfo.cipf.es/paintomics
+#  Technical contact paintomicsai@gmail.com
+#**************************************************************
+"""How close a KEGG compound name is to the name a user actually uploaded.
+
+Two callers have to agree on this number or step 2 contradicts itself:
+
+  * :meth:`src.classes.Feature.Compound.calculateSimilarity`, run once per
+    candidate while step 1 maps names. Its answer is what splits a matched
+    name's candidates into ``mainCompounds`` and ``otherCompounds``, and that
+    split is what the step-2 cards are drawn from.
+  * :mod:`src.classes.CompoundDisambiguation.ranker`, run again at step 2 when
+    the user asks for help. It scores candidates that were loaded back out of
+    MongoDB, where nothing guarantees a stored ``similarity`` survived a
+    reopen, so it recomputes rather than trusting the record.
+
+A ranker that scored "main" differently from the mapper would offer to resolve
+a set the user cannot see, or leave one it can. One function, imported twice.
+"""
+
+from difflib import SequenceMatcher
+
+#: Prefixes that do not change which compound is meant, only which form of it.
+#: A candidate whose name is the input plus one of these is treated as a direct
+#: hit rather than as a fuzzy one -- "L-Alanine" for an input of "Alanine".
+#:
+#: Note what this deliberately does NOT settle: it makes L-Alanine, D-Alanine
+#: and beta-Alanine all score 0.9 against "Alanine". They are three different
+#: metabolites, and choosing between them is exactly the judgement the ranker
+#: escalates rather than guesses.
+MAIN_PREFIXES = frozenset([
+    "", "cis-", "trans-", "d-", "l-", "(s)-", "alpha-", "beta-",
+    "alpha-d-", "beta-d-", "alpha-l-", "beta-l-",
+])
+
+#: At or above this, a candidate is a "main" compound: the same substance under
+#: a spelling the mapper recognises. Below it, an "other" -- a substring hit
+#: like "UDP-glucose" for "Glucose".
+MAIN_SIMILARITY_THRESHOLD = 0.9
+
+
+def nameSimilarity(candidateName, inputName):
+    """Score a KEGG candidate name against the name the user uploaded.
+
+    @param {String} candidateName, a name or synonym from ``kegg_compounds``
+    @param {String} inputName, the identifier as it appeared in the user's file
+    @returns {Float} 1.0 for an exact match, 0.9 for a main-prefix variant,
+             otherwise difflib's ratio in [0, 1]
+    """
+    candidate = (candidateName or "").lower()
+    query = (inputName or "").lower()
+
+    if candidate == query:
+        return 1.0
+    # `query` is guarded because "".replace("", "") returns the whole string,
+    # which would score every candidate 0.9 against an empty input name.
+    if query and candidate.replace(query, "") in MAIN_PREFIXES:
+        return MAIN_SIMILARITY_THRESHOLD
+    return SequenceMatcher(a=candidate, b=query).ratio()
+
+
+def isMainCandidate(candidateName, inputName):
+    """Whether ``candidateName`` belongs in the main bucket for ``inputName``."""
+    return nameSimilarity(candidateName, inputName) >= MAIN_SIMILARITY_THRESHOLD

--- a/PaintomicsServer/src/paintomicsserver.py
+++ b/PaintomicsServer/src/paintomicsserver.py
@@ -101,6 +101,10 @@ from src.servlets.AdminServlet import (
     adminServletSystemInformation,
     clearFailedData,
 )
+from src.servlets.CompoundSuggestionServlet import (
+    compoundSuggestionInitiate,
+    compoundSuggestionStatus,
+)
 from src.servlets.AIInterpretServlet import (
     aiGenerateExpDesign,
     aiInterpretChat,
@@ -675,6 +679,17 @@ class Application(object):
         @self.app.route(SERVER_SUBDOMAIN + '/pa_step2', methods=['OPTIONS', 'POST'])
         def pathwayAcquisitionStep2Handler():
             return pathwayAcquisitionStep2_PART1(request, Response(), self.queue, self.ROOT_DIRECTORY).getResponse()
+
+        # Step 2's "Choose for me" button. Enqueue-and-poll rather than one
+        # blocking call: uWSGI runs this site on four threads, so a route that
+        # waits on the LLM gateway would take a quarter of the site with it.
+        @self.app.route(SERVER_SUBDOMAIN + '/pa_suggest_compounds', methods=['OPTIONS', 'POST'])
+        def compoundSuggestionInitiateHandler():
+            return compoundSuggestionInitiate(request, Response(), self.queue).getResponse()
+
+        @self.app.route(SERVER_SUBDOMAIN + '/pa_suggest_compounds_status', methods=['OPTIONS', 'POST'])
+        def compoundSuggestionStatusHandler():
+            return compoundSuggestionStatus(request, Response(), self.queue).getResponse()
         #*******************************************************************************************
         # STEP 3 HANDLERS
         #*******************************************************************************************

--- a/PaintomicsServer/src/resources/example_serverconf.py
+++ b/PaintomicsServer/src/resources/example_serverconf.py
@@ -176,6 +176,13 @@ EMAIL_REPORT_RECIPIENTS = [
 # ========== AI INTERPRETATION ==========
 AI_INTERPRETATION_ENABLED = os.getenv("AI_INTERPRETATION_ENABLED", "true").lower() == "true"
 
+# Step 2's "Choose for me" button. Separate from AI_INTERPRETATION_ENABLED so a
+# deployment can offer compound disambiguation without the literature pipeline
+# or the other way round -- they cost very differently (one short batched call
+# against a multi-phase run with PubMed retrieval). Both must be on for the
+# button to appear; AI_INTERPRETATION_ENABLED remains the master switch.
+AI_COMPOUND_SUGGESTIONS_ENABLED = os.getenv("AI_COMPOUND_SUGGESTIONS_ENABLED", "true").lower() == "true"
+
 # AI-assisted conversion of uploaded files. Ships inert: it spends gateway
 # quota that is shared with AI report generation, so a deployment opts in.
 AI_INPUT_CONVERTER = os.getenv("AI_INPUT_CONVERTER", "false").lower() == "true"

--- a/PaintomicsServer/src/servlets/CompoundSuggestionServlet.py
+++ b/PaintomicsServer/src/servlets/CompoundSuggestionServlet.py
@@ -136,7 +136,7 @@ def runCompoundSuggestion(jobID):
     # see coerceCompoundSets for why that is normalised here.
     compoundSets = ranker.coerceCompoundSets(jobInstance.getFoundCompounds())
     if not compoundSets:
-        return {"decisions": [], "unresolved": [], "model": "",
+        return {"decisions": [], "unresolved": [],
                 "stats": {"deterministic": 0, "ai": 0, "unresolved": 0, "rejected": 0}}
 
     organism = jobInstance.getOrganism()
@@ -166,10 +166,13 @@ def runCompoundSuggestion(jobID):
                    "candidates": entry.get("candidates", [])}
                   for entry in suggestions["abstained"]]
 
+    # The model identifier is deliberately NOT in this payload. The interface
+    # never names a specific build (see PA_Step1Views on the consent copy), and
+    # the surest way to keep it that way is not to hand the browser the string.
+    # It stays in the server log, where the audit trail wants it.
     return {
         "decisions": decisions,
         "unresolved": unresolved,
-        "model": suggestions.get("model", ""),
         "stats": {
             "deterministic": len(resolved),
             "ai": len(suggestions["accepted"]),

--- a/PaintomicsServer/src/servlets/CompoundSuggestionServlet.py
+++ b/PaintomicsServer/src/servlets/CompoundSuggestionServlet.py
@@ -1,0 +1,270 @@
+#***************************************************************
+#  This file is part of Paintomics v4
+#
+#  Paintomics is free software: you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License as
+#  published by the Free Software Foundation, either version 3 of
+#  the License, or (at your option) any later version.
+#
+#  Paintomics is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Paintomics.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  More info http://bioinfo.cipf.es/paintomics
+#  Technical contact paintomicsai@gmail.com
+#**************************************************************
+"""The "Choose for me" button behind step 2's compound cards.
+
+Two routes, enqueue-and-poll rather than one blocking call. That is not
+politeness: uWSGI serves this whole site with ``processes=1 threads=4``, so a
+route that waits on the LLM gateway takes a quarter of the site's capacity with
+it, and four concurrent clicks are an outage. The work goes on the same
+in-process queue every other long step uses, and the browser polls.
+
+Nothing here writes to the job. The response is advice the user can accept,
+adjust or ignore; ``pathwayAcquisitionStep2`` remains the only thing that ever
+stores a compound selection.
+"""
+
+import logging
+
+from src.common.JobInformationManager import JobInformationManager
+from src.common.PySiQ import JobStatus
+from src.common.UserSessionManager import UserSessionManager
+from src.classes.CompoundDisambiguation import ranker, resolver
+from src.servlets.AIInterpretServlet import _requireJobAccess, getAIProviderInfo
+# serverconf.py is gitignored: it is generated once per deployment from
+# resources/example_serverconf.py and then never overwritten. Deploying this
+# code to a server that already has one therefore lands a serverconf without
+# this setting, and a plain `from ... import` would ImportError the whole
+# application at startup over a feature flag. Default on, matching the template.
+try:
+    from src.conf.serverconf import AI_COMPOUND_SUGGESTIONS_ENABLED
+except ImportError:
+    AI_COMPOUND_SUGGESTIONS_ENABLED = True
+
+from src.common.ServerErrorManager import handleException
+
+#: Queue ids are namespaced so a suggestion run and the step-2 run it advises
+#: can never collide on the same job.
+QUEUE_PREFIX = "cs_"
+
+
+def _queueID(jobID):
+    return QUEUE_PREFIX + str(jobID)
+
+
+def _requireCapability():
+    """Refuse early when this deployment cannot answer at all.
+
+    Distinct from consent and from access: this is "is the feature switched on
+    and is there a token", which the browser also asks before drawing the
+    button. Checked again here because a disabled button is a convenience, not
+    an authorisation.
+    """
+    if not AI_COMPOUND_SUGGESTIONS_ENABLED:
+        raise UserWarning("AI compound selection is switched off on this server.")
+
+    info = getAIProviderInfo()
+    if not info.get("enabled"):
+        raise UserWarning("AI features are switched off on this server.")
+    if not info.get("configured"):
+        raise UserWarning("This server has no API key for its AI provider, so "
+                          "compound selection cannot run. Ask the administrator "
+                          "to configure one.")
+
+
+def _panelNames(jobInstance):
+    """Every compound name the user's files carried, for context.
+
+    With no experiment design written this is the strongest signal available:
+    a panel of amino acids and TCA intermediates identifies itself as primary
+    metabolism without anyone saying so.
+    """
+    names = []
+    for compoundSet in ranker.coerceCompoundSets(jobInstance.getFoundCompounds()):
+        title = (compoundSet.getTitle() or "").strip()
+        if title and title not in names:
+            names.append(title)
+    return names
+
+
+def _omicNames(jobInstance):
+    omics = []
+    for entry in (list(jobInstance.getGeneBasedInputOmics() or []) +
+                  list(jobInstance.getCompoundBasedInputOmics() or [])):
+        name = (entry or {}).get("omicName") if isinstance(entry, dict) else None
+        if name and name not in omics:
+            omics.append(name)
+    return omics
+
+
+def buildContext(jobInstance):
+    """Everything the model is told about the experiment, all of it already stored."""
+    return {
+        "organism": jobInstance.getOrganism(),
+        "organismLabel": "",
+        "jobDescription": jobInstance.getName(),
+        "experimentDesign": jobInstance.getExperimentDesign(),
+        "omics": _omicNames(jobInstance),
+        "panel": _panelNames(jobInstance),
+    }
+
+
+def runCompoundSuggestion(jobID):
+    """The queued half: rank deterministically, then ask the model for the rest.
+
+    Returned rather than stored. The queue keeps a job's return value and hands
+    it to the status route below, which is enough for advice that the user is
+    about to accept or discard; persisting it would add a schema the job does
+    not need and a second copy of the truth to keep in step with the ticks.
+
+    @param {String} jobID
+    @returns {Dict} the payload the browser applies
+    """
+    logging.info("COMPOUND SUGGESTION - job %s starting", jobID)
+
+    jobInstance = JobInformationManager().loadJobInstance(jobID)
+    if jobInstance is None:
+        raise UserWarning("Job " + str(jobID) + " was not found at database.")
+
+    # Reopened jobs hand back plain Feature objects with no accessors;
+    # see coerceCompoundSets for why that is normalised here.
+    compoundSets = ranker.coerceCompoundSets(jobInstance.getFoundCompounds())
+    if not compoundSets:
+        return {"decisions": [], "unresolved": [], "model": "",
+                "stats": {"deterministic": 0, "ai": 0, "unresolved": 0, "rejected": 0}}
+
+    organism = jobInstance.getOrganism()
+    onMapIDs = ranker.loadOrganismCompoundIDs(organism)
+    synonymsByID = ranker.loadCompoundSynonyms(ranker.collectKeggIDs(compoundSets))
+
+    resolved, residual, skipped = ranker.partitionCompoundSets(
+        compoundSets, onMapIDs, organism, synonymsByID)
+
+    logging.info("COMPOUND SUGGESTION - job %s: %d sets, %d settled by rule, "
+                 "%d to the model, %d with no card (%d compounds on %s maps)",
+                 jobID, len(compoundSets), len(resolved), len(residual),
+                 len(skipped), len(onMapIDs), organism)
+
+    suggestions = resolver.suggestCompounds(
+        residual, buildContext(jobInstance), jobID=jobID)
+
+    decisions = [{"title": decision["title"], "keggID": decision["keggID"],
+                  "tier": "deterministic", "confidence": "", "reason": decision["reason"],
+                  "candidates": decision.get("candidates", [])}
+                 for decision in resolved]
+    decisions.extend(suggestions["accepted"])
+
+    unresolved = [{"title": entry["title"],
+                   "reason": entry.get("reason", ""),
+                   "detail": entry.get("detail", ""),
+                   "candidates": entry.get("candidates", [])}
+                  for entry in suggestions["abstained"]]
+
+    return {
+        "decisions": decisions,
+        "unresolved": unresolved,
+        "model": suggestions.get("model", ""),
+        "stats": {
+            "deterministic": len(resolved),
+            "ai": len(suggestions["accepted"]),
+            "unresolved": len(unresolved),
+            "rejected": len(suggestions["rejected"]),
+        },
+    }
+
+
+def compoundSuggestionInitiate(REQUEST, RESPONSE, QUEUE_INSTANCE):
+    """POST /pa_suggest_compounds -- queue a suggestion run for a job."""
+    userID = None
+    try:
+        userID = REQUEST.cookies.get('userID')
+        sessionToken = REQUEST.cookies.get('sessionToken')
+        UserSessionManager().isValidUser(userID, sessionToken)
+
+        jobID = REQUEST.form.get("jobID")
+        if not jobID:
+            raise UserWarning("Missing jobID parameter for compound suggestion.")
+
+        _requireCapability()
+
+        jobInstance = _requireJobAccess(jobID, userID)
+
+        # Read off the STORED record, never off the request.
+        # test_ai_consent_enforced.py asserts that at the AST level, and the
+        # reason is that a request-borne flag is the caller asserting their own
+        # consent. The upload form now submits a hidden 'true', so this passes
+        # for anything created through the UI and still refuses a job whose
+        # record predates that or was created with the box cleared.
+        if not jobInstance.getAIConsent():
+            raise UserWarning(
+                "AI features were not enabled for this job. Re-run the analysis "
+                "if you want its compound names sent to the AI service.")
+
+        queueID = _queueID(jobID)
+        existing = QUEUE_INSTANCE.fetch_job(queueID)
+        if existing is not None:
+            if existing.status in (JobStatus.QUEUED, JobStatus.STARTED):
+                RESPONSE.setContent({"success": True, "jobID": jobID, "status": "running"})
+                return RESPONSE
+            # A finished or failed run from a previous click is spent: drop it
+            # so this click gets a fresh answer rather than the old one.
+            QUEUE_INSTANCE.get_result(queueID, remove=True)
+
+        QUEUE_INSTANCE.enqueue(
+            fn=runCompoundSuggestion,
+            args=(jobID,),
+            timeout=600,
+            job_id=queueID)
+
+        RESPONSE.setContent({"success": True, "jobID": jobID, "status": "queued"})
+    except Exception as ex:
+        handleException(RESPONSE, ex, __file__, "compoundSuggestionInitiate", userID=userID)
+    finally:
+        return RESPONSE
+
+
+def compoundSuggestionStatus(REQUEST, RESPONSE, QUEUE_INSTANCE):
+    """POST /pa_suggest_compounds_status -- poll, and collect the result once."""
+    userID = None
+    try:
+        userID = REQUEST.cookies.get('userID')
+        sessionToken = REQUEST.cookies.get('sessionToken')
+        UserSessionManager().isValidUser(userID, sessionToken)
+
+        jobID = REQUEST.form.get("jobID")
+        if not jobID:
+            raise UserWarning("Missing jobID parameter for compound suggestion status.")
+
+        # Same entitlement rule as the initiate route. This one returns the
+        # job's compound names, so it is not a free read either.
+        _requireJobAccess(jobID, userID)
+
+        queueID = _queueID(jobID)
+        status = QUEUE_INSTANCE.check_status(queueID)
+
+        if status == JobStatus.FINISHED:
+            payload = QUEUE_INSTANCE.get_result(queueID, remove=True)
+            if not isinstance(payload, dict):
+                raise UserWarning("The compound suggestion finished without a result.")
+            RESPONSE.setContent(dict({"success": True, "jobID": jobID,
+                                      "status": "finished"}, **payload))
+        elif status == JobStatus.FAILED:
+            message = QUEUE_INSTANCE.get_error_message(queueID) or "unknown error"
+            QUEUE_INSTANCE.get_result(queueID, remove=True)
+            logging.warning("COMPOUND SUGGESTION - job %s failed: %s", jobID, message)
+            RESPONSE.setContent({"success": False, "jobID": jobID, "status": "failed",
+                                 "errorMessage": "AI compound selection failed: " + str(message)})
+        elif status == JobStatus.NOT_QUEUED:
+            RESPONSE.setContent({"success": True, "jobID": jobID, "status": "not_queued"})
+        else:
+            RESPONSE.setContent({"success": True, "jobID": jobID, "status": "running"})
+    except Exception as ex:
+        handleException(RESPONSE, ex, __file__, "compoundSuggestionStatus", userID=userID)
+    finally:
+        return RESPONSE

--- a/PaintomicsServer/src/servlets/PathwayAcquisitionServlet.py
+++ b/PaintomicsServer/src/servlets/PathwayAcquisitionServlet.py
@@ -377,6 +377,12 @@ def pathwayAcquisitionStep1_PART2(jobInstance, userID, exampleMode, RESPONSE):
             "compoundBasedInputOmics": inputOmicsForClient(jobInstance.getCompoundBasedInputOmics()),
             "databases": jobInstance.getDatabases(),
             "name": jobInstance.getName(),
+            # Step 3 and pa_recover_job have always sent this; step 1 did not,
+            # so a browser arriving at step 2 straight from step 1 had no
+            # consent flag on its job model at all. Step 2's "Choose for me"
+            # button is gated on it, so without this the button was invisible
+            # on the only path a user actually takes to step 2.
+            "aiConsent": jobInstance.getAIConsent(),
             "timestamp": int(time())
         })
 

--- a/PaintomicsServer/src/tests/test_compound_disambiguation_closed_set.py
+++ b/PaintomicsServer/src/tests/test_compound_disambiguation_closed_set.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""The closed-set guarantee: a model answer is applied only if it was offered.
+
+Step 2's "Choose for me" asks an LLM which KEGG compound an ambiguous metabolite
+name meant. The whole safety property of that feature is one sentence:
+
+    an answer is applied only if it names a KEGG id that was in THAT input
+    name's own candidate list.
+
+Everything else -- an invented id, an id lifted from a different input name in
+the same batch, a name nobody asked about, an answer given twice, a
+low-confidence guess -- must leave the user's ticks alone. That matters more
+here than in most places because a wrong compound has no symptom: the run
+succeeds, the pathways are drawn, and the analysis is simply about a different
+metabolite than the one that was measured.
+
+These tests never reach a gateway. validateChoice and applyChoices are pure
+functions over one reply and the question it claims to answer, which is exactly
+why the guarantee can be pinned without a network, a job or a key.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from src.classes.CompoundDisambiguation import resolver
+
+
+def decision(title, *keggIDs):
+    return {"title": title, "status": "residual", "tier": "residual",
+            "candidates": [{"keggID": keggID, "names": [keggID + " name"],
+                            "similarity": 0.9, "isMain": True}
+                           for keggID in keggIDs]}
+
+
+ALANINE = decision("Alanine", "C00041", "C00133", "C00099", "C01401")
+SERINE = decision("Serine", "C00065", "C00740")
+
+
+class ValidateChoiceTest(unittest.TestCase):
+
+    def test_a_candidate_from_the_list_is_accepted(self):
+        verdict = resolver.validateChoice(
+            {"kegg_id": "C00041", "confidence": "high", "reason": "mouse"}, ALANINE)
+        self.assertEqual("accepted", verdict["outcome"])
+        self.assertEqual("C00041", verdict["keggID"])
+
+    def test_an_invented_id_is_rejected(self):
+        """The failure this whole design exists to make impossible."""
+        verdict = resolver.validateChoice(
+            {"kegg_id": "C99999", "confidence": "high", "reason": "looks right"}, ALANINE)
+        self.assertEqual("rejected", verdict["outcome"])
+        self.assertIsNone(verdict["keggID"])
+
+    def test_an_id_from_another_input_name_is_rejected(self):
+        """C00065 is a real KEGG compound and a real candidate -- for Serine.
+
+        Answering it for "Alanine" is the batching-specific failure: every set
+        in a batch is in the same prompt, so a model CAN reach across. Being a
+        valid id somewhere in the batch must not make it a valid answer here.
+        """
+        verdict = resolver.validateChoice(
+            {"kegg_id": "C00065", "confidence": "high", "reason": "serine"}, ALANINE)
+        self.assertEqual("rejected", verdict["outcome"])
+
+    def test_the_abstain_token_abstains(self):
+        verdict = resolver.validateChoice(
+            {"kegg_id": "ABSTAIN", "confidence": "high", "reason": "ambiguous"}, ALANINE)
+        self.assertEqual("abstained", verdict["outcome"])
+        self.assertIsNone(verdict["keggID"])
+
+    def test_an_empty_id_abstains(self):
+        verdict = resolver.validateChoice(
+            {"kegg_id": "", "confidence": "high", "reason": ""}, ALANINE)
+        self.assertEqual("abstained", verdict["outcome"])
+
+    def test_low_confidence_abstains_even_on_a_legal_id(self):
+        """Low confidence is the model saying it does not know.
+
+        Applying it anyway would turn "I am guessing" into a tick the user has
+        no reason to re-examine.
+        """
+        verdict = resolver.validateChoice(
+            {"kegg_id": "C00041", "confidence": "low", "reason": "not sure"}, ALANINE)
+        self.assertEqual("abstained", verdict["outcome"])
+        self.assertIsNone(verdict["keggID"])
+
+    def test_a_missing_confidence_is_not_treated_as_low(self):
+        """A gateway that dropped response_format still returns usable answers."""
+        verdict = resolver.validateChoice({"kegg_id": "C00041", "reason": "mouse"}, ALANINE)
+        self.assertEqual("accepted", verdict["outcome"])
+        self.assertEqual("medium", verdict["confidence"])
+
+
+class ApplyChoicesTest(unittest.TestCase):
+
+    def test_answers_are_matched_by_name_not_by_position(self):
+        """A reordered reply must not shift answers onto the wrong metabolite.
+
+        This is the one failure mode in the feature that produces confident,
+        plausible, uniformly wrong output: every tick lands on a real compound,
+        and every one belongs to a different input name.
+        """
+        accepted, abstained, rejected = resolver.applyChoices(
+            [ALANINE, SERINE],
+            [{"input_name": "Serine", "kegg_id": "C00065", "confidence": "high", "reason": "L"},
+             {"input_name": "Alanine", "kegg_id": "C00041", "confidence": "high", "reason": "L"}])
+
+        self.assertEqual([], rejected)
+        picks = dict((entry["title"], entry["keggID"]) for entry in accepted)
+        self.assertEqual({"Alanine": "C00041", "Serine": "C00065"}, picks)
+
+    def test_a_set_the_model_ignored_becomes_an_abstention(self):
+        accepted, abstained, rejected = resolver.applyChoices(
+            [ALANINE, SERINE],
+            [{"input_name": "Alanine", "kegg_id": "C00041", "confidence": "high", "reason": ""}])
+
+        self.assertEqual(["Alanine"], [entry["title"] for entry in accepted])
+        self.assertEqual(["Serine"], [entry["title"] for entry in abstained])
+
+    def test_an_unknown_input_name_is_rejected(self):
+        accepted, abstained, rejected = resolver.applyChoices(
+            [ALANINE],
+            [{"input_name": "Tryptophan", "kegg_id": "C00078", "confidence": "high", "reason": ""}])
+
+        self.assertEqual([], accepted)
+        self.assertEqual(["Tryptophan"], [entry["title"] for entry in rejected])
+        # ...and Alanine is still reported as undecided rather than dropped.
+        self.assertEqual(["Alanine"], [entry["title"] for entry in abstained])
+
+    def test_the_same_name_answered_twice_keeps_only_the_first(self):
+        accepted, abstained, rejected = resolver.applyChoices(
+            [ALANINE],
+            [{"input_name": "Alanine", "kegg_id": "C00041", "confidence": "high", "reason": ""},
+             {"input_name": "Alanine", "kegg_id": "C00133", "confidence": "high", "reason": ""}])
+
+        self.assertEqual(["C00041"], [entry["keggID"] for entry in accepted])
+        self.assertEqual(1, len(rejected))
+
+    def test_matching_tolerates_case_and_surrounding_space(self):
+        accepted, _, rejected = resolver.applyChoices(
+            [ALANINE],
+            [{"input_name": "  alanine ", "kegg_id": "C00041", "confidence": "high", "reason": ""}])
+        self.assertEqual([], rejected)
+        self.assertEqual(["C00041"], [entry["keggID"] for entry in accepted])
+
+
+class ParseChoicesTest(unittest.TestCase):
+
+    def test_a_plain_schema_reply_parses(self):
+        text = '{"choices": [{"input_name": "Alanine", "kegg_id": "C00041", ' \
+               '"confidence": "high", "reason": "mouse"}]}'
+        self.assertEqual(1, len(resolver.parseChoices(text)))
+
+    def test_a_fenced_reply_parses(self):
+        """Gateways that ignore response_format wrap JSON in markdown."""
+        text = '```json\n{"choices": [{"input_name": "A", "kegg_id": "C1", ' \
+               '"confidence": "high", "reason": ""}]}\n```'
+        self.assertEqual(1, len(resolver.parseChoices(text)))
+
+    def test_json_buried_in_prose_parses(self):
+        text = 'Here you go:\n{"choices": [{"input_name": "A", "kegg_id": "C1", ' \
+               '"confidence": "high", "reason": ""}]}\nHope that helps.'
+        self.assertEqual(1, len(resolver.parseChoices(text)))
+
+    def test_unparseable_text_yields_nothing_rather_than_raising(self):
+        """An empty list becomes a batch of abstentions, which is safe.
+
+        Raising here would lose the whole batch to an error the user cannot act
+        on; returning junk would be worse still.
+        """
+        for text in ("", None, "I could not do that", "{not json"):
+            self.assertEqual([], resolver.parseChoices(text))
+
+    def test_non_object_entries_are_dropped(self):
+        text = '{"choices": ["C00041", {"input_name": "A", "kegg_id": "C1", ' \
+               '"confidence": "high", "reason": ""}]}'
+        self.assertEqual(1, len(resolver.parseChoices(text)))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_compound_disambiguation_on_example_data.py
+++ b/PaintomicsServer/src/tests/test_compound_disambiguation_on_example_data.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Tier 1 over the shipped STATegra metabolomics example, against real KEGG.
+
+The unit tests build compound sets by hand. This one builds them the way step 1
+does -- the same substring query against `global-paintomics.kegg_compounds`, the
+same similarity split into main/other -- and runs the ranker over the result, so
+the rules are exercised against the actual shape of the data rather than against
+a fixture that agrees with them by construction.
+
+It asserts named outcomes rather than a total, because a KEGG reinstall moves
+totals and none of these compounds. The one count it does check is a floor: if
+the deterministic tier ever settles nothing, the feature has become a pure LLM
+call and the whole design has quietly inverted.
+
+Needs MongoDB with `global-paintomics` and `mmu-paintomics` installed, and
+reaches no gateway at all. Skipped when either database is missing.
+"""
+
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from src.classes.Feature import Compound
+from src.classes.FoundFeature import FoundFeature
+from src.classes.CompoundDisambiguation import ranker
+from src.common.CompoundNameSimilarity import MAIN_SIMILARITY_THRESHOLD
+
+VALUES_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "examplefiles", "datasets",
+    "08-stategra-multiomics", "data", "metabolomics_values.tab")
+
+ORGANISM = "mmu"
+MAX_COMPOUND_MATCHES = 500
+
+
+def _mongo():
+    """The client, or None when this machine has no usable database."""
+    try:
+        import pymongo
+        from src.conf.serverconf import MONGODB_HOST, MONGODB_PORT
+        client = pymongo.MongoClient(MONGODB_HOST, MONGODB_PORT,
+                                     serverSelectionTimeoutMS=2000)
+        names = client.list_database_names()
+        if "global-paintomics" not in names or (ORGANISM + "-paintomics") not in names:
+            return None
+        if client[ORGANISM + "-paintomics"]["kegg"].estimated_document_count() == 0:
+            return None
+        return client
+    except Exception:
+        return None
+
+
+CLIENT = _mongo()
+
+
+@unittest.skipIf(CLIENT is None,
+                 "needs MongoDB with global-paintomics and %s-paintomics" % ORGANISM)
+class RankerOnExampleDataTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        compounds = CLIENT["global-paintomics"]["kegg_compounds"]
+
+        cls.onMapIDs = frozenset(
+            compound["id"]
+            for pathway in CLIENT[ORGANISM + "-paintomics"]["kegg"].find({}, {"compounds.id": 1})
+            for compound in (pathway.get("compounds") or [])
+            if compound.get("id"))
+
+        with open(os.path.abspath(VALUES_FILE), encoding="utf-8") as handle:
+            cls.inputNames = [line.split("\t")[0].strip() for line in handle
+                              if line.strip() and not line.startswith("#")]
+
+        cls.sets = []
+        for name in cls.inputNames:
+            compoundSet = cls._buildCompoundSet(compounds, name)
+            if compoundSet is not None:
+                cls.sets.append(compoundSet)
+
+        synonyms = ranker.loadCompoundSynonyms(ranker.collectKeggIDs(cls.sets))
+        cls.resolved, cls.residual, cls.skipped = ranker.partitionCompoundSets(
+            cls.sets, cls.onMapIDs, ORGANISM, synonyms)
+
+        cls.resolvedByTitle = dict((d["title"], d) for d in cls.resolved)
+        cls.residualByTitle = dict((d["title"], d) for d in cls.residual)
+
+    @staticmethod
+    def _buildCompoundSet(compounds, name):
+        """Reproduce mapCompoundsIdentifiers for one input name."""
+        pattern = re.compile(re.escape(name), re.IGNORECASE)
+        hits = list(compounds.find({"name": {"$regex": pattern}})
+                    .limit(MAX_COMPOUND_MATCHES + 1))
+        if len(hits) > MAX_COMPOUND_MATCHES:
+            exact = re.compile("^" + re.escape(name) + "$", re.IGNORECASE)
+            hits = list(compounds.find({"name": {"$regex": exact}}).limit(MAX_COMPOUND_MATCHES))
+        if not hits:
+            return None
+
+        found = FoundFeature("")
+        found.setTitle(name)
+        for hit in hits:
+            candidate = Compound(hit["id"])
+            candidate.setName(hit["name"])
+            if candidate.calculateSimilarity(name) >= MAIN_SIMILARITY_THRESHOLD:
+                found.addMainCompound(candidate)
+            else:
+                found.addOtherCompound(candidate)
+        return found
+
+    # ------------------------------------------------------------------
+    # The deterministic tier still carries real weight
+    # ------------------------------------------------------------------
+    def test_the_rules_settle_a_substantial_share_without_a_model(self):
+        """A floor, not a total: KEGG reinstalls move totals, not this property.
+
+        Measured when written: 31 settled, 18 escalated, 2 with no card, of 51
+        sets built from 58 input names.
+        """
+        self.assertGreater(len(self.resolved), len(self.sets) // 2,
+                           "the deterministic tier settled %d of %d sets; if this "
+                           "has collapsed, the feature has become a pure LLM call"
+                           % (len(self.resolved), len(self.sets)))
+        self.assertGreater(len(self.residual), 0,
+                           "nothing was escalated, so either the data changed or a "
+                           "rule started deciding things it should not")
+
+    # ------------------------------------------------------------------
+    # Named outcomes
+    # ------------------------------------------------------------------
+    def test_a_clean_single_match_is_settled(self):
+        self.assertIn("Pyruvic acid", self.resolvedByTitle)
+        self.assertEqual("C00022", self.resolvedByTitle["Pyruvic acid"]["keggID"])
+
+    def test_the_comma_in_a_kegg_name_does_not_break_l_arginine(self):
+        """C04137 is stored as "Arginine, N2-(1-carboxyethyl)-, L-".
+
+        Splitting synonyms on commas invented "Arginine", scored it as a direct
+        hit for "L-arginine", and turned a set the rules can settle into one
+        they cannot. Real data is the only place this shows up.
+        """
+        self.assertIn("L-arginine", self.resolvedByTitle)
+        self.assertEqual("C00062", self.resolvedByTitle["L-arginine"]["keggID"])
+
+    def test_alanine_is_escalated_and_not_resolved_to_the_unspecified_form(self):
+        """The trap: C01401 is literally named "Alanine" AND is on mouse maps.
+
+        Neither an exact-name rule nor the species filter can save this one, so
+        it must reach the model with the real alternatives still in the pool.
+        """
+        self.assertNotIn("Alanine", self.resolvedByTitle)
+        self.assertIn("Alanine", self.residualByTitle)
+
+        offered = set(candidate["keggID"]
+                      for candidate in self.residualByTitle["Alanine"]["candidates"])
+        self.assertIn("C00041", offered, "L-Alanine must remain choosable")
+        self.assertIn("C01401", offered, "the unspecified form must not be hidden")
+
+    def test_glucose_reaches_the_model_with_only_the_on_map_forms(self):
+        """113 candidates in, three out: the parent and its two anomers."""
+        self.assertIn("Glucose", self.residualByTitle)
+        offered = set(candidate["keggID"]
+                      for candidate in self.residualByTitle["Glucose"]["candidates"])
+        self.assertEqual({"C00031", "C00221", "C00267"}, offered)
+
+    def test_the_species_filter_drops_the_off_map_generic_lactic_acid(self):
+        """C01432 is literally named "Lactic acid" and is on no mouse pathway.
+
+        The name still has to be escalated -- L- and D-lactate are both drawn
+        and both real -- but the generic form must not be among the choices,
+        because selecting it would contribute nothing to any mouse pathway.
+        """
+        decision = self.residualByTitle.get("Lactic acid")
+        self.assertIsNotNone(decision, "Lactic acid should still need a decision")
+
+        offered = set(candidate["keggID"] for candidate in decision["candidates"])
+        self.assertNotIn("C01432", offered,
+                         "an off-map generic form was offered as a real choice")
+        self.assertIn("C00186", offered, "L-lactate must remain choosable")
+
+    # ------------------------------------------------------------------
+    # Candidate hygiene
+    # ------------------------------------------------------------------
+    def test_no_candidate_is_offered_under_an_accession_or_chebi_name(self):
+        for decision in self.residual:
+            for candidate in decision["candidates"]:
+                for name in candidate["names"]:
+                    self.assertFalse(name.lower().startswith("chebi:"),
+                                     "%s offered as %r" % (candidate["keggID"], name))
+                    self.assertFalse(name.isdigit(),
+                                     "%s offered as %r" % (candidate["keggID"], name))
+
+    def test_every_escalated_set_offers_at_least_two_real_choices(self):
+        """A one-candidate 'choice' is a rule that failed to fire."""
+        for decision in self.residual:
+            self.assertGreaterEqual(
+                len(decision["candidates"]), 2,
+                "%r was escalated with %d candidate(s)"
+                % (decision["title"], len(decision["candidates"])))
+
+    def test_the_prompt_pool_never_exceeds_its_cap(self):
+        for decision in self.residual:
+            self.assertLessEqual(len(decision["candidates"]),
+                                 ranker.MAX_CANDIDATES_IN_PROMPT)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_compound_disambiguation_ranker.py
+++ b/PaintomicsServer/src/tests/test_compound_disambiguation_ranker.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""What tier 1 may and may not settle on its own.
+
+Every rule here was measured against the real KEGG tables before it was
+written, and two of the tests pin decisions the ranker deliberately REFUSES to
+make. Those matter most: a rule that resolves an ambiguous name to the wrong
+compound produces no error, no warning and a completed analysis about a
+different metabolite than the user measured.
+
+No MongoDB. The on-map compound set and the synonym table are both plain
+arguments, which is the point of taking them as parameters rather than reading
+them inside the ranker.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from src.classes.Feature import Compound
+from src.classes.FoundFeature import FoundFeature
+from src.classes.CompoundDisambiguation import ranker
+
+
+def compoundSet(title, mains, others=()):
+    """A step-2 compound set, bucketed the way the mapper buckets one."""
+    found = FoundFeature("")
+    found.setTitle(title)
+    for keggID, name in mains:
+        compound = Compound(keggID)
+        compound.setName(name)
+        compound.calculateSimilarity(title)
+        found.addMainCompound(compound)
+    for keggID, name in others:
+        compound = Compound(keggID)
+        compound.setName(name)
+        compound.calculateSimilarity(title)
+        found.addOtherCompound(compound)
+    return found
+
+
+class DeterministicRulesTest(unittest.TestCase):
+
+    def test_one_main_candidate_resolves(self):
+        """"Glyceric acid" matched one compound plus substring noise."""
+        decision = ranker.rankCompoundSet(
+            compoundSet("Glyceric acid",
+                        [("C00258", "Glyceric acid")],
+                        [("C00197", "3-Phospho-D-glycerate")]),
+            onMapIDs=set())
+        self.assertEqual("resolved", decision["status"])
+        self.assertEqual("C00258", decision["keggID"])
+        self.assertEqual("deterministic", decision["tier"])
+
+    def test_the_species_filter_breaks_a_two_way_tie(self):
+        """Only one of the two matching forms is drawn on this organism's maps."""
+        decision = ranker.rankCompoundSet(
+            compoundSet("Lactic acid",
+                        [("C00186", "L-Lactic acid"), ("C01432", "Lactic acid")]),
+            onMapIDs={"C00186"}, organismLabel="mmu")
+        self.assertEqual("resolved", decision["status"])
+        self.assertEqual("C00186", decision["keggID"])
+        self.assertIn("mmu", decision["reason"])
+
+    def test_a_single_candidate_resolves(self):
+        decision = ranker.rankCompoundSet(
+            compoundSet("Mannitol", [("C00392", "Mannitol")], [("C00392", "D-Mannitol")]),
+            onMapIDs=set())
+        self.assertEqual("resolved", decision["status"])
+        self.assertEqual("C00392", decision["keggID"])
+
+
+class RulesTheRankerRefusesTest(unittest.TestCase):
+    """The two measured traps, pinned so no future 'obvious' rule reopens them."""
+
+    def test_an_exact_name_match_does_not_win(self):
+        """Measured: KEGG's compound literally named "Alanine" is C01401.
+
+        C01401 is the unspecified form AND it is drawn on mouse pathways, so
+        neither an exact-name rule nor the species filter rescues this one. A
+        mouse experiment means C00041 L-Alanine, and only judgement gets there
+        -- so the ranker must escalate rather than take the literal match.
+        """
+        decision = ranker.rankCompoundSet(
+            compoundSet("Alanine",
+                        [("C01401", "Alanine"), ("C00041", "L-Alanine"),
+                         ("C00133", "D-Alanine"), ("C00099", "beta-Alanine")]),
+            onMapIDs={"C01401", "C00041", "C00133", "C00099"}, organismLabel="mmu")
+
+        self.assertEqual("residual", decision["status"])
+        self.assertNotEqual("C01401", decision.get("keggID"))
+        offered = set(c["keggID"] for c in decision["candidates"])
+        self.assertIn("C00041", offered)
+        self.assertIn("C01401", offered)
+
+    def test_stereoisomers_both_on_the_map_are_escalated(self):
+        """L- and D-Serine are both real and both drawn. Not a rule's call."""
+        decision = ranker.rankCompoundSet(
+            compoundSet("Serine", [("C00065", "L-Serine"), ("C00740", "D-Serine")]),
+            onMapIDs={"C00065", "C00740"}, organismLabel="mmu")
+        self.assertEqual("residual", decision["status"])
+
+
+class SpeciesFilterSafetyTest(unittest.TestCase):
+
+    def test_an_empty_on_map_set_skips_the_filter_rather_than_emptying_everything(self):
+        """A missing organism database must weaken ranking, never narrow it.
+
+        Treating "I could not read the pathways" as "no compound is on any
+        pathway" would make every filtered set collapse to zero candidates.
+        """
+        decision = ranker.rankCompoundSet(
+            compoundSet("Serine", [("C00065", "L-Serine"), ("C00740", "D-Serine")]),
+            onMapIDs=frozenset())
+        self.assertEqual("residual", decision["status"])
+        self.assertEqual(2, len(decision["candidates"]))
+
+    def test_the_filter_narrows_the_prompt_when_it_cannot_decide(self):
+        """Three matches, two on the map: the model is asked about those two."""
+        decision = ranker.rankCompoundSet(
+            compoundSet("Glucose",
+                        [("C00031", "Glucose"), ("C00221", "beta-D-Glucose"),
+                         ("C00267", "alpha-D-Glucose"), ("C00936", "Off-map glucose")]),
+            onMapIDs={"C00031", "C00221", "C00267"})
+        self.assertEqual("residual", decision["status"])
+        offered = set(c["keggID"] for c in decision["candidates"])
+        self.assertEqual({"C00031", "C00221", "C00267"}, offered)
+
+
+class CandidateCollapsingTest(unittest.TestCase):
+
+    def test_names_are_not_split_on_commas(self):
+        """6,581 KEGG names contain a comma; C04137 is "Arginine, N2-..., L-".
+
+        Splitting it produced a synonym "Arginine", which scored as a direct hit
+        for an input of "L-arginine" and pulled an unrelated compound into the
+        choice -- turning a set the ranker could settle into one it could not.
+        """
+        found = compoundSet("L-arginine", [("C00062", "L-Arginine")],
+                            [("C04137", "Arginine, N2-(1-carboxyethyl)-, L-")])
+        byID = ranker.candidatesByKeggID(found)
+
+        self.assertIn("Arginine, N2-(1-carboxyethyl)-, L-", byID["C04137"]["names"])
+        self.assertFalse(byID["C04137"]["isMain"])
+
+        decision = ranker.rankCompoundSet(found, onMapIDs=set())
+        self.assertEqual("resolved", decision["status"])
+        self.assertEqual("C00062", decision["keggID"])
+
+    def test_main_comes_from_the_mapper_bucket_not_from_a_rescore(self):
+        """The cards are drawn from the buckets, so the ranker must use them.
+
+        Here the stored name scores poorly against the title, but the mapper put
+        it in mainCompounds. Rescoring would call it "other", disagree with the
+        card the user is looking at, and resolve a set they can still edit.
+        """
+        found = FoundFeature("")
+        found.setTitle("Glucose")
+        odd = Compound("C00031")
+        odd.setName("Grape sugar")          # a real C00031 synonym, distant name
+        found.addMainCompound(odd)
+        other = Compound("C00092")
+        other.setName("D-Glucose 6-phosphate")
+        found.addOtherCompound(other)
+
+        byID = ranker.candidatesByKeggID(found)
+        self.assertTrue(byID["C00031"]["isMain"])
+        self.assertFalse(byID["C00092"]["isMain"])
+
+    def test_synonyms_are_ordered_by_closeness_to_the_input(self):
+        """C00065 introduced itself as "L-2-Amino-3-hydroxypropionic acid"."""
+        found = compoundSet("Serine", [("C00065", "L-Serine")])
+        byID = ranker.candidatesByKeggID(found, synonymsByID={
+            "C00065": ["L-2-Amino-3-hydroxypropionic acid", "L-Serine", "L-3-Hydroxy-alanine"]})
+        self.assertEqual("L-Serine", byID["C00065"]["names"][0])
+
+    def test_accession_and_chebi_pseudonyms_are_dropped(self):
+        found = compoundSet("Glucose", [("C00031", "Glucose")])
+        byID = ranker.candidatesByKeggID(found, synonymsByID={
+            "C00031": ["C00031", "chebi:4167", "4167", "D-Glucose"]})
+        self.assertEqual(["Glucose", "D-Glucose"], byID["C00031"]["names"])
+
+    def test_a_candidate_is_never_left_without_a_name(self):
+        """Dropping pseudonyms must not empty a candidate that has only those."""
+        found = compoundSet("C00031", [("C00031", "C00031")])
+        byID = ranker.candidatesByKeggID(found)
+        self.assertEqual(["C00031"], byID["C00031"]["names"])
+
+    def test_the_prompt_pool_is_capped(self):
+        mains = [("C%05d" % n, "Glucose variant %d" % n) for n in range(40)]
+        decision = ranker.rankCompoundSet(compoundSet("Glucose", mains), onMapIDs=set())
+        self.assertEqual("residual", decision["status"])
+        self.assertEqual(ranker.MAX_CANDIDATES_IN_PROMPT, len(decision["candidates"]))
+
+
+class ReopenedJobShapeTest(unittest.TestCase):
+    """A job reopened from MongoDB carries a different shape entirely.
+
+    ``FoundFeatureDAO.findAll`` is ``FeatureDAO.findAll``, which constructs a
+    plain ``Feature("")`` whatever the subclass; parseBSON then setattrs the
+    stored document onto it. The result HAS ``title`` and ``mainCompounds``, but
+    the candidates are raw dicts and ``getMainCompounds()`` does not exist.
+
+    Measured against a running server: pressing "Choose for me" on a job opened
+    by its ?jobID= URL failed with "'Feature' object has no attribute
+    'getMainCompounds'". The in-memory step-1 path had hidden it completely.
+    """
+
+    def _storedRecord(self):
+        return {
+            "ID": "", "title": "Alanine",
+            "mainCompounds": [
+                {"ID": "C01401", "name": "Alanine", "similarity": 1.0},
+                {"ID": "C00041", "name": "L-Alanine", "similarity": 0.9},
+                {"ID": "C00133", "name": "D-Alanine", "similarity": 0.9}],
+            "otherCompounds": [
+                {"ID": "C00099", "name": "beta-Alanine", "similarity": 0.5}],
+        }
+
+    def test_a_stored_record_is_ranked_like_a_live_one(self):
+        [coerced] = ranker.coerceCompoundSets([self._storedRecord()])
+        decision = ranker.rankCompoundSet(
+            coerced, onMapIDs={"C01401", "C00041", "C00133"}, organismLabel="mmu")
+
+        self.assertEqual("residual", decision["status"])
+        offered = set(c["keggID"] for c in decision["candidates"])
+        self.assertEqual({"C01401", "C00041", "C00133"}, offered)
+
+    def test_the_bucket_split_survives_the_round_trip(self):
+        """beta-Alanine was an "other"; it must not become a main candidate."""
+        [coerced] = ranker.coerceCompoundSets([self._storedRecord()])
+        byID = ranker.candidatesByKeggID(coerced)
+        self.assertFalse(byID["C00099"]["isMain"])
+        self.assertTrue(byID["C00041"]["isMain"])
+
+    def test_a_live_foundfeature_is_passed_through_untouched(self):
+        live = compoundSet("Serine", [("C00065", "L-Serine")])
+        [coerced] = ranker.coerceCompoundSets([live])
+        self.assertIs(live, coerced)
+
+    def test_an_object_with_attributes_rather_than_a_dict_also_works(self):
+        """Feature.parseBSON setattrs, so the record arrives as an object."""
+        class StoredFeature(object):
+            pass
+
+        record = StoredFeature()
+        record.ID = ""
+        record.title = "Serine"
+        record.mainCompounds = [{"ID": "C00065", "name": "L-Serine"}]
+        record.otherCompounds = []
+
+        [coerced] = ranker.coerceCompoundSets([record])
+        self.assertEqual("Serine", coerced.getTitle())
+        self.assertEqual(["C00065"], [c.getID() for c in coerced.getMainCompounds()])
+
+    def test_an_empty_list_is_not_an_error(self):
+        self.assertEqual([], ranker.coerceCompoundSets(None))
+        self.assertEqual([], ranker.coerceCompoundSets([]))
+
+
+class NeedsDisambiguationTest(unittest.TestCase):
+    """Mirrors PA_Step2CompoundSetView.needsDisambiguation."""
+
+    def test_a_set_with_no_candidates_draws_no_card(self):
+        decision = ranker.rankCompoundSet(compoundSet("Nothing", []), onMapIDs=set())
+        self.assertEqual("skip", decision["status"])
+
+    def test_a_lone_selected_candidate_draws_no_card(self):
+        found = compoundSet("Urea", [("C00086", "Urea")])
+        found.getMainCompounds()[0].selected = True
+        decision = ranker.rankCompoundSet(found, onMapIDs=set())
+        self.assertEqual("skip", decision["status"])
+
+    def test_a_lone_unselected_candidate_still_draws_a_card(self):
+        """The cross-box de-duplicator can leave a lone candidate unticked."""
+        found = compoundSet("Alanine", [("C00041", "L-Alanine")])
+        found.getMainCompounds()[0].selected = False
+        decision = ranker.rankCompoundSet(found, onMapIDs=set())
+        self.assertEqual("resolved", decision["status"])
+
+
+class PartitionTest(unittest.TestCase):
+
+    def test_sets_land_in_the_right_three_buckets(self):
+        resolved, residual, skipped = ranker.partitionCompoundSets(
+            [compoundSet("Glyceric acid", [("C00258", "Glyceric acid")],
+                         [("C00197", "3-Phospho-D-glycerate")]),
+             compoundSet("Serine", [("C00065", "L-Serine"), ("C00740", "D-Serine")]),
+             compoundSet("Nothing", [])],
+            onMapIDs={"C00065", "C00740"})
+
+        self.assertEqual(["Glyceric acid"], [d["title"] for d in resolved])
+        self.assertEqual(["Serine"], [d["title"] for d in residual])
+        self.assertEqual(["Nothing"], [d["title"] for d in skipped])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_compound_suggestion_authorisation.py
+++ b/PaintomicsServer/src/tests/test_compound_suggestion_authorisation.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Who may spend this deployment's LLM budget on compound disambiguation.
+
+/pa_suggest_compounds enqueues a gateway call. Three separate questions gate it
+and they are not the same question:
+
+  * capability -- is the feature on and is there a token at all;
+  * access     -- is this caller entitled to this job;
+  * consent    -- did this JOB's record say its contents may be sent outward.
+
+The consent one has a trap with history. test_ai_consent_enforced.py asserts at
+the AST level that no AI route reads `formFields.get("aiConsent")`, because a
+request-borne flag is the caller asserting their own consent. This file checks
+the same rule behaviourally for the new route, and pins the source-level rule
+for this file specifically so it cannot drift back.
+
+No server, no queue thread, no gateway: the servlet is driven with fakes.
+"""
+
+import ast
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from src.servlets import CompoundSuggestionServlet as servlet
+
+
+SERVLET_SOURCE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                              "..", "servlets", "CompoundSuggestionServlet.py")
+
+
+class FakeResponse:
+    def __init__(self):
+        self.content = None
+        self.status = 200
+
+    def setContent(self, content):
+        self.content = content
+        return self
+
+    def setStatus(self, status):
+        # handleException calls this BEFORE setContent, so a fake without it
+        # raises inside the error handler and every refusal looks like a
+        # response with no content at all.
+        self.status = status
+        return self
+
+
+class FakeRequest:
+    def __init__(self, form=None, cookies=None):
+        self.form = form or {}
+        self.cookies = cookies or {"userID": "u1", "sessionToken": "t1"}
+
+
+class FakeJob:
+    def __init__(self, userID="u1", consent=True, sharing=False):
+        self._userID = userID
+        self._consent = consent
+        self._sharing = sharing
+
+    def getUserID(self):
+        return self._userID
+
+    def getAIConsent(self):
+        return self._consent
+
+    def getAllowSharing(self):
+        return self._sharing
+
+
+class FakeQueue:
+    def __init__(self):
+        self.enqueued = []
+
+    def fetch_job(self, job_id):
+        return None
+
+    def enqueue(self, fn, args, timeout=None, job_id=None):
+        self.enqueued.append(job_id)
+
+    def get_result(self, job_id, remove=True):
+        return None
+
+    def check_status(self, job_id):
+        from src.common.PySiQ import JobStatus
+        return JobStatus.NOT_QUEUED
+
+    def get_error_message(self, job_id):
+        return None
+
+
+class ServletGuardsTest(unittest.TestCase):
+
+    def setUp(self):
+        self._patched = {}
+        self._patch(servlet.UserSessionManager, "isValidUser", lambda self, u, t: True)
+        self._patch(servlet, "_requireCapability", lambda: None)
+        self.queue = FakeQueue()
+
+    def _patch(self, target, name, value):
+        self._patched[(target, name)] = getattr(target, name, None)
+        setattr(target, name, value)
+
+    def tearDown(self):
+        for (target, name), old in self._patched.items():
+            if old is None:
+                delattr(target, name)
+            else:
+                setattr(target, name, old)
+
+    def _run(self, job, form=None):
+        servlet._requireJobAccess = lambda jobID, userID: job
+        response = FakeResponse()
+        # `form if form is not None` and not `form or ...`: an empty form is
+        # exactly the missing-jobID case, and it is falsy.
+        servlet.compoundSuggestionInitiate(
+            FakeRequest(form if form is not None else {"jobID": "J1"}),
+            response, self.queue)
+        return response.content
+
+    def test_a_consenting_job_is_queued(self):
+        content = self._run(FakeJob(consent=True))
+        self.assertTrue(content["success"])
+        self.assertEqual("queued", content["status"])
+        self.assertEqual(["cs_J1"], self.queue.enqueued)
+
+    def test_a_job_whose_record_withholds_consent_is_refused(self):
+        content = self._run(FakeJob(consent=False))
+        self.assertFalse(content.get("success"))
+        self.assertEqual([], self.queue.enqueued)
+
+    def test_consent_on_the_request_cannot_override_the_record(self):
+        """The exact bypass the AST guard in test_ai_consent_enforced exists for."""
+        content = self._run(FakeJob(consent=False),
+                            form={"jobID": "J1", "aiConsent": "true"})
+        self.assertFalse(content.get("success"))
+        self.assertEqual([], self.queue.enqueued)
+
+    def test_a_missing_jobid_is_refused_before_anything_is_queued(self):
+        content = self._run(FakeJob(), form={})
+        self.assertFalse(content.get("success"))
+        self.assertEqual([], self.queue.enqueued)
+
+    def test_the_queue_id_is_namespaced_away_from_the_step_2_run(self):
+        """`cs_<jobID>`, so a suggestion cannot collide with step 2 itself.
+
+        Enqueuing under the bare jobID would make the two runs the same queue
+        entry -- and step 2 is the one that overwrites the job's results.
+        """
+        self._run(FakeJob())
+        self.assertEqual(["cs_J1"], self.queue.enqueued)
+        self.assertNotIn("J1", self.queue.enqueued)
+
+
+class ConsentSourceRuleTest(unittest.TestCase):
+    """The source-level half: this file must never read consent off the form."""
+
+    def test_the_servlet_never_reads_aiconsent_from_the_request(self):
+        with open(os.path.abspath(SERVLET_SOURCE), encoding="utf-8") as handle:
+            source = handle.read()
+
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute) or node.func.attr != "get":
+                continue
+            for argument in node.args:
+                if isinstance(argument, ast.Constant) and argument.value == "aiConsent":
+                    self.fail("CompoundSuggestionServlet reads aiConsent from a "
+                              "request. Consent must be read from the stored job "
+                              "record (jobInstance.getAIConsent()); a request-borne "
+                              "flag is the caller asserting their own consent.")
+
+    def test_the_servlet_does_ask_the_stored_record(self):
+        with open(os.path.abspath(SERVLET_SOURCE), encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertIn("getAIConsent()", source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_compound_suggestion_authorisation.py
+++ b/PaintomicsServer/src/tests/test_compound_suggestion_authorisation.py
@@ -96,7 +96,9 @@ class ServletGuardsTest(unittest.TestCase):
 
     def setUp(self):
         self._patched = {}
-        self._patch(servlet.UserSessionManager, "isValidUser", lambda self, u, t: True)
+        # *_ rather than named parameters: the stub ignores them, and vulture
+        # reports a named-but-unused one as dead code at 100% confidence.
+        self._patch(servlet.UserSessionManager, "isValidUser", lambda *_: True)
         self._patch(servlet, "_requireCapability", lambda: None)
         self.queue = FakeQueue()
 
@@ -112,7 +114,11 @@ class ServletGuardsTest(unittest.TestCase):
                 setattr(target, name, old)
 
     def _run(self, job, form=None):
-        servlet._requireJobAccess = lambda jobID, userID: job
+        # Through _patch, so tearDown restores it. Assigned directly, the stub
+        # outlived the test and every later test in the same interpreter got a
+        # permanently stubbed authorisation function -- an access-control
+        # regression in _requireJobAccess would have passed unnoticed.
+        self._patch(servlet, "_requireJobAccess", lambda jobID, userID: job)
         response = FakeResponse()
         # `form if form is not None` and not `form or ...`: an empty form is
         # exactly the missing-jobID case, and it is falsy.

--- a/PaintomicsServer/src/tests/test_step2_ai_suggestions.py
+++ b/PaintomicsServer/src/tests/test_step2_ai_suggestions.py
@@ -211,6 +211,54 @@ const out = {};
                 banner: view.renderAISummary()};
 }
 
+// --- a model identifier must never reach the interface ----------------------
+{
+    const set = compoundSet("Alanine", [
+        compound("C00041", "L-Alanine", true),
+        compound("C00133", "D-Alanine", true)]);
+    const view = jobView([set]);
+    view.applyAISuggestions({
+        decisions: [{title: "Alanine", keggID: "C00041", tier: "ai",
+                     confidence: "high", reason: "mouse"}],
+        unresolved: [],
+        model: "deepseek-ai/DeepSeek-V4-Flash-0731"});
+    out.modelLeak = {banner: view.renderAISummary()};
+}
+
+// --- the same compound must not be selected under two input names ----------
+{
+    const alanine = compoundSet("Alanine", [
+        compound("C00099", "beta-Alanine", true),
+        compound("C00041", "L-Alanine", false)]);
+    const betaAla = compoundSet("beta-alanine", [compound("C00099", "beta-Alanine", false)]);
+    const view = jobView([alanine, betaAla]);
+    const counts = view.applyAISuggestions({
+        decisions: [
+            {title: "beta-alanine", keggID: "C00099", tier: "ai",
+             confidence: "high", reason: "exact"}],
+        unresolved: []});
+    out.crossSet = {
+        alanineTicks: ticks(alanine), betaTicks: ticks(betaAla),
+        counts: counts, betaState: view.items[1].aiState};
+}
+
+// --- Undo after a second run returns the USER's ticks, not the first result --
+{
+    const set = compoundSet("Serine", [
+        compound("C00065", "L-Serine", false),
+        compound("C00740", "D-Serine", true)]);
+    const view = jobView([set]);
+    const original = ticks(set);
+    view.applyAISuggestions({decisions: [{title: "Serine", keggID: "C00065",
+        tier: "ai", confidence: "high", reason: "L"}], unresolved: []});
+    const afterFirst = ticks(set);
+    view.applyAISuggestions({decisions: [{title: "Serine", keggID: "C00740",
+        tier: "ai", confidence: "high", reason: "D"}], unresolved: []});
+    view.undoAISuggestions();
+    out.doubleRunUndo = {original: original, afterFirst: afterFirst,
+                         afterUndo: ticks(set)};
+}
+
 process.stdout.write(JSON.stringify(out));
 """
 
@@ -271,6 +319,48 @@ class Step2AISuggestionsTest(unittest.TestCase):
         self.assertIn("AI unsure", case["card"])
         self.assertIn("aiBox-unsure", case["card"])
         self.assertIn("aiBadge-unsure", case["card"])
+
+    def test_a_compound_already_used_elsewhere_is_not_selected_twice(self):
+        """Step 1 de-duplicates across boxes on purpose; applying picks must too.
+
+        JobController unselects the losing copy when two input names propose the
+        same KEGG id, and the checkbox carries a duplicate warning. That warning
+        only fires on a real `change` event, so applying set by set would have
+        re-created exactly the duplicate both guards exist to prevent -- silently,
+        and posted twice to step 3.
+        """
+        case = self.out["crossSet"]
+        # "Alanine" keeps C00099; "beta-alanine" is left alone and explained.
+        self.assertEqual([True, False], case["alanineTicks"])
+        self.assertEqual([False], case["betaTicks"])
+        self.assertEqual(0, case["counts"]["byAI"])
+        self.assertEqual(1, case["counts"]["unsure"])
+        self.assertEqual("unsure", case["betaState"]["status"])
+        self.assertIn("already uses this compound", case["betaState"]["reason"])
+
+    def test_undo_after_a_second_run_restores_the_users_own_ticks(self):
+        """The snapshot is taken once, not refreshed by "Choose again".
+
+        Overwritten on the second run, Undo restored the AI's FIRST answer while
+        the control still promised to put every tick back as it was.
+        """
+        case = self.out["doubleRunUndo"]
+        self.assertEqual([False, True], case["original"])
+        self.assertEqual([True, False], case["afterFirst"])
+        self.assertEqual(case["original"], case["afterUndo"])
+
+    def test_the_model_identifier_never_reaches_the_banner(self):
+        """PA_Step1Views states the rule for the consent copy; it holds here too.
+
+        Naming a specific build invites the reader to evaluate the model rather
+        than the decision in front of them, and the string goes stale the moment
+        the gateway is repointed. The server no longer sends it either -- this
+        pins the rendering half, by handing the view one anyway.
+        """
+        banner = self.out["modelLeak"]["banner"]
+        self.assertNotIn("deepseek", banner.lower())
+        self.assertNotIn("DeepSeek", banner)
+        self.assertIn("checked against the candidates", banner)
 
     def test_a_decision_that_changes_nothing_leaves_no_badge(self):
         """A chip on every card is a chip on none.

--- a/PaintomicsServer/src/tests/test_step2_ai_suggestions.py
+++ b/PaintomicsServer/src/tests/test_step2_ai_suggestions.py
@@ -287,7 +287,9 @@ class Step2AISuggestionsTest(unittest.TestCase):
         case = self.out["noop"]
         self.assertEqual(0, case["counts"]["byRule"])
         self.assertEqual(0, case["counts"]["byAI"])
-        self.assertIn("already matched", case["banner"])
+        # Asserted as "claims no changes" rather than against a phrase, so
+        # rewording the banner cannot fail a test about arithmetic.
+        self.assertNotIn("Changed", case["banner"])
 
 
 if __name__ == "__main__":

--- a/PaintomicsServer/src/tests/test_step2_ai_suggestions.py
+++ b/PaintomicsServer/src/tests/test_step2_ai_suggestions.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""The browser half of the closed-set guarantee, and Undo.
+
+The server refuses to answer with a KEGG id that was not on a card. This file
+pins the other half: the code that moves the checkboxes refuses to act on one
+either, and it only ever touches candidates inside the set it was given.
+
+Both halves are needed. The server's validation protects against the model; this
+protects against the payload -- a decision for an input name this browser has no
+card for, or an id that belongs to a different set. Neither is hypothetical:
+the server deliberately ranks compound sets this view draws no card for, because
+`selected` does not exist server-side and its needsDisambiguation is therefore
+more permissive than the view's.
+
+Runs the real PA_Step2Views.js inside node with stubs for Ext, jQuery and View,
+exactly as test_step2_compound_panel.py does. Skipped where node is missing.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(TESTS_DIR, "..", "..", ".."))
+STEP2_VIEW = os.path.join(
+    REPO_ROOT, "PaintomicsClient", "public_html", "app", "view",
+    "PathwayAcquisitionViews", "PA_Step2Views.js")
+
+NODE = shutil.which("node")
+
+HARNESS = r"""
+const fs = require('fs');
+const vm = require('vm');
+const source = fs.readFileSync(process.argv[2], 'utf8');
+
+function htmlEncode(value) {
+    return String(value).replace(/&/g, '&amp;').replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+
+// jQuery is only used here for the toolbar buttons; every call is a no-op that
+// returns a chainable stub, so setAIButtonState and the click wiring can run.
+function jqStub() {
+    const self = {
+        length: 0,
+        on: () => self, click: () => self, html: () => self, show: () => self,
+        hide: () => self, addClass: () => self, removeClass: () => self,
+        hasClass: () => false, attr: () => undefined, is: () => false,
+        closest: () => self, val: () => "", toggle: () => self, find: () => self,
+        prev: () => self, remove: () => self
+    };
+    return self;
+}
+
+const sandbox = {
+    console: {log(){}, info(){}, warn(){}, error(){}},
+    View: function View() {
+        this.model = null; this.component = null;
+        this.getModel = function () { return this.model; };
+        this.getComponent = function () { return this.component; };
+        this.loadModel = function (model) { this.model = model; return this; };
+    },
+    Ext: {
+        String: {htmlEncode: htmlEncode},
+        widget: function () { return {}; },
+        create: function () { return {}; }
+    },
+    $: jqStub,
+    initializeTooltips: function () {},
+    showWarningMessage: function () {},
+    withAIProviderInfo: function () {}
+};
+sandbox.globalThis = sandbox;
+vm.createContext(sandbox);
+vm.runInContext(source + "\n;globalThis.__api = {" +
+    "PA_Step2CompoundSetView: PA_Step2CompoundSetView," +
+    "PA_Step2JobView: PA_Step2JobView};", sandbox, {filename: 'PA_Step2Views.js'});
+const api = sandbox.__api;
+
+function compound(id, name, selected) {
+    return {
+        ID: id, name: name, selected: selected,
+        getID: function () { return this.ID; },
+        getName: function () { return this.name; },
+        isSelected: function () { return this.selected; }
+    };
+}
+function compoundSet(title, main, other) {
+    return {
+        title: title, mainCompounds: main, otherCompounds: other || [],
+        getTitle: function () { return this.title; },
+        getMainCompounds: function () { return this.mainCompounds; },
+        getOtherCompounds: function () { return this.otherCompounds; },
+        addObserver: function () {}
+    };
+}
+function jobView(sets) {
+    const view = new api.PA_Step2JobView();
+    view.loadModel({
+        getFoundCompounds: function () { return sets; },
+        deleteObserver: function () {},
+        getJobID: function () { return "job1"; },
+        aiConsent: true
+    });
+    view.items = sets.map(function (set) {
+        const cardView = new api.PA_Step2CompoundSetView();
+        cardView.loadModel(set);
+        return cardView;
+    });
+    // The panel component only exists once the widget is built; refresh must
+    // survive its absence, which is also what happens in a background tab.
+    view.component = null;
+    return view;
+}
+
+function ticks(set) {
+    return set.mainCompounds.concat(set.otherCompounds)
+        .map(function (c) { return c.selected === true; });
+}
+
+const out = {};
+
+// --- a legal decision moves exactly one tick, and clears its rivals ---------
+{
+    const alanine = compoundSet("Alanine", [
+        compound("C01401", "Alanine", true),
+        compound("C00041", "L-Alanine", true),
+        compound("C00133", "D-Alanine", true)]);
+    const view = jobView([alanine]);
+    const counts = view.applyAISuggestions({
+        decisions: [{title: "Alanine", keggID: "C00041", tier: "ai",
+                     confidence: "high", reason: "mouse"}],
+        unresolved: [], model: "m"});
+    out.legal = {ticks: ticks(alanine), counts: counts,
+                 badge: view.items[0].aiState};
+}
+
+// --- an id this set does not contain must change nothing -------------------
+{
+    const serine = compoundSet("Serine", [
+        compound("C00065", "L-Serine", true),
+        compound("C00740", "D-Serine", true)]);
+    const view = jobView([serine]);
+    const counts = view.applyAISuggestions({
+        decisions: [{title: "Serine", keggID: "C00041", tier: "ai",
+                     confidence: "high", reason: "wrong set"}],
+        unresolved: [], model: "m"});
+    out.foreignID = {ticks: ticks(serine), counts: counts};
+}
+
+// --- a decision for a card this view does not have is dropped --------------
+{
+    const serine = compoundSet("Serine", [
+        compound("C00065", "L-Serine", true),
+        compound("C00740", "D-Serine", true)]);
+    const view = jobView([serine]);
+    const counts = view.applyAISuggestions({
+        decisions: [{title: "Pyruvic acid", keggID: "C00022", tier: "deterministic",
+                     confidence: "", reason: "not drawn here"}],
+        unresolved: [], model: "m"});
+    out.unknownCard = {ticks: ticks(serine), counts: counts};
+}
+
+// --- undo restores every tick exactly ---------------------------------------
+{
+    const glucose = compoundSet("Glucose",
+        [compound("C00031", "Glucose", true), compound("C00221", "beta-D-Glucose", true)],
+        [compound("C00092", "D-Glucose 6-phosphate", false)]);
+    const view = jobView([glucose]);
+    const before = ticks(glucose);
+    view.applyAISuggestions({
+        decisions: [{title: "Glucose", keggID: "C00031", tier: "ai",
+                     confidence: "high", reason: "no anomer named"}],
+        unresolved: [], model: "m"});
+    const during = ticks(glucose);
+    view.undoAISuggestions();
+    out.undo = {before: before, during: during, after: ticks(glucose),
+                summaryCleared: view.aiSummary === null,
+                badgeCleared: view.items[0].aiState === null};
+}
+
+// --- an abstention badges the card and leaves it alone ----------------------
+{
+    const lysine = compoundSet("Lysine", [
+        compound("C00047", "L-Lysine", true),
+        compound("C00739", "D-Lysine", true)]);
+    const view = jobView([lysine]);
+    const counts = view.applyAISuggestions({
+        decisions: [],
+        unresolved: [{title: "Lysine", reason: "both forms are plausible", detail: ""}],
+        model: "m"});
+    out.abstain = {ticks: ticks(lysine), counts: counts,
+                   badge: view.items[0].aiState,
+                   card: view.items[0].renderCard(0)};
+}
+
+// --- the summary counts cards changed, not decisions received ---------------
+{
+    const already = compoundSet("Urea", [compound("C00086", "Urea", true)]);
+    const view = jobView([already]);
+    const counts = view.applyAISuggestions({
+        decisions: [{title: "Urea", keggID: "C00086", tier: "deterministic",
+                     confidence: "", reason: "only match"}],
+        unresolved: [], model: "m"});
+    out.noop = {counts: counts, summary: view.aiSummary,
+                badge: view.items[0].aiState || null,
+                banner: view.renderAISummary()};
+}
+
+process.stdout.write(JSON.stringify(out));
+"""
+
+
+@unittest.skipIf(NODE is None, "node is not installed")
+class Step2AISuggestionsTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        handle, path = tempfile.mkstemp(suffix=".js")
+        with os.fdopen(handle, "w") as harness:
+            harness.write(HARNESS)
+        try:
+            result = subprocess.run([NODE, path, STEP2_VIEW],
+                                    stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            if result.returncode != 0:
+                raise AssertionError("harness failed:\n" + result.stderr.decode("utf-8"))
+            cls.out = json.loads(result.stdout.decode("utf-8"))
+        finally:
+            os.unlink(path)
+
+    def test_a_legal_decision_ticks_one_candidate_and_clears_the_rest(self):
+        case = self.out["legal"]
+        self.assertEqual([False, True, False], case["ticks"])
+        self.assertEqual(1, case["counts"]["byAI"])
+        self.assertEqual(0, case["counts"]["byRule"])
+        self.assertEqual("picked", case["badge"]["status"])
+        self.assertEqual("C00041", case["badge"]["keggID"])
+
+    def test_an_id_from_another_set_changes_nothing(self):
+        """selectOnly must not clear a set just because it cannot find the id.
+
+        Unticking everything would be the worst outcome available: the user
+        loses a selection they made, to an answer that was never valid.
+        """
+        case = self.out["foreignID"]
+        self.assertEqual([True, True], case["ticks"])
+        self.assertEqual(0, case["counts"]["byAI"])
+
+    def test_a_decision_for_a_card_this_view_lacks_is_dropped(self):
+        case = self.out["unknownCard"]
+        self.assertEqual([True, True], case["ticks"])
+        self.assertEqual(0, case["counts"]["byAI"] + case["counts"]["byRule"])
+
+    def test_undo_restores_every_tick_including_collapsed_alternatives(self):
+        case = self.out["undo"]
+        self.assertEqual([True, True, False], case["before"])
+        self.assertEqual([True, False, False], case["during"])
+        self.assertEqual(case["before"], case["after"])
+        self.assertTrue(case["summaryCleared"])
+        self.assertTrue(case["badgeCleared"])
+
+    def test_an_abstention_badges_the_card_without_touching_it(self):
+        case = self.out["abstain"]
+        self.assertEqual([True, True], case["ticks"])
+        self.assertEqual(1, case["counts"]["unsure"])
+        self.assertEqual("unsure", case["badge"]["status"])
+        self.assertIn("AI unsure", case["card"])
+        self.assertIn("aiBox-unsure", case["card"])
+        self.assertIn("aiBadge-unsure", case["card"])
+
+    def test_a_decision_that_changes_nothing_leaves_no_badge(self):
+        """A chip on every card is a chip on none.
+
+        The server decides every compound set it holds, and on a typical job
+        most of those agree with what was already ticked. Marking those too put
+        a badge on 52 of 47 cards and made the changes impossible to find.
+        """
+        case = self.out["noop"]
+        self.assertIsNone(case["badge"])
+
+    def test_a_decision_that_changes_nothing_is_not_counted_as_work(self):
+        """The banner must not credit the feature with ticks it did not move."""
+        case = self.out["noop"]
+        self.assertEqual(0, case["counts"]["byRule"])
+        self.assertEqual(0, case["counts"]["byAI"])
+        self.assertIn("already matched", case["banner"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -133,8 +133,12 @@ PUBLISHED = {
     # v=1.0 adds AI_POLL_MAX_FAILURES. A browser keeping the old copy would
     # read it as undefined, and `failures >= undefined` is false for ever --
     # which is precisely the endless poll this release exists to stop.
+    # v=1.2: the step-2 compound-suggestion endpoints, and a poll ceiling that
+    # actually outlasts the server's own worst case (400 x 3s) plus a separate
+    # transport-failure budget. A browser holding the old copy would poll two
+    # URLs it has no constants for.
     "resources/ServerConfiguration.js": (
-        "1.0", "6d9d416610b8384c78fb7e46b10aa4414aea0886d720a840499904aec0e9fe85"),
+        "1.2", "5eebc8f3202877310f0b4e8df4d14d4a5e412292eefbbb12b5bdde13a6d05361"),
     # The evidence layer itself: MORE relationships drawn on the diagram and
     # classified against KEGG, Reactome and OmniPath.
     # v=2.8 draws regulators the map does not print, colours them from the

--- a/scripts/ci/vulture_baseline.txt
+++ b/scripts/ci/vulture_baseline.txt
@@ -156,6 +156,8 @@ PaintomicsServer/src/paintomicsserver.py: unused function 'aiProviderHandler' (6
 PaintomicsServer/src/paintomicsserver.py: unused function 'applyReplicateMappingHandler' (60% confidence)
 PaintomicsServer/src/paintomicsserver.py: unused function 'changePasswordHandler' (60% confidence)
 PaintomicsServer/src/paintomicsserver.py: unused function 'checkJobStatus' (60% confidence)
+PaintomicsServer/src/paintomicsserver.py: unused function 'compoundSuggestionInitiateHandler' (60% confidence)
+PaintomicsServer/src/paintomicsserver.py: unused function 'compoundSuggestionStatusHandler' (60% confidence)
 PaintomicsServer/src/paintomicsserver.py: unused function 'deleteFileHandler' (60% confidence)
 PaintomicsServer/src/paintomicsserver.py: unused function 'deleteJobHandler' (60% confidence)
 PaintomicsServer/src/paintomicsserver.py: unused function 'deleteMessage' (60% confidence)


### PR DESCRIPTION
## The problem

Step 1 maps a metabolite name to KEGG by case-insensitive **substring** match, so `"Glucose"` reaches step 2 carrying 113 candidates and `"Alanine"` 105. Step 2 then pre-ticks *every* candidate scoring ≥ 0.9, and `mainPrefixes` treats `d-`, `l-` and `beta-` as free prefixes.

Measured live on the STATegra mouse example — an input of `Alanine` arrives with **three boxes already ticked**:

```
L-Alanine       C00041  ✓
D-Alanine       C00133  ✓   <- bacterial, not in a mouse study
Alanine         C01401  ✓   <- the unspecified form
beta-Alanine    C00099  ☐   <- a different metabolite entirely
```

Click *Next step* without pruning and one metabolite's values are painted onto three KEGG nodes. There is no error and no warning — the analysis is simply about different metabolites than were measured.

## What this adds

A **Choose for me** control in the Compounds disambiguation section, deciding in two tiers.

**Tier 1 — deterministic** (`ranker.py`). One main candidate wins; otherwise the candidates this organism actually draws on a pathway win. Settles **34 of 52** sets on the STATegra example with no gateway call.

**Tier 2 — the residual, as a closed-set choice** (`resolver.py`). Each input name is shown only its own candidate ids, and:

> an answer is applied only if it names a KEGG id that was in **that** input name's own candidate list.

`validateChoice` is a pure function over one reply and the question it answers, so the guarantee is tested with no gateway, job or key. An invented id, an id borrowed from another name in the same batch, an unknown name, a duplicate answer, or low confidence all become abstentions — and an abstention leaves the user's ticks exactly as they were.

## One rule is deliberately absent

**Exact name wins.** Measured against `kegg_compounds`:

| Input | Exact-name match | Correct for mouse |
|---|---|---|
| `Alanine` | **C01401** (unspecified) | C00041 L-Alanine |
| `Serine` | C00716 **and** C00065 | C00065 |
| `Malic acid` | C00149 **and** C00711 | C00149 |
| `Lactic acid` | C01432 (generic) | C00186 |

The species filter rescues three of those; it does **not** rescue `Alanine`, because C01401 is on mouse maps. So that name is escalated instead of guessed. Two tests pin the absence of this rule so no future "obvious" cleanup reopens it.

## Nothing is written to the job

The run returns advice. The browser applies it to its own model, **Undo** restores every tick from a snapshot taken before anything moved, and `pathwayAcquisitionStep2` remains the only writer of a compound selection. Enqueue-and-poll, not a blocking route — uWSGI serves the whole site on four threads.

## Two bugs found by driving the real UI

- The **step-1 response never carried `aiConsent`** (only step 3 and `pa_recover_job` did), so a browser arriving at step 2 from step 1 had no consent flag and the button was invisible on the only path users take.
- A job **reopened by `?jobID=`** loads its compound sets through `FeatureDAO.findAll`, which builds a plain `Feature` whatever the subclass — candidates come back as raw dicts and `getMainCompounds()` does not exist. `coerceCompoundSets` normalises both shapes rather than changing what the shared job-loading path returns.

`Feature.calculateSimilarity` now delegates to `src/common/CompoundNameSimilarity` so the ranker cannot disagree with the mapper about what "main" means. Scores verified identical before and after.

## Verified in Chrome

Live CSIC gateway, STATegra mouse example: **18 of 18** residual names chosen correctly — `Alanine` → C00041 (not the generic C01401), `Glucose` → C00031 (not an anomer), `ethanolamine` → C00189 (not diethanolamine). 0 rejected, 0 abstained. Undo restored all 25 changed ticks.

Provenance is legible at a glance, in three states: grey **Auto** (a rule), blue **AI**, orange **AI unsure**. Cards the run did not change carry no mark at all — badging those too put a chip on nearly every card, which makes the chip meaningless. Light and dark both checked; contrast ≥ 4.9:1 throughout; alignment-guides HUD reports 0 off-rail elements from this markup.

## Checks

- 123 tests pass across 10 suites (5 new files, plus the adjacent step-2/consent suites)
- `ruff --select E9,F` clean
- The whole application still imports against a `serverconf.py` predating the new `AI_COMPOUND_SUGGESTIONS_ENABLED` flag (it is gitignored, so an existing deployment keeps its old copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
