### PR TITLE
Let "Draft this for me" read the MORE panel's files too

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -5175,6 +5175,37 @@ function plainFieldLabel(text) {
    Read off the component tree, never off the field's name. Every panel agrees
    on its itemIds and its labels and disagrees on its field NAMES, which is the
    whole of the bug this replaces. */
+/* The omic name the user typed for this file's panel, or "".
+
+   Two traps, both measured in Chrome. A region or pairwise card holds TWO
+   #omicNameField -- the first is the disabled, empty twin of the "already
+   mapped" alternative form -- so panel.down('#omicNameField') returned the
+   twin and the name the user typed never reached the label. And MORE stacks
+   regulators: block i names its files file_i / relevant_file_i / assoc_file_i
+   and its omic name omic_name_i, with no itemId at all, so every file of the
+   2nd regulator was labelled with the 1st regulator's name. The conditions and
+   gene-expression (rnaseqaux) files belong to the whole MORE panel, not to a
+   regulator: they take the panel heading. */
+function typedOmicName(panel, field) {
+	var fieldName = String((field && field.name) || "");
+	var block = fieldName.match(/^(?:file|relevant_file|assoc_file)_(\d+)(?:_file)?$/);
+	if (block) {
+		var combos = panel.query ? panel.query('[name=omic_name_' + block[1] + ']') : [];
+		var typed = (combos.length && combos[0].getValue) ? combos[0].getValue() : "";
+		return typed ? String(typed).trim() : "";
+	}
+	if (/^(?:conditions|rnaseqaux)(?:_file)?$/.test(fieldName)) { return ""; }
+
+	var fields = panel.query ? panel.query('#omicNameField') : [];
+	var live = fields.filter(function (f) { return !(f.isDisabled ? f.isDisabled() : f.disabled); });
+	var pool = live.length ? live : fields;
+	for (var i = 0; i < pool.length; i++) {
+		var value = pool[i].getValue && pool[i].getValue();
+		if (value && String(value).trim()) { return String(value).trim(); }
+	}
+	return "";
+}
+
 function pickedFileLabel(field) {
 	var panel = field.up('[cls~=omicbox]');
 	var selector = field.up('myFilesSelectorButton');
@@ -5184,8 +5215,7 @@ function pickedFileLabel(field) {
 	if (panel) {
 		/* What the user typed, when they typed one; otherwise the heading the
 		   panel prints, which every panel type renders the same way. */
-		var nameField = panel.down ? panel.down('#omicNameField') : null;
-		omic = (nameField && nameField.getValue && nameField.getValue()) || "";
+		omic = typedOmicName(panel, field);
 		if (!omic && panel.el && panel.el.dom) {
 			var heading = panel.el.dom.querySelector('.omicboxTitle h4');
 			omic = heading ? plainFieldLabel(heading.textContent) : "";
@@ -5223,6 +5253,13 @@ function collectPickedOmicFiles() {
 
 		var input = field.fileInputEl && field.fileInputEl.dom;
 		if (!input || !input.files || input.files.length === 0) { return; }
+
+		/* The region panel's GTF: its first line is an annotation record or a
+		   "#!genome-build" comment, not column names -- nothing for a design
+		   drafter to read, and the one file the old name filter excluded on
+		   purpose. */
+		var selector = field.up('myFilesSelectorButton');
+		if (selector && selector.itemId === 'tertiaryFileSelector') { return; }
 
 		picked.push({
 			omicName: pickedFileLabel(field),

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -5120,13 +5120,15 @@ function fillAIProvenance(root) {
 /*****************************************************************************
 **** "DRAFT THIS FOR ME" - EXPERIMENT DESIGN *********************************
 *****************************************************************************/
-/* Reads the header row of each data file the user has picked, sends just those
-   names to /ai_generate_exp_design, and writes the reply into the experiment
-   design box.
+/* Reads the header row of each file the user has picked, sends just those names
+   to /ai_generate_exp_design, and writes the reply into the experiment design
+   box.
 
-   Only the first line of each file is read, and only the main data files --
-   never the relevant-features lists, which are one column of identifiers and
-   describe no design. Nothing is read from disk until the button is pressed. */
+   Only the first line of each file is read, and nothing is read from disk until
+   the button is pressed. Every picked file is taken: one line each costs
+   nothing, and each one says something about the design the others do not --
+   a conditions file names the factors, an associations file says the study is
+   regulatory, a values matrix names the samples. */
 
 /* Enough of the file to be sure of catching the first newline. A header row for
    a wide matrix can be long, but not this long, and reading a fixed slice keeps
@@ -5157,23 +5159,73 @@ function readHeaderRow(file, callback) {
 	reader.readAsText(file.slice(0, EXP_DESIGN_HEADER_BYTES));
 }
 
-/* Every main data file the user has picked, as
-   [{omicName, fileName, fileField}]. The runtime field names are omicN_file
-   for the data file and omicN_relevant_file / omicN_associations_file for the
-   others, so the pattern anchors on the end to take only the first. */
+/* Plain text out of a fieldLabel, which may carry markup
+   ('Relevant regulators file<br>(optional)') and a trailing colon. */
+function plainFieldLabel(text) {
+	return String(text == null ? "" : text)
+		.replace(/<[^>]*>/g, " ")
+		.replace(/\s+/g, " ")
+		.replace(/^ | $/g, "")
+		.replace(/\s*:$/, "");
+}
+
+/* What one picked file is: which panel it sits in, and which slot of it.
+   "Regulatory Omic - MORE / Conditions file", "Gene expression / Data file".
+
+   Read off the component tree, never off the field's name. Every panel agrees
+   on its itemIds and its labels and disagrees on its field NAMES, which is the
+   whole of the bug this replaces. */
+function pickedFileLabel(field) {
+	var panel = field.up('[cls~=omicbox]');
+	var selector = field.up('myFilesSelectorButton');
+	var slot = selector ? plainFieldLabel(selector.fieldLabel) : "";
+	var omic = "";
+
+	if (panel) {
+		/* What the user typed, when they typed one; otherwise the heading the
+		   panel prints, which every panel type renders the same way. */
+		var nameField = panel.down ? panel.down('#omicNameField') : null;
+		omic = (nameField && nameField.getValue && nameField.getValue()) || "";
+		if (!omic && panel.el && panel.el.dom) {
+			var heading = panel.el.dom.querySelector('.omicboxTitle h4');
+			omic = heading ? plainFieldLabel(heading.textContent) : "";
+		}
+		if (!omic) { omic = panel.type || ""; }
+	}
+
+	if (omic && slot) { return omic + " / " + slot; }
+	return omic || slot || field.name || "file";
+}
+
+/* A form cannot hand over an unbounded number of files. Six omics with four
+   selectors each is 24, which is past anything the form is used for. */
+var EXP_DESIGN_MAX_FILES = 24;
+
+/* Every file the user has picked, as [{omicName, file}].
+ *
+ * This used to keep only fields whose NAME matched /^omic\d+_file$/. That is
+ * the plain, region-based and miRNA panels' convention and it is not the MORE
+ * panel's: MORE names its five selectors conditions, rnaseqaux, file_0,
+ * relevant_file_0 and assoc_file_0. So a form holding a MORE panel and four
+ * chosen files collected NOTHING, and "Draft this for me" answered "There is
+ * nothing to read yet. Add an omic ... and pick its Data file" to a user who
+ * had done exactly that. Reported 2026-08-26; MORE was the only panel affected,
+ * and the file it most wanted -- the conditions file -- is the experimental
+ * design itself.
+ *
+ * Nothing about any panel's field names is encoded here now, so a fifth panel
+ * type cannot go blind the same way.
+ */
 function collectPickedOmicFiles() {
 	var picked = [];
 	Ext.each(Ext.ComponentQuery.query('filefield'), function(field) {
-		var name = field.name || "";
-		if (!/^omic\d+_file$/.test(name)) { return; }
+		if (picked.length >= EXP_DESIGN_MAX_FILES) { return false; }
 
 		var input = field.fileInputEl && field.fileInputEl.dom;
 		if (!input || !input.files || input.files.length === 0) { return; }
 
-		var omicPrefix = name.replace(/_file$/, "");
-		var nameField = Ext.ComponentQuery.query('[name=' + omicPrefix + '_omic_name]')[0];
 		picked.push({
-			omicName: nameField ? nameField.getValue() : omicPrefix,
+			omicName: pickedFileLabel(field),
 			file: input.files[0]
 		});
 	});

--- a/PaintomicsServer/src/servlets/AIInterpretServlet.py
+++ b/PaintomicsServer/src/servlets/AIInterpretServlet.py
@@ -494,7 +494,12 @@ def aiInterpretChat(REQUEST, RESPONSE):
 # 60 columns is enough to show the shape of every design this form accepts --
 # a 2 x 6 timecourse in triplicate is 36 -- and the count of what was dropped
 # is still sent, so the model is told the matrix is wider than the sample.
-_EXPDESIGN_MAX_OMICS = 10
+# The client sends up to EXP_DESIGN_MAX_FILES = 24 entries (six omics with four
+# selectors each). This was 10, so a form with six plain omics had its sixth
+# omic's Data file -- the design signal -- silently dropped after five
+# one-identifier relevant lists, and the note under the button said nothing.
+# Each entry is already bounded to 60 columns of 80 characters.
+_EXPDESIGN_MAX_OMICS = 24
 _EXPDESIGN_MAX_COLUMNS = 60
 _EXPDESIGN_MAX_COLUMN_LEN = 80
 
@@ -665,13 +670,19 @@ def aiGenerateExpDesign(REQUEST, RESPONSE, EXAMPLE_FILES_DIR=None):
         for entry in omics[:_EXPDESIGN_MAX_OMICS]:
             if not isinstance(entry, dict):
                 continue
-            columns, dropped = _sanitizeColumnNames(entry.get("columns") or [])
+            rawColumns = [str(column) for column in (entry.get("columns") or [])]
+            # A headerless file's first line is measurements, not column names
+            # -- the same rule the example path applies -- and the note would
+            # otherwise promise "no values were sent" over a row of values.
+            if _looksLikeDataRow(rawColumns):
+                continue
+            columns, dropped = _sanitizeColumnNames(rawColumns)
             if not columns:
                 continue
             totalDropped += dropped
 
             omicName = _EXPDESIGN_CONTROL_CHARS.sub(
-                " ", str(entry.get("omicName") or "Omic"))[:60].strip() or "Omic"
+                " ", str(entry.get("omicName") or "Omic"))[:100].strip() or "Omic"
             described.append(
                 "- %s: %d column%s%s\n  %s" % (
                     omicName, len(columns) + dropped,

--- a/PaintomicsServer/src/tests/test_exp_design_draft_reads_every_panel.py
+++ b/PaintomicsServer/src/tests/test_exp_design_draft_reads_every_panel.py
@@ -45,6 +45,7 @@ Usage:
 """
 import json
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -58,6 +59,7 @@ STEP1_VIEWS = os.path.join(
 
 BLOCK_HEADERS = {
     "plainFieldLabel": "function plainFieldLabel(text) {",
+    "typedOmicName": "function typedOmicName(panel, field) {",
     "pickedFileLabel": "function pickedFileLabel(field) {",
     "collectPickedOmicFiles": "function collectPickedOmicFiles() {",
 }
@@ -131,15 +133,25 @@ var Ext = {
     }
 };
 
-function makePanel(cls, heading, omicNameValue, type) {
+/* nameFields: the #omicNameField list the panel answers query() with -- a
+   region or pairwise card really holds two, the first disabled and empty.
+   blocks: MORE's omic_name_<i> combos by index. */
+function makePanel(cls, heading, omicNameValue, type, extra) {
+    extra = extra || {};
+    var nameFields = extra.nameFields || (omicNameValue === null ? [] :
+        [{disabled: false, getValue: function () { return omicNameValue; }}]);
     var panel = {
         cls: cls,
         type: type,
         ownerCt: null,
-        down: function (selector) {
-            if (selector !== '#omicNameField') { throw new Error(selector); }
-            if (omicNameValue === null) { return null; }
-            return {getValue: function () { return omicNameValue; }};
+        query: function (selector) {
+            if (selector === '#omicNameField') { return nameFields; }
+            var block = selector.match(/^\[name=omic_name_(\d+)\]$/);
+            if (block) {
+                var typed = (extra.blocks || {})[block[1]];
+                return typed === undefined ? [] : [{getValue: function () { return typed; }}];
+            }
+            throw new Error(selector);
         },
         el: {dom: {querySelector: function (selector) {
             if (selector !== '.omicboxTitle h4') { throw new Error(selector); }
@@ -149,8 +161,8 @@ function makePanel(cls, heading, omicNameValue, type) {
     return panel;
 }
 
-function addSelector(panel, fieldLabel, fieldName, pickedFileName) {
-    var selector = {xtype: 'myFilesSelectorButton', fieldLabel: fieldLabel, ownerCt: panel};
+function addSelector(panel, fieldLabel, fieldName, pickedFileName, itemId) {
+    var selector = {xtype: 'myFilesSelectorButton', fieldLabel: fieldLabel, ownerCt: panel, itemId: itemId};
     var field = {
         xtype: 'filefield',
         name: fieldName,
@@ -172,6 +184,7 @@ function addSelector(panel, fieldLabel, fieldName, pickedFileName) {
 }
 
 %(plainFieldLabel)s
+%(typedOmicName)s
 %(pickedFileLabel)s
 %(EXP_DESIGN_MAX_FILES)s
 %(collectPickedOmicFiles)s
@@ -244,6 +257,30 @@ results.slotOnly = run(function () {
     addSelector(panel, 'Data file:', 'omic1_file', 'orphan.tab');
 });
 
+// A region card holds two #omicNameField: the disabled, empty twin of the
+// "already mapped" form comes FIRST, and down() used to return it.
+results.twinNameFields = run(function () {
+    var panel = makePanel('omicbox regionBasedOmic', 'Region-based omic', null, undefined, {
+        nameFields: [{disabled: true, getValue: function () { return ""; }},
+                     {disabled: false, getValue: function () { return "ATAC-seq"; }}]});
+    addSelector(panel, 'Regions file (BED + Quantification):', 'omic1_file', 'peaks.bed');
+});
+// MORE's second regulator has its own omic_name_1 combo and no itemId at all;
+// its files were labelled with regulator 0's name. The conditions and gene
+// expression files belong to the panel, not to a regulator.
+results.moreSecondRegulator = run(function () {
+    var more = makePanel('omicbox moreBasedOmic', 'Regulatory Omic - MORE', 'miRNA-seq', 'moreanalysis',
+                         {blocks: {"0": "miRNA-seq", "1": "Transcription factor"}});
+    addSelector(more, 'Conditions file', 'conditions_file', 'design.tab');
+    addSelector(more, 'Regulators expression file', 'file_0_file', 'mirna.tab');
+    addSelector(more, 'Regulators expression file', 'file_1_file', 'tf.tab');
+});
+// The region panel's GTF is annotation rows, not column names: never sent.
+results.gtfSkipped = run(function () {
+    var panel = makePanel('omicbox regionBasedOmic', 'Region-based omic', 'DNase', undefined);
+    addSelector(panel, 'Regions file (BED + Quantification):', 'omic1_file', 'regions.tab', 'mainFileSelector');
+    addSelector(panel, 'Annotations file (GTF):', 'omic1_annotations_file', 'mmu.gtf', 'tertiaryFileSelector');
+});
 console.log(JSON.stringify(results));
 """
 
@@ -293,7 +330,7 @@ class DraftReadsEveryPanelTest(unittest.TestCase):
     def test_the_conditions_file_is_named_as_what_it_is(self):
         """It is the experimental design; the drafter has to know that."""
         self.assertEqual(self.labels("moreOnly")[0],
-                         "miRNA-Seq data / Conditions file")
+                         "Regulatory Omic - MORE / Conditions file")
 
     def test_markup_never_reaches_the_label(self):
         for name in self.results:
@@ -320,6 +357,29 @@ class DraftReadsEveryPanelTest(unittest.TestCase):
     def test_the_label_falls_back_to_the_panel_heading(self):
         self.assertEqual(self.labels("headingFallback"),
                          ["Region-based omic / Regions file (BED + Quantification)"])
+
+    def test_the_typed_name_wins_over_the_disabled_twin(self):
+        labels = [p["label"] for p in self.results["twinNameFields"]["picked"]]
+        self.assertEqual(labels, ["ATAC-seq / Regions file (BED + Quantification)"])
+
+    def test_each_more_regulator_carries_its_own_name(self):
+        labels = [p["label"] for p in self.results["moreSecondRegulator"]["picked"]]
+        self.assertEqual(labels, ["Regulatory Omic - MORE / Conditions file",
+                                  "miRNA-seq / Regulators expression file",
+                                  "Transcription factor / Regulators expression file"])
+
+    def test_the_gtf_is_never_sent(self):
+        files = [p["file"] for p in self.results["gtfSkipped"]["picked"]]
+        self.assertEqual(files, ["regions.tab"])
+
+    def test_the_server_keeps_every_entry_the_client_can_send(self):
+        """The server cap was 10 against a client cap of 24: entries 11+ were
+        silently dropped and the note under the button said nothing."""
+        client = read(STEP1_VIEWS) if "STEP1_VIEWS" in globals() else read(SOURCE)
+        server = read(os.path.join(os.path.dirname(__file__), "..", "servlets", "AIInterpretServlet.py"))
+        clientCap = int(re.search(r"var EXP_DESIGN_MAX_FILES = (\d+);", client).group(1))
+        serverCap = int(re.search(r"_EXPDESIGN_MAX_OMICS = (\d+)", server).group(1))
+        self.assertGreaterEqual(serverCap, clientCap)
 
     def test_a_panel_with_no_identity_still_labels_the_slot(self):
         self.assertEqual(self.labels("slotOnly"), ["Data file"])

--- a/PaintomicsServer/src/tests/test_exp_design_draft_reads_every_panel.py
+++ b/PaintomicsServer/src/tests/test_exp_design_draft_reads_every_panel.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+""""Draft this for me" must read the files of every omic panel, MORE included.
+
+The behaviour this guards
+-------------------------
+Step 1's "Draft this for me" writes an experiment-design description from the
+header row of the files the user has picked. `collectPickedOmicFiles()` used to
+keep only fields whose NAME matched `/^omic\\d+_file$/`:
+
+    if (!/^omic\\d+_file$/.test(name)) { return; }
+
+That is the naming convention of the plain, region-based and miRNA panels. It
+is not the MORE panel's: MORE calls its five selectors `conditions`,
+`rnaseqaux`, `file_0`, `relevant_file_0` and `assoc_file_0`, so their runtime
+field names are `conditions_file`, `rnaseqaux_file`, `file_0_file` and so on,
+and not one of them matched.
+
+So a user who filled in a Regulatory Omic panel and nothing else collected
+NOTHING, and the button answered
+
+    "There is nothing to read yet. Add an omic under 3. Choose the files to
+     upload and pick its Data file, then press Draft this for me again."
+
+to someone who had done exactly that. Reported 2026-08-26, by the same user as
+the Invalid Form report. Measured in Chrome with her four real files plus a
+region-based file on the same form: five files picked, one collected.
+
+The file it most wanted was the one it could not see -- for a MORE run the
+conditions file *is* the experimental design.
+
+The fix takes every picked file (one header row each costs nothing) and labels
+it from the component tree instead of the field name, so a fifth panel type
+cannot go blind the same way.
+
+Why node runs a browser file
+----------------------------
+The client has no test harness of its own. The three functions are lifted out
+of PA_Step1Views.js as shipped and driven against stand-ins for the panels and
+the file inputs -- the pattern of test_step1_drops_empty_omic_panels and
+test_organism_search.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_exp_design_draft_reads_every_panel
+"""
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+CLIENT_ROOT = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), "..", "..", "..",
+    "PaintomicsClient", "public_html"))
+STEP1_VIEWS = os.path.join(
+    CLIENT_ROOT, "app", "view", "PathwayAcquisitionViews", "PA_Step1Views.js")
+
+BLOCK_HEADERS = {
+    "plainFieldLabel": "function plainFieldLabel(text) {",
+    "pickedFileLabel": "function pickedFileLabel(field) {",
+    "collectPickedOmicFiles": "function collectPickedOmicFiles() {",
+}
+MAX_FILES_STATEMENT = "var EXP_DESIGN_MAX_FILES ="
+
+
+def read(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _scan(source, start, stop):
+    """Walk from `start`, skipping strings, comments and regex literals."""
+    index, depth, length = start, 0, len(source)
+    while index < length:
+        char = source[index]
+        if char in "\"'":
+            quote = char
+            index += 1
+            while index < length and source[index] != quote:
+                index += 2 if source[index] == "\\" else 1
+        elif source.startswith("//", index):
+            index = source.find("\n", index)
+            if index == -1:
+                break
+            continue
+        elif source.startswith("/*", index):
+            index = source.index("*/", index) + 1
+        else:
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+            if stop(char, depth):
+                return index
+        index += 1
+    raise AssertionError("ran off the end from offset %d" % start)
+
+
+def extract_block(source, header):
+    start = source.find(header)
+    if start == -1:
+        raise AssertionError("%s is missing from PA_Step1Views.js" % header)
+    opening = source.index("{", start + len(header) - 1)
+    end = _scan(source, opening, lambda char, depth: char == "}" and depth == 0)
+    return source[start:end + 1]
+
+
+def extract_statement(source, header):
+    start = source.find(header)
+    if start == -1:
+        raise AssertionError("%s is missing from PA_Step1Views.js" % header)
+    end = _scan(source, start, lambda char, depth: char == ";" and depth == 0)
+    return source[start:end + 1]
+
+
+# The four panel types with their REAL field names and labels, so the test
+# fails if the shipped naming and this drift apart.
+HARNESS = """
+var ALL_FIELDS = [];
+
+var Ext = {
+    each: function (list, fn) {
+        for (var i = 0; i < list.length; i++) { if (fn(list[i], i) === false) { break; } }
+    },
+    ComponentQuery: {
+        query: function (selector) {
+            if (selector !== 'filefield') { throw new Error(selector); }
+            return ALL_FIELDS;
+        }
+    }
+};
+
+function makePanel(cls, heading, omicNameValue, type) {
+    var panel = {
+        cls: cls,
+        type: type,
+        ownerCt: null,
+        down: function (selector) {
+            if (selector !== '#omicNameField') { throw new Error(selector); }
+            if (omicNameValue === null) { return null; }
+            return {getValue: function () { return omicNameValue; }};
+        },
+        el: {dom: {querySelector: function (selector) {
+            if (selector !== '.omicboxTitle h4') { throw new Error(selector); }
+            return heading === null ? null : {textContent: heading};
+        }}}
+    };
+    return panel;
+}
+
+function addSelector(panel, fieldLabel, fieldName, pickedFileName) {
+    var selector = {xtype: 'myFilesSelectorButton', fieldLabel: fieldLabel, ownerCt: panel};
+    var field = {
+        xtype: 'filefield',
+        name: fieldName,
+        ownerCt: selector,
+        fileInputEl: {dom: {files: pickedFileName ? [{name: pickedFileName}] : []}},
+        up: function (query) {
+            var node = field.ownerCt;
+            while (node) {
+                if (query === 'myFilesSelectorButton' && node.xtype === 'myFilesSelectorButton') { return node; }
+                if (query === '[cls~=omicbox]' && node.cls &&
+                    node.cls.split(' ').indexOf('omicbox') !== -1) { return node; }
+                node = node.ownerCt;
+            }
+            return null;
+        }
+    };
+    ALL_FIELDS.push(field);
+    return field;
+}
+
+%(plainFieldLabel)s
+%(pickedFileLabel)s
+%(EXP_DESIGN_MAX_FILES)s
+%(collectPickedOmicFiles)s
+
+function run(build) {
+    ALL_FIELDS = [];
+    build();
+    var threw = null, picked = null;
+    try { picked = collectPickedOmicFiles(); } catch (e) { threw = String(e && e.stack || e); }
+    return {
+        threw: threw,
+        picked: picked && picked.map(function (p) { return {label: p.omicName, file: p.file.name}; })
+    };
+}
+
+var results = {};
+
+/* The MORE panel exactly as the view builds it: five selectors, none of whose
+   field names match the old /^omic\\d+_file$/. The four files are the ones the
+   reporting user uploaded. */
+function buildMore(withFiles) {
+    var more = makePanel('omicbox moreBasedOmic', 'Regulatory Omic - MORE', 'miRNA-Seq data', 'moreanalysis');
+    addSelector(more, 'Conditions file', 'conditions_file', withFiles ? 'samplemetadata_miRNA.csv' : null);
+    addSelector(more, 'Gene expression dataset', 'rnaseqaux_file', withFiles ? 'DEGs2.txt' : null);
+    addSelector(more, 'Regulators expression file', 'file_0_file', withFiles ? 'DEmiRNA.txt' : null);
+    addSelector(more, 'Relevant regulators file<br>(optional)', 'relevant_file_0_file', null);
+    addSelector(more, 'Associations file', 'assoc_file_0_file', withFiles ? 'Targets3.txt' : null);
+    return more;
+}
+
+// The report: a MORE panel and nothing else.
+results.moreOnly = run(function () { buildMore(true); });
+
+// Every panel type at once -- the three that already worked must keep working.
+results.everyPanel = run(function () {
+    var gene = makePanel('omicbox', 'Gene expression', '', 'geneexpression');
+    addSelector(gene, 'Data file:', 'omic0_file', 'gene_expression_values.tab');
+    addSelector(gene, 'Relevant features file:', 'omic0_relevant_file', 'gene_expression_relevant.tab');
+
+    var region = makePanel('omicbox regionBasedOmic', 'Region-based omic', '', undefined);
+    addSelector(region, 'Regions file (BED + Quantification):', 'omic3_file', 'dnase_regions_values.tab');
+    addSelector(region, 'Annotations file (GTF):', 'omic3_annotations_file', 'synthetic_mmu.gtf');
+
+    var mirna = makePanel('omicbox miRNABasedOmic', 'Regulatory Omic - Pairwise', 'miRNA-seq', undefined);
+    addSelector(mirna, 'Data file:', 'omic2_file', 'mirna_values.tab');
+
+    buildMore(true);
+});
+
+// Nothing chosen anywhere.
+results.nothingPicked = run(function () { buildMore(false); });
+
+// A form cannot hand over an unbounded number of files.
+results.capped = run(function () {
+    var panel = makePanel('omicbox', 'Other data type', '', 'otheromic');
+    for (var i = 0; i < 40; i++) {
+        addSelector(panel, 'Data file:', 'omic' + i + '_file', 'file' + i + '.tab');
+    }
+});
+
+// No omic name typed: fall back to the heading the panel prints.
+results.headingFallback = run(function () {
+    var panel = makePanel('omicbox regionBasedOmic', 'Region-based omic', '', undefined);
+    addSelector(panel, 'Regions file (BED + Quantification):', 'omic1_file', 'regions.tab');
+});
+
+// Neither a name nor a heading: the slot alone still says something.
+results.slotOnly = run(function () {
+    var panel = makePanel('omicbox', null, null, '');
+    addSelector(panel, 'Data file:', 'omic1_file', 'orphan.tab');
+});
+
+console.log(JSON.stringify(results));
+"""
+
+
+def run_node(script):
+    directory = tempfile.mkdtemp(prefix="paintomics-draft-collect-")
+    try:
+        path = os.path.join(directory, "check.js")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(script)
+        completed = subprocess.run(["node", path], capture_output=True,
+                                   text=True, timeout=60)
+        if completed.returncode != 0:
+            raise AssertionError("node failed:\n%s" % completed.stderr)
+        return json.loads(completed.stdout)
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class DraftReadsEveryPanelTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        source = read(STEP1_VIEWS)
+        pieces = {name: extract_block(source, header)
+                  for name, header in BLOCK_HEADERS.items()}
+        pieces["EXP_DESIGN_MAX_FILES"] = extract_statement(source, MAX_FILES_STATEMENT)
+        cls.results = run_node(HARNESS % pieces)
+
+    def files(self, name):
+        return [entry["file"] for entry in self.results[name]["picked"]]
+
+    def labels(self, name):
+        return [entry["label"] for entry in self.results[name]["picked"]]
+
+    def test_it_runs(self):
+        for name, result in self.results.items():
+            self.assertIsNone(result["threw"], "%s: %s" % (name, result["threw"]))
+
+    def test_a_more_panel_on_its_own_is_read(self):
+        """The reported bug, in one assertion: this used to collect nothing."""
+        self.assertEqual(self.files("moreOnly"),
+                         ["samplemetadata_miRNA.csv", "DEGs2.txt",
+                          "DEmiRNA.txt", "Targets3.txt"])
+
+    def test_the_conditions_file_is_named_as_what_it_is(self):
+        """It is the experimental design; the drafter has to know that."""
+        self.assertEqual(self.labels("moreOnly")[0],
+                         "miRNA-Seq data / Conditions file")
+
+    def test_markup_never_reaches_the_label(self):
+        for name in self.results:
+            for label in self.labels(name):
+                self.assertNotIn("<", label)
+                self.assertNotIn(">", label)
+
+    def test_the_panels_that_already_worked_still_do(self):
+        self.assertEqual(self.files("everyPanel"), [
+            "gene_expression_values.tab", "gene_expression_relevant.tab",
+            "dnase_regions_values.tab", "synthetic_mmu.gtf",
+            "mirna_values.tab",
+            "samplemetadata_miRNA.csv", "DEGs2.txt", "DEmiRNA.txt", "Targets3.txt",
+        ])
+
+    def test_an_unpicked_selector_is_skipped(self):
+        self.assertEqual(self.files("nothingPicked"), [])
+        self.assertNotIn("relevant_file_0_file",
+                         " ".join(self.labels("moreOnly")))
+
+    def test_the_number_of_files_is_bounded(self):
+        self.assertEqual(len(self.files("capped")), 24)
+
+    def test_the_label_falls_back_to_the_panel_heading(self):
+        self.assertEqual(self.labels("headingFallback"),
+                         ["Region-based omic / Regions file (BED + Quantification)"])
+
+    def test_a_panel_with_no_identity_still_labels_the_slot(self):
+        self.assertEqual(self.labels("slotOnly"), ["Data file"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_exp_design_draft_reads_every_panel.py
+++ b/PaintomicsServer/src/tests/test_exp_design_draft_reads_every_panel.py
@@ -375,7 +375,7 @@ class DraftReadsEveryPanelTest(unittest.TestCase):
     def test_the_server_keeps_every_entry_the_client_can_send(self):
         """The server cap was 10 against a client cap of 24: entries 11+ were
         silently dropped and the note under the button said nothing."""
-        client = read(STEP1_VIEWS) if "STEP1_VIEWS" in globals() else read(SOURCE)
+        client = read(STEP1_VIEWS)
         server = read(os.path.join(os.path.dirname(__file__), "..", "servlets", "AIInterpretServlet.py"))
         clientCap = int(re.search(r"var EXP_DESIGN_MAX_FILES = (\d+);", client).group(1))
         serverCap = int(re.search(r"_EXPDESIGN_MAX_OMICS = (\d+)", server).group(1))


### PR DESCRIPTION
## The report

From the same user as the Invalid Form report, the same day. With a **Regulatory Omic (MORE)** panel filled in and nothing else, **Draft this for me** answered:

> There is nothing to read yet. Add an omic under **3. Choose the files to upload** and pick its **Data file**, then press **Draft this for me** again.

— to someone who had done exactly that.

## Cause

`collectPickedOmicFiles()` kept only fields whose **name** matched `/^omic\d+_file$/`:

```js
if (!/^omic\d+_file$/.test(name)) { return; }
```

That is the plain, region-based and miRNA panels' convention. It is **not** the MORE panel's — MORE names its five selectors `conditions`, `rnaseqaux`, `file_0`, `relevant_file_0`, `assoc_file_0`, so their runtime field names are `conditions_file`, `rnaseqaux_file`, `file_0_file`, … and not one matched.

Measured in Chrome with the reporting user's four real files plus a region-based file on the same form:

| field name | file | collected |
|---|---|---|
| `conditions_file` | samplemetadata_miRNA.csv | ✗ |
| `rnaseqaux_file` | DEGs2.txt | ✗ |
| `file_0_file` | DEmiRNA.txt | ✗ |
| `assoc_file_0_file` | Targets3.txt | ✗ |
| `omic3_file` *(region-based)* | dnase_regions_values.tab | ✓ |

**Five files picked, one collected.** MORE was the only panel affected — and the file it most wanted was the one it could not see: for a MORE run the **conditions file *is* the experimental design**.

This is the third instance of the same family (`[cls=omicbox]` exact-match at `PA_Step1Views.js:964`, the `checkForm` ordering in #90, and now a field-name pattern).

## The fix

Take **every** picked file. Only the first line of each is ever read, so one more file costs one row — and each says something the others do not: a conditions file names the factors, an associations file says the study is regulatory, a values matrix names the samples.

The label now comes off the **component tree** — the panel's heading plus the selector's own `fieldLabel` — instead of the field name, so a fifth panel type cannot go blind the same way. Markup is stripped from labels (`Relevant regulators file<br>(optional)`), and the count is bounded at 24.

## Verification (Chrome, live CSIC gateway, the reporting user's own files)

MORE panel alone on the form, her four files:

```
Regulatory Omic — MORE / Conditions file            <- samplemetadata_miRNA.csv
Regulatory Omic — MORE / Gene expression dataset    <- DEGs2.txt
Regulatory Omic — MORE / Regulators expression file <- DEmiRNA.txt
Regulatory Omic — MORE / Associations file          <- Targets3.txt
```

→ *"Drafted from 9 column names — no values were sent."* and the box reads:

> I compared gene and miRNA expression between treatment and control groups in Mus musculus, **using the `treatment` column to define the two conditions**. Each subject was assigned to either the treatment or control group, with no timepoints indicated in the data. The number of replicates per group is not specified by the column headers, so I cannot state it.

That first clause comes from `samplemetadata_miRNA.csv` — the file that was invisible before.

**No regression:** a plain Gene expression panel still drafts correctly (*"six timepoints (0, 2, 6, 12, 18, and 24 hours)"* off the STATegra headers), labelled `Gene expression / Data file`.

## What leaves the machine is unchanged

Still header rows only — `readHeaderRow` reads the first line of a bounded 256 KB slice and sends the split field names. Taking more *files* does not widen what is sent from any one of them, and the note under the button still states the exact count.

One honest note: a relevant-features list has no header, so its first row is a real identifier rather than column names. Identifiers, not measured values, and the UI reports what was sent — but flagging it since the old comment drew that line deliberately.

## Tests

`src/tests/test_exp_design_draft_reads_every_panel.py` — 9 assertions, lifting `plainFieldLabel`, `pickedFileLabel`, `EXP_DESIGN_MAX_FILES` and `collectPickedOmicFiles` **verbatim** out of `PA_Step1Views.js` and driving them against stand-ins for the four real panel types with their real field names and labels. Confirmed to fail when the old name filter is put back (the MORE case and two others).

`test_example_mode_client_wiring`, `test_database_checkboxes_follow_the_server`, `test_reset_destroys_every_job_view`, `test_organism_search`, `test_step2_compound_panel`, `test_versioned_assets_are_bumped` all still pass; `ruff check .` clean.

No `?v=` bump: `PA_Step1Views.js` is loaded by `app.js` through jQuery's script loader, which is cache-busting by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)