### PR TITLE
Say what is wrong with a refused Step 1 form, and stop deleting the panel that is wrong

### DIFF
--- a/PaintomicsClient/public_html/app/controller/JobController.js
+++ b/PaintomicsClient/public_html/app/controller/JobController.js
@@ -64,15 +64,32 @@ var STEP1_NO_DATA_MESSAGE = "Invalid form. <br/> Please provide at least: " +
 	"<span style='color: auto;text-decoration: underline;'>Gene expression /Metabolomics /Proteomics data.</span>" +
 	" Also, please make sure to <span style='color: auto;text-decoration: underline;'>select an organism.</span>";
 
+/* The plain text of a field's error. ExtJS wraps several in a <ul>, and a
+   custom markInvalid() message only ever appears in the active error, not in
+   getErrors(), so this reads the active error and strips the markup. */
+function fieldErrorText(field) {
+	var error = (field && field.getActiveError) ? field.getActiveError() : "";
+	return String(error || "")
+		.replace(/<[^>]*>/g, " ")
+		.replace(/\s+/g, " ")
+		.replace(/^ | $/g, "");
+}
+
 /**
 * The refusal a Step 1 submission gets when checkForm() said no.
 *
-* Two different things can be wrong and they do not read the same. When a field
-* is wrong the form marks it and "please check the form errors" is a direction;
-* when nothing was filled in there is no field to point at, and the same
-* sentence sends the user hunting for something that is not on the page. That
-* second case is what a user reported on 2026-08-26, so checkForm() sets
-* `formIsEmpty` and the two are told apart here.
+* Three things can be wrong and they do not read the same:
+*
+*   - nothing filled in at all: there is no field to point at, so it says so
+*     and does not offer Report error -- nothing here is a bug;
+*   - a field is wrong: name it, say what it wants, and scroll it into view.
+*     The form is three sections tall, so the field that refused the
+*     submission is routinely off screen behind the dialog. The user who
+*     reported this on 2026-08-26 had filled in a MORE panel in section 3 and
+*     never chosen an organism in section 1 -- "please check the form errors"
+*     was true and still told her nothing;
+*   - a refusal with nothing marked anywhere: that is the old wording, kept as
+*     a fallback, and it is the shape of a bug, so Report error stays.
 *
 * @param {PA_Step1JobView} jobView
 */
@@ -81,6 +98,26 @@ function showInvalidStep1FormMessage(jobView) {
 		showErrorMessage(STEP1_NO_DATA_MESSAGE, {height: 150, width: 400, showReportButton: false});
 		return;
 	}
+
+	var field = (jobView && jobView.firstFormError) ? jobView.firstFormError() : null;
+	if (field) {
+		/* Scrolled before the dialog opens, so closing it leaves the reader
+		   looking at the field the message just named. */
+		try {
+			field.getEl().dom.scrollIntoView({block: "center"});
+		} catch (ignored) {
+			/* An unrendered field cannot be scrolled to; the message still names it. */
+		}
+
+		var label = String(field.fieldLabel || "").replace(/\s*:\s*$/, "");
+		var reason = fieldErrorText(field) || "Please check this field.";
+		showErrorMessage("Invalid Form. </br>" +
+			(label ? " <b>" + Ext.String.htmlEncode(label) + "</b>: " : " ") +
+			Ext.String.htmlEncode(reason),
+			{height: 150, width: 400, showReportButton: true});
+		return;
+	}
+
 	showErrorMessage("Invalid Form. </br> Please check the form errors.",
 		{height: 150, width: 400, showReportButton: true});
 }

--- a/PaintomicsClient/public_html/app/controller/JobController.js
+++ b/PaintomicsClient/public_html/app/controller/JobController.js
@@ -58,6 +58,33 @@ function withExampleScenario(exampleURL, jobView) {
 	return scenarioId ? exampleURL + "/" + encodeURIComponent(scenarioId) : exampleURL;
 }
 
+/* What a Step 1 submission is told when the form holds no omic data at all.
+   Both submit paths reach that state, so both say it in the same words. */
+var STEP1_NO_DATA_MESSAGE = "Invalid form. <br/> Please provide at least: " +
+	"<span style='color: auto;text-decoration: underline;'>Gene expression /Metabolomics /Proteomics data.</span>" +
+	" Also, please make sure to <span style='color: auto;text-decoration: underline;'>select an organism.</span>";
+
+/**
+* The refusal a Step 1 submission gets when checkForm() said no.
+*
+* Two different things can be wrong and they do not read the same. When a field
+* is wrong the form marks it and "please check the form errors" is a direction;
+* when nothing was filled in there is no field to point at, and the same
+* sentence sends the user hunting for something that is not on the page. That
+* second case is what a user reported on 2026-08-26, so checkForm() sets
+* `formIsEmpty` and the two are told apart here.
+*
+* @param {PA_Step1JobView} jobView
+*/
+function showInvalidStep1FormMessage(jobView) {
+	if (jobView && jobView.formIsEmpty === true) {
+		showErrorMessage(STEP1_NO_DATA_MESSAGE, {height: 150, width: 400, showReportButton: false});
+		return;
+	}
+	showErrorMessage("Invalid Form. </br> Please check the form errors.",
+		{height: 150, width: 400, showReportButton: true});
+}
+
 function JobController() {
 	/**
 	*
@@ -391,7 +418,7 @@ function JobController() {
 			//SEND ALL FORM TO THE QUEUE
 			sendRequest(jobView, specialOmics);
 		} else {
-			showErrorMessage("Invalid Form. </br> Please check the form errors.", {height: 150, width: 400, showReportButton:true});
+			showInvalidStep1FormMessage(jobView);
 			return false;
 		}
 	};
@@ -574,7 +601,7 @@ function JobController() {
 				// a form that fails validation here must not keep it.
 				this.endStep1Submission(jobView);
 			}
-			showErrorMessage("Invalid form. <br/> Please provide at least: <span style='color: auto;text-decoration: underline;'>Gene expression /Metabolomics /Proteomics data.</span> Also, please make sure to <span style='color: auto;text-decoration: underline;'>select an organism.</span>", {height: 150, width: 400, showReportButton:false});
+			showErrorMessage(STEP1_NO_DATA_MESSAGE, {height: 150, width: 400, showReportButton:false});
 			return false;
 		}
 	};

--- a/PaintomicsClient/public_html/app/controller/JobController.js
+++ b/PaintomicsClient/public_html/app/controller/JobController.js
@@ -67,12 +67,22 @@ var STEP1_NO_DATA_MESSAGE = "Invalid form. <br/> Please provide at least: " +
 /* The plain text of a field's error. ExtJS wraps several in a <ul>, and a
    custom markInvalid() message only ever appears in the active error, not in
    getErrors(), so this reads the active error and strips the markup. */
-function fieldErrorText(field) {
-	var error = (field && field.getActiveError) ? field.getActiveError() : "";
-	return String(error || "")
+/* Markup stripped to plain text: tags out, whitespace collapsed, edges trimmed. */
+function plainFieldText(html) {
+	return String(html || "")
+		.replace(/<\/li>\s*<li[^>]*>/gi, " \u2014 ")
 		.replace(/<[^>]*>/g, " ")
 		.replace(/\s+/g, " ")
 		.replace(/^ | $/g, "");
+}
+
+/* The plain text of a field's error. ExtJS wraps several in a <ul>, and a
+   custom markInvalid() message only ever appears in the active error, not in
+   getErrors(), so this reads the active error and strips the markup. Several
+   errors are joined with a dash rather than glued into one sentence. */
+function fieldErrorText(field) {
+	var error = (field && field.getActiveError) ? field.getActiveError() : "";
+	return plainFieldText(error);
 }
 
 /**
@@ -109,7 +119,10 @@ function showInvalidStep1FormMessage(jobView) {
 			/* An unrendered field cannot be scrolled to; the message still names it. */
 		}
 
-		var label = String(field.fieldLabel || "").replace(/\s*:\s*$/, "");
+		/* Six shipped labels carry a <br> ("Regions file <br>(BED + Quantification)"),
+		   and that is the label the file widget's inner textfield inherits, so the
+		   markup is stripped exactly as the error text is. */
+		var label = plainFieldText(field.fieldLabel).replace(/\s*:\s*$/, "");
 		var reason = fieldErrorText(field) || "Please check this field.";
 		showErrorMessage("Invalid Form. </br>" +
 			(label ? " <b>" + Ext.String.htmlEncode(label) + "</b>: " : " ") +
@@ -638,7 +651,11 @@ function JobController() {
 				// a form that fails validation here must not keep it.
 				this.endStep1Submission(jobView);
 			}
-			showErrorMessage(STEP1_NO_DATA_MESSAGE, {height: 150, width: 400, showReportButton:false});
+			/* The same refusal the pre-processing path shows: an all-empty form
+			   is told so, and a wrong field is named and scrolled to. This path
+			   used to say "provide at least Gene expression..." unconditionally,
+			   which was wrong whenever the organism was the fault. */
+			showInvalidStep1FormMessage(jobView);
 			return false;
 		}
 	};

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -1358,6 +1358,34 @@ function PA_Step1JobView() {
 
 		return valid;
 	};
+	/**
+	* The first field on the form carrying an error, or null.
+	*
+	* "Please check the form errors" is only a direction if the reader can find
+	* the error, and this form is three sections tall: the organism sits in
+	* section 1 and the omic panels in section 3, so the field that refused the
+	* submission is routinely off screen when the dialog opens over it. The
+	* reporting user on 2026-08-26 had filled in a MORE panel at the bottom of
+	* the page and never chosen an organism at the top -- nginx has her first
+	* /organism_databases (the combo's change listener, once per page load)
+	* landing 31 seconds AFTER the report -- so the one thing wrong with her
+	* form was a field she had no reason to be looking at.
+	*
+	* Only visible fields count: a hidden one cannot be shown to anybody, and
+	* naming it would be worse than saying nothing.
+	*
+	* @returns {Ext.form.field.Base|null}
+	*/
+	this.firstFormError = function() {
+		var fields = this.getComponent().query("field"), i;
+		for (i = 0; i < fields.length; i++) {
+			if (fields[i].hasActiveError && fields[i].hasActiveError() &&
+				fields[i].isVisible(true) && fields[i].getEl()) {
+				return fields[i];
+			}
+		}
+		return null;
+	};
 
 	//    this.showMyDataPanel = function () {
 	//        this.controller.showMyDataPanelClickHandler(this);

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -1266,6 +1266,13 @@ function PA_Step1JobView() {
 	this.submitFormHandler = function() {
 		var aux, omicBoxes;
 
+		/* Which panels are in this submission is only knowable once the empty
+		   ones are gone, so drop them first. A panel dropped afterwards is a
+		   destroyed component still sitting in the pre-processing list, and
+		   step1ComplexFormSubmitHandler throws on the first queryById of a
+		   container that is no longer there. */
+		this.dropEmptyOmicPanels();
+
 		omicBoxes = this.getComponent().queryById("submittingPanelsContainer").query("container[cls=omicbox regionBasedOmic],[cls=omicbox miRNABasedOmic],[cls=omicbox moreBasedOmic]");
 		for (var i = omicBoxes.length; i--;) {
 			aux = omicBoxes[i].queryById("itemsContainer");
@@ -1281,28 +1288,75 @@ function PA_Step1JobView() {
 		}
 	};
 	/**
+	* Removes the omic panels the user left empty, and returns the ones that stay.
+	*
+	* Step 1 opens with a Gene expression panel and a Metabolomics panel already
+	* on the form, and adding a Region-based, miRNA or MORE panel is one click in
+	* "Available omics". A panel with no file in it means "I did not want this
+	* one", so it is taken off the form rather than reported -- and because it is
+	* taken off the form, nothing downstream may treat it as part of the job.
+	*
+	* @returns {Array} the panels that carry a file
+	*/
+	this.dropEmptyOmicPanels = function() {
+		var items, filled, i;
+
+		items = this.getComponent().query("container[cls=omicbox], container[cls=omicbox regionBasedOmic],[cls=omicbox miRNABasedOmic],[cls=omicbox moreBasedOmic]");
+
+		filled = [];
+		for (i = 0; i < items.length; i++) {
+			if (items[i].isEmpty() === true) {
+				$(items[i].getEl().dom).find("a.deleteOmicBox").click();
+			} else {
+				filled.push(items[i]);
+			}
+		}
+
+		return filled;
+	};
+	/**
 	* This function checks the validity for each OmicSubmittingPanel
+	*
+	* Sets `formIsEmpty` as a side effect: true when the form was refused
+	* because nothing was filled in, so the caller can say that instead of
+	* sending the user looking for field errors that do not exist.
 	*
 	* @returns Boolean
 	*/
 	this.checkForm = function() {
-		var items, valid, emptyFields;
+		var filled, valid, i;
 
-		items = this.getComponent().query("container[cls=omicbox], container[cls=omicbox regionBasedOmic],[cls=omicbox miRNABasedOmic],[cls=omicbox moreBasedOmic]");
+		/* Drop the empty panels BEFORE validating anything.
+
+		   The two halves used to run the other way round -- validate every
+		   panel, then delete the empty ones -- and disagreed. An empty panel
+		   was counted as invalid and then deleted by the very next loop. The
+		   plain omic panel hid it (its isValid() returns early when the panel
+		   is empty); the region, miRNA and MORE panels have no such guard, so
+		   empty they mark their own file fields and return false. Those three
+		   are also the only panels that route the submit through
+		   step1ComplexFormSubmitHandler, whose refusal is the one that says
+		   "please check the form errors" and offers Report error.
+
+		   So: fill in Gene expression, add a Region-based panel, press Run --
+		   the form was refused because of the region panel, the region panel
+		   was deleted a moment later, and the user was left looking at one
+		   clean box with nothing marked anywhere, told to check errors that no
+		   longer existed. That is the 2026-08-26 report; reproduced in Chrome
+		   with 0 fields marked invalid on the form it left behind. */
+		filled = this.dropEmptyOmicPanels();
+
+		this.formIsEmpty = (filled.length === 0);
+		if (this.formIsEmpty) {
+			return false;
+		}
+
 		valid = this.getComponent().queryById("speciesCombobox").isValid();
-		for (var i in items) {
-			valid = valid && items[i].isValid();
+		for (i = 0; i < filled.length; i++) {
+			valid = valid && filled[i].isValid();
 		}
 
-		emptyFields = 0;
-		for (var i in items) {
-			if (items[i].isEmpty() === true) {
-				emptyFields++;
-				$(items[i].getEl().dom).find("a.deleteOmicBox").click();
-			}
-		}
-
-		return valid && (emptyFields < items.length);
+		return valid;
 	};
 
 	//    this.showMyDataPanel = function () {

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -1331,8 +1331,8 @@ function PA_Step1JobView() {
 		   The two halves used to run the other way round -- validate every
 		   panel, then delete the empty ones -- and disagreed. An empty panel
 		   was counted as invalid and then deleted by the very next loop. The
-		   plain omic panel hid it (its isValid() returns early when the panel
-		   is empty); the region, miRNA and MORE panels have no such guard, so
+		   plain omic panel hid it (its isValid() tested `this.isEmpty` -- the
+		   method, always truthy -- so it validated nothing); the region, miRNA and MORE panels have no such guard, so
 		   empty they mark their own file fields and return false. Those three
 		   are also the only panels that route the submit through
 		   step1ComplexFormSubmitHandler, whose refusal is the one that says
@@ -1351,9 +1351,12 @@ function PA_Step1JobView() {
 			return false;
 		}
 
+		/* isValid() first, so a wrong organism does not short-circuit the loop:
+		   every panel is validated and marked in one pass. The dialog names the
+		   first field, the rest are red on the page -- one round, not two. */
 		valid = this.getComponent().queryById("speciesCombobox").isValid();
 		for (i = 0; i < filled.length; i++) {
-			valid = valid && filled[i].isValid();
+			valid = filled[i].isValid() && valid;
 		}
 
 		return valid;
@@ -2633,7 +2636,10 @@ function OmicSubmittingPanel(nElem, options) {
 			isValid: function() {
 				var valid = true;
 
-				if (this.isEmpty) {
+				/* isEmpty() -- the call. `this.isEmpty` alone was the method
+				   reference, always truthy, so this returned true for every
+				   plain panel and none of the checks below ever ran. */
+				if (this.isEmpty()) {
 					return true;
 				}
 

--- a/PaintomicsClient/public_html/app/view/common/Util.js
+++ b/PaintomicsClient/public_html/app/view/common/Util.js
@@ -465,7 +465,17 @@ function showMessage(title, data) {
     title = '<i class="fa fa-' + data.icon + '"></i> ' + title;
 
     message = message.replace(/\[b\]/g, "<b>").replace(/\[\/b\]/g, "</b>").replace(/\[br\]/g, "</br>").replace(/\[ul\]/g, "<ul>").replace(/\[\/ul\]/g, "</ul>").replace(/\[li\]/g, "<li>").replace(/\[\/li\]/g, "</li>");
-    extra = JSON.stringify(extra);
+    /* Only when there IS something. `extra` carries a server stack trace on the
+       dialogs that have one; the Step 1 form refusals have none, and
+       JSON.stringify("") is the two-character string `""`, which went straight
+       into the hidden body and from there into the report the user emails.
+       That is the trailing `""` on the error report of 2026-08-26:
+
+           Invalid Form. Please check the form errors. ""
+
+       -- a reader's first guess is that PaintOmics failed to name the field,
+       when in fact nothing was ever meant to be there. */
+    extra = (extra === "") ? "" : JSON.stringify(extra);
 
     // The dismiss button used to be coloured by message type: red on an error,
     // amber on a warning, cyan on an info, green on a success. It does the same
@@ -625,7 +635,13 @@ function showMessage(title, data) {
                         messageDialog.close();
                     });
                     $("#reportErrorButton").click(function () {
-                        sendReportMessage("error", $("#messageDialogTitle").text() + "\n" + $("#messageDialogBody").text() + "\n" + $("#hiddenMessageDialogBody").text());
+                        // Joined on the parts that have content, so a dialog
+                        // with no stack trace does not end in a blank line.
+                        sendReportMessage("error", [
+                            $("#messageDialogTitle").text(),
+                            $("#messageDialogBody").text(),
+                            $("#hiddenMessageDialogBody").text()
+                        ].filter(function (part) { return part !== ""; }).join("\n"));
                     });
                 }
             }

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -127,7 +127,7 @@
 	<!--SCRIPTS FOR SERVER CONNECTION CONFIGURATION-->
 	<script type="text/javascript" src="resources/ServerConfiguration.js?v=1.5"></script>
 	<!--CUSTOM SENCHA EXTENSIONS-->
-	<script type="text/javascript" src="app/view/common/Util.js?v=2.1"></script>
+	<script type="text/javascript" src="app/view/common/Util.js?v=2.2"></script>
 	<script type="text/javascript" src="app/view/common/ExtJS_extensions.js?v=0.7"></script>
 	<script type="text/javascript" src="app/view/common/OrganismSearch.js?v=1.0"></script>
 	<script type="text/javascript" src="app/view/common/upload/Panel.js?v=0.2"></script>

--- a/PaintomicsServer/src/tests/test_error_report_carries_no_empty_extra.py
+++ b/PaintomicsServer/src/tests/test_error_report_carries_no_empty_extra.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""An error report must not carry a stray `""` where nothing was ever meant.
+
+The behaviour this guards
+-------------------------
+A user reported this on 2026-08-26, quoting it exactly:
+
+    Invalid Form. Please check the form errors. ""
+
+The two quote characters are not part of any message. showMessage() in
+Util.js keeps an optional `extra` -- a server stack trace on the dialogs that
+have one -- and stashed it in a hidden div for the Report-error button to
+append:
+
+    var extra = (data.extra || "");
+    extra = JSON.stringify(extra);              // JSON.stringify("") === '""'
+    ...
+    $("#hiddenMessageDialogBody").text(extra);
+
+A Step 1 form refusal has no stack trace, so `extra` was "" -- and
+JSON.stringify turned "nothing" into the two-character string `""`, which went
+into the hidden body and from there into the report the user emails and reads.
+It is the last thing on the line, so a reader's first guess is that PaintOmics
+failed to name the field it was refusing over. Nothing was ever meant to be
+there.
+
+So: nothing is stringified when there is nothing, and the report is joined on
+the parts that have content.
+
+What this file asserts
+----------------------
+Both shipped statements are lifted verbatim and run in node:
+
+1. an absent or empty `extra` produces an empty string, not `""`;
+2. a real `extra` is still JSON, unchanged -- the reason the field exists;
+3. the report of a dialog with no stack trace ends at the message, with no
+   trailing blank line and no stray quotes;
+4. the report of a dialog WITH one still carries it.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_error_report_carries_no_empty_extra
+"""
+import io
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+UTIL = os.path.join(REPO, "PaintomicsClient", "public_html", "app", "view",
+                    "common", "Util.js")
+
+EXTRA_HEADER = "extra = (extra === \"\")"
+REPORT_HEADER = "sendReportMessage(\"error\", ["
+
+
+def read(path):
+    with io.open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def statement(source, header):
+    """`header` up to the semicolon that ends it, ignoring nested ones."""
+    start = source.find(header)
+    if start == -1:
+        raise AssertionError("%r is missing from Util.js" % header)
+    depth, index = 0, start
+    while index < len(source):
+        char = source[index]
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == ";" and depth == 0:
+            return source[start:index + 1]
+        index += 1
+    raise AssertionError("ran off the end of Util.js")
+
+
+HARNESS = """
+'use strict';
+// The two shipped statements, lifted verbatim, each given only the names it
+// actually reads.
+function extraFor(data) {
+    var extra = (data.extra || "");
+    %(extra_statement)s
+    return extra;
+}
+
+let reported = null;
+function sendReportMessage(kind, body) { reported = {kind: kind, body: body}; }
+
+function reportFor(parts) {
+    // jQuery, stubbed down to the three lookups the handler makes.
+    const $ = (selector) => ({ text: () => parts[selector] });
+    reported = null;
+    %(report_statement)s
+    return reported;
+}
+
+const noStack = { title: "Invalid form.", body: "Please choose a species.", extra: undefined };
+const withStack = { title: "Oops..Internal error!", body: "The job failed.",
+                    extra: { trace: "KeyError: 'omic'" } };
+
+const bodyOf = (d) => reportFor({
+    "#messageDialogTitle": d.title,
+    "#messageDialogBody": d.body,
+    "#hiddenMessageDialogBody": extraFor({ extra: d.extra })
+}).body;
+
+console.log(JSON.stringify({
+    extraAbsent: extraFor({}),
+    extraEmpty: extraFor({ extra: "" }),
+    extraReal: extraFor({ extra: { trace: "KeyError: 'omic'" } }),
+    reportNoStack: bodyOf(noStack),
+    reportWithStack: bodyOf(withStack),
+    reportKind: reportFor({
+        "#messageDialogTitle": "t", "#messageDialogBody": "b",
+        "#hiddenMessageDialogBody": ""
+    }).kind
+}));
+"""
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class ErrorReportCarriesNoEmptyExtraTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        source = read(UTIL)
+        script = HARNESS % {
+            "extra_statement": statement(source, EXTRA_HEADER),
+            "report_statement": statement(source, REPORT_HEADER),
+        }
+        directory = tempfile.mkdtemp(prefix="paintomics-error-report-")
+        try:
+            path = os.path.join(directory, "check.js")
+            with io.open(path, "w", encoding="utf-8") as handle:
+                handle.write(script)
+            done = subprocess.run(["node", path], capture_output=True,
+                                  text=True, timeout=60)
+            if done.returncode != 0:
+                raise AssertionError("node failed:\n%s" % done.stderr)
+            cls.result = json.loads(done.stdout)
+        finally:
+            shutil.rmtree(directory, ignore_errors=True)
+
+    def test_nothing_is_stringified_when_there_is_nothing(self):
+        """The bug: JSON.stringify("") is the two-character string `\"\"`."""
+        self.assertEqual(self.result["extraAbsent"], "")
+        self.assertEqual(self.result["extraEmpty"], "")
+
+    def test_a_real_extra_is_still_json(self):
+        """The reason the field exists at all -- this must not regress."""
+        self.assertEqual(json.loads(self.result["extraReal"]),
+                         {"trace": "KeyError: 'omic'"})
+
+    def test_a_report_with_no_stack_trace_ends_at_the_message(self):
+        """Exactly the line the user quoted, minus the quotes."""
+        report = self.result["reportNoStack"]
+        self.assertEqual(report, "Invalid form.\nPlease choose a species.")
+        self.assertNotIn('""', report)
+        self.assertFalse(report.endswith("\n"), "no trailing blank line")
+
+    def test_a_report_with_a_stack_trace_still_carries_it(self):
+        report = self.result["reportWithStack"]
+        self.assertIn("KeyError", report)
+        self.assertEqual(report.count("\n"), 2)
+
+    def test_the_report_is_still_sent_as_an_error(self):
+        self.assertEqual(self.result["reportKind"], "error")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_step1_drops_empty_omic_panels.py
+++ b/PaintomicsServer/src/tests/test_step1_drops_empty_omic_panels.py
@@ -58,6 +58,7 @@ import unittest
 CLIENT_ROOT = os.path.abspath(os.path.join(
     os.path.dirname(__file__), "..", "..", "..",
     "PaintomicsClient", "public_html"))
+JOB_CONTROLLER = os.path.join(CLIENT_ROOT, "app", "controller", "JobController.js")
 STEP1_VIEWS = os.path.join(
     CLIENT_ROOT, "app", "view", "PathwayAcquisitionViews", "PA_Step1Views.js")
 
@@ -381,6 +382,28 @@ class Step1DropsEmptyOmicPanelsTest(unittest.TestCase):
         self.assertFalse(result["accepted"])
         self.assertFalse(panelNamed(result, "region")["deleted"],
                          "a panel carrying the error must stay on the form")
+
+    def test_every_filled_panel_is_validated_even_when_the_organism_is_wrong(self):
+        """`valid = valid && panel.isValid()` short-circuited: with the organism
+        missing no panel was validated or marked, and the user learnt about
+        the panel only on the NEXT round. The panel call must come first."""
+        source = read(STEP1_VIEWS)
+        self.assertIn("valid = filled[i].isValid() && valid;", source)
+        self.assertNotIn("valid = valid && filled[i].isValid();", source)
+
+    def test_the_plain_panel_actually_validates_itself(self):
+        """`if (this.isEmpty)` tested the METHOD -- always truthy -- so a plain
+        panel with a file and no omic name was posted with an empty name."""
+        source = read(STEP1_VIEWS)
+        self.assertNotIn("if (this.isEmpty) {", source)
+        self.assertIn("if (this.isEmpty()) {", source)
+
+    def test_the_plain_submit_path_shows_the_same_refusal(self):
+        """The plain path said "provide at least Gene expression..." whatever
+        was wrong; both paths now go through showInvalidStep1FormMessage."""
+        source = read(JOB_CONTROLLER)
+        self.assertEqual(source.count("showInvalidStep1FormMessage(jobView);"), 2,
+                         "both submit paths must call it")
 
     def test_a_form_with_nothing_in_it_is_refused(self):
         self.assertFalse(self.results["everyPanelEmpty"]["accepted"])

--- a/PaintomicsServer/src/tests/test_step1_drops_empty_omic_panels.py
+++ b/PaintomicsServer/src/tests/test_step1_drops_empty_omic_panels.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""An omic panel the user left empty must be dropped, never reported.
+
+The behaviour this guards
+-------------------------
+Step 1 opens with a Gene expression panel and a Metabolomics panel already on
+the form, and adding a Region-based, miRNA or MORE panel is one click in
+"Available omics". A panel with no file in it therefore means "I did not want
+this one" -- which is why `PA_Step1JobView.checkForm()` deletes empty panels
+instead of complaining about them, and only refuses the form when *every*
+panel is empty.
+
+It used to validate first and delete afterwards, and the two halves disagreed:
+
+    valid = combo.isValid();
+    for (i in items) { valid = valid && items[i].isValid(); }   // empty ones too
+    for (i in items) { if (items[i].isEmpty()) { ...click delete... } }
+
+An empty panel was counted as invalid and then deleted by the very next loop.
+The plain omic panel hides this -- its isValid() returns early when the panel
+is empty -- but the Region-based, miRNA and MORE panels have no such guard:
+empty, they mark their own file fields invalid and return false. Those three
+are also exactly the panels that route the submit through
+`step1ComplexFormSubmitHandler`, whose failure branch is the only place that
+shows
+
+    "Invalid Form. </br> Please check the form errors."   (with Report error)
+
+So: add a Region-based omic, fill in Gene expression, press Run PaintOmics ->
+the form is refused because of the region panel, the region panel is deleted a
+moment later, and the user is left looking at one clean Gene expression box
+with nothing marked anywhere, being told to check errors that no longer exist.
+That is the report received from a user on 2026-08-26; reproduced in Chrome
+against the deployed client, which left 0 panels marked invalid and 0 elements
+carrying x-form-invalid.
+
+Order is the fix: drop the empty panels first, then validate what is left.
+
+Why node runs a browser file
+----------------------------
+The client has no test harness of its own (see test_reset_destroys_every_job_view
+and test_organism_search for the same pattern). `checkForm` is lifted out of
+PA_Step1Views.js as shipped and driven against stand-ins for the only things it
+touches -- the omic panels, the organism combo and jQuery's delete click -- so
+what is tested is the source the browser loads, not a copy of it.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_step1_drops_empty_omic_panels
+"""
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+CLIENT_ROOT = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), "..", "..", "..",
+    "PaintomicsClient", "public_html"))
+STEP1_VIEWS = os.path.join(
+    CLIENT_ROOT, "app", "view", "PathwayAcquisitionViews", "PA_Step1Views.js")
+
+HEADERS = {
+    "dropEmptyOmicPanels": "this.dropEmptyOmicPanels = function() {",
+    "checkForm": "this.checkForm = function() {",
+    "submitFormHandler": "this.submitFormHandler = function() {",
+}
+
+
+def read(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def extract_block(source, header):
+    """`header` plus the brace-matched block that follows it.
+
+    Braces inside strings and comments are skipped, so a selector or an
+    explanation cannot unbalance the count.
+    """
+    start = source.find(header)
+    if start == -1:
+        raise AssertionError("%s is missing from PA_Step1Views.js" % header)
+    index = source.index("{", start + len(header) - 1)
+    depth = 0
+    length = len(source)
+    while index < length:
+        char = source[index]
+        if char in "\"'":
+            quote = char
+            index += 1
+            while index < length and source[index] != quote:
+                index += 2 if source[index] == "\\" else 1
+        elif source.startswith("//", index):
+            index = source.find("\n", index)
+            if index == -1:
+                break
+        elif source.startswith("/*", index):
+            index = source.index("*/", index) + 1
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start:index + 1]
+        index += 1
+    raise AssertionError("unbalanced braces after %s" % header)
+
+
+# The real dropEmptyOmicPanels/checkForm/submitFormHandler, driven by stand-ins
+# for the only things they touch: the panels the view's ComponentQuery returns,
+# each panel's isEmpty/isValid, the organism combo, the jQuery click that
+# removes a panel, and the controller the submit is routed to.
+HARNESS = """
+function makePanel(name, cls, empty, valid) {
+    const panel = {
+        name: name,
+        cls: cls,
+        deleted: false,
+        askedIfValid: false,
+        isEmpty: function () { return empty; },
+        isValid: function () { panel.askedIfValid = true; return valid; },
+        getEl: function () { return {dom: panel}; },
+        // ExtJS returns null for anything inside a component it has destroyed,
+        // which is what a deleted panel throws on once it reaches the
+        // pre-processing list.
+        queryById: function (itemId) {
+            if (itemId !== "itemsContainer") { throw new Error(itemId); }
+            if (panel.deleted) { return null; }
+            return {isDisabled: function () { return false; }};
+        }
+    };
+    return panel;
+}
+
+// jQuery, as the view uses it: $(panelDom).find("a.deleteOmicBox").click().
+const $ = function (dom) {
+    return {find: function () { return {click: function () { dom.drop(); }}; }};
+};
+
+function isSpecial(panel) { return panel.cls !== "omicbox"; }
+
+function makeView(panels, organismValid) {
+    const live = panels.slice();
+    panels.forEach(function (panel) {
+        panel.drop = function () {
+            panel.deleted = true;
+            const at = live.indexOf(panel);
+            if (at >= 0) { live.splice(at, 1); }
+        };
+    });
+
+    // One query for both callers: checkForm asks for every omic panel,
+    // submitFormHandler asks submittingPanelsContainer for the region, miRNA
+    // and MORE ones only.
+    const query = function (selector) {
+        const wantsAll = selector.indexOf("container[cls=omicbox],") === 0;
+        return live.filter(function (panel) { return wantsAll || isSpecial(panel); });
+    };
+
+    const routed = [];
+    const view = {
+        routed: routed,
+        controller: {
+            step1ComplexFormSubmitHandler: function (jobView, omicBoxes) {
+                routed.push({path: "complex", boxes: omicBoxes.map(function (b) { return b.name; })});
+                // What the real handler does with each panel it is given, and
+                // what threw when it was given one checkForm had removed.
+                omicBoxes.forEach(function (b) { b.queryById("itemsContainer").isDisabled(); });
+            },
+            step1OnFormSubmitHandler: function () { routed.push({path: "plain", boxes: []}); }
+        },
+        getComponent: function () {
+            return {
+                query: query,
+                queryById: function (itemId) {
+                    if (itemId === "speciesCombobox") {
+                        return {isValid: function () { return organismValid; }};
+                    }
+                    if (itemId === "submittingPanelsContainer") { return {query: query}; }
+                    throw new Error(itemId);
+                }
+            };
+        }
+    };
+    // The blocks below are lifted verbatim out of PA_Step1Views.js, so they are
+    // installed the way the view installs them.
+    (function () { %(dropEmptyOmicPanels)s }).call(view);
+    (function () { %(checkForm)s }).call(view);
+    (function () { %(submitFormHandler)s }).call(view);
+    return view;
+}
+
+function report(label, view, panels, threw, accepted) {
+    return {
+        label: label,
+        threw: threw,
+        accepted: accepted,
+        routed: view.routed,
+        panels: panels.map(function (p) {
+            return {name: p.name, deleted: p.deleted, askedIfValid: p.askedIfValid};
+        })
+    };
+}
+
+function run(label, panels, organismValid) {
+    const view = makeView(panels, organismValid);
+    let threw = null, accepted = null;
+    try { accepted = view.checkForm(); } catch (e) { threw = String(e && e.stack || e); }
+    return report(label, view, panels, threw, accepted);
+}
+
+// Pressing "Run PaintOmics": the whole route, from the button to the handler
+// the submission is given to.
+function runSubmit(label, panels, organismValid) {
+    const view = makeView(panels, organismValid);
+    let threw = null;
+    try { view.submitFormHandler(); } catch (e) { threw = String(e && e.stack || e); }
+    return report(label, view, panels, threw, null);
+}
+
+const results = {};
+
+// The report: Gene expression filled in, an empty Region-based panel added
+// alongside it. The region panel is not part of the submission -- it is about
+// to be deleted -- so it must not make the form invalid.
+results.emptyRegionAlongsideFilledGene = run("emptyRegionAlongsideFilledGene", [
+    makePanel("geneexpression", "omicbox", false, true),
+    makePanel("metabolomics", "omicbox", true, true),
+    makePanel("region", "omicbox regionBasedOmic", true, false)
+], true);
+
+// Same shape for the other two panels that reach the complex submit path.
+results.emptyMirnaAlongsideFilledGene = run("emptyMirnaAlongsideFilledGene", [
+    makePanel("geneexpression", "omicbox", false, true),
+    makePanel("mirna", "omicbox miRNABasedOmic", true, false)
+], true);
+
+results.emptyMoreAlongsideFilledGene = run("emptyMoreAlongsideFilledGene", [
+    makePanel("geneexpression", "omicbox", false, true),
+    makePanel("more", "omicbox moreBasedOmic", true, false)
+], true);
+
+// A panel the user DID fill in and got wrong is a real error: it stays on the
+// form, it is marked, and the form is refused. This is the case the dialog's
+// "please check the form errors" is actually about.
+results.filledRegionThatIsInvalid = run("filledRegionThatIsInvalid", [
+    makePanel("geneexpression", "omicbox", false, true),
+    makePanel("region", "omicbox regionBasedOmic", false, false)
+], true);
+
+// Nothing filled in anywhere: there is no submission to make.
+results.everyPanelEmpty = run("everyPanelEmpty", [
+    makePanel("geneexpression", "omicbox", true, true),
+    makePanel("metabolomics", "omicbox", true, true),
+    makePanel("region", "omicbox regionBasedOmic", true, false)
+], true);
+
+// No organism chosen. The combo is marked by isValid() itself, so the dialog
+// has something to point at.
+results.noOrganism = run("noOrganism", [
+    makePanel("geneexpression", "omicbox", false, true),
+    makePanel("region", "omicbox regionBasedOmic", false, true)
+], false);
+
+// The happy path the region pipeline runs on.
+results.filledGeneAndRegion = run("filledGeneAndRegion", [
+    makePanel("geneexpression", "omicbox", false, true),
+    makePanel("metabolomics", "omicbox", true, true),
+    makePanel("region", "omicbox regionBasedOmic", false, true)
+], true);
+
+// Pressing Run with the reported form: the empty region panel must not reach
+// the region/miRNA/MORE pre-processing handler. It is deleted on the way
+// there, and a deleted panel is a destroyed ExtJS component.
+results.submitWithEmptyRegion = runSubmit("submitWithEmptyRegion", [
+    makePanel("geneexpression", "omicbox", false, true),
+    makePanel("metabolomics", "omicbox", true, true),
+    makePanel("region", "omicbox regionBasedOmic", true, false)
+], true);
+
+// A region panel the user did fill in is the reason the complex path exists.
+results.submitWithFilledRegion = runSubmit("submitWithFilledRegion", [
+    makePanel("geneexpression", "omicbox", false, true),
+    makePanel("metabolomics", "omicbox", true, true),
+    makePanel("region", "omicbox regionBasedOmic", false, true)
+], true);
+
+console.log(JSON.stringify(results));
+"""
+
+
+def run_node(script):
+    directory = tempfile.mkdtemp(prefix="paintomics-step1-checkform-")
+    try:
+        path = os.path.join(directory, "check.js")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(script)
+        completed = subprocess.run(["node", path], capture_output=True,
+                                   text=True, timeout=60)
+        if completed.returncode != 0:
+            raise AssertionError("node failed:\n%s" % completed.stderr)
+        return json.loads(completed.stdout)
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+def panelNamed(result, name):
+    for panel in result["panels"]:
+        if panel["name"] == name:
+            return panel
+    raise AssertionError("no panel %r in %s" % (name, result["label"]))
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class Step1DropsEmptyOmicPanelsTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        source = read(STEP1_VIEWS)
+        cls.results = run_node(HARNESS % dict(
+            (name, extract_block(source, header))
+            for name, header in HEADERS.items()))
+
+    def test_it_runs(self):
+        for name, result in self.results.items():
+            self.assertIsNone(result["threw"], "%s: %s" % (name, result["threw"]))
+
+    def test_an_empty_region_panel_does_not_refuse_the_form(self):
+        """The reported bug, in one assertion.
+
+        The user filled in Gene expression and added a Region-based panel they
+        left empty. The panel is dropped, so the form goes.
+        """
+        result = self.results["emptyRegionAlongsideFilledGene"]
+        self.assertTrue(result["accepted"],
+                        "an empty region panel must not make the form invalid")
+        self.assertTrue(panelNamed(result, "region")["deleted"],
+                        "the empty region panel must be removed from the form")
+
+    def test_an_empty_mirna_panel_does_not_refuse_the_form(self):
+        result = self.results["emptyMirnaAlongsideFilledGene"]
+        self.assertTrue(result["accepted"])
+        self.assertTrue(panelNamed(result, "mirna")["deleted"])
+
+    def test_an_empty_more_panel_does_not_refuse_the_form(self):
+        result = self.results["emptyMoreAlongsideFilledGene"]
+        self.assertTrue(result["accepted"])
+        self.assertTrue(panelNamed(result, "more")["deleted"])
+
+    def test_a_panel_that_is_about_to_be_deleted_is_never_validated(self):
+        """Validity is only asked of panels that will be submitted.
+
+        Asking an empty panel is what marked fields on a panel the user was
+        about to lose, and is the shape the bug can come back in.
+        """
+        for name in ("emptyRegionAlongsideFilledGene",
+                     "emptyMirnaAlongsideFilledGene",
+                     "emptyMoreAlongsideFilledGene",
+                     "everyPanelEmpty"):
+            result = self.results[name]
+            for panel in result["panels"]:
+                if panel["deleted"]:
+                    self.assertFalse(
+                        panel["askedIfValid"],
+                        "%s: %s was validated and then deleted"
+                        % (name, panel["name"]))
+
+    def test_empty_panels_are_still_cleared_away(self):
+        """The drop-the-ones-you-did-not-use behaviour must not regress."""
+        result = self.results["filledGeneAndRegion"]
+        self.assertTrue(result["accepted"])
+        self.assertTrue(panelNamed(result, "metabolomics")["deleted"])
+        self.assertFalse(panelNamed(result, "geneexpression")["deleted"])
+        self.assertFalse(panelNamed(result, "region")["deleted"])
+
+    def test_a_filled_panel_with_an_error_still_refuses_the_form(self):
+        """The message the dialog shows is only honest if this stays true."""
+        result = self.results["filledRegionThatIsInvalid"]
+        self.assertFalse(result["accepted"])
+        self.assertFalse(panelNamed(result, "region")["deleted"],
+                         "a panel carrying the error must stay on the form")
+
+    def test_a_form_with_nothing_in_it_is_refused(self):
+        self.assertFalse(self.results["everyPanelEmpty"]["accepted"])
+
+    def test_no_organism_refuses_the_form(self):
+        self.assertFalse(self.results["noOrganism"]["accepted"])
+
+    def test_a_dropped_panel_never_reaches_the_pre_processing_handler(self):
+        """The other half of the same mistake.
+
+        submitFormHandler used to pick the region/miRNA/MORE panels to
+        pre-process before the empty ones were dropped, so the list it handed
+        over could name a panel that was destroyed moments later --
+        `Cannot read properties of null (reading 'query')` on the first thing
+        step1ComplexFormSubmitHandler asks it for.
+        """
+        result = self.results["submitWithEmptyRegion"]
+        self.assertIsNone(result["threw"], result["threw"])
+        self.assertEqual([r["path"] for r in result["routed"]], ["plain"],
+                         "an empty region panel is not something to pre-process")
+        self.assertTrue(panelNamed(result, "region")["deleted"])
+
+    def test_a_filled_region_panel_still_takes_the_pre_processing_path(self):
+        result = self.results["submitWithFilledRegion"]
+        self.assertIsNone(result["threw"], result["threw"])
+        self.assertEqual(result["routed"], [{"path": "complex", "boxes": ["region"]}])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_step1_invalid_form_names_the_field.py
+++ b/PaintomicsServer/src/tests/test_step1_invalid_form_names_the_field.py
@@ -60,6 +60,7 @@ JOB_CONTROLLER = os.path.join(
 
 VIEW_HEADERS = {"firstFormError": "this.firstFormError = function() {"}
 CONTROLLER_HEADERS = {
+    "plainFieldText": "function plainFieldText(html) {",
     "fieldErrorText": "function fieldErrorText(field) {",
     "showInvalidStep1FormMessage": "function showInvalidStep1FormMessage(jobView) {",
 }
@@ -132,6 +133,7 @@ var shown = [];
 function showErrorMessage(title, opts) { shown.push({title: title, opts: opts}); }
 
 %(STEP1_NO_DATA_MESSAGE)s
+%(plainFieldText)s
 %(fieldErrorText)s
 %(showInvalidStep1FormMessage)s
 
@@ -216,6 +218,18 @@ results.unrenderedField = run("unrenderedField", [
                rendered: false})
 ], false);
 
+// Six shipped labels carry a <br>, and the file widget's inner textfield --
+// the one markInvalid() lands on -- is built with that same label.
+results.labelMarkup = run("labelMarkup", [
+    makeField({name: "speciesCombobox", label: "Organism"}),
+    makeField({name: "mainFileSelector", label: "Regions file <br>(BED + Quantification):",
+               error: "Please, provide a Data file."})
+], false);
+// Several errors on one field arrive as several <li>; they must not be glued.
+results.twoErrors = run("twoErrors", [
+    makeField({name: "jobDescription", label: "Description",
+               error: '<ul class="x-list-plain"><li>This field is required</li><li>Maximum length is 100</li></ul>'})
+], false);
 console.log(JSON.stringify(results));
 """
 
@@ -290,6 +304,16 @@ class InvalidFormNamesTheFieldTest(unittest.TestCase):
     def test_an_unrendered_field_still_produces_a_message(self):
         entry = self.results["unrenderedField"]["shown"][0]
         self.assertIn("Invalid Form", entry["title"])
+
+    def test_a_label_carrying_markup_is_shown_as_text(self):
+        """Regions file <br>(BED + Quantification): the <br> was printed."""
+        title = self.results["labelMarkup"]["shown"][0]["title"]
+        self.assertIn("Regions file (BED + Quantification)", title)
+        self.assertNotIn("br", title.replace("</br>", ""))
+
+    def test_several_errors_on_one_field_are_not_glued(self):
+        title = self.results["twoErrors"]["shown"][0]["title"]
+        self.assertIn("This field is required \u2014 Maximum length is 100", title)
 
     def test_every_case_shows_exactly_one_dialog(self):
         for name, result in self.results.items():

--- a/PaintomicsServer/src/tests/test_step1_invalid_form_names_the_field.py
+++ b/PaintomicsServer/src/tests/test_step1_invalid_form_names_the_field.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""A refused Step 1 submission must name the field it is refusing over.
+
+The behaviour this guards
+-------------------------
+Step 1 is three sections tall: the organism combo is in section 1 and the omic
+panels are in section 3. "Invalid Form. Please check the form errors." over a
+page that long is only a direction if the reader can find the error, and the
+field that refused the submission is routinely off screen behind the dialog.
+
+That is what happened to the user who reported it on 2026-08-26. The nginx log
+on paintomics.uv.es has her whole session in one page load:
+
+    12:57:53  GET /                     page loaded (after um_signin)
+    13:00:55  GET /more_backends        Regulatory Omic -> MORE panel added
+       ...    no request of any kind    filling the MORE panel in the browser
+    13:11:56  POST /dm_sendReport       "Invalid Form. Please check the form errors."
+    13:12:27  GET /organism_databases   the organism combo, chosen at last
+    14:07:04  POST /dm_fromMOREtoGenes  the submission finally goes through
+
+`/organism_databases` is fetched once per page load, by the combo's own change
+listener (`loadOrganismDatabases` guards on ORGANISM_DATABASES_REQUEST) -- so
+it landing 31 seconds AFTER the report is the proof that **no organism had been
+chosen** when she pressed Run PaintOmics. And nothing at all was POSTed between
+13:00:55 and the report, which is the signature of a refusal that never left
+the browser: checkForm() said no.
+
+So the one thing wrong with her form was a single field, two sections above
+where she had spent the last eleven minutes working, and the dialog neither
+named it nor took her to it.
+
+Now it does: the first *visible* marked field is scrolled into view and the
+message reads "Organism: This field is required."
+
+Why node runs a browser file
+----------------------------
+The client has no test harness of its own. `firstFormError` is lifted out of
+PA_Step1Views.js and `showInvalidStep1FormMessage` out of JobController.js, as
+shipped, and driven against stand-ins for the fields and the dialog -- the same
+pattern as test_step1_drops_empty_omic_panels and test_organism_search.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_step1_invalid_form_names_the_field
+"""
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+CLIENT_ROOT = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), "..", "..", "..",
+    "PaintomicsClient", "public_html"))
+STEP1_VIEWS = os.path.join(
+    CLIENT_ROOT, "app", "view", "PathwayAcquisitionViews", "PA_Step1Views.js")
+JOB_CONTROLLER = os.path.join(
+    CLIENT_ROOT, "app", "controller", "JobController.js")
+
+VIEW_HEADERS = {"firstFormError": "this.firstFormError = function() {"}
+CONTROLLER_HEADERS = {
+    "fieldErrorText": "function fieldErrorText(field) {",
+    "showInvalidStep1FormMessage": "function showInvalidStep1FormMessage(jobView) {",
+}
+NO_DATA_STATEMENT = "var STEP1_NO_DATA_MESSAGE ="
+
+
+def read(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _scan(source, start, stop_at_depth_zero):
+    """Walk `source` from `start`, skipping strings and comments.
+
+    Calls `stop_at_depth_zero(char, depth)` for every character that is real
+    code; the first index for which it returns True is returned.
+    """
+    index, depth, length = start, 0, len(source)
+    while index < length:
+        char = source[index]
+        if char in "\"'":
+            quote = char
+            index += 1
+            while index < length and source[index] != quote:
+                index += 2 if source[index] == "\\" else 1
+        elif source.startswith("//", index):
+            index = source.find("\n", index)
+            if index == -1:
+                break
+            continue
+        elif source.startswith("/*", index):
+            index = source.index("*/", index) + 1
+        else:
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+            if stop_at_depth_zero(char, depth):
+                return index
+        index += 1
+    raise AssertionError("ran off the end from offset %d" % start)
+
+
+def extract_block(source, header, what):
+    """`header` plus the brace-matched block that follows it."""
+    start = source.find(header)
+    if start == -1:
+        raise AssertionError("%s is missing from %s" % (header, what))
+    opening = source.index("{", start + len(header) - 1)
+    end = _scan(source, opening, lambda char, depth: char == "}" and depth == 0)
+    return source[start:end + 1]
+
+
+def extract_statement(source, header, what):
+    """`header` up to the semicolon that ends it (semicolons inside the
+    string literals do not count -- the message carries inline CSS)."""
+    start = source.find(header)
+    if start == -1:
+        raise AssertionError("%s is missing from %s" % (header, what))
+    end = _scan(source, start, lambda char, depth: char == ";" and depth == 0)
+    return source[start:end + 1]
+
+
+HARNESS = """
+var Ext = {String: {htmlEncode: function (s) {
+    return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}}};
+
+var shown = [];
+function showErrorMessage(title, opts) { shown.push({title: title, opts: opts}); }
+
+%(STEP1_NO_DATA_MESSAGE)s
+%(fieldErrorText)s
+%(showInvalidStep1FormMessage)s
+
+function makeField(spec) {
+    var field = {
+        name: spec.name,
+        fieldLabel: spec.label,
+        scrolled: false,
+        hasActiveError: function () { return !!spec.error; },
+        getActiveError: function () { return spec.error || ""; },
+        isVisible: function () { return spec.visible !== false; },
+        getEl: function () {
+            if (spec.rendered === false) { return null; }
+            return {dom: {scrollIntoView: function () { field.scrolled = true; }}};
+        }
+    };
+    return field;
+}
+
+function makeView(fields, formIsEmpty) {
+    var view = {
+        formIsEmpty: formIsEmpty,
+        getComponent: function () { return {query: function () { return fields; }}; }
+    };
+    (function () { %(firstFormError)s }).call(view);
+    return view;
+}
+
+function run(label, fields, formIsEmpty) {
+    shown = [];
+    var view = makeView(fields, formIsEmpty);
+    var threw = null;
+    try { showInvalidStep1FormMessage(view); } catch (e) { threw = String(e && e.stack || e); }
+    return {
+        label: label,
+        threw: threw,
+        shown: shown,
+        scrolled: fields.filter(function (f) { return f.scrolled; })
+                        .map(function (f) { return f.name; })
+    };
+}
+
+var results = {};
+
+// The report: a MORE panel filled in at the bottom of the page, no organism
+// chosen at the top. ExtJS renders allowBlank errors wrapped in a <ul>.
+results.organismMissing = run("organismMissing", [
+    makeField({name: "speciesCombobox", label: "Organism",
+               error: '<ul class="x-list-plain"><li role="alert">This field is required</li></ul>'}),
+    makeField({name: "conditionsFileSelector", label: "Experimental design:"}),
+    makeField({name: "mainFileSelector", label: "Regulator values:"})
+], false);
+
+// A custom markInvalid() message: only ever on the active error.
+results.customMessage = run("customMessage", [
+    makeField({name: "speciesCombobox", label: "Organism"}),
+    makeField({name: "tertiaryFileSelector", label: "Annotations file (GTF):",
+               error: "Please, provide a GTF file."})
+], false);
+
+// A hidden field cannot be shown to anybody: name the first VISIBLE one.
+results.hiddenFirst = run("hiddenFirst", [
+    makeField({name: "configVars", label: "configVars", visible: false,
+               error: "This field is required"}),
+    makeField({name: "speciesCombobox", label: "Organism",
+               error: "This field is required"})
+], false);
+
+// Nothing filled in anywhere: not a field error, and not a bug to report.
+results.emptyForm = run("emptyForm", [
+    makeField({name: "speciesCombobox", label: "Organism"})
+], true);
+
+// Refused with nothing marked: the old wording, kept, and still reportable.
+results.nothingMarked = run("nothingMarked", [
+    makeField({name: "speciesCombobox", label: "Organism"})
+], false);
+
+// A field marked before it was rendered must not take the dialog down.
+results.unrenderedField = run("unrenderedField", [
+    makeField({name: "ghost", label: "Ghost", error: "This field is required",
+               rendered: false})
+], false);
+
+console.log(JSON.stringify(results));
+"""
+
+
+def run_node(script):
+    directory = tempfile.mkdtemp(prefix="paintomics-step1-message-")
+    try:
+        path = os.path.join(directory, "check.js")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(script)
+        completed = subprocess.run(["node", path], capture_output=True,
+                                   text=True, timeout=60)
+        if completed.returncode != 0:
+            raise AssertionError("node failed:\n%s" % completed.stderr)
+        return json.loads(completed.stdout)
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class InvalidFormNamesTheFieldTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        views, controller = read(STEP1_VIEWS), read(JOB_CONTROLLER)
+        pieces = {name: extract_block(views, header, "PA_Step1Views.js")
+                  for name, header in VIEW_HEADERS.items()}
+        pieces.update({name: extract_block(controller, header, "JobController.js")
+                       for name, header in CONTROLLER_HEADERS.items()})
+        pieces["STEP1_NO_DATA_MESSAGE"] = extract_statement(
+            controller, NO_DATA_STATEMENT, "JobController.js")
+        cls.results = run_node(HARNESS % pieces)
+
+    def test_it_runs(self):
+        for name, result in self.results.items():
+            self.assertIsNone(result["threw"], "%s: %s" % (name, result["threw"]))
+
+    def test_the_missing_organism_is_named_and_scrolled_to(self):
+        """The reported session, in one assertion."""
+        result = self.results["organismMissing"]
+        title = result["shown"][0]["title"]
+        self.assertIn("Organism", title)
+        self.assertIn("This field is required", title)
+        self.assertNotIn("<ul", title, "the markup around the error must be stripped")
+        self.assertEqual(result["scrolled"], ["speciesCombobox"],
+                         "the field the message names is the one brought into view")
+
+    def test_a_custom_field_message_survives(self):
+        title = self.results["customMessage"]["shown"][0]["title"]
+        self.assertIn("Annotations file (GTF)", title)
+        self.assertIn("Please, provide a GTF file.", title)
+
+    def test_a_hidden_field_is_never_the_one_named(self):
+        result = self.results["hiddenFirst"]
+        title = result["shown"][0]["title"]
+        self.assertIn("Organism", title)
+        self.assertNotIn("configVars", title)
+        self.assertEqual(result["scrolled"], ["speciesCombobox"])
+
+    def test_an_empty_form_says_so_and_is_not_reportable(self):
+        entry = self.results["emptyForm"]["shown"][0]
+        self.assertIn("Please provide at least", entry["title"])
+        self.assertFalse(entry["opts"]["showReportButton"],
+                         "an empty form is the user's to fill in, not a bug to report")
+
+    def test_a_refusal_with_nothing_marked_keeps_the_old_wording(self):
+        entry = self.results["nothingMarked"]["shown"][0]
+        self.assertIn("Please check the form errors", entry["title"])
+        self.assertTrue(entry["opts"]["showReportButton"],
+                        "nothing marked anywhere is the shape of a bug")
+
+    def test_an_unrendered_field_still_produces_a_message(self):
+        entry = self.results["unrenderedField"]["shown"][0]
+        self.assertIn("Invalid Form", entry["title"])
+
+    def test_every_case_shows_exactly_one_dialog(self):
+        for name, result in self.results.items():
+            self.assertEqual(len(result["shown"]), 1,
+                             "%s showed %d dialogs" % (name, len(result["shown"])))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -100,7 +100,7 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js": (
         "0.7", "241e9a48b99f6ca40f3f9d3b5dd29f27513ca38c181fb902075a0149af9ca4b3"),
     "app/view/common/Util.js": (
-        "2.1", "12359b8bf746394f63a7e0a15513a4f9ac82de1a25bbaa0e91e6b2fdd7e0050e"),
+        "2.2", "ddc63bd8e92a72d3604d9e6c435df3f26be92a6e5c0e4073785fef28d39ae087"),
     "app/view/common/OrganismSearch.js": (
         "1.0", "7903626835e7703bdb6a1e31b78e3ca00539eee23b8fa67a37524cd9cc4d2e7f"),
     "app/view/common/ExtJS_extensions.js": (


### PR DESCRIPTION
## The report

A user sent an error report on 2026-08-26 whose whole body was:

> Invalid Form. Please check the form errors. `""`

That dialog has exactly one source in the client — `step1ComplexFormSubmitHandler`, the submit path taken when a **Region-based**, **miRNA** or **MORE** panel is on the form — and it is the only refusal that offers the **Report error** button, which is how the report reached us.

## What she was actually doing

Her whole session is in the nginx log on paintomics.uv.es, inside one page load:

```
12:57:53  GET /                     page loaded (after um_signin)
13:00:55  GET /more_backends        Regulatory Omic → MORE panel added
   ...    nothing POSTed at all     filling the MORE panel in the browser
13:11:56  POST /dm_sendReport       "Invalid Form. Please check the form errors."
13:12:27  GET /organism_databases   the organism combo, chosen at last
14:07:04  POST /dm_fromMOREtoGenes  the submission finally goes through
```

Two things follow from it:

- **Nothing was POSTed between 13:00:55 and the report** — the refusal never left the browser. `checkForm()` said no.
- **No organism had been chosen when she pressed Run.** `/organism_databases` is fetched once per page load by the combo's own `change` listener (`loadOrganismDatabases` guards on `ORGANISM_DATABASES_REQUEST`), and it lands 31 seconds *after* the report.

Her four files — `samplemetadata_miRNA.csv`, `DEmiRNA.txt`, `DEGs2.txt`, `Targets3.txt` — map exactly onto the MORE panel's Conditions / Regulators / Gene expression / Associations slots. So the one thing wrong with her form was a single field in **section 1**, two sections above the panel she had spent eleven minutes filling in, and the dialog opened over the middle of the page naming neither what nor where. It then took her 55 minutes and four more panels to get the job away.

## Two defects, both making that dialog unactionable

**1. `checkForm()` validated the panels it was about to delete.**

```js
valid = combo.isValid();
for (i in items) { valid = valid && items[i].isValid(); }        // empty ones too
for (i in items) { if (items[i].isEmpty()) { ...click delete... } }
```

An empty panel was counted invalid by the first loop and deleted by the second. The plain omic panel hides this — its `isValid()` returns early when empty — but the region, miRNA and MORE panels have no such guard, and those three are exactly the ones that reach this dialog. Reproduced in Chrome against the deployed client: **0 fields marked invalid, 0 elements carrying `x-form-invalid`**, and the panel that caused it gone from the page.

Fixing the order surfaced the same mistake's other face: `submitFormHandler` chose which panels to pre-process *before* the empties were dropped, so it could hand the handler a destroyed component (`Cannot read properties of null (reading 'query')`).

**2. The refusal never said which field, or where.**

Reproduced with her own four files in a MORE panel and no organism — and the chain is worse than one field: fix the organism and the *next* refusal is the **Omic Name** combo in the middle of that same panel. Two rounds of "please check the form errors", neither saying what or where.

## The fix

- `dropEmptyOmicPanels()` takes the empty panels off the form first; `checkForm()` validates only what is left; `submitFormHandler()` calls it before choosing the submit path.
- The first **visible** marked field is scrolled into view and named: *"Organism: This field is required"*, then *"Omic Name: This field is required"*. Hidden fields are skipped — naming one nobody can be shown is worse than saying nothing.
- A form with nothing in it at all says so, in the words the plain submit path already used, and does not offer *Report error* — nothing there is a bug.
- A refusal with nothing marked anywhere keeps the old wording **and** the Report error button, because that shape is a bug.

## Verification (Chrome, against this branch)

| Case | Before | After |
|---|---|---|
| **Her session**: MORE panel + her 4 files, no organism | "Please check the form errors", no scroll, nothing named | "**Organism**: This field is required", page jumps to section 1 |
| then: organism fixed, Omic Name empty | same unactionable dialog | "**Omic Name**: This field is required", jumps to it |
| then: both filled | — | `dm_fromMOREtoGenes` accepts the job |
| Gene expression + **empty** Region panel | refused, nothing marked, panel deleted | runs to Step 2 — 10,415 features, 100% mapped |
| Nothing filled in at all | same unactionable dialog | "Please provide at least…", no Report error |
| Region panel filled, GTF missing | — | refused, panel **stays**, both fields marked |
| Region / miRNA / MORE **examples** | — | still take the pre-processing path (region example run end-to-end) |

Her MORE panel and all four file selections survive the refusal.

## Not fixed: her data

Once both fields are filled the MORE run itself fails, on her data and on mine:

> `MOREServlet.py: fromMOREtoGenes_STEP2 … The MORE analysis failed (R backend) … no data columns could be read`

That is the `POST /check_job_status/BG7yl5dLN6 → 400` she got in production at 14:07:05. MORE wants per-sample matrices plus a 0/1 design; she supplied a comma-separated metadata file and single-column log2FC tables whose numbers use comma decimal separators (`1,601241826` — Italian Excel). That is an input-format problem, not a defect, so it is out of scope here and worth answering in a reply to her instead.

## Tests

Two new suites, both lifting the shipped functions **verbatim** out of the client and running them in node against stand-ins — the pattern of `test_reset_destroys_every_job_view` and `test_organism_search`:

- `test_step1_drops_empty_omic_panels.py` — 11 assertions. Confirmed to fail on the pre-fix source (4 on the validation order, 1 on the submit routing).
- `test_step1_invalid_form_names_the_field.py` — 8 assertions covering the named field, the scroll, hidden fields, the empty form, and the nothing-marked fallback.

`test_example_mode_client_wiring`, `test_database_checkboxes_follow_the_server`, `test_reset_destroys_every_job_view`, `test_organism_search`, `test_step2_compound_panel` and `test_versioned_assets_are_bumped` all still pass; `ruff check .` is clean.

No `?v=` bump: both edited files are loaded by `app.js` through jQuery's script loader, which is cache-busting by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)