### PR TITLE
Check the file a user picks, whichever omic panel they picked it into

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js
@@ -1005,6 +1005,27 @@
             var chosen = out.values.filter(function (f) { return f.recommended; })[0] || out.values[0];
             var addOthers = false;
 
+            /* The file that belongs in the slot the drawer was opened from.
+             *
+             * Everything below used to key off `out.values`, and a conversion
+             * that produces no values table has none -- so the review ended
+             * with Cancel and "Download all", and the user had to save the
+             * file to disk and pick it again through Browse. Reported on the
+             * conversion that made this obvious: a MORE Conditions file, where
+             * the agent read 24 rows of sample metadata and wrote exactly the
+             * 0/1 experimental design PaintOmics wanted, named it design.tab,
+             * and then offered no way to put it in the field the user had
+             * clicked Convert on.
+             *
+             * Same shape as the rest of this family: code that enumerates omic
+             * files knows the plain values case and forgets design,
+             * associations and relevant-associations. The slot the user
+             * started from already says which role is wanted, so match on it.
+             */
+            var slotRole = (context && context.slotRole) || "values";
+            var forSlot = chosen ? null
+                : (out.files.filter(function (f) { return f.role === slotRole; })[0] || null);
+
             out.values.forEach(function (f) {
                 var rcard = el("article", "pa-convert-result" + (f === chosen ? " pa-convert-result-chosen" : ""));
                 var rhead = el("header", "pa-convert-result-head");
@@ -1106,7 +1127,7 @@
             actions.innerHTML = "";
             actions.appendChild(dismiss);
             actions.appendChild(downloadAll);
-            if (out.values.length) actions.appendChild(accept);
+            if (out.values.length || forSlot) actions.appendChild(accept);
 
             function syncActions() {
                 accept.textContent = addOthers
@@ -1116,6 +1137,16 @@
             syncActions();
 
             accept.addEventListener("click", function () {
+                if (!chosen && forSlot) {
+                    // No values table -- the conversion produced the file this
+                    // slot asked for. Put it straight back in the field.
+                    input.__paConverted = { from: file.name, original: file,
+                                            fieldName: fieldName, label: forSlot.label,
+                                            attempts: result.attempts || 1, relevant: false };
+                    setFile(input, forSlot.bytes, forSlot.name);
+                    shutdown();
+                    return;
+                }
                 if (!chosen) return;
                 var omicType = (context && context.omicType) || "Gene expression";
                 var linkedList = out.lists.filter(function (l) { return l.relevantFor === chosen.name; })[0];
@@ -1194,7 +1225,7 @@
      * file differently from a gene-expression one and would otherwise be
      * guessing from the file alone.
      */
-    function openConvertDrawer(input, file, fieldName) {
+    function openConvertDrawer(input, file, fieldName, slotRole) {
         var prefix = String(fieldName || "").replace(/_file$/, "");
         function fieldValue(name) {
             if (!window.Ext || !Ext.ComponentQuery) return null;
@@ -1203,7 +1234,8 @@
         }
         return openDrawer(input, file, fieldName, {
             omicType: fieldValue(prefix + "_omic_name") || "unknown",
-            species: fieldValue("specie") || "unknown"
+            species: fieldValue("specie") || "unknown",
+            slotRole: slotRole || "values"
         });
     }
 

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js
@@ -893,6 +893,35 @@
                     ? ["PaintOmics refused this job when the analysis ran. It said: "
                        + input.__paServerSaid]
                         .concat(input.__paSiblings ? [input.__paSiblings] : [])
+                        /* The limit of what you can DO, stated separately from
+                           what you can SEE.
+                         *
+                           The sandbox receives exactly one file (files:
+                           {fileKey: bytes}), so the other files are readable
+                           context and nothing more. Without this the agent
+                           offered "use the contrast as-is and adjust the design
+                           to match it" -- an action it cannot perform -- then
+                           edited the one file it holds, reported success, and
+                           the run failed in the same place. Reported as "the AI
+                           said it fixed the problem and it fails again".
+
+                           Measured, on this job: MORE intersects sample names
+                           across target, condition and every regulator file, so
+                           renaming this file's column to match the target
+                           leaves the design disagreeing, and renaming it to
+                           match the design leaves the target disagreeing. Both
+                           give 0 common samples. No edit to ONE file can
+                           satisfy a three-way intersection. */
+                        .concat(["You can rewrite ONLY the file you were given. "
+                                 + "The other files listed above are read-only "
+                                 + "context -- you cannot edit them, and you must "
+                                 + "not offer to. If the remedy needs a different "
+                                 + "file changed, or needs data that is not in any "
+                                 + "of them, say which file and what has to change "
+                                 + "and let the user do it. A fix that only makes "
+                                 + "THIS file self-consistent, while the others "
+                                 + "still disagree, is not a fix: it will fail "
+                                 + "again in the same place."])
                         .concat(["This file may well be valid on its own -- the "
                                  + "format check passed it. Judge it against the "
                                  + "other files listed above: what has to agree "

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js
@@ -283,6 +283,23 @@
         return (box && window.Ext && Ext.getCmp) ? Ext.getCmp(box.id) : null;
     }
 
+    /* The omic-name field a card would submit. A region or pairwise card holds
+       two with the same itemId -- the first is the disabled, empty twin of the
+       "already mapped" form -- so queryById returned the one the form ignores.
+       Same rule as format-panel's omicNameFieldIn. */
+    function liveNameField(component) {
+        if (!component || !component.query) return null;
+        var fields = component.query("#omicNameField");
+        if (!fields.length) return null;
+        var live = fields.filter(function (f) { return !(f.isDisabled ? f.isDisabled() : f.disabled); });
+        var pool = live.length ? live : fields;
+        for (var i = 0; i < pool.length; i++) {
+            var value = pool[i].getValue && pool[i].getValue();
+            if (value && String(value).trim()) return pool[i];
+        }
+        return pool[0];
+    }
+
     function fileInputIn(component, itemId) {
         var selector = component && component.queryById ? component.queryById(itemId) : null;
         var field = selector && selector.queryById ? selector.queryById("fileField") : null;
@@ -310,7 +327,7 @@
             if (!panel || !panel.getComponent) return false;
             var component = panel.getComponent();
             var fill = function () {
-                var nameField = component.queryById("omicNameField");
+                var nameField = liveNameField(component);
                 if (nameField && nameField.setValue) nameField.setValue(omicName);
                 var main = fileInputIn(component, "mainFileSelector");
                 if (main) setFile(main, values.bytes, values.name);
@@ -1193,7 +1210,8 @@
             actions.innerHTML = "";
             actions.appendChild(dismiss);
             actions.appendChild(downloadAll);
-            if (out.values.length || forSlot) actions.appendChild(accept);
+            var wantsValues = ((context && context.slotRole) || "values") === "values";
+            if ((wantsValues && out.values.length) || forSlot) actions.appendChild(accept);
 
             function syncActions() {
                 accept.textContent = addOthers
@@ -1203,9 +1221,18 @@
             syncActions();
 
             accept.addEventListener("click", function () {
-                if (!chosen && forSlot) {
-                    // No values table -- the conversion produced the file this
-                    // slot asked for. Put it straight back in the field.
+                var slotRole = (context && context.slotRole) || "values";
+                if (slotRole !== "values" && !forSlot) {
+                    // The slot asked for a design / relevant / associations
+                    // file and the conversion made none: a values table in a
+                    // conditions slot is worse than an empty one. Leave the
+                    // downloads on the review and keep the field as it was.
+                    shutdown();
+                    return;
+                }
+                if (forSlot && (!chosen || slotRole !== "values")) {
+                    // The conversion produced the file this slot asked for.
+                    // Put it straight back in the field.
                     input.__paConverted = { from: file.name, original: file,
                                             fieldName: fieldName, label: forSlot.label,
                                             attempts: result.attempts || 1, relevant: false };
@@ -1220,7 +1247,7 @@
 
                 if (addOthers) {
                     // Keep names unique across the job: the server keys omics by name.
-                    var nameField = component && component.queryById("omicNameField");
+                    var nameField = liveNameField(component);
                     if (nameField && nameField.setValue) nameField.setValue(omicType + " (" + chosen.label + ")");
                     out.values.filter(function (v) { return v !== chosen; }).forEach(function (v) {
                         var vList = out.lists.filter(function (l) { return l.relevantFor === v.name; })[0];
@@ -1298,8 +1325,13 @@
             var f = Ext.ComponentQuery.query("[name=" + name + "]")[0];
             return f && f.getValue ? f.getValue() : null;
         }
+        /* The card's own live name field first: "omicN_omic_name" is the plain
+           panels' convention only, and MORE's slots (file_0, conditions,
+           rnaseqaux) and every relevant slot resolved to "unknown". */
+        var cardName = liveNameField(omicComponentOf(input));
+        var typed = cardName && cardName.getValue && cardName.getValue();
         return openDrawer(input, file, fieldName, {
-            omicType: fieldValue(prefix + "_omic_name") || "unknown",
+            omicType: (typed && String(typed).trim()) || fieldValue(prefix + "_omic_name") || "unknown",
             species: fieldValue("specie") || "unknown",
             slotRole: slotRole || "values"
         });

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js
@@ -883,6 +883,43 @@
                 omicType: (context && context.omicType) || "unknown",
                 species: (context && context.species) || "unknown",
                 goal: "Convert this file into the format PaintOmics accepts, keeping every measurement it holds.",
+                /* When the SERVER is the one that refused, hand the agent what
+                   it said. Without this the agent re-reads a file the client
+                   checker already considers valid and finds nothing, because
+                   the fault is one only the server can see -- a sample name
+                   that does not line up with the design file, an identifier
+                   space that does not match the other omics. */
+                instructions: (input && input.__paServerSaid)
+                    ? ["PaintOmics refused this job when the analysis ran. It said: "
+                       + input.__paServerSaid]
+                        .concat(input.__paSiblings ? [input.__paSiblings] : [])
+                        .concat(["This file may well be valid on its own -- the "
+                                 + "format check passed it. Judge it against the "
+                                 + "other files listed above: what has to agree "
+                                 + "between them, and what does not.",
+                                 /* The guard, added after watching the agent
+                                    do exactly this: given the siblings, it
+                                    renamed a column so the two VALUES files
+                                    agreed with each other, ignored the design
+                                    file entirely, and reported success. The
+                                    job would have failed again in the same
+                                    place. Cross-file context makes a confident
+                                    wrong answer as easy as a right one, so the
+                                    authority has to be named. */
+                                 "The design/conditions file is the AUTHORITY on "
+                                 + "sample names. Never rename a column to make two "
+                                 + "values files agree with each other: rename only "
+                                 + "to a name that actually appears in the design "
+                                 + "file. If the values files hold CONTRASTS "
+                                 + "(names like A_vs_B) while the design lists "
+                                 + "individual samples, they cannot be reconciled by "
+                                 + "renaming at all. In that case ASK THE USER rather "
+                                 + "than converting: state what each file holds, why "
+                                 + "the two cannot be matched, and that this analysis "
+                                 + "needs one column per sample. Asking is a real "
+                                 + "answer here; a converted file that still will not "
+                                 + "run is not."])
+                    : undefined,
                 ask: askUser,
                 onEvent: onEvent
             }, extra || {}));

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
@@ -975,7 +975,15 @@
                 });
             });
             if (!found.length) return;
-            requestAnimationFrame(function () {
+            /* paDeferFrame, not a bare requestAnimationFrame: Chrome throttles
+               rAF to zero in a hidden tab, and a card primed in a bare frame
+               would then have no strip and no input check at all until the tab
+               came forward. Util.js keeps the house version of this -- rAF when
+               visible, setTimeout(0) when hidden -- and four pieces of this app
+               have already been caught scheduling layout work on the bare one.
+               Guarded, because this module is loaded on its own in the tests. */
+            var defer = window.paDeferFrame || requestAnimationFrame;
+            defer(function () {
                 found.forEach(function (c) {
                     try { primeCard(c); }
                     catch (e) { if (window.console && console.warn) console.warn("[inputformat] prime failed", e); }

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
@@ -673,31 +673,44 @@
             var repaired = repairs.length ? API.applyRepairs(read.rows, repairs) : null;
             var fixable = repaired && validate(repaired.rows).ok && !partial;
 
+            /*
+             * ONE implementation, used by all three ways of applying a repair.
+             *
+             * There used to be three copies, and the one the user actually
+             * clicks -- the "Fix automatically" button -- was the only one that
+             * forgot `clearBlocked`. The block is keyed by field name and kept
+             * alive by comparing the picked file's NAME, and a repair rewrites
+             * the file in place under the same name. So the card went green and
+             * the entry stayed live: the strip said
+             *
+             *     OK Gene expression: 112 rows - 1 value column
+             *
+             * while the submit interceptor still refused, with
+             *
+             *     X Gene expression: the server will reject this file
+             *
+             * -- two verdicts on the same file, from this module, at the same
+             * moment. The banner renders at the END of the form, so from the
+             * top of a long Step 1 the Run button simply looks dead. Hit on the
+             * reporting user's own DEGs2.txt, whose only fault was decimal
+             * commas that this very button had just fixed.
+             */
+            var applyRepair = function () {
+                replaceFile(input, repaired.rows, file.name);
+                clearBlocked(fieldName);
+                renderOk(hostFor(input), validate(repaired.rows).summary, false, input);
+            };
+
             if (fixable) {
-                if (autoApply) {
-                    replaceFile(input, repaired.rows, file.name);
-                    clearBlocked(fieldName);
-                    renderOk(hostFor(input), validate(repaired.rows).summary, false, input);
-                    return;
-                }
+                if (autoApply) { applyRepair(); return; }
                 markBlocked(fieldName, {
                     fieldName: fieldName, fileName: file.name, input: input,
-                    omic: strip.__omic, fixable: true,
-                    apply: function () {
-                        replaceFile(input, repaired.rows, file.name);
-                        clearBlocked(fieldName);
-                        renderOk(hostFor(input),
-                                 validate(repaired.rows).summary, false, input);
-                    }
+                    omic: strip.__omic, fixable: true, apply: applyRepair
                 });
-                var body = renderProblem(strip, "warn", describeProblems(result),
+                renderProblem(strip, "warn", describeProblems(result),
                     repairs.map(function (r) { return r.describe(); }).join(" ") +
                     " This is a direct find-and-replace, not an AI conversion.",
-                    [{ label: "Fix automatically", primary: true, onClick: function () {
-                          replaceFile(input, repaired.rows, file.name);
-                          renderOk(hostFor(input), validate(repaired.rows).summary, false, input);
-                      } },
-                    ]);
+                    [{ label: "Fix automatically", primary: true, onClick: applyRepair }]);
                 return;
             }
 

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
@@ -228,21 +228,35 @@
      * ------------------------------------------------------------------ */
 
     /*
-     * The omic cards are `flex: 1` items in an ExtJS vbox, and the vbox lays
-     * them out as position:absolute elements carrying an inline `top`. That is
-     * the whole difficulty: growing a card's DOM does not move the card below
-     * it, because nothing rewrites that `top`.
+     * The omic cards are items in an ExtJS vbox, and the vbox lays them out as
+     * position:absolute elements carrying an inline `top`. That is the whole
+     * difficulty: growing a card's DOM does not move the card below it,
+     * because nothing rewrites that `top`.
      *
-     * Ext rewrites it when a child's height changes IN THE LAYOUT MODEL. So the
-     * recipe is: drop `flex` so the card stops sharing a budget, then set an
-     * explicit height with setHeight(), inside suspendLayouts/resumeLayouts.
-     * Measured: growing a card by 90px moved the card beneath it down 95px and
-     * grew the column from 314 to 404.
+     * What this module used to do about that was compute the height the card
+     * ought to have and setHeight() it. A computed height is a MEASUREMENT,
+     * and a measurement has a moment. The MORE card is tall enough that its
+     * sections had not settled when the card was primed -- 662px recorded
+     * where itemsContainer alone settles at 684 -- so the card was pinned 66px
+     * short of its own contents. The omic title is itself a `flex: 1` item, so
+     * the vbox took the entire shortfall out of the title: it was allocated
+     * 0px, CSS min-height painted it at 44px regardless, and it landed on top
+     * of the first section heading. Reported twice from a screenshot.
      *
-     * What does NOT work, all measured: raw DOM insertion; adding a real
-     * Ext.Component; dropping flex without setting a height; updateLayout() on
-     * the card, the column or the form; and suspendLayouts + resumeLayouts(true)
-     * around any of those. Each grew the card and left every sibling in place.
+     * There is no number to get wrong in what replaces it. A vbox child with
+     * neither `flex` nor an explicit height shrink-wraps its own items, so the
+     * card is whatever its contents are, whenever they change; updateLayout()
+     * is what rewrites the siblings' `top`.
+     *
+     * Dropping `flex` is what makes that hold, and it is also the reading
+     * behind the older note here that "updateLayout() on the card does not
+     * work": while the card shares a height budget with its siblings, its
+     * height is the layout's to decide and updateLayout() can only hand back
+     * the same number. Out of the budget, it works. Measured on the MORE card:
+     * idle strip -> card 771px, title 44px, overlap 0; growing the strip by
+     * 34px -> card 805px and the card below moved from 1028 to 1062. Plain
+     * cards go 178 -> 175, which is exactly the 3px the title's own flex had
+     * been stretching them by.
      */
     function hostFor(input) {
         return hostForComponent(cardComponentFor(input));
@@ -254,71 +268,48 @@
         var existing = component.down && component.down("[itemId=paFormatHost]");
         if (existing) return existing.getEl().dom.firstChild;
 
-        // Remember what the card looked like before we touched it, so the
-        // original layout can be restored exactly when the file becomes valid.
-        if (component.__paBaseHeight === undefined) {
-            component.__paBaseHeight = component.getHeight();
-            component.__paBaseFlex = component.flex;
-        }
-
         var host = null;
         Ext.suspendLayouts();
+        freeCardHeight(component);
         host = component.add(Ext.create("Ext.Component", {
             itemId: "paFormatHost",
             cls: "pa-format-strip-host",
             html: '<div class="pa-format-strip"></div>'
         }));
         Ext.resumeLayouts(true);
+        component.updateLayout();
         return host.getEl().dom.firstChild;
     }
 
     /*
-     * Resize the card to fit whatever the message currently is.
+     * Take the card out of the vbox's height budget, once, so that it sizes
+     * itself from its items from here on. Both halves are needed: `flex` keeps
+     * the layout deciding the height, and the inline height the layout has
+     * already written keeps the DOM at that decision.
+     */
+    function freeCardHeight(component) {
+        if (!component || component.__paFreed) return;
+        component.__paFreed = true;
+        component.flex = null;
+        component.height = null;
+        if (component.el && component.el.dom) component.el.dom.style.height = "";
+    }
+
+    /*
+     * Re-lay the card out to fit whatever the message currently is.
      *
      * Called after every render because the message changes height -- opening
-     * the change preview roughly doubles it -- and a card sized for the old
-     * message would clip the new one.
+     * the change preview roughly doubles it -- and the vbox does not notice a
+     * child's DOM growing underneath it. Measured with the strip grown by 34px
+     * and no relayout: the strip hangs 33px below the card's own bottom edge.
      */
     function syncCardHeight(input) {
         syncCardHeightFor(cardComponentFor(input));
     }
 
     function syncCardHeightFor(component) {
-        if (!component || component.__paBaseHeight === undefined) return;
-        var host = component.down && component.down("[itemId=paFormatHost]");
-        if (!host || !host.getEl()) return;
-
-        var strip = host.getEl().dom.firstChild;
-        var needed = strip ? strip.getBoundingClientRect().height : 0;
-        if (!needed) return;
-
-        /* Size from what the card's own items want NOW, not from the height
-           snapshot taken when it was primed.
-
-           The snapshot is not always the settled height. A card is primed as
-           soon as it is laid out once, and the MORE panel is tall enough that
-           its sections had not finished: it recorded 662 where itemsContainer
-           alone settles at 684. Growing that by the strip pinned the card 64px
-           short of its contents -- and the omic title is a `flex: 1` item, so
-           the vbox took the whole shortfall out of the title, which collapsed
-           to nothing and overlapped the first heading. Measured: title bottom
-           74px, next section top 30px.
-
-           Summing the items cannot drift the same way, and it stays a maximum
-           against the snapshot so the cards whose height their parent assigns
-           are unaffected. */
-        var content = 0;
-        component.items.each(function (child) {
-            if (child === host) return;
-            var dom = child.el && child.el.dom;
-            if (dom) content += Math.max(child.getHeight() || 0, dom.scrollHeight || 0);
-        });
-
-        Ext.suspendLayouts();
-        component.flex = null;
-        component.setHeight(Math.max(component.__paBaseHeight, content) +
-                            Math.ceil(needed) + 12);
-        Ext.resumeLayouts(true);
+        if (!component || component.isDestroyed || !component.__paFreed) return;
+        component.updateLayout();
     }
 
     /*
@@ -336,19 +327,6 @@
             body.appendChild(region);
         }
         return region;
-    }
-
-    /* Give the card back exactly the layout it had before this module ran. */
-    function releaseCard(input) {
-        var component = cardComponentFor(input);
-        if (!component || component.__paBaseHeight === undefined) return;
-        var host = component.down && component.down("[itemId=paFormatHost]");
-        Ext.suspendLayouts();
-        if (host) component.remove(host, true);
-        component.setHeight(undefined);
-        component.flex = component.__paBaseFlex;
-        Ext.resumeLayouts(true);
-        component.__paBaseHeight = undefined;
     }
 
     /*
@@ -952,9 +930,11 @@
      * upload step reads as "bring any file" before a file is picked rather
      * than only after one fails. Cards are created by ExtJS on drag or on the
      * plus button, so they are found by watching the DOM; the strip is added
-     * only once the card has been laid out, because hostFor records the
-     * card's height as the base to grow from and a card measured before its
-     * first layout is 0px tall.
+     * once the card is rendered, which is all `component.add()` needs. It used
+     * to wait for a card taller than 100px as well, because the card's height
+     * was recorded here as the base to grow from -- nothing is recorded now,
+     * and that wait was in any case no guarantee the height had settled: on
+     * the MORE card it fired at 662px against a settled 771px.
      */
     function primeCard(cardEl) {
         if (!cardEl || cardEl.__paPrimed || !window.Ext || !Ext.getCmp) return;
@@ -972,7 +952,7 @@
             renderIdle(strip);
             syncCardHeightFor(component);
         };
-        if (component.rendered && component.getHeight() > 100) prime();
+        if (component.rendered) prime();
         else component.on("afterlayout", prime, null, { single: true, delay: 30 });
     }
 

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
@@ -292,9 +292,32 @@
         var needed = strip ? strip.getBoundingClientRect().height : 0;
         if (!needed) return;
 
+        /* Size from what the card's own items want NOW, not from the height
+           snapshot taken when it was primed.
+
+           The snapshot is not always the settled height. A card is primed as
+           soon as it is laid out once, and the MORE panel is tall enough that
+           its sections had not finished: it recorded 662 where itemsContainer
+           alone settles at 684. Growing that by the strip pinned the card 64px
+           short of its contents -- and the omic title is a `flex: 1` item, so
+           the vbox took the whole shortfall out of the title, which collapsed
+           to nothing and overlapped the first heading. Measured: title bottom
+           74px, next section top 30px.
+
+           Summing the items cannot drift the same way, and it stays a maximum
+           against the snapshot so the cards whose height their parent assigns
+           are unaffected. */
+        var content = 0;
+        component.items.each(function (child) {
+            if (child === host) return;
+            var dom = child.el && child.el.dom;
+            if (dom) content += Math.max(child.getHeight() || 0, dom.scrollHeight || 0);
+        });
+
         Ext.suspendLayouts();
         component.flex = null;
-        component.setHeight(component.__paBaseHeight + Math.ceil(needed) + 12);
+        component.setHeight(Math.max(component.__paBaseHeight, content) +
+                            Math.ceil(needed) + 12);
         Ext.resumeLayouts(true);
     }
 

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
@@ -721,7 +721,13 @@
        silently does nothing reads as a broken page. */
     function requestAgent(input, file, fieldName) {
         if (window.PaintomicsInputFormat.openConvertDrawer) {
-            window.PaintomicsInputFormat.openConvertDrawer(input, file, fieldName);
+            // The slot's role goes with it. The drawer decides from this which
+            // produced file belongs back in the field the user started from --
+            // without it, it can only recognise a `values` table, and a
+            // conversion that produces a design or an associations file has no
+            // way home.
+            window.PaintomicsInputFormat.openConvertDrawer(
+                input, file, fieldName, roleForInput(input));
             return;
         }
         var strip = hostFor(input);

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
@@ -985,7 +985,22 @@
             var nameField = card && card.queryById && card.queryById("omicNameField");
             var omic = nameField && nameField.getValue && nameField.getValue();
             if (!omic || String(omic).trim().length < 3) continue;
-            var needle = String(omic).replace(/[\s_]+/g, " ").trim().toLowerCase();
+            /* `omic:` and not a bare `omic`.
+             *
+             * Matching the name anywhere in the text was far too loose to stand
+             * on its own -- omic names are ordinary words. Measured: the form's
+             * own refusal, "Please provide at least: Gene expression
+             * /Metabolomics /Proteomics data", contains "Gene expression", so a
+             * card carrying the default name matched it and both buttons
+             * appeared on a dialog that names no file and reports no file
+             * problem at all. Reported as "why do these two buttons always
+             * exist".
+             *
+             * A failure that is about an omic writes it as a label -- the
+             * preparation dialog builds "<omic>: <what the server said>" -- and
+             * prose does not put a colon there. That one character is the
+             * difference between naming a subject and mentioning a word. */
+            var needle = String(omic).replace(/[\s_]+/g, " ").trim().toLowerCase() + ":";
             if (haystack.indexOf(needle) !== -1) {
                 return { input: dom, file: file, fieldName: fields[i].name };
             }

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
@@ -579,6 +579,22 @@
            associations or relevant-features file fell through to the generic
            sentence below, which tells the reader nothing they can act on --
            and telling them is the whole purpose of this module. */
+        if (counts.DUPLICATE_IDENTIFIER) {
+            /* First, because it is fatal and because every other complaint
+               about this file is downstream of it. The numbers are in the
+               message on purpose: "you have duplicates" sends someone hunting,
+               "65 rows share ENSMUSG00000104758" tells them where to look and
+               how bad it is. */
+            var dup = result.problems.filter(function (p) {
+                return p.code === "DUPLICATE_IDENTIFIER";
+            })[0].detail;
+            return dup.ids + " identifier" + (dup.ids === 1 ? "" : "s") +
+                   " name more than one row — " + dup.rows + " rows in all, and " +
+                   "\u201C" + dup.worst + "\u201D appears " + dup.worstCount +
+                   " times. Every row has to name a different feature: the " +
+                   "analysis reads this file into a table keyed on that column, " +
+                   "and cannot hold two values under one name.";
+        }
         if (counts.NOT_INDICATOR) {
             return "A conditions file marks each sample with 1 or 0 in every " +
                    "group column; this one holds other values.";

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
@@ -748,8 +748,15 @@
     /* Layer 2 hand-off. Replaced by convert-drawer.js when that ships; until
        then it says so plainly rather than doing nothing, because a button that
        silently does nothing reads as a broken page. */
-    function requestAgent(input, file, fieldName) {
+    function requestAgent(input, file, fieldName, serverSaid, siblings) {
         if (window.PaintomicsInputFormat.openConvertDrawer) {
+            // What the server said, when it is the server that refused, and
+            // what the job's other files look like. The agent is otherwise
+            // reading ONE file blind against a fault that is not in it: these
+            // files disagree with EACH OTHER, and no single one of them is
+            // wrong on its own -- the format check passed all of them.
+            if (serverSaid) { input.__paServerSaid = serverSaid; }
+            if (siblings) { input.__paSiblings = siblings; }
             // The slot's role goes with it. The drawer decides from this which
             // produced file belongs back in the field the user started from --
             // without it, it can only recognise a `values` table, and a
@@ -892,6 +899,100 @@
      * all of those the user still lands on the error dialog, and that dialog is
      * where the offer to fix belongs.
      */
+    /* What every OTHER file in this job looks like, one line each.
+     *
+     * The converter is per-file, and the failures that actually reach a user
+     * with real data are not. Each file here is individually valid -- the
+     * client check passes all of them -- and they are wrong TOGETHER:
+     *
+     *   MORE ERROR: No common sample names across input files.
+     *   Target samples: DSSmEVs_vs_DSS
+     *   Condition rows: 1-C1, 2-C2, 3-C3, ...
+     *   miRNA-Seq_data samples: DSS_SDmEV_vs_DSS
+     *
+     * Nothing about the regulator file on its own says that. The agent needs
+     * to see the design file's sample column and the target file's headers
+     * next to it, or it re-reads a valid file and finds nothing wrong.
+     *
+     * Only the HEADER of each -- the first 64 KB is read, never the
+     * measurements -- because column names are what disagree. Same rule as the
+     * rest of this module: the numbers stay in the browser.
+     */
+    function siblingSummaries(exceptInput) {
+        if (!window.Ext || !Ext.ComponentQuery) return Promise.resolve([]);
+        var jobs = [];
+        Ext.ComponentQuery.query("filefield").forEach(function (field) {
+            var role = roleForField(field);
+            if (!role) return;
+            var dom = field.fileInputEl && field.fileInputEl.dom;
+            var file = dom && dom.files && dom.files[0];
+            if (!file || dom === exceptInput) return;
+            var card = field.up && field.up("[cls~=omicbox]");
+            var nameField = card && card.queryById && card.queryById("omicNameField");
+            jobs.push(new Promise(function (resolve) {
+                var reader = new FileReader();
+                reader.onload = function () {
+                    var first = String(reader.result || "").split(/\r?\n/)[0] || "";
+                    var cells = first.split(first.indexOf("\t") !== -1 ? "\t" : ",");
+                    resolve({
+                        name: file.name, role: role,
+                        omic: (nameField && nameField.getValue && nameField.getValue()) || "",
+                        columns: cells.length,
+                        header: cells.slice(0, 12).join(" | ")
+                    });
+                };
+                reader.onerror = function () { resolve(null); };
+                reader.readAsText(file.slice(0, 65536));
+            }));
+        });
+        return Promise.all(jobs).then(function (all) {
+            return all.filter(Boolean);
+        });
+    }
+
+    /* The sibling summaries as one instruction the agent can read. */
+    function siblingBrief(summaries) {
+        if (!summaries.length) return "";
+        return "The other files in this job, so you can judge whether they " +
+               "agree with each other (only their first line was read):\n" +
+               summaries.map(function (f) {
+                   return "- " + f.name + " (" + f.role +
+                          (f.omic ? ", omic \u201C" + f.omic + "\u201D" : "") +
+                          ", " + f.columns + " columns): " + f.header;
+               }).join("\n");
+    }
+
+    /* The values file of whichever omic card the error names.
+     *
+     * Second chance for the errors that identify the omic rather than the
+     * file, which is most of what the analysis stage produces: it knows which
+     * omic it was modelling, not which upload the bytes came from. */
+    function pickedFileForOmicNamedIn(text) {
+        if (!window.Ext || !Ext.ComponentQuery) return null;
+        var haystack = String(text).replace(/[\s_]+/g, " ").toLowerCase();
+        var fields = Ext.ComponentQuery.query("filefield");
+        for (var i = 0; i < fields.length; i++) {
+            if (roleForField(fields[i]) !== "values") continue;
+            var dom = fields[i].fileInputEl && fields[i].fileInputEl.dom;
+            var file = dom && dom.files && dom.files[0];
+            if (!file) continue;
+            /* `[cls~=omicbox]`, not `.omicbox`: ComponentQuery has no CSS
+               class selector, and `.omicbox` silently matches nothing. Same
+               family as the `[cls=omicbox]` exact-match trap that has caught
+               this file's neighbours -- one entry of the whitespace list, not
+               the whole string and not a CSS class. */
+            var card = fields[i].up && fields[i].up("[cls~=omicbox]");
+            var nameField = card && card.queryById && card.queryById("omicNameField");
+            var omic = nameField && nameField.getValue && nameField.getValue();
+            if (!omic || String(omic).trim().length < 3) continue;
+            var needle = String(omic).replace(/[\s_]+/g, " ").trim().toLowerCase();
+            if (haystack.indexOf(needle) !== -1) {
+                return { input: dom, file: file, fieldName: fields[i].name };
+            }
+        }
+        return null;
+    }
+
     function pickedFileMatching(reportedName) {
         if (!window.Ext || !Ext.ComponentQuery) return null;
         var fields = Ext.ComponentQuery.query("filefield");
@@ -916,25 +1017,83 @@
         if (!body || !closeButton || !closeButton.parentNode) return;
         if (document.getElementById("pa-format-dialog-fix")) return;
 
+        /* Which file the server is complaining about, from ANY error that
+           names one.
+         *
+         * This used to require the literal phrase "Errors detected while
+         * processing", which is one servlet's wording. Every other failure --
+         * and the ones that actually reach a user with real data are the MORE
+         * ones -- says something else entirely, so the offer never appeared:
+         *
+         *   The MORE analysis failed (more-rs backend). Details:
+         *   MORE ERROR: no data columns could be read from
+         *     /.../inputData/mirna_values.tab
+         *
+         * That names the file perfectly well. So the dialog is read for
+         * anything shaped like one of OUR file names and matched against what
+         * the user actually picked, which is the question that was being asked
+         * all along. Reported by a user watching a MORE run fail with the agent
+         * sitting one click away and never offered. */
         var text = body.textContent || "";
-        if (text.indexOf("Errors detected while processing") === -1) return;
+        var picked = null;
+        var names = text.match(/[\w./\\-]+\.(?:tab|txt|csv|tsv|xls|xlsx|xlsm|ods|gtf|bed)\b/gi) || [];
+        for (var n = 0; n < names.length && !picked; n++) {
+            picked = pickedFileMatching(names[n].replace(/^.*[\\/]/, ""));
+        }
+        /* Some failures name no file at all. The one that sent a user looking
+           for this button is the clearest example -- it names sample names and
+           an omic, and nothing else:
 
-        var match = /Errors detected while processing ([^\s:]+)/.exec(text);
-        if (!match) return;
-        var picked = pickedFileMatching(match[1]);
+             MORE ERROR: No common sample names across input files.
+             Target samples: DSSmEVs_vs_DSS
+             Condition rows: 1-C1, 2-C2, 3-C3, ...
+             miRNA-Seq_data samples: DSS_SDmEV_vs_DSS
+
+           `miRNA-Seq_data` is the name the user typed into Omic Name, so the
+           card is identifiable even though the file is not. Underscores because
+           the backend substitutes them for spaces. */
+        if (!picked) picked = pickedFileForOmicNamedIn(text);
         if (!picked) return;
 
-        var button = el("a", "button btn-secondary btn-right", "Fix this file");
-        button.title = "Repairs the file in place, then you can run again.";
-        button.id = "pa-format-dialog-fix";
-        button.href = "#";
-        button.style.display = "inline-block";
-        button.addEventListener("click", function (event) {
+        /* Two different offers, because they do different things and the
+           difference matters. Re-checking applies a MECHANICAL repair and is
+           only useful when the fault is one this module models. The agent can
+           be told what the server said, which is the only route open when the
+           server knows something the client checker does not -- a sample name
+           that does not line up, an identifier space that does not match. */
+        var wrap = el("span", null, null);
+        wrap.id = "pa-format-dialog-fix";
+
+        var ask = el("a", "button btn-secondary btn-right", "Ask the PaintOmics AI agent");
+        ask.title = "Opens the agent on this file, with what the server said.";
+        ask.href = "#";
+        ask.style.display = "inline-block";
+        ask.addEventListener("click", function (event) {
+            event.preventDefault();
+            var serverSaid = text.replace(/\s+/g, " ").trim();
+            // Gathered BEFORE the dialog closes, while every field still holds
+            // its file, so the agent starts with the whole job in front of it
+            // rather than one file out of context.
+            siblingSummaries(picked.input).then(function (others) {
+                if (typeof closeButton.click === "function") closeButton.click();
+                requestAgent(picked.input, picked.file, picked.fieldName,
+                             serverSaid, siblingBrief(others));
+            });
+        });
+
+        var again = el("a", "button btn-secondary btn-right", "Check this file again");
+        again.title = "Re-reads the file and repairs what can be repaired mechanically.";
+        again.href = "#";
+        again.style.display = "inline-block";
+        again.addEventListener("click", function (event) {
             event.preventDefault();
             if (typeof closeButton.click === "function") closeButton.click();
             check(picked.input, picked.file, picked.fieldName, true);
         });
-        closeButton.parentNode.insertBefore(button, closeButton);
+
+        wrap.appendChild(again);
+        wrap.appendChild(ask);
+        closeButton.parentNode.insertBefore(wrap, closeButton);
     }
 
     // The dialog is rendered by Util.js's showMessage, which several call sites

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
@@ -69,10 +69,50 @@
         secondaryFileSelector: "relevant",
         moreRelevantFileSelector: "relevant",
         mainAssociationFileSelector: "associations",
+        /* The miRNA panel's targets table -- miRNA / gene / score. It was left
+           out because it is not the 2-column `associations` contract, and so
+           went completely unchecked; it now has a contract of its own. */
+        mirnaTargetsFileSelector: "regulator-targets",
         moreAssociationsFileSelector: "associations",
         secondaryAssociationFileSelector: "relevant-associations",
         conditionsFileSelector: "design"
     };
+
+    /* The omic-name field a card would actually submit.
+     *
+     * A card can hold TWO of them. The miRNA panel builds one name field inside
+     * `itemsContainer` and another inside `itemsContainerAlt` -- the two
+     * layouts of the "map regions" toggle -- both with itemId `omicNameField`
+     * and both with name `omicN_omic_name`; the inactive one is DISABLED, which
+     * is how the browser knows not to serialise it. `queryById`/`down` return
+     * the first match, which on a real miRNA card is the disabled, empty one.
+     *
+     * Measured in Chrome on the reporting user's own form (2026-08-27):
+     *
+     *   combobox-1412  itemsContainerAlt  disabled:true   value ""
+     *   combobox-1466  itemsContainer     disabled:false  value "miRNA-Seq data"
+     *
+     * So every lookup of the omic name on a miRNA card read "" -- which is why
+     * the failure dialog for that job offered no agent button at all: the
+     * matcher requires a name to look for and was handed nothing.
+     *
+     * `disabled` is the discriminator rather than visibility, because
+     * visibility is the thing that is unreliable here (a hidden tab, a card
+     * mid-layout), while disabled is exactly the flag the form itself obeys. */
+    function omicNameFieldIn(card) {
+        if (!card || !card.query) return null;
+        var fields = card.query("#omicNameField");
+        if (!fields.length) return null;
+        var live = fields.filter(function (f) {
+            return !(f.isDisabled ? f.isDisabled() : f.disabled);
+        });
+        var pool = live.length ? live : fields;
+        for (var i = 0; i < pool.length; i++) {
+            var value = pool[i].getValue && pool[i].getValue();
+            if (value && String(value).trim()) return pool[i];
+        }
+        return pool[0];
+    }
 
     /* The Ext filefield that owns this DOM input, or null. */
     function extFieldFor(input) {
@@ -160,7 +200,7 @@
     function omicNameFor(input, fieldName) {
         var card = cardComponentFor(input);
         if (card) {
-            var combo = card.down && card.down("#omicNameField");
+            var combo = omicNameFieldIn(card);
             var typed = combo && combo.getValue && combo.getValue();
             if (typed) return typed;
             var heading = card.el && card.el.dom &&
@@ -595,6 +635,25 @@
                    "analysis reads this file into a table keyed on that column, " +
                    "and cannot hold two values under one name.";
         }
+        if (counts.BLANK_IDENTIFIER) {
+            /* Before DUPLICATE and before the shape complaints: a blank id is
+               not a weak row, it is a row that will JOIN to every other blank
+               id in the job and quietly outvote the real data. */
+            var blank = result.problems.filter(function (p) {
+                return p.code === "BLANK_IDENTIFIER";
+            })[0].detail;
+            return blank.rows + " row" + (blank.rows === 1 ? "" : "s") +
+                   " of " + blank.total + " have no identifier (first at line " +
+                   blank.line + ", column " + blank.column + "). An empty name " +
+                   "is still a name to the analysis: those rows match every " +
+                   "other blank cell in your other files, and can end up being " +
+                   "the only thing that matches.";
+        }
+        if (counts.BAD_COLUMN_COUNT) {
+            return "Every line of this file needs the same columns; at least " +
+                   "one line does not. A regulator-to-target table is " +
+                   "Regulator, Target and optionally a score.";
+        }
         if (counts.NOT_INDICATOR) {
             return "A conditions file marks each sample with 1 or 0 in every " +
                    "group column; this one holds other values.";
@@ -928,7 +987,7 @@
             var file = dom && dom.files && dom.files[0];
             if (!file || dom === exceptInput) return;
             var card = field.up && field.up("[cls~=omicbox]");
-            var nameField = card && card.queryById && card.queryById("omicNameField");
+            var nameField = omicNameFieldIn(card);
             jobs.push(new Promise(function (resolve) {
                 var reader = new FileReader();
                 reader.onload = function () {
@@ -982,7 +1041,7 @@
                this file's neighbours -- one entry of the whitespace list, not
                the whole string and not a CSS class. */
             var card = fields[i].up && fields[i].up("[cls~=omicbox]");
-            var nameField = card && card.queryById && card.queryById("omicNameField");
+            var nameField = omicNameFieldIn(card);
             var omic = nameField && nameField.getValue && nameField.getValue();
             if (!omic || String(omic).trim().length < 3) continue;
             /* `omic:` and not a bare `omic`.

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
@@ -73,7 +73,10 @@
            out because it is not the 2-column `associations` contract, and so
            went completely unchecked; it now has a contract of its own. */
         mirnaTargetsFileSelector: "regulator-targets",
-        moreAssociationsFileSelector: "associations",
+        /* runMORE.R stops only on fewer than 2 or more than 3 columns and
+           documents the third (interaction type / area), so the two-column
+           `associations` contract was refusing a file the server takes. */
+        moreAssociationsFileSelector: "regulator-targets",
         secondaryAssociationFileSelector: "relevant-associations",
         conditionsFileSelector: "design"
     };
@@ -138,6 +141,18 @@
         return roleForField(extFieldFor(input));
     }
 
+    /* Whether the slot feeds MORE, whose R and Rust readers refuse a repeated
+       identifier. Every other pipeline merges repeats, so the duplicate rule
+       is only a hard block here. Recognised by the slot MORE alone has (the
+       conditions file) or by the card's class; never by a field NAME. */
+    function feedsMore(input) {
+        var component = cardComponentFor(input);
+        if (!component) return false;
+        if (component.down && component.down("[itemId=conditionsFileSelector]")) return true;
+        var cls = String((component.cls || "") + " " + (component.initialConfig && component.initialConfig.cls || ""));
+        return cls.indexOf("moreBasedOmic") !== -1;
+    }
+
     /*
      * Files we KNOW the server will reject, keyed by field name.
      *
@@ -176,19 +191,13 @@
     /*
      * Where the message lives, and why the omic card carries the state.
      *
-     * The message cannot go INSIDE the omic card. The cards are `flex: 1` items
-     * in a vbox whose height is fixed at 314px by an hbox pinned at 400px, so
-     * the layout ASSIGNS each card its height out of a fixed budget rather than
-     * measuring its content. Nothing added to a card can make it taller; it can
-     * only overflow, and the row is overflow:hidden. Measured three ways -- raw
-     * DOM insertion, a real Ext.Component, and updateLayout on the card, its
-     * container and the form -- and the sibling omic moved 0px every time.
-     *
-     * So the message sits just below the omics row, but pinned to the same left
-     * edge and width as the cards and pulled up into the row's unused space, and
-     * the CARD is tinted to carry the state. The tint is what makes a problem
-     * impossible to miss; the message below it is what says how to fix it.
-     * Neither costs a single pixel of layout.
+     * The strip lives INSIDE the omic card now (hostForComponent adds it as a
+     * child component), which took freeCardHeight: the cards used to be
+     * `flex: 1` items in a vbox with a fixed height budget, so nothing added
+     * to one could make it taller -- measured three ways, and the sibling
+     * omic moved 0px every time. Each card sizes itself since; the CARD is
+     * still tinted to carry the state, because the tint is what makes a
+     * problem impossible to miss, and the strip is what says how to fix it.
      */
     // The omic's display name, used by the submit-time banner, which can be
     // about several omics at once.
@@ -246,15 +255,29 @@
      * one line later. addCls/removeCls put the class in the list Ext rebuilds
      * from, so it survives.
      */
+    /* The other slots of this input's card that still hold a blocked file.
+       A MORE or pairwise card has five to eight slots and ONE strip, so each
+       pick overwrote the previous verdict: a bad conditions file, then a good
+       regulators file, and the card went green with the bad file still in it
+       and the refusal waiting at the end of the form. */
+    function otherBlockedInCard(input) {
+        var card = cardFor(input);
+        if (!card) return [];
+        return liveBlocked().filter(function (entry) {
+            return entry.input && entry.input !== input && cardFor(entry.input) === card;
+        });
+    }
+
     function setCardState(input, state) {
         var component = cardComponentFor(input);
         var card = cardFor(input);
+        var cardState = (state !== "err" && otherBlockedInCard(input).length) ? "err" : state;
         if (component && component.addCls) {
             CARD_STATES.forEach(function (cls) { component.removeCls(cls); });
-            if (state) component.addCls("pa-state-" + state);
+            if (cardState) component.addCls("pa-state-" + cardState);
         } else if (card) {
             CARD_STATES.forEach(function (cls) { card.classList.remove(cls); });
-            if (state) card.classList.add("pa-state-" + state);
+            if (cardState) card.classList.add("pa-state-" + cardState);
         }
 
         var box = filenameBoxFor(input);
@@ -456,6 +479,16 @@
         var body = el("div", "pa-format-body");
         var line = el("div", "pa-format-text",
             (strip.__omic ? strip.__omic + ": " : "") + bits.join(" · "));
+        /* Repeated identifiers outside MORE: the server merges them, so this
+           is information, not a fault -- but "65 rows share one id" is worth
+           knowing before the values are averaged into one feature. */
+        var dup = summary && summary.duplicates;
+        if (dup) {
+            line.appendChild(el("span", "pa-format-note",
+                " · " + dup.ids + " identifier" + (dup.ids === 1 ? "" : "s") +
+                " repeat" + (dup.ids === 1 ? "s" : "") + " (\u201C" + dup.worst + "\u201D " +
+                dup.worstCount + " times); the server merges their rows"));
+        }
         if (partial) {
             line.appendChild(el("span", "pa-format-note",
                 " (checked the first " + Math.round(PARTIAL_CHECK_BYTES / 1048576) + " MB)"));
@@ -498,7 +531,27 @@
             body.appendChild(prov);
         }
         strip.appendChild(body);
-        if (input) { setCardState(input, "ok"); syncCardHeight(input); }
+        if (input) { appendCardReminder(body, input); setCardState(input, "ok"); syncCardHeight(input); }
+    }
+
+    /* "Still blocked in this card: Conditions file (design.csv)" -- so a green
+       verdict on one slot never hides a red one on another. */
+    function appendCardReminder(body, input) {
+        var others = otherBlockedInCard(input);
+        if (!others.length) return;
+        var names = others.map(function (entry) {
+            var label = slotLabelFor(entry.input) || entry.fieldName;
+            return label + (entry.fileName ? " (" + entry.fileName + ")" : "");
+        });
+        body.appendChild(el("div", "pa-format-note pa-format-reminder",
+            "Still blocked in this card: " + names.join("; ") + "."));
+    }
+
+    function slotLabelFor(input) {
+        var field = extFieldFor(input);
+        var selector = field && field.up && field.up("myFilesSelectorButton");
+        var label = selector && selector.fieldLabel;
+        return label ? String(label).replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").replace(/\s*:\s*$/, "").trim() : "";
     }
 
     function markBlocked(fieldName, entry) { blocked[fieldName] = entry; }
@@ -566,6 +619,7 @@
         body.appendChild(bar);
         strip.appendChild(body);
         if (strip.__input) {
+            appendCardReminder(body, strip.__input);
             setCardState(strip.__input, kind === "warn" ? "warn" : "err");
             syncCardHeight(strip.__input);
         }
@@ -596,7 +650,7 @@
     function describeProblems(result) {
         var counts = {};
         result.problems.forEach(function (p) { counts[p.code] = (counts[p.code] || 0) + 1; });
-        var summary = result.summary;
+        var summary = result.summary || {};
 
         if (counts.DECIMAL_COMMA) {
             return "Numbers use commas as the decimal mark; PaintOmics needs dots.";
@@ -619,22 +673,6 @@
            associations or relevant-features file fell through to the generic
            sentence below, which tells the reader nothing they can act on --
            and telling them is the whole purpose of this module. */
-        if (counts.DUPLICATE_IDENTIFIER) {
-            /* First, because it is fatal and because every other complaint
-               about this file is downstream of it. The numbers are in the
-               message on purpose: "you have duplicates" sends someone hunting,
-               "65 rows share ENSMUSG00000104758" tells them where to look and
-               how bad it is. */
-            var dup = result.problems.filter(function (p) {
-                return p.code === "DUPLICATE_IDENTIFIER";
-            })[0].detail;
-            return dup.ids + " identifier" + (dup.ids === 1 ? "" : "s") +
-                   " name more than one row — " + dup.rows + " rows in all, and " +
-                   "\u201C" + dup.worst + "\u201D appears " + dup.worstCount +
-                   " times. Every row has to name a different feature: the " +
-                   "analysis reads this file into a table keyed on that column, " +
-                   "and cannot hold two values under one name.";
-        }
         if (counts.BLANK_IDENTIFIER) {
             /* Before DUPLICATE and before the shape complaints: a blank id is
                not a weak row, it is a row that will JOIN to every other blank
@@ -649,14 +687,30 @@
                    "other blank cell in your other files, and can end up being " +
                    "the only thing that matches.";
         }
+        if (counts.DUPLICATE_IDENTIFIER) {
+            /* Fatal on MORE's matrix readers (advisory elsewhere, where it never
+               reaches here). The numbers are in the
+               message on purpose: "you have duplicates" sends someone hunting,
+               "65 rows share ENSMUSG00000104758" tells them where to look and
+               how bad it is. */
+            var dup = result.problems.filter(function (p) {
+                return p.code === "DUPLICATE_IDENTIFIER";
+            })[0].detail;
+            return dup.ids + " identifier" + (dup.ids === 1 ? "" : "s") +
+                   " name more than one row — " + dup.rows + " rows in all, and " +
+                   "\u201C" + dup.worst + "\u201D appears " + dup.worstCount +
+                   " times. Every row has to name a different feature: the " +
+                   "analysis reads this file into a table keyed on that column, " +
+                   "and cannot hold two values under one name.";
+        }
         if (counts.BAD_COLUMN_COUNT) {
             return "Every line of this file needs the same columns; at least " +
                    "one line does not. A regulator-to-target table is " +
                    "Regulator, Target and optionally a score.";
         }
         if (counts.NOT_INDICATOR) {
-            return "A conditions file marks each sample with 1 or 0 in every " +
-                   "group column; this one holds other values.";
+            return "A conditions file holds a number (1 or 0) in every " +
+                   "group column; this one holds text there.";
         }
         if (counts.NOT_ONE_CONDITION) {
             return "Every sample must belong to exactly one condition — one 1 per row.";
@@ -666,9 +720,6 @@
         }
         if (counts.NOT_TWO_COLUMNS) {
             return "An associations file needs exactly two columns: the target and its regulator.";
-        }
-        if (counts.BAD_COLUMN_COUNT) {
-            return "The file does not have the number of columns this slot expects.";
         }
         if (counts.FIELD_TOO_LONG) {
             return "A field is far too long to be an identifier — this looks like the wrong file for the slot.";
@@ -688,7 +739,10 @@
            report faults they cannot have; format-roles.js already models
            each one. */
         role = role || roleForInput(input) || "values";
-        var validate = function (rows) { return API.validateForRole(role, rows); };
+        var strictKeys = feedsMore(input);
+        var validate = function (rows) {
+            return API.validateForRole(role, rows, undefined, { strictKeys: strictKeys });
+        };
         var strip = hostFor(input);
         if (!strip) return;
         strip.__input = input;
@@ -1029,7 +1083,16 @@
     function pickedFileForOmicNamedIn(text) {
         if (!window.Ext || !Ext.ComponentQuery) return null;
         var haystack = String(text).replace(/[\s_]+/g, " ").toLowerCase();
-        var fields = Ext.ComponentQuery.query("filefield");
+        /* mainFileSelector first: on a MORE card the gene-expression target
+           slot (rnaseqauxFileSelector) precedes the regulator's own data file
+           and both are `values`, so the first match sent the agent the TARGET
+           file for an error that named the regulator omic. */
+        var fields = Ext.ComponentQuery.query("filefield").slice().sort(function (a, b) {
+            var ia = a.up && a.up("myFilesSelectorButton"), ib = b.up && b.up("myFilesSelectorButton");
+            var ma = ia && ia.itemId === "mainFileSelector" ? 0 : 1;
+            var mb = ib && ib.itemId === "mainFileSelector" ? 0 : 1;
+            return ma - mb;
+        });
         for (var i = 0; i < fields.length; i++) {
             if (roleForField(fields[i]) !== "values") continue;
             var dom = fields[i].fileInputEl && fields[i].fileInputEl.dom;

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
@@ -24,7 +24,79 @@
     var FULL_CHECK_LIMIT = 25 * 1024 * 1024;
     var PARTIAL_CHECK_BYTES = 5 * 1024 * 1024;
 
-    var VALUES_FIELD = /^omic\d+_file$/;
+    /*
+     * The contract a picked file is held to, keyed by the SLOT it was picked
+     * into.
+     *
+     * This replaces a test on the field's NAME (/^omic\d+_file$/). That is the
+     * plain, region-based and miRNA panels' naming convention and it is not the
+     * MORE panel's -- MORE calls its five selectors conditions, rnaseqaux,
+     * file_0, relevant_file_0 and assoc_file_0 -- so every file picked into a
+     * Regulatory Omic (MORE) panel went unchecked: no strip, no warning, no
+     * offer to fix, and no block. Reported 2026-08-26 by a user whose files
+     * used decimal commas, the single fault this module exists to catch and
+     * blocks a submit over. She was told nothing, and the run failed on the
+     * server an hour later.
+     *
+     * itemId is the key because it is the one thing every panel type agrees
+     * on; the field names differ per panel and the file names are not evidence
+     * of anything (see roleForFileName's note in format-roles.js).
+     *
+     * Two slots are deliberately absent, because this module does not model
+     * what they hold and judging them by a validator that does not fit would
+     * block work that is correct:
+     *
+     *   tertiaryFileSelector    the region panel's GTF -- not a delimited
+     *                           table in any of these contracts;
+     *   third/fourthFileSelector  the miRNA panel's RESULTS container, filled
+     *                           by setContent with server paths rather than
+     *                           picked, so there is no browser file to read.
+     *                           An empty regulator_relevant_associations file
+     *                           is a legitimate conversion output and the
+     *                           relevant-associations contract rejects it, so
+     *                           judging them could only ever block correct work;
+     *   mirnaTargetsFileSelector  the miRNA2Genes prediction table, which is
+     *                           miRNA / gene / PLR. The shipped
+     *                           mirna_to_gene_associations.tab has THREE
+     *                           columns for that reason, so the two-column
+     *                           associations contract rejects it -- the very
+     *                           trap format-roles.js records under
+     *                           roleForFileName.
+     */
+    var ROLE_BY_SLOT = {
+        mainFileSelector: "values",
+        rnaseqauxFileSelector: "values",
+        secondaryFileSelector: "relevant",
+        moreRelevantFileSelector: "relevant",
+        mainAssociationFileSelector: "associations",
+        moreAssociationsFileSelector: "associations",
+        secondaryAssociationFileSelector: "relevant-associations",
+        conditionsFileSelector: "design"
+    };
+
+    /* The Ext filefield that owns this DOM input, or null. */
+    function extFieldFor(input) {
+        if (!window.Ext || !Ext.ComponentQuery) return null;
+        var fields = Ext.ComponentQuery.query("filefield");
+        for (var i = 0; i < fields.length; i++) {
+            var dom = fields[i].fileInputEl && fields[i].fileInputEl.dom;
+            if (dom === input) return fields[i];
+        }
+        return null;
+    }
+
+    /* The role of the slot a filefield sits in, or null when it is not one of
+       the omic panels' data slots. */
+    function roleForField(field) {
+        if (!field || !field.up) return null;
+        var selector = field.up("myFilesSelectorButton");
+        if (!selector || !selector.itemId) return null;
+        return ROLE_BY_SLOT[selector.itemId] || null;
+    }
+
+    function roleForInput(input) {
+        return roleForField(extFieldFor(input));
+    }
 
     /*
      * Files we KNOW the server will reject, keyed by field name.
@@ -80,12 +152,25 @@
      */
     // The omic's display name, used by the submit-time banner, which can be
     // about several omics at once.
-    function omicNameFor(fieldName) {
-        var prefix = fieldName.replace(/_file$/, "");
-        if (!window.Ext || !Ext.ComponentQuery) return prefix;
-        var field = Ext.ComponentQuery.query("[name=" + prefix + "_omic_name]")[0];
-        var value = field && field.getValue && field.getValue();
-        return value || prefix;
+    //
+    // Taken off the card the input sits in, not from the field name. The name
+    // lookup this replaces asked for "<prefix>_omic_name", which the MORE panel
+    // does not have -- its combo is `omic_name_0` -- so a MORE file would have
+    // been announced to the user as "file_0".
+    function omicNameFor(input, fieldName) {
+        var card = cardComponentFor(input);
+        if (card) {
+            var combo = card.down && card.down("#omicNameField");
+            var typed = combo && combo.getValue && combo.getValue();
+            if (typed) return typed;
+            var heading = card.el && card.el.dom &&
+                          card.el.dom.querySelector(".omicboxTitle h4");
+            if (heading) {
+                var text = String(heading.textContent || "").replace(/\s+/g, " ").trim();
+                if (text) return text;
+            }
+        }
+        return String(fieldName || "").replace(/_file$/, "") || "this omic";
     }
 
     function cardFor(input) {
@@ -299,14 +384,33 @@
 
     function aiExplainer() { return AI_EXPLAINER; }
 
+    /* What an accepted file is worth saying about it, per contract.
+     *
+     * Only the values summary carries numericColumns and idSample; a design
+     * matrix reports its conditions and the two association contracts report
+     * nothing but their shape. Reading the values fields unconditionally threw
+     * ("Cannot read properties of undefined") the moment this module started
+     * checking the other slots, leaving a blank green strip. */
+    function summaryBits(summary) {
+        var bits = [plural(summary.nRows, "row")];
+        if (summary.numericColumns) {
+            bits.push(plural(summary.numericColumns.length, "value column"));
+        } else if (summary.conditions) {
+            bits.push(plural(summary.conditions.length, "condition") +
+                      " (" + summary.conditions.slice(0, 4).join(", ") + ")");
+        } else if (summary.nCols) {
+            bits.push(plural(summary.nCols, "column"));
+        }
+        if (summary.idSample && summary.idSample.length) {
+            bits.push("IDs like " + summary.idSample.slice(0, 3).join(", "));
+        }
+        return bits;
+    }
+
     function renderOk(strip, summary, partial, input) {
         strip.className = "pa-format-strip pa-format-ok";
         strip.innerHTML = "";
-        var bits = [plural(summary.nRows, "row"),
-                    plural(summary.numericColumns.length, "value column")];
-        if (summary.idSample.length) {
-            bits.push("IDs like " + summary.idSample.slice(0, 3).join(", "));
-        }
+        var bits = summaryBits(summary || {});
         strip.appendChild(el("span", "pa-format-icon", "✓"));
         var body = el("div", "pa-format-body");
         var line = el("div", "pa-format-text",
@@ -456,7 +560,7 @@
         if (counts.DECIMAL_COMMA) {
             return "Numbers use commas as the decimal mark; PaintOmics needs dots.";
         }
-        if (counts.NON_NUMERIC && summary.textColumns.length) {
+        if (counts.NON_NUMERIC && summary.textColumns && summary.textColumns.length) {
             var names = summary.textColumns.map(function (i) {
                 return summary.columnNames[i] || ("column " + (i + 1));
             });
@@ -469,6 +573,30 @@
         if (counts.TOO_FEW_COLUMNS) return "The file has only one column; a values file needs an identifier plus at least one measurement.";
         if (counts.NO_FEATURE_LINES) return "The file has a header but no data rows.";
         if (counts.EMPTY) return "The file is empty.";
+
+        /* The other contracts. Without these every fault in a conditions,
+           associations or relevant-features file fell through to the generic
+           sentence below, which tells the reader nothing they can act on --
+           and telling them is the whole purpose of this module. */
+        if (counts.NOT_INDICATOR) {
+            return "A conditions file marks each sample with 1 or 0 in every " +
+                   "group column; this one holds other values.";
+        }
+        if (counts.NOT_ONE_CONDITION) {
+            return "Every sample must belong to exactly one condition — one 1 per row.";
+        }
+        if (counts.CONDITION_MISMATCH) {
+            return "This file does not have one column per condition.";
+        }
+        if (counts.NOT_TWO_COLUMNS) {
+            return "An associations file needs exactly two columns: the target and its regulator.";
+        }
+        if (counts.BAD_COLUMN_COUNT) {
+            return "The file does not have the number of columns this slot expects.";
+        }
+        if (counts.FIELD_TOO_LONG) {
+            return "A field is far too long to be an identifier — this looks like the wrong file for the slot.";
+        }
         return "The file does not match the format PaintOmics expects.";
     }
 
@@ -478,12 +606,18 @@
      * already asked for the file to be fixed -- making them find the strip and
      * press a second button would be two clicks for one intention.
      */
-    function check(input, file, fieldName, autoApply) {
+    function check(input, file, fieldName, autoApply, role) {
+        /* Every slot is held to its OWN contract. Running the values-matrix
+           validator over an associations file or a 0/1 design matrix would
+           report faults they cannot have; format-roles.js already models
+           each one. */
+        role = role || roleForInput(input) || "values";
+        var validate = function (rows) { return API.validateForRole(role, rows); };
         var strip = hostFor(input);
         if (!strip) return;
         strip.__input = input;
         strip.__field = fieldName;
-        strip.__omic = omicNameFor(fieldName);
+        strip.__omic = omicNameFor(input, fieldName);
         // Set by the conversion sheet just before it hands the table over;
         // consumed here so a file the user picks by hand afterwards carries no
         // stale provenance.
@@ -527,7 +661,7 @@
             // does not actually have.
             if (partial && read.rows.length > 1) read.rows.pop();
 
-            var result = API.validateValues(read.rows);
+            var result = validate(read.rows);
             if (result.ok) {
                 clearBlocked(fieldName);
                 renderOk(strip, result.summary, partial, input);
@@ -536,13 +670,13 @@
 
             var repairs = API.proposeRepairs(read.rows, read.delimiter, result.problems);
             var repaired = repairs.length ? API.applyRepairs(read.rows, repairs) : null;
-            var fixable = repaired && API.validateValues(repaired.rows).ok && !partial;
+            var fixable = repaired && validate(repaired.rows).ok && !partial;
 
             if (fixable) {
                 if (autoApply) {
                     replaceFile(input, repaired.rows, file.name);
                     clearBlocked(fieldName);
-                    renderOk(hostFor(input), API.validateValues(repaired.rows).summary, false, input);
+                    renderOk(hostFor(input), validate(repaired.rows).summary, false, input);
                     return;
                 }
                 markBlocked(fieldName, {
@@ -552,7 +686,7 @@
                         replaceFile(input, repaired.rows, file.name);
                         clearBlocked(fieldName);
                         renderOk(hostFor(input),
-                                 API.validateValues(repaired.rows).summary, false, input);
+                                 validate(repaired.rows).summary, false, input);
                     }
                 });
                 var body = renderProblem(strip, "warn", describeProblems(result),
@@ -560,7 +694,7 @@
                     " This is a direct find-and-replace, not an AI conversion.",
                     [{ label: "Fix automatically", primary: true, onClick: function () {
                           replaceFile(input, repaired.rows, file.name);
-                          renderOk(hostFor(input), API.validateValues(repaired.rows).summary, false, input);
+                          renderOk(hostFor(input), validate(repaired.rows).summary, false, input);
                       } },
                     ]);
                 return;
@@ -602,13 +736,8 @@
      * ------------------------------------------------------------------ */
 
     function extFieldNameFor(input) {
-        if (!window.Ext || !Ext.ComponentQuery) return null;
-        var fields = Ext.ComponentQuery.query("filefield");
-        for (var i = 0; i < fields.length; i++) {
-            var dom = fields[i].fileInputEl && fields[i].fileInputEl.dom;
-            if (dom === input) return fields[i].name || null;
-        }
-        return null;
+        var field = extFieldFor(input);
+        return (field && field.name) || null;
     }
 
     /* ------------------------------------------------------------------ *
@@ -731,7 +860,7 @@
         if (!window.Ext || !Ext.ComponentQuery) return null;
         var fields = Ext.ComponentQuery.query("filefield");
         for (var i = 0; i < fields.length; i++) {
-            if (!VALUES_FIELD.test(fields[i].name || "")) continue;
+            if (!roleForField(fields[i])) continue;
             var dom = fields[i].fileInputEl && fields[i].fileInputEl.dom;
             var file = dom && dom.files && dom.files[0];
             if (!file) continue;
@@ -809,7 +938,7 @@
         var component = Ext.getCmp(cardEl.id);
         if (!component || !component.query) return;
         var hasValuesField = component.query("filefield").some(function (f) {
-            return VALUES_FIELD.test(f.name || "");
+            return !!roleForField(f);
         });
         if (!hasValuesField) return;
         cardEl.__paPrimed = true;
@@ -858,9 +987,10 @@
         var input = event.target;
         if (!input || input.type !== "file" || !input.files || !input.files.length) return;
         var name = extFieldNameFor(input);
-        if (!name || !VALUES_FIELD.test(name)) return;
+        var role = roleForInput(input);
+        if (!name || !role) return;
         try {
-            check(input, input.files[0], name);
+            check(input, input.files[0], name, false, role);
         } catch (e) {
             // Never let a check failure take the upload with it: the user can
             // always still submit, exactly as before this module existed.

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-roles.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-roles.js
@@ -48,6 +48,31 @@
                  summary: { nRows: body.length, nCols: 2 } };
     }
 
+    /* A regulator-to-target table: two identifier columns, and optionally a
+     * third holding a prediction score.
+     *
+     * This is the miRNA panel's "targets" slot -- mirna_to_gene_associations.tab
+     * and mmu_mirBase_to_ensembl.tab both ship as miRNA / Ensembl.Gene.ID / PLR
+     * -- which is why it could not be held to the 2-column `associations`
+     * contract and was left with no role at all. Left unchecked, it accepted
+     * the file that broke a real run: 6,039 rows whose target column was empty.
+     */
+    function validateRegulatorTargets(rows) {
+        var problems = [];
+        var body = nonEmptyRows(rows);
+        if (!body.length) problems.push(problem("EMPTY", 0, "The file is empty."));
+        body.forEach(function (r, i) {
+            if (i > MAX_NUMBER_FEATURES) return;
+            if (r.length < 2 || r.length > 3) {
+                problems.push(problem("BAD_COLUMN_COUNT", i,
+                    "Expected 2 or 3 columns (Regulator, Target[, score]) but found " +
+                    r.length + "."));
+            }
+        });
+        return { ok: problems.length === 0, problems: problems.slice(0, 10),
+                 summary: { nRows: body.length } };
+    }
+
     /* One or two columns. */
     function validateRelevantAssociations(rows) {
         var problems = [];
@@ -148,7 +173,8 @@
                             conditions: header.slice(1) } };
     }
 
-    var ROLES = ["values", "relevant", "associations", "relevant-associations", "design"];
+    var ROLES = ["values", "relevant", "associations", "relevant-associations",
+                 "regulator-targets", "design"];
 
     /*
      * A LAST-RESORT guess at a file's contract from its name.
@@ -270,6 +296,55 @@
         return { count: repeated, rows: rowsOver, worst: worst, worstCount: worstCount };
     }
 
+    /* How many leading cells of a row are its identifier, per role.
+     *
+     * `values` and `design` defer to idColumnCount, which returns 3 for a
+     * region-based table (id, start, end) and 1 otherwise. The pair roles hold
+     * two ids side by side; a relevant-associations file may legitimately be a
+     * single column. */
+    function idColumnsForRole(role, body) {
+        var width = body.length ? body[0].length : 0;
+        if (role === "associations" || role === "regulator-targets") return Math.min(2, width);
+        if (role === "relevant-associations") return Math.min(2, width);
+        if (role === "relevant") return 1;
+        return idColumnCount(body);
+    }
+
+    /* Rows whose identifier cell is blank.
+     *
+     * An identifier is what makes a row mean anything, and a blank one is worse
+     * than a missing row: `""` is a valid key, so it JOINS -- to every other
+     * blank cell in every other file. Measured on a user's real job
+     * (2026-08-27): their targets file held 6,039 rows with an empty target id
+     * and their expression file 13 rows with an empty gene id, so `""` matched
+     * `""` and those 6,039 pairs were the only ones the server scored. Every
+     * real target was an ENSMUSG id and the expression file was keyed by gene
+     * symbol -- a true overlap of zero. The run was reported as a SUCCESS and
+     * produced an associations file that was blank down its whole first column.
+     *
+     * The header is skipped the same way duplicateIdentifiers skips it, so a
+     * labelled first row is not counted as a fault. */
+    function blankIdentifiers(rows, role) {
+        var all = nonEmptyRows(rows);
+        if (!all.length) return { rows: 0, first: 0, column: 1 };
+        var header = all[0].slice(1).every(function (c) { return V.isPythonFloat(String(c)); })
+            ? null : all[0];
+        var body = header ? all.slice(1) : all;
+        var idCols = idColumnsForRole(role, body);
+        var offset = header ? 2 : 1;
+        var count = 0, first = 0, column = 1;
+        for (var i = 0; i < body.length; i++) {
+            for (var c = 0; c < idCols; c++) {
+                if (String(body[i][c] === undefined ? "" : body[i][c]).trim() === "") {
+                    count++;
+                    if (!first) { first = i + offset; column = c + 1; }
+                    break;
+                }
+            }
+        }
+        return { rows: count, first: first, column: column, total: body.length };
+    }
+
     /* The roles whose identifier has to be unique.
      *
      * `values` and `design` are read into a matrix keyed on the identifier --
@@ -284,11 +359,23 @@
 
     function validateForRole(role, rows, conditions) {
         var report;
-        if (role === "associations") report = validateAssociations(rows);
+        if (role === "regulator-targets") report = validateRegulatorTargets(rows);
+        else if (role === "associations") report = validateAssociations(rows);
         else if (role === "relevant-associations") report = validateRelevantAssociations(rows);
         else if (role === "relevant") report = validateRelevant(rows, conditions);
         else if (role === "design") report = validateDesign(rows);
         else report = validateValuesWithRegionCheck(rows);
+
+        var blank = blankIdentifiers(rows, role);
+        if (blank.rows) {
+            report.problems = (report.problems || []).concat([
+                problem("BLANK_IDENTIFIER", blank.first, {
+                    rows: blank.rows, total: blank.total,
+                    line: blank.first, column: blank.column
+                })
+            ]);
+            report.ok = false;
+        }
 
         if (UNIQUE_KEY_ROLES[role || "values"]) {
             var dup = duplicateIdentifiers(rows);
@@ -307,6 +394,8 @@
 
     return {
         validateAssociations: validateAssociations,
+        validateRegulatorTargets: validateRegulatorTargets,
+        blankIdentifiers: blankIdentifiers,
         validateRelevantAssociations: validateRelevantAssociations,
         validateRelevant: validateRelevant,
         validateDesign: validateDesign,

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-roles.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-roles.js
@@ -63,9 +63,12 @@
         if (!body.length) problems.push(problem("EMPTY", 0, "The file is empty."));
         body.forEach(function (r, i) {
             if (i > MAX_NUMBER_FEATURES) return;
-            if (r.length < 2 || r.length > 3) {
+            /* Fewer than two is the only shape the server cannot use:
+               miRNA2Target.py reads line[0] and line[1] and ignores the rest,
+               and runMORE.R documents a third column and tolerates more. */
+            if (r.length < 2) {
                 problems.push(problem("BAD_COLUMN_COUNT", i,
-                    "Expected 2 or 3 columns (Regulator, Target[, score]) but found " +
+                    "Expected at least 2 columns (Regulator, Target[, score]) but found " +
                     r.length + "."));
             }
         });
@@ -73,11 +76,14 @@
                  summary: { nRows: body.length } };
     }
 
-    /* One or two columns. */
+    /* One or two columns. Empty is fine: a run whose correlation filter kept
+       no pair writes an empty relevant-associations file, and the server's
+       loop over it (PathwayAcquisitionJob.py, the relevant-associations
+       reader) raises nothing on zero lines -- the same reason third/fourth
+       FileSelector are exempt from checking altogether. */
     function validateRelevantAssociations(rows) {
         var problems = [];
         var body = nonEmptyRows(rows);
-        if (!body.length) problems.push(problem("EMPTY", 0, "The file is empty."));
         body.forEach(function (r, i) {
             if (r.length !== 1 && r.length !== 2) {
                 problems.push(problem("BAD_COLUMN_COUNT", i,
@@ -143,34 +149,41 @@
             problems.push(problem("EMPTY", 0, "A design file needs a header and at least one sample."));
             return { ok: false, problems: problems, summary: { nRows: 0 } };
         }
+        /* What runMORE.R's read_matrix actually requires, replicated in R
+           4.6.0: a header of N or N-1 cells (R's own write.table default
+           leaves the row-name column unnamed), numeric cells, unique sample
+           names -- and nothing else. The first cut also demanded 0/1 cells
+           with exactly one 1 per row, and blocked three files R accepts: an
+           R-written header one cell short, a multi-factor row (which
+           MOREServlet._designPatternNames handles on purpose), and numeric
+           levels such as Time 0/24/48. The design-matrix advice stays as
+           advice; only what R rejects is refused here. */
         var header = body[0];
-        if (header.length < 2) {
+        var samples = body.slice(1);
+        var wide = samples.length && samples.every(function (r) { return r.length === header.length + 1; });
+        var width = wide ? header.length + 1 : header.length;
+        var conditions = wide ? header.slice(0) : header.slice(1);
+        if (width < 2) {
             problems.push(problem("TOO_FEW_COLUMNS", 0,
                 "Expected a Sample column and at least one condition column."));
         }
-        body.slice(1).forEach(function (r, i) {
+        samples.forEach(function (r, i) {
             var line = i + 1;
-            if (r.length !== header.length) {
+            if (r.length !== width) {
                 problems.push(problem("RAGGED", line,
-                    "Expected " + header.length + " columns but found " + r.length + "."));
+                    "Expected " + width + " columns but found " + r.length + "."));
                 return;
             }
-            var ones = 0;
             r.slice(1).forEach(function (cell) {
                 var t = String(cell).trim();
-                if (t !== "0" && t !== "1") {
+                if (!V.isPythonFloat(t)) {
                     problems.push(problem("NOT_INDICATOR", line,
-                        "Condition columns must be 0 or 1, found " + JSON.stringify(t) + "."));
-                } else if (t === "1") ones++;
+                        "Condition columns must be numeric (1/0 indicators), found " + JSON.stringify(t) + "."));
+                }
             });
-            if (ones !== 1) {
-                problems.push(problem("NOT_ONE_CONDITION", line,
-                    "Each sample must belong to exactly one condition, found " + ones + "."));
-            }
         });
         return { ok: problems.length === 0, problems: problems.slice(0, 10),
-                 summary: { nRows: body.length - 1, nCols: header.length,
-                            conditions: header.slice(1) } };
+                 summary: { nRows: samples.length, nCols: width, conditions: conditions } };
     }
 
     var ROLES = ["values", "relevant", "associations", "relevant-associations",
@@ -327,6 +340,15 @@
     function blankIdentifiers(rows, role) {
         var all = nonEmptyRows(rows);
         if (!all.length) return { rows: 0, first: 0, column: 1 };
+        /* A relevance list wider than one column is one column PER CONDITION
+           (example 03-gene-multi-condition-relevance): a gene not relevant in
+           condition 1 has an empty first cell, and that is the format, not a
+           fault -- the server's parseSignificativeFeaturesFile skips blank
+           cells by design. Only the one-column list keys on column 1, and
+           nonEmptyRows already guarantees each row holds something. */
+        if (role === "relevant" && all[0].length > 1) {
+            return { rows: 0, first: 0, column: 1, total: all.length };
+        }
         var header = all[0].slice(1).every(function (c) { return V.isPythonFloat(String(c)); })
             ? null : all[0];
         var body = header ? all.slice(1) : all;
@@ -357,7 +379,16 @@
      * there is the file working as intended. */
     var UNIQUE_KEY_ROLES = { values: true, design: true };
 
-    function validateForRole(role, rows, conditions) {
+    /* options.strictKeys: the file is bound for a MORE slot, whose R/Rust
+       matrix readers refuse a repeated key. Anywhere else a repeated
+       identifier in a values file is MERGED by the server
+       (Job.addInputGeneData -> addOmicValues) and never rejected -- so a hard
+       block there was a false "the server will reject this file", and it
+       also took the decimal-comma repair away from files that carried both
+       (the repair is only offered when the repaired file validates). Outside
+       MORE the repeat is reported on the summary and the file stays OK. */
+    function validateForRole(role, rows, conditions, options) {
+        options = options || {};
         var report;
         if (role === "regulator-targets") report = validateRegulatorTargets(rows);
         else if (role === "associations") report = validateAssociations(rows);
@@ -380,13 +411,17 @@
         if (UNIQUE_KEY_ROLES[role || "values"]) {
             var dup = duplicateIdentifiers(rows);
             if (dup.count) {
-                report.problems = (report.problems || []).concat([
-                    problem("DUPLICATE_IDENTIFIER", 0, {
-                        ids: dup.count, rows: dup.rows,
-                        worst: dup.worst, worstCount: dup.worstCount
-                    })
-                ]);
-                report.ok = false;
+                var detail = { ids: dup.count, rows: dup.rows,
+                               worst: dup.worst, worstCount: dup.worstCount };
+                if (role === "design" || options.strictKeys) {
+                    report.problems = (report.problems || []).concat([
+                        problem("DUPLICATE_IDENTIFIER", 0, detail)
+                    ]);
+                    report.ok = false;
+                } else {
+                    report.summary = report.summary || {};
+                    report.summary.duplicates = detail;
+                }
             }
         }
         return report;

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-roles.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-roles.js
@@ -229,12 +229,80 @@
         return report;
     }
 
+    /* How wide the identifier is.
+     *
+     * One column normally, three for a region file, where chr/start/end
+     * together name the feature and column 0 alone repeats for every region on
+     * a chromosome. Lifted from convert-agent.js, which has graded the AI's
+     * own output this way since the converter shipped -- the rule was right,
+     * it just never ran on a file the user picked themselves. */
+    function idColumnCount(body) {
+        if (!body.length || body[0].length < 4) return 1;
+        var sample = body.slice(0, 200);
+        var pairs = 0, checked = 0;
+        for (var i = 0; i < sample.length; i++) {
+            var a = sample[i][1], b = sample[i][2];
+            if (!/^-?\d+$/.test(String(a).trim()) || !/^-?\d+$/.test(String(b).trim())) return 1;
+            checked++;
+            if (parseInt(b, 10) >= parseInt(a, 10)) pairs++;
+        }
+        return (checked && pairs / checked >= 0.9) ? 3 : 1;
+    }
+
+    /* Every identifier that names more than one row, worst first. */
+    function duplicateIdentifiers(rows) {
+        var all = nonEmptyRows(rows);
+        if (!all.length) return { count: 0, rows: 0, worst: null, worstCount: 0 };
+        var header = all[0].slice(1).every(function (c) { return V.isPythonFloat(String(c)); })
+            ? null : all[0];
+        var body = header ? all.slice(1) : all;
+        var idCols = idColumnCount(body);
+        var seen = Object.create(null), repeated = 0, rowsOver = 0;
+        var worst = null, worstCount = 0;
+        for (var i = 0; i < body.length; i++) {
+            var key = body[i].slice(0, idCols).map(function (c) { return String(c).trim(); }).join(":");
+            if (key.replace(/:/g, "") === "") continue;
+            seen[key] = (seen[key] || 0) + 1;
+            if (seen[key] === 2) repeated++;
+            if (seen[key] > 1) rowsOver++;
+            if (seen[key] > worstCount) { worstCount = seen[key]; worst = key; }
+        }
+        return { count: repeated, rows: rowsOver, worst: worst, worstCount: worstCount };
+    }
+
+    /* The roles whose identifier has to be unique.
+     *
+     * `values` and `design` are read into a matrix keyed on the identifier --
+     * runMORE.R:82 uses row.names=1, and the Rust port reproduces the same
+     * rejection deliberately (MORE/rust/src/data.rs:141) -- so a repeat is
+     * fatal on both engines, not a matter of taste.
+     *
+     * The association roles are deliberately absent: many regulators to one
+     * target is the whole point of those files, and a repeated identifier
+     * there is the file working as intended. */
+    var UNIQUE_KEY_ROLES = { values: true, design: true };
+
     function validateForRole(role, rows, conditions) {
-        if (role === "associations") return validateAssociations(rows);
-        if (role === "relevant-associations") return validateRelevantAssociations(rows);
-        if (role === "relevant") return validateRelevant(rows, conditions);
-        if (role === "design") return validateDesign(rows);
-        return validateValuesWithRegionCheck(rows);
+        var report;
+        if (role === "associations") report = validateAssociations(rows);
+        else if (role === "relevant-associations") report = validateRelevantAssociations(rows);
+        else if (role === "relevant") report = validateRelevant(rows, conditions);
+        else if (role === "design") report = validateDesign(rows);
+        else report = validateValuesWithRegionCheck(rows);
+
+        if (UNIQUE_KEY_ROLES[role || "values"]) {
+            var dup = duplicateIdentifiers(rows);
+            if (dup.count) {
+                report.problems = (report.problems || []).concat([
+                    problem("DUPLICATE_IDENTIFIER", 0, {
+                        ids: dup.count, rows: dup.rows,
+                        worst: dup.worst, worstCount: dup.worstCount
+                    })
+                ]);
+                report.ok = false;
+            }
+        }
+        return report;
     }
 
     return {
@@ -246,6 +314,7 @@
         rolesFromManifest: rolesFromManifest,
         ROLES: ROLES,
         validateForRole: validateForRole,
+        duplicateIdentifiers: duplicateIdentifiers,
         looksLikeRegionHeader: looksLikeRegionHeader,
         validateValuesWithRegionCheck: validateValuesWithRegionCheck
     };

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -4428,18 +4428,30 @@ function MORESubmittingPanel(nElem, options) {
 								xtype: "myFilesSelectorButton",
 								fieldLabel: 'Regulators expression file',
 								namePrefix: 'file_' + i,
+								/* The same itemIds as the first regulator's
+								   selectors: the input check keys its
+								   contract on the slot's itemId, and without
+								   one these three went completely unchecked
+								   (measured: the same decimal-comma file was
+								   flagged in file_0 and passed silently in
+								   file_1). Siblings may share an itemId; the
+								   check reaches it through up(), not
+								   queryById. */
+								itemId: "mainFileSelector",
 								helpTip: "Upload the quantification file (i.e. miRNA Quantification) or choose it from your data folder. See above the accepted format for the file."
 							},
 							{
 								xtype: "myFilesSelectorButton",
 								fieldLabel: 'Relevant regulators file<br>(optional)',
 								namePrefix: 'relevant_file_' + i,
+								itemId: "moreRelevantFileSelector",
 								helpTip: "Upload the list of relevant (differentially expressed) features (TAB format) or choose it from your data folder. See above the accepted format for the file."
 							},
 							{
 								xtype: "myFilesSelectorButton",
 								fieldLabel: 'Associations file',
 								namePrefix: 'assoc_file_' + i,
+								itemId: "moreAssociationsFileSelector",
 								helpTip: "Upload the reference file that relates each feature (i.e. miRNA) with its potential targets. This information is usually extracted from popular databases such as miRbase for miRNAs. See above the accepted format for the file."
 							},
 							{

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -2408,7 +2408,14 @@ function OmicSubmittingPanel(nElem, options) {
 			type: me.type, layout: {align: 'stretch',type: 'vbox'},
 			items: [
 				{
-					xtype: "box", flex: 1, cls: "omicboxTitle " + this.class, html:
+/* No `flex`. The title is a fixed 44px bar (.omicboxTitle min-height), and a
+					   flexed item in a vbox is where the layout puts any height the card has
+					   left over -- or, when the card is SHORT of its contents, where it takes
+					   the shortfall from. That is what a short MORE card did to this heading:
+					   allocated 0px, painted at 44px by the CSS min-height, sitting on top of
+					   the first section. Nothing else in the card is flexed, so slack now
+					   simply stays at the bottom where it is invisible. */
+					xtype: "box", cls: "omicboxTitle " + this.class, html:
 					'<h4>' +
 					' <a class="deleteOmicBox" href="javascript:void(0)" style="margin: 0; float:right;  padding-right: 15px;"><i class="fa fa-trash"></i></a>' +
 					this.title +
@@ -2729,8 +2736,10 @@ function RegionBasedOmicSubmittingPanel(nElem, options) {
 				type: 'vbox'
 			},
 			items: [{
+				/* No `flex` -- see the note on the first omicboxTitle above: a
+				   flexed 44px header is where a short card takes its shortfall
+				   from, and it landed on the section heading below. */
 				xtype: "box",
-				flex: 1,
 				cls: "omicboxTitle " + this.class,
 				html: '<h4><a class="deleteOmicBox" href="javascript:void(0)" style="margin: 0; float:right;  padding-right: 15px;">' +
 				(me.removable ? ' <i class="fa fa-trash"></i></a>' : "</a>") + this.title +
@@ -3573,8 +3582,10 @@ function MiRNAOmicSubmittingPanel(nElem, options) {
 				type: 'vbox'
 			},
 			items: [{
+				/* No `flex` -- see the note on the first omicboxTitle above: a
+				   flexed 44px header is where a short card takes its shortfall
+				   from, and it landed on the section heading below. */
 				xtype: "box",
-				flex: 1,
 				cls: "omicboxTitle " + this.class,
 				html: '<h4><a class="deleteOmicBox" href="javascript:void(0)" style="margin: 0; float:right;  padding-right: 15px;">' +
 				(me.removable ? ' <i class="fa fa-trash"></i></a>' : "</a>") + this.title +
@@ -4244,8 +4255,10 @@ function MORESubmittingPanel(nElem, options) {
 				type: 'vbox'
 			},
 			items: [{
+				/* No `flex` -- see the note on the first omicboxTitle above: a
+				   flexed 44px header is where a short card takes its shortfall
+				   from, and it landed on the section heading below. */
 				xtype: "box",
-				flex: 1,
 				cls: "omicboxTitle moreBasedFileBox",
 				html: '<h4><a class="deleteOmicBox" href="javascript:void(0)" style="margin: 0; float:right;  padding-right: 15px;">' +
 				(me.removable ? ' <i class="fa fa-trash"></i></a>' : "</a>") + this.title +

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -141,7 +141,7 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-reader.js?v=0.1"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-validator.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-repair.js?v=0.1"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=1.9"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=2.0"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.6"></script>

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -141,11 +141,11 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-reader.js?v=0.1"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-validator.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-repair.js?v=0.1"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=2.4"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=2.8"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.6"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=0.8"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=1.2"></script>
 	<!--MORE REGULATOR–TARGET NETWORK VIEW -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js?v=0.7"></script>
 	<!--OMNIPATH PATHWAY NETWORK VIEW (OmniPath ships no diagram; its pathways render as graphs) -->

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -141,7 +141,7 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-reader.js?v=0.1"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-validator.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-repair.js?v=0.1"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=2.8"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=2.9"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.6"></script>

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -141,7 +141,7 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-reader.js?v=0.1"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-validator.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-repair.js?v=0.1"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=2.2"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=2.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.6"></script>

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -145,7 +145,7 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.6"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=1.2"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=1.3"></script>
 	<!--MORE REGULATOR–TARGET NETWORK VIEW -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js?v=0.7"></script>
 	<!--OMNIPATH PATHWAY NETWORK VIEW (OmniPath ships no diagram; its pathways render as graphs) -->

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -141,11 +141,11 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-reader.js?v=0.1"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-validator.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-repair.js?v=0.1"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=2.1"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=2.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.6"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=0.7"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=0.8"></script>
 	<!--MORE REGULATOR–TARGET NETWORK VIEW -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js?v=0.7"></script>
 	<!--OMNIPATH PATHWAY NETWORK VIEW (OmniPath ships no diagram; its pathways render as graphs) -->

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -41,7 +41,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
 	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.61" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.14" />
-	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.4" />
+	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.5" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.7" />
 	<!-- Shared chrome for both of Step 3's graph surfaces. Before more-network.css,
 	     which layers this view's own legend and layout on top of it. -->

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -141,7 +141,7 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-reader.js?v=0.1"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-validator.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-repair.js?v=0.1"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=2.0"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=2.1"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.6"></script>

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -141,8 +141,8 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-reader.js?v=0.1"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-validator.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-repair.js?v=0.1"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=2.3"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.2"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=2.4"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.6"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=0.8"></script>

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -141,11 +141,11 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-reader.js?v=0.1"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-validator.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-repair.js?v=0.1"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=3.0"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.4"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=3.1"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.5"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.6"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=1.3"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=1.4"></script>
 	<!--MORE REGULATOR–TARGET NETWORK VIEW -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js?v=0.7"></script>
 	<!--OMNIPATH PATHWAY NETWORK VIEW (OmniPath ships no diagram; its pathways render as graphs) -->

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -141,8 +141,8 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-reader.js?v=0.1"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-validator.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-repair.js?v=0.1"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=2.9"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.3"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=3.0"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.4"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js?v=0.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.6"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=1.3"></script>

--- a/PaintomicsClient/public_html/resources/css/inputconvert.css
+++ b/PaintomicsClient/public_html/resources/css/inputconvert.css
@@ -935,7 +935,12 @@
 .pa-convert-composer-input:disabled { opacity: 0.55; }
 .pa-convert-composer-send {
     flex: 0 0 auto;
-    min-height: 38px;
+    /* The same height as the input at rest (66px, its two rows), so the two
+       read as one block. At 38px against a 66px box the button was a small
+       control parked under a tall one, with a 28px step between their top
+       edges. It stays bottom-aligned, so when the input grows with what is
+       typed the button keeps its size and sits on the same baseline. */
+    min-height: 66px;
     padding: 0 16px;
     border-radius: var(--pa-radius-sm, 6px);
     border: 1px solid var(--cv-ai-ink);

--- a/PaintomicsServer/src/tests/test_a_blank_identifier_is_refused.py
+++ b/PaintomicsServer/src/tests/test_a_blank_identifier_is_refused.py
@@ -199,6 +199,10 @@ class BlankIdentifierTest(unittest.TestCase):
                  "rows": [["a", "b", "c", "d"], ["e", "f", "g", "h"]]},
                 {"name": "blank-association", "role": "associations",
                  "rows": [["ENSMUSG1", "mmu-miR-1"], ["", "mmu-miR-2"]]},
+                # One column per condition: a gene not relevant in condition 1
+                # has an empty first cell. That is the format (example 03).
+                {"name": "per-condition-relevant", "role": "relevant",
+                 "rows": [["ENSMUSG1", "ENSMUSG2"], ["", "ENSMUSG3"], ["ENSMUSG4", ""]]},
             ]),
         })}
         cls.names = run_node(NAME_FIELD % {
@@ -251,9 +255,19 @@ class BlankIdentifierTest(unittest.TestCase):
         self.assertTrue(self.reports["shipped-targets"]["ok"],
                         self.reports["shipped-targets"]["codes"])
 
-    def test_two_columns_are_accepted_and_four_are_not(self):
+    def test_a_per_condition_relevance_list_is_not_a_blank_identifier(self):
+        """The shipped 03 example was refused as "627 rows of 895 have no
+        identifier": a per-condition list has blank cells by design, and the
+        server's parseSignificativeFeaturesFile skips them."""
+        report = self.reports["per-condition-relevant"]
+        self.assertTrue(report["ok"], report["codes"])
+        self.assertIsNone(report["blank"])
+
+    def test_two_columns_are_accepted_and_so_are_four(self):
+        """miRNA2Target.py reads line[0] and line[1] and ignores the rest, and
+        runMORE.R documents a third column: extra columns are not a fault."""
         self.assertTrue(self.reports["two-column-targets"]["ok"])
-        self.assertFalse(self.reports["four-column-targets"]["ok"])
+        self.assertTrue(self.reports["four-column-targets"]["ok"])
 
     def test_the_slot_has_a_role(self):
         self.assertIn('mirnaTargetsFileSelector: "regulator-targets"', self.source)

--- a/PaintomicsServer/src/tests/test_a_blank_identifier_is_refused.py
+++ b/PaintomicsServer/src/tests/test_a_blank_identifier_is_refused.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""A row with no identifier must be refused, and the omic must be named right.
+
+The run this comes from
+-----------------------
+A user submitted a miRNA job four times on 2026-08-27 and got, each time:
+
+    miRNA-Seq data: Exception: AT MiRNA2GenesServlet.py: fromMiRNAtoGenes_STEP2.
+    Your mirna2gene association process did not return any result. Please,
+    check the files (same identifiers, etc) and parameters.
+
+Their own files, read: the targets file held 6,039 rows whose target column was
+empty, and the gene expression file 13 rows whose gene column was empty. `""` is
+a perfectly good dict key, so miRNA2Target joined blank to blank -- and because
+every real target was an ENSMUSG id while the expression file was keyed by gene
+SYMBOL, an overlap of exactly zero, those 6,039 blank pairs were the only ones
+the server ever scored. PaintOmics called that run a success and handed back an
+associations file blank down its entire first column. Feeding THAT file back in
+is what produced the "no result" error above: nothing left to join on at all.
+
+Two client-side gaps let it get that far:
+
+1. `mirnaTargetsFileSelector` -- the slot the targets file goes into -- had no
+   role in ROLE_BY_SLOT, so it was never checked. It was exempted because the
+   table is miRNA/gene/PLR and does not fit the two-column `associations`
+   contract; it now has `regulator-targets` of its own.
+
+2. Nothing checked for a blank identifier in ANY role. Blank is worse than
+   missing: a missing row is absent, a blank row JOINS.
+
+And one that hid the way out:
+
+3. A miRNA card holds TWO #omicNameField combos -- one per layout of the "map
+   regions" toggle -- and the inactive one is disabled and empty. `queryById`
+   returns the first, which is that one. Measured in Chrome on this user's form:
+
+       combobox-1412  itemsContainerAlt  disabled:true   value ""
+       combobox-1466  itemsContainer     disabled:false  value "miRNA-Seq data"
+
+   So the failure dialog's "Ask the PaintOmics AI agent" button never appeared:
+   it looks for the omic named in the message, and the name it read was "".
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_a_blank_identifier_is_refused
+"""
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+JS_DIR = os.path.join(REPO, "PaintomicsClient", "public_html", "app", "view",
+                      "PathwayAcquisitionViews", "InputFormat")
+PANEL = os.path.join(JS_DIR, "format-panel.js")
+
+
+def read(path):
+    with io.open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def statement(source, header):
+    """The one top-level statement that starts with `header`."""
+    start = source.find(header)
+    if start == -1:
+        raise AssertionError("%r is missing from format-panel.js" % header)
+    depth = 0
+    for index in range(start, len(source)):
+        char = source[index]
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+            if depth == 0 and char == "}":
+                return source[start:index + 1]
+    raise AssertionError("ran off the end of format-panel.js")
+
+
+def run_node(script):
+    directory = tempfile.mkdtemp(prefix="paintomics-blank-id-")
+    try:
+        path = os.path.join(directory, "check.js")
+        with io.open(path, "w", encoding="utf-8") as handle:
+            handle.write(script)
+        done = subprocess.run(["node", path], capture_output=True,
+                              text=True, timeout=120)
+        if done.returncode != 0:
+            raise AssertionError("node failed:\n%s" % done.stderr)
+        return json.loads(done.stdout)
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+VALIDATE = """
+const path = require("path");
+const DIR = %(jsdir)s;
+const API = Object.assign({},
+    require(path.join(DIR, "format-reader.js")),
+    require(path.join(DIR, "format-validator.js")),
+    require(path.join(DIR, "format-roles.js")));
+
+const cases = %(cases)s;
+const out = [];
+for (const c of cases) {
+    const report = API.validateForRole(c.role, c.rows);
+    const codes = (report.problems || []).map(p => p.code);
+    const blank = (report.problems || []).filter(p => p.code === "BLANK_IDENTIFIER")[0];
+    out.push({name: c.name, ok: !!report.ok, codes: codes,
+              blank: blank ? blank.detail : null});
+}
+console.log(JSON.stringify(out));
+"""
+
+# The shapes of the reporting user's own files, cut down. Nothing here is
+# invented: the blank cells sit exactly where they sat in result_test/.
+USER_TARGETS_BLANK = [["mirnaid", "gene_ID"],
+                      ["ENSMUSG00000065402", "ENSMUSG00000062006"],
+                      ["ENSMUSG00000065402", ""],
+                      ["ENSMUSG00000065402", ""]]
+PAINTOMICS_OWN_OUTPUT = [["", "ENSMUSG00000065402"],
+                         ["", "ENSMUSG00000065402"]]
+USER_DEGS_BLANK = [["genesymbol", "DSSmEVs_vs_DSS"],
+                   ["Fxyd4", "-10.88295478"],
+                   ["", "-5.62969707"]]
+SHIPPED_TARGETS = [["miRNA", "Ensembl.Gene.ID", "PLR"],
+                   ["mmu-miR-100-3p", "ENSMUSG00000016498", "4.22"],
+                   ["mmu-miR-101a-3p", "ENSMUSG00000026034", "3.55"]]
+
+
+NAME_FIELD = """
+'use strict';
+%(fn)s
+
+function combo(opts) {
+    return {
+        id: opts.id,
+        disabled: !!opts.disabled,
+        isDisabled: function () { return this.disabled; },
+        getValue: function () { return opts.value; }
+    };
+}
+function card(fields) {
+    return { query: function (sel) {
+        return sel === "#omicNameField" ? fields : [];
+    } };
+}
+
+const out = {};
+// The reporting user's own card, measured in Chrome.
+out.miRNAcard = omicNameFieldIn(card([
+    combo({id: "combobox-1412", disabled: true,  value: ""}),
+    combo({id: "combobox-1466", disabled: false, value: "miRNA-Seq data"})
+])).id;
+// The order must not matter: the disabled twin can be built first or second.
+out.reversed = omicNameFieldIn(card([
+    combo({id: "combobox-1466", disabled: false, value: "miRNA-Seq data"}),
+    combo({id: "combobox-1412", disabled: true,  value: ""})
+])).id;
+// A plain card has one, and it is returned whether or not it is filled in.
+out.single = omicNameFieldIn(card([combo({id: "only", value: "Gene expression"})])).id;
+out.singleEmpty = omicNameFieldIn(card([combo({id: "only", value: ""})])).id;
+// An enabled but empty field still beats a disabled one that is filled in --
+// only the enabled one is submitted, so only it names the omic on the server.
+out.enabledEmptyWins = omicNameFieldIn(card([
+    combo({id: "enabled", disabled: false, value: ""}),
+    combo({id: "disabledFull", disabled: true, value: "Stale"})
+])).id;
+// Nothing to choose from is not a crash.
+out.none = omicNameFieldIn(card([])) === null;
+out.noCard = omicNameFieldIn(null) === null;
+console.log(JSON.stringify(out));
+"""
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class BlankIdentifierTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.source = read(PANEL)
+        cls.reports = {r["name"]: r for r in run_node(VALIDATE % {
+            "jsdir": json.dumps(JS_DIR),
+            "cases": json.dumps([
+                {"name": "user-targets", "role": "regulator-targets",
+                 "rows": USER_TARGETS_BLANK},
+                {"name": "paintomics-own-output", "role": "regulator-targets",
+                 "rows": PAINTOMICS_OWN_OUTPUT},
+                {"name": "user-degs", "role": "values", "rows": USER_DEGS_BLANK},
+                {"name": "shipped-targets", "role": "regulator-targets",
+                 "rows": SHIPPED_TARGETS},
+                {"name": "two-column-targets", "role": "regulator-targets",
+                 "rows": [["mmu-miR-1", "ENSMUSG1"], ["mmu-miR-2", "ENSMUSG2"]]},
+                {"name": "four-column-targets", "role": "regulator-targets",
+                 "rows": [["a", "b", "c", "d"], ["e", "f", "g", "h"]]},
+                {"name": "blank-association", "role": "associations",
+                 "rows": [["ENSMUSG1", "mmu-miR-1"], ["", "mmu-miR-2"]]},
+            ]),
+        })}
+        cls.names = run_node(NAME_FIELD % {
+            "fn": statement(cls.source, "function omicNameFieldIn(card)"),
+        })
+
+    # ---------------- the blank identifier ----------------
+
+    def test_the_users_targets_file_is_refused(self):
+        """6,039 rows with an empty target column, cut down to two."""
+        report = self.reports["user-targets"]
+        self.assertFalse(report["ok"])
+        self.assertIn("BLANK_IDENTIFIER", report["codes"])
+        self.assertEqual(report["blank"]["rows"], 2)
+
+    def test_paintomics_own_broken_output_is_refused(self):
+        """The file this bug produced, handed back in as an input.
+
+        It has two columns and no ragged rows, so every shape check passes it.
+        The first column is empty top to bottom.
+        """
+        report = self.reports["paintomics-own-output"]
+        self.assertFalse(report["ok"])
+        self.assertIn("BLANK_IDENTIFIER", report["codes"])
+        self.assertEqual(report["blank"]["column"], 1)
+
+    def test_a_values_file_with_a_blank_id_is_refused(self):
+        """The 13 blank rows in their DEGs file -- the other half of the join."""
+        report = self.reports["user-degs"]
+        self.assertFalse(report["ok"])
+        self.assertIn("BLANK_IDENTIFIER", report["codes"])
+
+    def test_a_blank_in_an_associations_file_is_refused_too(self):
+        self.assertIn("BLANK_IDENTIFIER", self.reports["blank-association"]["codes"])
+
+    def test_the_header_is_not_counted_as_a_blank(self):
+        """Both files above carry a labelled header; only data rows are faults."""
+        self.assertEqual(self.reports["user-targets"]["blank"]["rows"], 2)
+        self.assertEqual(self.reports["user-degs"]["blank"]["rows"], 1)
+
+    def test_the_line_number_points_at_the_first_bad_row(self):
+        """A count sends someone hunting; a line number does not."""
+        self.assertEqual(self.reports["user-targets"]["blank"]["line"], 3)
+        self.assertEqual(self.reports["user-degs"]["blank"]["line"], 3)
+
+    # ---------------- the new contract ----------------
+
+    def test_the_shipped_three_column_targets_table_is_accepted(self):
+        """The reason this slot was left unchecked; it must not now be blocked."""
+        self.assertTrue(self.reports["shipped-targets"]["ok"],
+                        self.reports["shipped-targets"]["codes"])
+
+    def test_two_columns_are_accepted_and_four_are_not(self):
+        self.assertTrue(self.reports["two-column-targets"]["ok"])
+        self.assertFalse(self.reports["four-column-targets"]["ok"])
+
+    def test_the_slot_has_a_role(self):
+        self.assertIn('mirnaTargetsFileSelector: "regulator-targets"', self.source)
+
+    def test_the_message_says_what_a_blank_identifier_costs(self):
+        """Not "invalid file": the reason a blank id is fatal is not obvious."""
+        self.assertIn("counts.BLANK_IDENTIFIER", self.source)
+        self.assertIn("have no identifier", self.source)
+
+    # ---------------- the omic name ----------------
+
+    def test_the_enabled_name_field_is_the_one_read(self):
+        """The measured case: the disabled twin is built first and is empty."""
+        self.assertEqual(self.names["miRNAcard"], "combobox-1466")
+
+    def test_the_order_of_the_twins_does_not_matter(self):
+        self.assertEqual(self.names["reversed"], "combobox-1466")
+
+    def test_an_enabled_field_wins_even_when_empty(self):
+        """Only the enabled one is submitted, so only it names the omic."""
+        self.assertEqual(self.names["enabledEmptyWins"], "enabled")
+
+    def test_a_plain_card_is_unaffected(self):
+        self.assertEqual(self.names["single"], "only")
+        self.assertEqual(self.names["singleEmpty"], "only")
+
+    def test_no_card_and_no_field_are_not_crashes(self):
+        self.assertTrue(self.names["none"])
+        self.assertTrue(self.names["noCard"])
+
+    def test_every_reader_goes_through_it(self):
+        """Two call sites read the omic name; both were wrong the same way."""
+        code = re.sub(r"/\*.*?\*/", "", self.source, flags=re.S)
+        self.assertEqual(code.count('queryById("omicNameField")'), 0,
+                         "a raw queryById would find the disabled twin again")
+        self.assertEqual(code.count('down("#omicNameField")'), 0)
+        self.assertGreaterEqual(code.count("omicNameFieldIn("), 3)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_conditions_file_is_held_to_r_rules.py
+++ b/PaintomicsServer/src/tests/test_conditions_file_is_held_to_r_rules.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""The conditions (design) contract refuses what runMORE.R refuses, and nothing more.
+
+The first cut of `validateDesign` demanded 0/1 cells with exactly one 1 per
+row and a header as wide as the rows. Replicating runMORE.R's `read_matrix`
+in R 4.6.0 showed it blocking three files R accepts:
+
+    - an R `write.table` default, whose header is one cell short (the
+      row-name column is unnamed);
+    - a multi-factor row (`s2 0 1 1`), which MOREServlet._designPatternNames
+      handles on purpose ("a hand-written design file may carry one");
+    - numeric levels such as `Time 0/24/48` -- numeric is R's only demand.
+
+Text labels and a repeated sample name ARE refused by R, and stay refused.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_conditions_file_is_held_to_r_rules
+"""
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+JS_DIR = os.path.join(REPO, "PaintomicsClient", "public_html", "app", "view",
+                      "PathwayAcquisitionViews", "InputFormat")
+
+SCRIPT = """
+const path = require("path");
+const DIR = %(dir)s;
+const API = Object.assign({},
+    require(path.join(DIR, "format-reader.js")),
+    require(path.join(DIR, "format-validator.js")),
+    require(path.join(DIR, "format-roles.js")));
+const out = {};
+const check = (name, rows) => {
+    const r = API.validateForRole("design", rows);
+    out[name] = { ok: !!r.ok, codes: (r.problems || []).map(p => p.code), summary: r.summary };
+};
+check("indicator",     [["Sample","C","DSS"], ["s1","1","0"], ["s2","0","1"]]);
+check("r_short_header", [["C","DSS"], ["s1","1","0"], ["s2","0","1"]]);
+check("multi_factor",  [["Sample","A","B","T"], ["s1","1","0","0"], ["s2","0","1","1"]]);
+check("numeric_levels", [["Sample","Time"], ["s1","0"], ["s2","24"], ["s3","48"]]);
+check("text_labels",   [["Sample","Group"], ["s1","control"], ["s2","treated"]]);
+check("dup_sample",    [["Sample","C","DSS"], ["s1","1","0"], ["s1","0","1"]]);
+check("ragged",        [["Sample","C","DSS"], ["s1","1","0"], ["s2","0"]]);
+check("header_only",   [["Sample","C","DSS"]]);
+console.log(JSON.stringify(out));
+"""
+
+
+def run_node(script):
+    directory = tempfile.mkdtemp(prefix="paintomics-design-")
+    try:
+        path = os.path.join(directory, "check.js")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(script)
+        done = subprocess.run(["node", path], capture_output=True, text=True, timeout=120)
+        if done.returncode != 0:
+            raise AssertionError("node failed:\n%s" % done.stderr)
+        return json.loads(done.stdout)
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class ConditionsFileIsHeldToRRulesTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.r = run_node(SCRIPT % {"dir": json.dumps(JS_DIR)})
+
+    def test_the_documented_shape_passes(self):
+        self.assertTrue(self.r["indicator"]["ok"], self.r["indicator"]["codes"])
+        self.assertEqual(self.r["indicator"]["summary"]["conditions"], ["C", "DSS"])
+
+    def test_an_r_written_header_one_cell_short_passes(self):
+        """write.table's default; read_matrix reads it as a 2x2 with row names."""
+        r = self.r["r_short_header"]
+        self.assertTrue(r["ok"], r["codes"])
+        self.assertEqual(r["summary"]["conditions"], ["C", "DSS"])
+        self.assertEqual(r["summary"]["nRows"], 2)
+
+    def test_a_multi_factor_row_passes(self):
+        self.assertTrue(self.r["multi_factor"]["ok"], self.r["multi_factor"]["codes"])
+
+    def test_numeric_levels_pass(self):
+        self.assertTrue(self.r["numeric_levels"]["ok"], self.r["numeric_levels"]["codes"])
+
+    def test_text_labels_are_refused(self):
+        """R's as.numeric turns them into NA; the run dies."""
+        self.assertFalse(self.r["text_labels"]["ok"])
+        self.assertIn("NOT_INDICATOR", self.r["text_labels"]["codes"])
+
+    def test_a_repeated_sample_is_refused(self):
+        self.assertFalse(self.r["dup_sample"]["ok"])
+        self.assertIn("DUPLICATE_IDENTIFIER", self.r["dup_sample"]["codes"])
+
+    def test_a_ragged_row_is_refused(self):
+        self.assertIn("RAGGED", self.r["ragged"]["codes"])
+
+    def test_a_header_alone_is_refused(self):
+        self.assertIn("EMPTY", self.r["header_only"]["codes"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_converted_file_goes_back_to_its_slot.py
+++ b/PaintomicsServer/src/tests/test_converted_file_goes_back_to_its_slot.py
@@ -213,7 +213,7 @@ class ConvertedFileGoesBackToItsSlotTest(unittest.TestCase):
         """The one line that caused this."""
         code = re.sub(r"/\*.*?\*/", "", self.drawer, flags=re.S)
         self.assertNotIn("if (out.values.length) actions.appendChild(accept)", code)
-        self.assertIn("if (out.values.length || forSlot) actions.appendChild(accept)", code)
+        self.assertIn("if ((wantsValues && out.values.length) || forSlot) actions.appendChild(accept)", code)
 
 
 if __name__ == "__main__":

--- a/PaintomicsServer/src/tests/test_converted_file_goes_back_to_its_slot.py
+++ b/PaintomicsServer/src/tests/test_converted_file_goes_back_to_its_slot.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""A converted file must be usable in the slot it was converted for.
+
+The behaviour this guards
+-------------------------
+The convert drawer ends on a review, and the review's whole point is the
+button that puts the result back in the form. That button was appended on one
+condition:
+
+    if (out.values.length) actions.appendChild(accept);
+
+`out.values` is the produced files whose role is "values". A conversion that
+produces no values table has none -- so the review ended with "Cancel" and
+"Download all", and the only way to use the result was to save it to disk and
+pick it again through Browse.
+
+Reported on the conversion that makes it plainest: a MORE Conditions file. The
+agent read 24 rows of sample metadata, wrote exactly the 0/1 experimental
+design PaintOmics wants, named it design.tab -- and then offered no way to put
+it in the field the user had clicked Convert on. Four of the five roles this
+form accepts (relevant, associations, relevant-associations, design) had the
+same dead end.
+
+Same shape as the rest of this family: code that enumerates omic files knows
+the plain values case and forgets the others. The slot the drawer was opened
+from already says which role is wanted, so the fix is to carry it -- format
+panel passes roleForInput(input), the drawer matches a produced file against
+it, and that file is what "Use this file" applies.
+
+Verified in Chrome on the reporting user's own samplemetadata_miRNA.csv:
+"Use this file" appears, and clicking it puts design.tab (373 bytes) in the
+Conditions field, closes the drawer, and the strip re-checks it green --
+"24 rows - 4 conditions (C, DSS, DSS_SDExc, DSS_SDmEVs)".
+
+What this file asserts
+----------------------
+The decision rule, lifted verbatim from the shipped drawer and run in node
+against every role the form has; plus the two ends of the wiring that carries
+the role there.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_converted_file_goes_back_to_its_slot
+"""
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+FORMAT_DIR = os.path.join(REPO, "PaintomicsClient", "public_html", "app", "view",
+                          "PathwayAcquisitionViews", "InputFormat")
+DRAWER = os.path.join(FORMAT_DIR, "convert-drawer.js")
+PANEL = os.path.join(FORMAT_DIR, "format-panel.js")
+
+ROLES = ("values", "relevant", "associations", "relevant-associations", "design")
+
+
+def read(path):
+    with io.open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def statement(source, header, what):
+    """`header` up to the semicolon that ends it, ignoring nested ones."""
+    start = source.find(header)
+    if start == -1:
+        raise AssertionError("%r is missing from %s" % (header, what))
+    depth = 0
+    for index in range(start, len(source)):
+        char = source[index]
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == ";" and depth == 0:
+            return source[start:index + 1]
+    raise AssertionError("ran off the end of %s" % what)
+
+
+HARNESS = """
+'use strict';
+// The rule, lifted from the shipped drawer. Only the two names it reads are
+// stubbed: `out` (what the conversion produced) and `context` (what the drawer
+// was opened with).
+function decide(context, files) {
+    const out = {
+        files: files,
+        values: files.filter(f => f.role === 'values'),
+        lists:  files.filter(f => f.role === 'relevant')
+    };
+    let chosen = out.values.filter(f => f.recommended)[0] || out.values[0];
+    %(slot_role)s
+    %(for_slot)s
+    const offered = !!(out.values.length || forSlot);
+    return {
+        offered: offered,
+        applies: chosen ? chosen.name : (forSlot ? forSlot.name : null),
+        viaSlot: !chosen && !!forSlot
+    };
+}
+
+const out = {};
+const ROLES = %(roles)s;
+
+// One produced file, of each role, converted from that role's own slot.
+for (const role of ROLES) {
+    out['only_' + role] = decide({slotRole: role},
+        [{name: role + '.tab', role: role}]);
+}
+
+// The reported case: a design file produced for the Conditions slot.
+out.design_for_conditions = decide({slotRole: 'design'},
+    [{name: 'design.tab', role: 'design'}]);
+
+// A values table still wins when there is one, and the recommended one at that.
+out.values_still_win = decide({slotRole: 'values'},
+    [{name: 'a.tab', role: 'values'}, {name: 'b.tab', role: 'values', recommended: true}]);
+
+// A values slot that also received a relevant list: the values table is applied.
+out.values_with_list = decide({slotRole: 'values'},
+    [{name: 'v.tab', role: 'values'}, {name: 'r.tab', role: 'relevant'}]);
+
+// Nothing matching the slot and no values table: no button, rather than one
+// that would put the wrong file in the field.
+out.nothing_for_this_slot = decide({slotRole: 'design'},
+    [{name: 'assoc.tab', role: 'associations'}]);
+
+// No context at all falls back to values, as the drawer's default does.
+out.no_context = decide(null, [{name: 'v.tab', role: 'values'}]);
+
+console.log(JSON.stringify(out));
+"""
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class ConvertedFileGoesBackToItsSlotTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.drawer = read(DRAWER)
+        cls.panel = read(PANEL)
+        script = HARNESS % {
+            "slot_role": statement(cls.drawer, "var slotRole = (context",
+                                   "convert-drawer.js"),
+            "for_slot": statement(cls.drawer, "var forSlot = chosen ? null",
+                                  "convert-drawer.js"),
+            "roles": json.dumps(list(ROLES)),
+        }
+        directory = tempfile.mkdtemp(prefix="paintomics-convert-slot-")
+        try:
+            path = os.path.join(directory, "check.js")
+            with io.open(path, "w", encoding="utf-8") as handle:
+                handle.write(script)
+            done = subprocess.run(["node", path], capture_output=True,
+                                  text=True, timeout=60)
+            if done.returncode != 0:
+                raise AssertionError("node failed:\n%s" % done.stderr)
+            cls.result = json.loads(done.stdout)
+        finally:
+            shutil.rmtree(directory, ignore_errors=True)
+
+    # -- the decision -----------------------------------------------------
+
+    def test_every_role_can_be_used_from_its_own_slot(self):
+        """The regression: four of the five had no way back into the form."""
+        for role in ROLES:
+            case = self.result["only_" + role]
+            self.assertTrue(case["offered"],
+                            "a %s conversion offers no way to use the result"
+                            % role)
+            self.assertEqual(case["applies"], role + ".tab")
+
+    def test_the_reported_case(self):
+        """A design file produced for a MORE Conditions slot."""
+        case = self.result["design_for_conditions"]
+        self.assertTrue(case["offered"])
+        self.assertEqual(case["applies"], "design.tab")
+        self.assertTrue(case["viaSlot"], "it should be applied by role match")
+
+    def test_a_values_table_still_wins_when_there_is_one(self):
+        """The path that already worked must keep working, unchanged."""
+        case = self.result["values_still_win"]
+        self.assertEqual(case["applies"], "b.tab", "the recommended table")
+        self.assertFalse(case["viaSlot"], "values go through the old path")
+        self.assertEqual(self.result["values_with_list"]["applies"], "v.tab")
+        self.assertEqual(self.result["no_context"]["applies"], "v.tab")
+
+    def test_a_file_of_the_wrong_role_is_not_offered(self):
+        """Better no button than one that puts the wrong file in the field."""
+        case = self.result["nothing_for_this_slot"]
+        self.assertFalse(case["offered"])
+        self.assertIsNone(case["applies"])
+
+    # -- the wiring that carries the role ---------------------------------
+
+    def test_the_panel_tells_the_drawer_which_slot_it_opened(self):
+        code = re.sub(r"/\*.*?\*/", "", self.panel, flags=re.S)
+        self.assertIn("openConvertDrawer(\n                input, file, fieldName, roleForInput(input))",
+                      code.replace("\r", ""))
+
+    def test_the_drawer_takes_the_role_and_keeps_it(self):
+        code = re.sub(r"/\*.*?\*/", "", self.drawer, flags=re.S)
+        self.assertIn("function openConvertDrawer(input, file, fieldName, slotRole)", code)
+        self.assertIn("slotRole: slotRole || \"values\"", code)
+        self.assertIn("var slotRole = (context && context.slotRole) || \"values\";", code)
+
+    def test_the_button_is_no_longer_gated_on_values_alone(self):
+        """The one line that caused this."""
+        code = re.sub(r"/\*.*?\*/", "", self.drawer, flags=re.S)
+        self.assertNotIn("if (out.values.length) actions.appendChild(accept)", code)
+        self.assertIn("if (out.values.length || forSlot) actions.appendChild(accept)", code)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_duplicate_identifiers_are_refused.py
+++ b/PaintomicsServer/src/tests/test_duplicate_identifiers_are_refused.py
@@ -81,8 +81,8 @@ const assoc = [["G1","R1"], ["G1","R2"], ["G2","R1"]];
 
 const dupCode = (r) => (r.problems||[]).filter(p => p.code === "DUPLICATE_IDENTIFIER");
 const out = {};
-const check = (name, role, rows) => {
-    const report = API.validateForRole(role, rows);
+const check = (name, role, rows, options) => {
+    const report = API.validateForRole(role, rows, undefined, options);
     const found = dupCode(report);
     out[name] = { ok: !!report.ok, flagged: found.length > 0,
                   detail: found.length ? found[0].detail : null };
@@ -90,10 +90,12 @@ const check = (name, role, rows) => {
 
 check("values_clean",      "values", clean);
 check("values_dupes",      "values", dupes);
+check("values_dupes_more", "values", dupes, { strictKeys: true });
+out.values_dupes.summary = API.validateForRole("values", dupes).summary;
 check("design_clean",      "design", design);
 check("design_dupes",      "design", dupDesign);
 check("regions_clean",     "values", regions);
-check("regions_dupes",     "values", dupRegions);
+check("regions_dupes",     "values", dupRegions, { strictKeys: true });
 check("assoc_many_to_one", "associations", assoc);
 check("relevant_repeats",  "relevant", [["G1"],["G1"],["G2"]]);
 
@@ -125,10 +127,20 @@ class DuplicateIdentifiersAreRefusedTest(unittest.TestCase):
 
     # -- the rule ----------------------------------------------------------
 
-    def test_a_repeated_identifier_is_refused_in_a_values_file(self):
-        """The regression: this file got a green tick and killed the job."""
-        self.assertTrue(self.r["values_dupes"]["flagged"])
-        self.assertFalse(self.r["values_dupes"]["ok"])
+    def test_a_repeated_identifier_is_refused_in_a_more_values_file(self):
+        """The regression: this file got a green tick and killed the MORE job
+        (runMORE.R row.names=1). strictKeys is what a MORE slot passes."""
+        self.assertTrue(self.r["values_dupes_more"]["flagged"])
+        self.assertFalse(self.r["values_dupes_more"]["ok"])
+
+    def test_a_repeat_outside_more_is_advisory(self):
+        """Everywhere else the server MERGES repeats (Job.addInputGeneData),
+        so a hard block was a false "the server will reject this file" -- it
+        refused a user's kinase table and PaintOmics' own miRNA2Genes output,
+        and took the decimal-comma repair away from files carrying both."""
+        self.assertFalse(self.r["values_dupes"]["flagged"])
+        self.assertTrue(self.r["values_dupes"]["ok"])
+        self.assertEqual(self.r["values_dupes"]["summary"]["duplicates"]["worst"], "G1")
 
     def test_a_repeated_sample_is_refused_in_a_design_file(self):
         """runMORE.R intersects sample names; a repeat breaks the same read."""
@@ -137,7 +149,7 @@ class DuplicateIdentifiersAreRefusedTest(unittest.TestCase):
 
     def test_the_message_carries_the_numbers(self):
         """"You have duplicates" sends someone hunting; the count says where."""
-        detail = self.r["values_dupes"]["detail"]
+        detail = self.r["values_dupes_more"]["detail"]
         self.assertEqual(detail["ids"], 1)
         self.assertEqual(detail["worst"], "G1")
         self.assertEqual(detail["worstCount"], 3)

--- a/PaintomicsServer/src/tests/test_duplicate_identifiers_are_refused.py
+++ b/PaintomicsServer/src/tests/test_duplicate_identifiers_are_refused.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""A repeated identifier must be caught before the submit, not by the R backend.
+
+The behaviour this guards
+-------------------------
+A user's MORE run died on the server with:
+
+    MORE ERROR: no data columns could be read from mirna_values.tab.
+    Tried tab and comma separators.
+    (tab: duplicate 'row.names' are not allowed: 'ENSMUSG00000092770')
+
+The file has 1803 data rows and 503 distinct identifiers; one appears 65 times.
+Both engines reject it -- runMORE.R reads with row.names=1, and the Rust port
+reproduces the rejection deliberately (MORE/rust/src/data.rs) -- so switching
+engines does not help.
+
+The client-side check passed it. Fifteen problem codes across five roles and
+not one of them looked at whether an identifier repeats, so the file got a
+green tick reading "1,803 rows - 2 columns" and, because the strip only offers
+the AI when it has a problem to offer it for, **the "Convert it for me" button
+never appeared**. The AI agent that could have asked about the duplicates was
+never reachable. That was the whole chain: no rule -> green tick -> no offer ->
+the server dies.
+
+The rule already existed and worked, in convert-agent.js, where it has graded
+the AI's own output since the converter shipped. It just never ran on a file
+the user picked themselves. It now lives in format-roles.js and runs for every
+role whose identifier has to be unique.
+
+Uniqueness is required for `values` and `design` and NOT for the association
+roles, where many regulators to one target is the entire point of the file.
+Getting that wrong in the other direction would refuse every valid
+associations file in the repository.
+
+No mechanical repair is offered. Measured on this file, 315 of 315 duplicate
+groups disagree on their values and 165 span both signs -- they are distinct
+miRNAs collapsed onto a host-gene Ensembl id, not repeated measurements -- so
+averaging or taking the first would produce a file that runs and is wrong.
+The refusal names the numbers and hands the question to the AI agent, which
+asks what the duplicates mean instead of assuming.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_duplicate_identifiers_are_refused
+"""
+import glob
+import io
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+JS_DIR = os.path.join(REPO, "PaintomicsClient", "public_html", "app", "view",
+                      "PathwayAcquisitionViews", "InputFormat")
+DATASETS = os.path.join(REPO, "PaintomicsServer", "src", "examplefiles", "datasets")
+
+SCRIPT = """
+const path = require("path");
+const DIR = %(dir)s;
+const API = Object.assign({},
+    require(path.join(DIR, "format-reader.js")),
+    require(path.join(DIR, "format-validator.js")),
+    require(path.join(DIR, "format-roles.js")));
+
+const H = ["#gene", "s1", "s2"];
+const clean  = [H, ["G1","1","2"], ["G2","3","4"], ["G3","5","6"]];
+const dupes  = [H, ["G1","1","2"], ["G2","3","4"], ["G1","9","9"], ["G1","7","7"]];
+const design = [["Sample","A","B"], ["s1","1","0"], ["s2","0","1"]];
+const dupDesign = [["Sample","A","B"], ["s1","1","0"], ["s1","0","1"]];
+// chr/start/end: column 0 repeats legitimately on every region of a chromosome.
+const regions = [["chr","start","end","v"],
+                 ["chr1","100","200","1"], ["chr1","300","400","2"],
+                 ["chr1","500","600","3"]];
+const dupRegions = [["chr","start","end","v"],
+                    ["chr1","100","200","1"], ["chr1","100","200","2"]];
+// Many regulators to one target is the POINT of an associations file.
+const assoc = [["G1","R1"], ["G1","R2"], ["G2","R1"]];
+
+const dupCode = (r) => (r.problems||[]).filter(p => p.code === "DUPLICATE_IDENTIFIER");
+const out = {};
+const check = (name, role, rows) => {
+    const report = API.validateForRole(role, rows);
+    const found = dupCode(report);
+    out[name] = { ok: !!report.ok, flagged: found.length > 0,
+                  detail: found.length ? found[0].detail : null };
+};
+
+check("values_clean",      "values", clean);
+check("values_dupes",      "values", dupes);
+check("design_clean",      "design", design);
+check("design_dupes",      "design", dupDesign);
+check("regions_clean",     "values", regions);
+check("regions_dupes",     "values", dupRegions);
+check("assoc_many_to_one", "associations", assoc);
+check("relevant_repeats",  "relevant", [["G1"],["G1"],["G2"]]);
+
+out.__direct = API.duplicateIdentifiers(dupes);
+console.log(JSON.stringify(out));
+"""
+
+
+def run_node(script):
+    directory = tempfile.mkdtemp(prefix="paintomics-dupe-ids-")
+    try:
+        path = os.path.join(directory, "check.js")
+        with io.open(path, "w", encoding="utf-8") as handle:
+            handle.write(script)
+        done = subprocess.run(["node", path], capture_output=True, text=True, timeout=120)
+        if done.returncode != 0:
+            raise AssertionError("node failed:\n%s" % done.stderr)
+        return json.loads(done.stdout)
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class DuplicateIdentifiersAreRefusedTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.r = run_node(SCRIPT % {"dir": json.dumps(JS_DIR)})
+
+    # -- the rule ----------------------------------------------------------
+
+    def test_a_repeated_identifier_is_refused_in_a_values_file(self):
+        """The regression: this file got a green tick and killed the job."""
+        self.assertTrue(self.r["values_dupes"]["flagged"])
+        self.assertFalse(self.r["values_dupes"]["ok"])
+
+    def test_a_repeated_sample_is_refused_in_a_design_file(self):
+        """runMORE.R intersects sample names; a repeat breaks the same read."""
+        self.assertTrue(self.r["design_dupes"]["flagged"])
+        self.assertFalse(self.r["design_dupes"]["ok"])
+
+    def test_the_message_carries_the_numbers(self):
+        """"You have duplicates" sends someone hunting; the count says where."""
+        detail = self.r["values_dupes"]["detail"]
+        self.assertEqual(detail["ids"], 1)
+        self.assertEqual(detail["worst"], "G1")
+        self.assertEqual(detail["worstCount"], 3)
+        self.assertEqual(detail["rows"], 2)
+
+    # -- and the other direction, which matters just as much ---------------
+
+    def test_a_clean_file_is_not_flagged(self):
+        for name in ("values_clean", "design_clean", "regions_clean"):
+            self.assertFalse(self.r[name]["flagged"], name)
+
+    def test_an_associations_file_may_repeat_a_target(self):
+        """Many regulators to one target is what the file is FOR."""
+        self.assertFalse(self.r["assoc_many_to_one"]["flagged"])
+        self.assertTrue(self.r["assoc_many_to_one"]["ok"])
+
+    def test_a_relevant_list_may_repeat(self):
+        self.assertFalse(self.r["relevant_repeats"]["flagged"])
+
+    def test_a_region_file_keys_on_all_three_columns(self):
+        """chr1 repeats on every region of the chromosome; that is not a dupe."""
+        self.assertFalse(self.r["regions_clean"]["flagged"])
+        self.assertTrue(self.r["regions_dupes"]["flagged"],
+                        "the same chr/start/end twice IS a duplicate")
+
+    def test_the_helper_is_exported_for_reuse(self):
+        self.assertEqual(self.r["__direct"]["worst"], "G1")
+
+    # -- the guarantee that this cannot start refusing valid uploads -------
+
+    def test_no_shipped_example_file_is_refused_for_duplicates(self):
+        # The role each shipped file is REALLY picked into, from the table the
+        # slot-coverage suite already maintains -- guessing from the filename
+        # gets mmu_mirBase_to_ensembl.tab wrong (it is the miRNA/gene/PLR
+        # prediction table, whose slot is exempt from checking altogether, and
+        # whose 898 repeated miRNAs are the file working as intended).
+        from src.tests.test_input_check_covers_every_omic_slot import EXAMPLE_ROLES
+        cases = []
+        for path in sorted(glob.glob(os.path.join(DATASETS, "*", "data", "*"))):
+            name = os.path.basename(path)
+            role = EXAMPLE_ROLES.get(name)
+            if role is None:
+                continue
+            cases.append({"file": name, "role": role, "path": path})
+        self.assertGreater(len(cases), 20, "the example corpus did not load")
+        script = """
+const fs = require("fs"), path = require("path");
+const DIR = %(dir)s;
+const API = Object.assign({},
+    require(path.join(DIR, "format-reader.js")),
+    require(path.join(DIR, "format-validator.js")),
+    require(path.join(DIR, "format-roles.js")));
+const out = [];
+for (const c of %(cases)s) {
+    const rows = API.readDelimited(new Uint8Array(fs.readFileSync(c.path))).rows;
+    const report = API.validateForRole(c.role, rows);
+    const dup = (report.problems||[]).filter(p => p.code === "DUPLICATE_IDENTIFIER");
+    if (dup.length) out.push([c.file, c.role, dup[0].detail]);
+}
+console.log(JSON.stringify(out));
+""" % {"dir": json.dumps(JS_DIR), "cases": json.dumps(cases)}
+        refused = run_node(script)
+        self.assertEqual(refused, [],
+                         "these shipped files would now be refused: %s" % refused)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_input_check_covers_every_omic_slot.py
+++ b/PaintomicsServer/src/tests/test_input_check_covers_every_omic_slot.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""The input check must run on every file slot of every omic panel.
+
+The behaviour this guards
+-------------------------
+InputFormat/format-panel.js checks a file the moment it is picked, and BLOCKS
+the submit when the fault is one the server is certain to reject. Its own
+comment says why that matters:
+
+    "Observed on the very first run-through: the strip said the numbers used
+     decimal commas, the form was submitted anyway, and the server answered
+     with ten identical lines of 'Perhaps you are using commas instead of dots
+     as decimal mark?'"
+
+It decided what to check with a test on the field's NAME:
+
+    var VALUES_FIELD = /^omic\\d+_file$/;
+
+That is the plain, region-based and miRNA panels' convention. It is not the
+MORE panel's -- MORE calls its five selectors `conditions`, `rnaseqaux`,
+`file_0`, `relevant_file_0` and `assoc_file_0`. So every file picked into a
+Regulatory Omic (MORE) panel went completely unchecked. Measured in Chrome with
+the same file in two panels:
+
+    plain Gene expression panel -> "Numbers use commas as the decimal mark;
+                                    PaintOmics needs dots" + [Fix automatically]
+    MORE panel                  -> stripsOnPage: 0
+
+The reporting user's files (2026-08-26) used decimal commas. The one guard
+written for exactly her mistake never looked at them; she lost an hour and the
+run died on the server.
+
+The slot is now the key, not the name, and each slot is held to its own
+contract (format-roles.js already models all five).
+
+What this file asserts
+----------------------
+1. every file-selector slot the form can show is either given a role or
+   explicitly exempt -- so a NEW panel cannot go blind the same way;
+2. no file shipped with the example datasets is rejected by the role it would
+   be picked into, which is what stops the wider net blocking valid uploads;
+3. the resolver returns the right role per slot, MORE's included, and nothing
+   for an input outside the omic panels.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_input_check_covers_every_omic_slot
+"""
+import glob
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+CLIENT = os.path.join(REPO, "PaintomicsClient", "public_html", "app", "view",
+                      "PathwayAcquisitionViews")
+FORMAT_PANEL = os.path.join(CLIENT, "InputFormat", "format-panel.js")
+JS_DIR = os.path.join(CLIENT, "InputFormat")
+STEP1_VIEWS = os.path.join(CLIENT, "PA_Step1Views.js")
+DATASETS = os.path.join(REPO, "PaintomicsServer", "src", "examplefiles", "datasets")
+
+# A GTF is not one of the delimited contracts this module models, so the region
+# panel's annotations slot is left alone on purpose. Anything else missing from
+# ROLE_BY_SLOT is a slot that silently goes unchecked.
+# Slots this module deliberately does not judge, each for a reason recorded
+# next to ROLE_BY_SLOT: a GTF is not a delimited contract; the miRNA targets
+# table is miRNA/gene/PLR and not the two-column associations contract; and
+# third/fourth live in the RESULTS container, which is filled with server paths
+# rather than picked, where an empty file is a legitimate output.
+EXEMPT_SLOTS = {"tertiaryFileSelector", "mirnaTargetsFileSelector",
+                "thirdFileSelector", "fourthFileSelector"}
+
+# The role each shipped example file would be picked into. Asserted exhaustive
+# below, so a new example file cannot slip through unchecked.
+EXAMPLE_ROLES = {
+    "dnase_regions_values.tab": "values",
+    "dnase_unmapped_values.tab": "values",
+    "dnase_values.tab": "values",
+    "gene_expression_targets.tab": "values",
+    "gene_expression_values.tab": "values",
+    "metabolomics_by_name_values.tab": "values",
+    "metabolomics_values.tab": "values",
+    "mirna_regulators.tab": "values",
+    "mirna_unmapped_values.tab": "values",
+    "mirna_values.tab": "values",
+    "proteomics_values.tab": "values",
+    "transcription_factor_regulators.tab": "values",
+    "transcription_factor_values.tab": "values",
+    "dnase_regions_relevant.tab": "relevant",
+    "dnase_relevant.tab": "relevant",
+    "dnase_unmapped_relevant.tab": "relevant",
+    "gene_expression_relevant.tab": "relevant",
+    "metabolomics_by_name_relevant.tab": "relevant",
+    "metabolomics_relevant.tab": "relevant",
+    "mirna_relevant.tab": "relevant",
+    "mirna_relevant_regulators.tab": "relevant",
+    "mirna_unmapped_relevant.tab": "relevant",
+    "proteomics_relevant.tab": "relevant",
+    "transcription_factor_relevant.tab": "relevant",
+    "transcription_factor_relevant_regulators.tab": "relevant",
+    "mirna_associations.tab": "associations",
+    # miRNA / gene / PLR -- the miRNA2Genes prediction table, which is NOT the
+    # two-column associations contract its name suggests. Its slot is exempt.
+    "mirna_to_gene_associations.tab": None,
+    "transcription_factor_associations.tab": "associations",
+    "mmu_mirBase_to_ensembl.tab": None,      # same three-column shape
+    "experimental_design.tab": "design",
+    "synthetic_mmu.gtf": None,          # not a delimited contract; never checked
+}
+
+
+def read(path):
+    with io.open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def role_by_slot():
+    """ROLE_BY_SLOT as the shipped module declares it."""
+    source = read(FORMAT_PANEL)
+    start = source.index("var ROLE_BY_SLOT = {")
+    body = source[start:source.index("};", start)]
+    return dict(re.findall(r"(\w+)\s*:\s*\"([\w-]+)\"", body))
+
+
+def declared_slots():
+    """Every itemId a myFilesSelectorButton is given in the Step 1 form."""
+    source = read(STEP1_VIEWS)
+    slots = set()
+    for match in re.finditer(r'xtype:\s*"myFilesSelectorButton"', source):
+        # The itemId sits inside the same object literal, within a few lines.
+        window = source[match.start():match.start() + 900]
+        window = window[:window.find("\n\t\t\t\t},")] if "\n\t\t\t\t}," in window else window
+        found = re.search(r'itemId:\s*"(\w+)"', window)
+        if found:
+            slots.add(found.group(1))
+    return slots
+
+
+def run_node(script):
+    directory = tempfile.mkdtemp(prefix="paintomics-slot-roles-")
+    try:
+        path = os.path.join(directory, "check.js")
+        with io.open(path, "w", encoding="utf-8") as handle:
+            handle.write(script)
+        done = subprocess.run(["node", path], capture_output=True, text=True, timeout=120)
+        if done.returncode != 0:
+            raise AssertionError("node failed:\n%s" % done.stderr)
+        return json.loads(done.stdout)
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+VALIDATE_SCRIPT = """
+const fs = require("fs");
+const path = require("path");
+const DIR = %(jsdir)s;
+// Each module is a UMD that exports its own factory under node, so they are
+// required and merged rather than read off a browser global.
+const API = Object.assign({},
+    require(path.join(DIR, "format-reader.js")),
+    require(path.join(DIR, "format-validator.js")),
+    require(path.join(DIR, "format-roles.js")));
+
+const cases = %(cases)s;
+const out = [];
+for (const c of cases) {
+    const bytes = new Uint8Array(fs.readFileSync(c.path));
+    const read = API.readDelimited(bytes);
+    const report = API.validateForRole(c.role, read.rows);
+    out.push({
+        file: c.file, role: c.role, ok: !!report.ok,
+        problems: (report.problems || []).map(p => p.code)
+    });
+}
+console.log(JSON.stringify(out));
+"""
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class InputCheckCoversEverySlotTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.roles = role_by_slot()
+        cls.slots = declared_slots()
+
+    def test_the_module_still_declares_a_role_table(self):
+        self.assertTrue(self.roles, "ROLE_BY_SLOT could not be read")
+        self.assertIn("mainFileSelector", self.roles)
+
+    def test_the_name_pattern_is_gone(self):
+        """The bug was a field-NAME test; it must not come back."""
+        source = read(FORMAT_PANEL)
+        self.assertNotIn("VALUES_FIELD", source)
+        # The three gates must all ask the slot, not the name. (The old regex
+        # still appears in the comment that explains the bug, so the check is
+        # on the calls rather than on the file's text.)
+        self.assertEqual(source.count("roleForField("), 4)
+        self.assertIn("var role = roleForInput(input);", source)
+
+    def test_every_slot_the_form_can_show_is_covered(self):
+        """The regression that keeps happening: a new panel goes unchecked."""
+        missing = sorted(self.slots - set(self.roles) - EXEMPT_SLOTS)
+        self.assertEqual(missing, [],
+                         "these file slots would go unchecked: %s" % missing)
+
+    def test_the_more_panel_slots_are_covered(self):
+        """Named explicitly: these are the ones that were blind."""
+        for slot in ("conditionsFileSelector", "rnaseqauxFileSelector",
+                     "moreRelevantFileSelector", "moreAssociationsFileSelector"):
+            self.assertIn(slot, self.roles)
+
+    def test_the_role_table_names_only_real_roles(self):
+        for slot, role in self.roles.items():
+            self.assertIn(role, ("values", "relevant", "associations",
+                                 "relevant-associations", "design"),
+                          "%s has role %r" % (slot, role))
+
+    def test_every_example_file_has_a_declared_role(self):
+        """So a new example file cannot quietly skip this test."""
+        shipped = {os.path.basename(p)
+                   for p in glob.glob(os.path.join(DATASETS, "*", "data", "*"))}
+        undeclared = sorted(shipped - set(EXAMPLE_ROLES))
+        self.assertEqual(undeclared, [],
+                         "add these to EXAMPLE_ROLES: %s" % undeclared)
+
+    def test_no_shipped_example_file_is_rejected_by_its_role(self):
+        """The wider net must not start blocking valid uploads.
+
+        Every one of these files runs today, so any of them failing its role
+        means the check would now refuse a submit that works.
+        """
+        cases, seen = [], set()
+        for path in sorted(glob.glob(os.path.join(DATASETS, "*", "data", "*"))):
+            name = os.path.basename(path)
+            role = EXAMPLE_ROLES.get(name)
+            if role is None or name in seen:
+                continue
+            seen.add(name)
+            cases.append({"file": name, "role": role, "path": path})
+
+        results = run_node(VALIDATE_SCRIPT % {
+            "jsdir": json.dumps(JS_DIR),
+            "cases": json.dumps(cases),
+        })
+        rejected = [(r["file"], r["role"], r["problems"])
+                    for r in results if not r["ok"]]
+        self.assertEqual(rejected, [],
+                         "these shipped files would now be blocked: %s" % rejected)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_input_check_covers_every_omic_slot.py
+++ b/PaintomicsServer/src/tests/test_input_check_covers_every_omic_slot.py
@@ -200,7 +200,12 @@ class InputCheckCoversEverySlotTest(unittest.TestCase):
         # The three gates must all ask the slot, not the name. (The old regex
         # still appears in the comment that explains the bug, so the check is
         # on the calls rather than on the file's text.)
-        self.assertEqual(source.count("roleForField("), 4)
+        # At least four -- the gates that must ask the slot. Not EXACTLY four:
+        # this was an exact count and it failed the first time a legitimate new
+        # caller appeared (siblingSummaries, which has to know each file's role
+        # to describe it). A test that breaks when the code grows correctly is
+        # a test people learn to edit rather than read.
+        self.assertGreaterEqual(source.count("roleForField("), 4)
         self.assertIn("var role = roleForInput(input);", source)
 
     def test_every_slot_the_form_can_show_is_covered(self):

--- a/PaintomicsServer/src/tests/test_input_check_covers_every_omic_slot.py
+++ b/PaintomicsServer/src/tests/test_input_check_covers_every_omic_slot.py
@@ -109,12 +109,14 @@ EXAMPLE_ROLES = {
     "proteomics_relevant.tab": "relevant",
     "transcription_factor_relevant.tab": "relevant",
     "transcription_factor_relevant_regulators.tab": "relevant",
-    "mirna_associations.tab": "associations",
+    "mirna_associations.tab": "regulator-targets",
     # miRNA / gene / PLR -- the miRNA2Genes prediction table, which is NOT the
     # two-column associations contract its name suggests; it has its own.
     "mirna_to_gene_associations.tab": "regulator-targets",
-    "transcription_factor_associations.tab": "associations",
+    "transcription_factor_associations.tab": "regulator-targets",
     "mmu_mirBase_to_ensembl.tab": "regulator-targets",   # same three-column shape
+    # MORE's associations slot takes 2 or 3 columns (runMORE.R), so it is the
+    # regulator-targets contract too; the two-column rule refused a third.
     "experimental_design.tab": "design",
     "synthetic_mmu.gtf": None,          # not a delimited contract; never checked
 }
@@ -142,8 +144,15 @@ def declared_slots():
         window = source[match.start():match.start() + 900]
         window = window[:window.find("\n\t\t\t\t},")] if "\n\t\t\t\t}," in window else window
         found = re.search(r'itemId:\s*"(\w+)"', window)
-        if found:
-            slots.add(found.group(1))
+        if not found:
+            # A selector without an itemId has NO role and goes unchecked --
+            # exactly how MORE's "Add another Regulatory Omic" slots escaped
+            # (the same decimal-comma file was flagged in file_0 and passed in
+            # file_1). This used to skip them silently.
+            raise AssertionError("a myFilesSelectorButton without an itemId at "
+                                 "PA_Step1Views.js offset %d cannot be checked: %s"
+                                 % (match.start(), window[:160].replace("\n", " ")))
+        slots.add(found.group(1))
     return slots
 
 
@@ -248,14 +257,17 @@ class InputCheckCoversEverySlotTest(unittest.TestCase):
         Every one of these files runs today, so any of them failing its role
         means the check would now refuse a submit that works.
         """
-        cases, seen = [], set()
+        # Every PATH, not every basename: the 11 datasets reuse names, and
+        # deduplicating on the name skipped 23 of the 50 shipped files --
+        # among them 03's per-condition relevance list, the one file the
+        # blank-identifier rule was refusing.
+        cases = []
         for path in sorted(glob.glob(os.path.join(DATASETS, "*", "data", "*"))):
             name = os.path.basename(path)
             role = EXAMPLE_ROLES.get(name)
-            if role is None or name in seen:
+            if role is None:
                 continue
-            seen.add(name)
-            cases.append({"file": name, "role": role, "path": path})
+            cases.append({"file": os.path.relpath(path, DATASETS), "role": role, "path": path})
 
         results = run_node(VALIDATE_SCRIPT % {
             "jsdir": json.dumps(JS_DIR),

--- a/PaintomicsServer/src/tests/test_input_check_covers_every_omic_slot.py
+++ b/PaintomicsServer/src/tests/test_input_check_covers_every_omic_slot.py
@@ -68,11 +68,17 @@ DATASETS = os.path.join(REPO, "PaintomicsServer", "src", "examplefiles", "datase
 # panel's annotations slot is left alone on purpose. Anything else missing from
 # ROLE_BY_SLOT is a slot that silently goes unchecked.
 # Slots this module deliberately does not judge, each for a reason recorded
-# next to ROLE_BY_SLOT: a GTF is not a delimited contract; the miRNA targets
-# table is miRNA/gene/PLR and not the two-column associations contract; and
-# third/fourth live in the RESULTS container, which is filled with server paths
-# rather than picked, where an empty file is a legitimate output.
-EXEMPT_SLOTS = {"tertiaryFileSelector", "mirnaTargetsFileSelector",
+# next to ROLE_BY_SLOT: a GTF is not a delimited contract; and third/fourth live
+# in the RESULTS container, which is filled with server paths rather than
+# picked, where an empty file is a legitimate output.
+#
+# `mirnaTargetsFileSelector` used to be here too, exempted because the miRNA
+# targets table is miRNA/gene/PLR and so does not fit the two-column
+# `associations` contract. "Does not fit the contract we have" was never a
+# reason to check nothing: that slot took the file that broke a real user's run
+# (2026-08-27) -- 6,039 rows with an empty target column -- without a word. It
+# now has a contract of its own, `regulator-targets`.
+EXEMPT_SLOTS = {"tertiaryFileSelector",
                 "thirdFileSelector", "fourthFileSelector"}
 
 # The role each shipped example file would be picked into. Asserted exhaustive
@@ -105,10 +111,10 @@ EXAMPLE_ROLES = {
     "transcription_factor_relevant_regulators.tab": "relevant",
     "mirna_associations.tab": "associations",
     # miRNA / gene / PLR -- the miRNA2Genes prediction table, which is NOT the
-    # two-column associations contract its name suggests. Its slot is exempt.
-    "mirna_to_gene_associations.tab": None,
+    # two-column associations contract its name suggests; it has its own.
+    "mirna_to_gene_associations.tab": "regulator-targets",
     "transcription_factor_associations.tab": "associations",
-    "mmu_mirBase_to_ensembl.tab": None,      # same three-column shape
+    "mmu_mirBase_to_ensembl.tab": "regulator-targets",   # same three-column shape
     "experimental_design.tab": "design",
     "synthetic_mmu.gtf": None,          # not a delimited contract; never checked
 }
@@ -217,13 +223,15 @@ class InputCheckCoversEverySlotTest(unittest.TestCase):
     def test_the_more_panel_slots_are_covered(self):
         """Named explicitly: these are the ones that were blind."""
         for slot in ("conditionsFileSelector", "rnaseqauxFileSelector",
-                     "moreRelevantFileSelector", "moreAssociationsFileSelector"):
+                     "moreRelevantFileSelector", "moreAssociationsFileSelector",
+                     "mirnaTargetsFileSelector"):
             self.assertIn(slot, self.roles)
 
     def test_the_role_table_names_only_real_roles(self):
         for slot, role in self.roles.items():
             self.assertIn(role, ("values", "relevant", "associations",
-                                 "relevant-associations", "design"),
+                                 "relevant-associations", "regulator-targets",
+                                 "design"),
                           "%s has role %r" % (slot, role))
 
     def test_every_example_file_has_a_declared_role(self):

--- a/PaintomicsServer/src/tests/test_omic_card_sizes_itself.py
+++ b/PaintomicsServer/src/tests/test_omic_card_sizes_itself.py
@@ -222,6 +222,24 @@ class OmicCardSizesItselfTest(unittest.TestCase):
         self.assertNotIn("__paBaseHeight", code)
         self.assertNotIn("setHeight", code)
 
+    def test_the_card_observer_does_not_schedule_on_a_bare_frame(self):
+        """Chrome throttles requestAnimationFrame to zero in a hidden tab.
+
+        The observer that primes each card deferred through a bare rAF, so a
+        card added while the tab was behind something got no strip and no input
+        check at all. Measured in a tab reporting visibilityState "hidden":
+        MORE card primed=false, host=false before; primed=true, host=true after.
+        Util.js keeps the house version -- rAF when visible, setTimeout(0) when
+        hidden -- and four other pieces of this app have already been caught on
+        the bare one.
+        """
+        code = re.sub(r"/\*.*?\*/", "", self.panel_source, flags=re.S)
+        self.assertIn("window.paDeferFrame", code)
+        primer = code[code.index("MutationObserver"):]
+        primer = primer[:primer.index("observer.observe")]
+        self.assertNotIn("requestAnimationFrame(function", primer,
+                         "the card observer must defer through paDeferFrame")
+
     def test_no_omic_title_is_flexed(self):
         """A flexed 44px header is where a short card takes its shortfall from.
 

--- a/PaintomicsServer/src/tests/test_omic_card_sizes_itself.py
+++ b/PaintomicsServer/src/tests/test_omic_card_sizes_itself.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""An omic card must size itself from its contents, never from a measurement.
+
+The behaviour this guards
+-------------------------
+The omic cards on Step 1 are items of an ExtJS vbox, which lays them out as
+absolutely positioned elements carrying an inline `top`. Growing a card's DOM
+therefore does not move the card below it.
+
+InputFormat/format-panel.js adds a strip to each card, so it has to deal with
+that. Its first answer was to compute the height the card ought to have and
+setHeight() it. A computed height is a MEASUREMENT, and a measurement has a
+moment -- which is where this went wrong twice:
+
+    __paBaseHeight was recorded when the card was primed. The MORE panel is
+    tall enough that its sections had not settled: 662px recorded against a
+    settled 771px. The card was pinned 66px short of its own contents.
+
+and the shortfall did not simply clip, because the omic title was declared
+`xtype: "box", flex: 1` in all four panel types. A flexed item in a vbox is
+where the layout puts leftover height -- and where it TAKES a shortfall from.
+The 44px title was allocated 0px, CSS `min-height: 44px` painted it anyway,
+and it came down on top of the first section heading. Measured on the reported
+screenshot: title bottom 292, "Experimental Design" top 277.
+
+The fix has two halves and this suite holds both:
+
+  * the card leaves the vbox's height budget (`flex` and the inline height
+    both cleared) and is then re-laid-out rather than re-measured, so there is
+    no number left to get wrong;
+  * no omic title is flexed, so a card that is short for any FUTURE reason
+    cannot destroy its own header again.
+
+Measured after the fix, in Chrome, on the MORE card: idle strip -> card 771px,
+title 44px, overlap 0; strip grown 34px + updateLayout() -> card 805px and the
+card below moved 1028 -> 1062. Plain cards 178 -> 175, which is the 3px the
+title's flex had been stretching them by.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_omic_card_sizes_itself
+"""
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+VIEWS = os.path.join(REPO, "PaintomicsClient", "public_html", "app", "view",
+                     "PathwayAcquisitionViews")
+FORMAT_PANEL = os.path.join(VIEWS, "InputFormat", "format-panel.js")
+STEP1_VIEWS = os.path.join(VIEWS, "PA_Step1Views.js")
+
+# The three functions that stand between the module and the layout. Lifted
+# verbatim so the test runs the shipped code rather than a copy of it.
+LIFTED = ("hostForComponent", "freeCardHeight", "syncCardHeightFor")
+
+
+def read(path):
+    with io.open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def lift(source, name):
+    """The text of one top-level `function name(...) {...}` in the module.
+
+    The module indents its functions by four spaces and closes them on a line
+    that is exactly `    }`, which makes the end unambiguous without parsing.
+    """
+    start = source.index("\n    function %s(" % name) + 1
+    end = source.index("\n    }\n", start) + len("\n    }\n")
+    return source[start:end]
+
+
+HARNESS = """
+'use strict';
+// A card, stubbed down to what the three lifted functions touch. Every call
+// that could change the card's size is recorded, so the test can assert on
+// HOW the card was sized and not merely that it ended up somewhere.
+const calls = [];
+function makeCard(overrides) {
+    const card = Object.assign({
+        flex: 1,
+        height: 706,                 // what the vbox had already written
+        isDestroyed: false,
+        el: { dom: { style: { height: '706px' } } },
+        _child: null,
+        down(sel) { return sel === '[itemId=paFormatHost]' ? this._child : null; },
+        add(child) { calls.push('add'); this._child = child; return child; },
+        remove() { calls.push('remove'); this._child = null; },
+        updateLayout() { calls.push('updateLayout'); },
+        setHeight(h) { calls.push('setHeight:' + h); this.height = h; },
+        getHeight() { return this.height; }
+    }, overrides || {});
+    return card;
+}
+const Ext = {
+    suspendLayouts() { calls.push('suspend'); },
+    resumeLayouts() { calls.push('resume'); },
+    create(xtype, cfg) {
+        return { cfg: cfg, getEl: () => ({ dom: { firstChild: { __strip: true } } }) };
+    }
+};
+
+__LIFTED__
+
+const out = {};
+
+// 1. Adding the host must free the card and then re-lay it out.
+let card = makeCard();
+calls.length = 0;
+const strip = hostForComponent(card);
+out.first = {
+    calls: calls.slice(),
+    flex: card.flex,
+    height: card.height,
+    inlineHeight: card.el.dom.style.height,
+    freed: card.__paFreed === true,
+    gotStrip: !!(strip && strip.__strip)
+};
+
+// 2. A second call finds the host that is already there and changes nothing.
+calls.length = 0;
+hostForComponent(card);
+out.second = { calls: calls.slice() };
+
+// 3. Re-syncing after the message changes height re-lays out, nothing else.
+calls.length = 0;
+syncCardHeightFor(card);
+out.sync = { calls: calls.slice() };
+
+// 4. A card that was never freed, and a destroyed one, are both left alone.
+calls.length = 0;
+syncCardHeightFor(makeCard());
+syncCardHeightFor(makeCard({ __paFreed: true, isDestroyed: true }));
+syncCardHeightFor(null);
+out.untouched = { calls: calls.slice() };
+
+// 5. freeCardHeight is once-only: a card already freed is not re-cleared, so a
+//    height the module itself did not write is never silently discarded.
+const already = makeCard({ __paFreed: true });
+freeCardHeight(already);
+out.idempotent = { flex: already.flex, height: already.height };
+
+console.log(JSON.stringify(out));
+"""
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class OmicCardSizesItselfTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        source = read(FORMAT_PANEL)
+        cls.panel_source = source
+        script = HARNESS.replace(
+            "__LIFTED__", "\n".join(lift(source, name) for name in LIFTED))
+        directory = tempfile.mkdtemp(prefix="paintomics-card-height-")
+        try:
+            path = os.path.join(directory, "check.js")
+            with io.open(path, "w", encoding="utf-8") as handle:
+                handle.write(script)
+            done = subprocess.run(["node", path], capture_output=True,
+                                  text=True, timeout=60)
+            if done.returncode != 0:
+                raise AssertionError("node failed:\n%s" % done.stderr)
+            cls.result = json.loads(done.stdout)
+        finally:
+            shutil.rmtree(directory, ignore_errors=True)
+
+    # -- the card leaves the height budget --------------------------------
+
+    def test_adding_the_host_frees_the_card_from_the_vbox_budget(self):
+        first = self.result["first"]
+        self.assertTrue(first["freed"])
+        self.assertIsNone(first["flex"], "flex must go, or the layout keeps "
+                                         "deciding the card's height")
+        self.assertIsNone(first["height"])
+        self.assertEqual(first["inlineHeight"], "",
+                         "the inline height the layout already wrote pins the "
+                         "DOM at that decision and has to be cleared too")
+
+    def test_adding_the_host_relayouts_and_returns_the_strip(self):
+        first = self.result["first"]
+        self.assertTrue(first["gotStrip"])
+        self.assertIn("add", first["calls"])
+        self.assertIn("updateLayout", first["calls"],
+                      "nothing rewrites the sibling cards' `top` without this")
+
+    def test_the_card_is_never_given_a_computed_height(self):
+        """The regression itself: a height is a measurement, and it was wrong."""
+        for stage in ("first", "second", "sync", "untouched"):
+            for call in self.result[stage]["calls"]:
+                self.assertFalse(call.startswith("setHeight"),
+                                 "%s called %s" % (stage, call))
+
+    def test_a_second_host_request_changes_nothing(self):
+        self.assertEqual(self.result["second"]["calls"], [])
+
+    def test_freeing_is_once_only(self):
+        """So a height the module did not write is never silently discarded."""
+        self.assertEqual(self.result["idempotent"]["flex"], 1)
+        self.assertEqual(self.result["idempotent"]["height"], 706)
+
+    # -- re-syncing -------------------------------------------------------
+
+    def test_sync_relayouts_and_does_nothing_else(self):
+        self.assertEqual(self.result["sync"]["calls"], ["updateLayout"])
+
+    def test_sync_leaves_unfreed_destroyed_and_missing_cards_alone(self):
+        self.assertEqual(self.result["untouched"]["calls"], [])
+
+    # -- the source-level halves ------------------------------------------
+
+    def test_the_height_measurement_is_gone_from_the_module(self):
+        """__paBaseHeight was the snapshot that was 66px short."""
+        code = re.sub(r"/\*.*?\*/", "", self.panel_source, flags=re.S)
+        self.assertNotIn("__paBaseHeight", code)
+        self.assertNotIn("setHeight", code)
+
+    def test_no_omic_title_is_flexed(self):
+        """A flexed 44px header is where a short card takes its shortfall from.
+
+        All four panel types (plain, region-based, miRNA, MORE) declared the
+        title as `xtype: "box", flex: 1`. Comments are stripped first, because
+        the note explaining this bug quotes the very declaration it removed.
+        """
+        code = re.sub(r"/\*.*?\*/", "", read(STEP1_VIEWS), flags=re.S)
+        titles = [m.start() for m in re.finditer(r'cls: "omicboxTitle', code)]
+        self.assertEqual(len(titles), 4,
+                         "expected the four omic panels; found %d" % len(titles))
+        for start in titles:
+            # The declaration is one object literal: look back to the `xtype`
+            # that opens it and forward to the `html` that closes it.
+            head = code.rfind("xtype:", 0, start)
+            declaration = code[head:code.index("html:", start)]
+            self.assertNotIn("flex", declaration,
+                             "a flexed omic title absorbs the card's shortfall "
+                             "and lands on the section below it:\n%s"
+                             % declaration.strip())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_repair_clears_the_submit_block.py
+++ b/PaintomicsServer/src/tests/test_repair_clears_the_submit_block.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Repairing a file must also lift the block that file put on the submit.
+
+The behaviour this guards
+-------------------------
+InputFormat/format-panel.js keeps a registry of files it knows the server will
+reject, and a capture-phase listener on #submitButton refuses the submit while
+any entry is live. Entries go stale, so liveBlocked() re-checks each one
+against the form before letting it stop anything -- by comparing the picked
+file's NAME:
+
+    if (!current || current.name !== blocked[fieldName].fileName) {
+        clearBlocked(fieldName);
+
+A repair rewrites the file IN PLACE, under the same name: DEGs2.txt with
+decimal commas becomes DEGs2.txt with dots. The name check therefore cannot
+notice, and the entry has to be cleared explicitly.
+
+Three code paths applied a repair -- the auto-apply branch, the banner's own
+`apply`, and the "Fix automatically" button -- and the button, the one a user
+actually clicks, was the only one that did not call clearBlocked. So the card
+went green and the block stayed live. Measured on the reporting user's DEGs2.txt,
+whose only fault was decimal commas that this very button had just fixed:
+
+    the card's strip     OK Gene expression: 112 rows - 1 value column
+    the submit banner    X  Gene expression: the server will reject this file
+
+Two verdicts on one file, from one module, at one moment. The banner renders at
+the END of the form, so from the top of a long Step 1 the Run button simply
+looks dead -- no dialog, no console error, nothing.
+
+There is one implementation now, used by all three, so the paths cannot drift
+apart again.
+
+What this file asserts
+----------------------
+1. the lifted applyRepair clears the block, replaces the file and re-renders;
+2. there is exactly ONE place that applies a repair;
+3. the button is wired to that one place;
+4. liveBlocked still keys on the file name -- which is WHY 1 is required.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_repair_clears_the_submit_block
+"""
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+PANEL = os.path.join(REPO, "PaintomicsClient", "public_html", "app", "view",
+                     "PathwayAcquisitionViews", "InputFormat", "format-panel.js")
+
+
+def read(path):
+    with io.open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def statement(source, header):
+    start = source.find(header)
+    if start == -1:
+        raise AssertionError("%r is missing from format-panel.js" % header)
+    depth = 0
+    for index in range(start, len(source)):
+        char = source[index]
+        if char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == ";" and depth == 0:
+            return source[start:index + 1]
+    raise AssertionError("ran off the end of format-panel.js")
+
+
+HARNESS = """
+'use strict';
+const calls = [];
+const blocked = { 'omic0_file': { fileName: 'DEGs2.txt' } };
+
+function replaceFile(input, rows, name) { calls.push('replaceFile:' + name); }
+function clearBlocked(fieldName) { calls.push('clearBlocked:' + fieldName);
+                                   delete blocked[fieldName]; }
+function renderOk() { calls.push('renderOk'); }
+function hostFor() { return {}; }
+function validate() { return { ok: true, summary: { nRows: 112 } }; }
+
+const input = {};
+const fieldName = 'omic0_file';
+const file = { name: 'DEGs2.txt' };
+const repaired = { rows: [['#gene', 'v'], ['Cp', '-1.86']] };
+
+%(apply_repair)s
+
+applyRepair();
+
+console.log(JSON.stringify({
+    calls: calls,
+    stillBlocked: Object.keys(blocked)
+}));
+"""
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class RepairClearsTheSubmitBlockTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.source = read(PANEL)
+        script = HARNESS % {
+            "apply_repair": statement(cls.source, "var applyRepair = function ()"),
+        }
+        directory = tempfile.mkdtemp(prefix="paintomics-repair-block-")
+        try:
+            path = os.path.join(directory, "check.js")
+            with io.open(path, "w", encoding="utf-8") as handle:
+                handle.write(script)
+            done = subprocess.run(["node", path], capture_output=True,
+                                  text=True, timeout=60)
+            if done.returncode != 0:
+                raise AssertionError("node failed:\n%s" % done.stderr)
+            cls.result = json.loads(done.stdout)
+        finally:
+            shutil.rmtree(directory, ignore_errors=True)
+
+    def test_applying_a_repair_lifts_the_block(self):
+        """The regression: the card went green and the submit stayed refused."""
+        self.assertEqual(self.result["stillBlocked"], [])
+        self.assertIn("clearBlocked:omic0_file", self.result["calls"])
+
+    def test_it_also_replaces_the_file_and_re_renders(self):
+        self.assertIn("replaceFile:DEGs2.txt", self.result["calls"])
+        self.assertIn("renderOk", self.result["calls"])
+        self.assertLess(self.result["calls"].index("replaceFile:DEGs2.txt"),
+                        self.result["calls"].index("renderOk"),
+                        "the file must be replaced before it is re-rendered")
+
+    def test_there_is_exactly_one_way_to_apply_a_repair(self):
+        """Three copies drifted apart once; one cannot."""
+        code = re.sub(r"/\\*.*?\\*/", "", self.source, flags=re.S)
+        self.assertEqual(code.count("replaceFile(input, repaired.rows, file.name)"), 1,
+                         "a second copy of the repair has appeared")
+        self.assertEqual(code.count("var applyRepair = function ()"), 1)
+
+    def test_every_path_goes_through_it(self):
+        code = re.sub(r"/\\*.*?\\*/", "", self.source, flags=re.S)
+        self.assertIn("if (autoApply) { applyRepair(); return; }", code)
+        self.assertIn("fixable: true, apply: applyRepair", code)
+        self.assertIn('onClick: applyRepair', code)
+
+    def test_the_block_is_still_kept_alive_by_file_name(self):
+        """Which is exactly why a repair has to clear it explicitly.
+
+        If this ever changes to compare content, size or an identity token, the
+        explicit clear may stop being necessary -- but until then it is.
+        """
+        code = re.sub(r"/\\*.*?\\*/", "", self.source, flags=re.S)
+        self.assertIn("current.name !== blocked[fieldName].fileName", code)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_repair_clears_the_submit_block.py
+++ b/PaintomicsServer/src/tests/test_repair_clears_the_submit_block.py
@@ -106,6 +106,20 @@ console.log(JSON.stringify({
 """
 
 
+def stripComments(source):
+    """The JS block comments removed, so an assertion reads code and not prose.
+
+    Spelled out because the inline version of this was wrong and passed anyway:
+    it was written `r"/\\*.*?\\*/"`, where `\\*` is "zero or more literal
+    backslashes", so the pattern reduced to `/ ... /` and paired up SLASHES --
+    eating regex literals and leaving comments in place. Every assertion below
+    still held, by luck, until an edit elsewhere in the file changed which
+    slashes paired with which. A test whose green depends on that is not
+    testing what it says it tests.
+    """
+    return re.sub(r"/\*.*?\*/", "", source, flags=re.S)
+
+
 @unittest.skipIf(shutil.which("node") is None, "node is not installed")
 class RepairClearsTheSubmitBlockTest(unittest.TestCase):
 
@@ -142,13 +156,13 @@ class RepairClearsTheSubmitBlockTest(unittest.TestCase):
 
     def test_there_is_exactly_one_way_to_apply_a_repair(self):
         """Three copies drifted apart once; one cannot."""
-        code = re.sub(r"/\\*.*?\\*/", "", self.source, flags=re.S)
+        code = stripComments(self.source)
         self.assertEqual(code.count("replaceFile(input, repaired.rows, file.name)"), 1,
                          "a second copy of the repair has appeared")
         self.assertEqual(code.count("var applyRepair = function ()"), 1)
 
     def test_every_path_goes_through_it(self):
-        code = re.sub(r"/\\*.*?\\*/", "", self.source, flags=re.S)
+        code = stripComments(self.source)
         self.assertIn("if (autoApply) { applyRepair(); return; }", code)
         self.assertIn("fixable: true, apply: applyRepair", code)
         self.assertIn('onClick: applyRepair', code)
@@ -159,7 +173,7 @@ class RepairClearsTheSubmitBlockTest(unittest.TestCase):
         If this ever changes to compare content, size or an identity token, the
         explicit clear may stop being necessary -- but until then it is.
         """
-        code = re.sub(r"/\\*.*?\\*/", "", self.source, flags=re.S)
+        code = stripComments(self.source)
         self.assertIn("current.name !== blocked[fieldName].fileName", code)
 
 

--- a/PaintomicsServer/src/tests/test_run_failure_reaches_the_agent.py
+++ b/PaintomicsServer/src/tests/test_run_failure_reaches_the_agent.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""A failure at run time must be able to reach the agent, with the whole job.
+
+The behaviour this guards
+-------------------------
+The offer to hand a refused file to the AI agent existed, and was keyed to one
+servlet's wording:
+
+    if (text.indexOf("Errors detected while processing") === -1) return;
+
+Every other failure says something else, and the ones that reach a user with
+real data are the analysis-stage ones. So a user watched a MORE run fail with
+the agent one click away and never offered it. Same shape as the rest of this
+family: matching on a STRING instead of on the situation.
+
+Worse, the error that prompted this names no file at all --
+
+    MORE ERROR: No common sample names across input files.
+    Target samples: DSSmEVs_vs_DSS
+    Condition rows: 1-C1, 2-C2, 3-C3, ...
+    miRNA-Seq_data samples: DSS_SDmEV_vs_DSS
+
+-- only sample names and an omic. `miRNA-Seq_data` is what the user typed into
+Omic Name, so the card is identifiable even when the file is not.
+
+And the fault is not IN any one file. Each is individually valid; the format
+check passes all of them. They are wrong TOGETHER. A per-file agent re-reads a
+valid file and finds nothing, so it is now given a one-line summary of every
+other file in the job -- headers only, never the measurements.
+
+That cross-file context is powerful and dangerous in equal measure. Measured,
+the first time it ran: given the siblings, the agent renamed a column so the
+two VALUES files agreed with each other, ignored the design file, and reported
+success -- a job that would have failed again in the same place. So the design
+file is named as the authority, and an irreconcilable case is routed to the
+ask channel rather than to a conversion. With that, on the same data, the agent
+stops and offers "Provide per-sample expression values", "Use the contrast
+as-is and adjust the design (not recommended)", "Cancel this analysis".
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_run_failure_reaches_the_agent
+"""
+import io
+import os
+import re
+import unittest
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+FORMAT_DIR = os.path.join(REPO, "PaintomicsClient", "public_html", "app", "view",
+                          "PathwayAcquisitionViews", "InputFormat")
+PANEL = os.path.join(FORMAT_DIR, "format-panel.js")
+DRAWER = os.path.join(FORMAT_DIR, "convert-drawer.js")
+
+# The error the user actually saw, verbatim.
+MORE_ERROR = (
+    "1 file(s) could not be prepared. miRNA-Seq data: RuntimeError: AT "
+    "MOREServlet.py: fromMOREtoGenes_STEP2. The MORE analysis failed "
+    "(more-rs backend). MORE ERROR: No common sample names across input files. "
+    "Target samples: DSSmEVs_vs_DSS Condition rows: 1-C1, 2-C2, 3-C3, ... "
+    "miRNA-Seq_data samples: DSS_SDmEV_vs_DSS"
+)
+
+
+def read(path):
+    with io.open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def uncommented(source):
+    return re.sub(r"/\*.*?\*/", "", source, flags=re.S)
+
+
+class RunFailureReachesTheAgentTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.panel = read(PANEL)
+        cls.drawer = read(DRAWER)
+        cls.panel_code = uncommented(cls.panel)
+        cls.drawer_code = uncommented(cls.drawer)
+
+    # -- the offer is no longer tied to one servlet's wording --------------
+
+    def test_the_hard_coded_phrase_is_gone(self):
+        """It gated the offer on one message out of every message we send."""
+        self.assertNotIn('indexOf("Errors detected while processing")',
+                         self.panel_code)
+
+    def test_a_file_is_found_by_name_anywhere_in_the_message(self):
+        hook = self.panel_code[self.panel_code.index("function attachDialogFix"):]
+        self.assertIn("pickedFileMatching", hook)
+        self.assertIn("tab|txt|csv", hook)
+
+    def test_an_omic_is_found_when_no_file_is_named(self):
+        """The reported error names sample names and an omic, and no file."""
+        self.assertIn("function pickedFileForOmicNamedIn", self.panel_code)
+        self.assertIn("pickedFileForOmicNamedIn(text)", self.panel_code)
+        # The regression that made the first attempt match nothing at all:
+        # ComponentQuery has no CSS class selector.
+        self.assertNotIn('up(".omicbox")', self.panel_code)
+        self.assertIn('up("[cls~=omicbox]")', self.panel_code)
+
+    def test_the_reported_error_names_no_file_but_does_name_the_omic(self):
+        """The premise of the fallback, asserted so it cannot rot silently."""
+        names = re.findall(r"[\w./\\-]+\.(?:tab|txt|csv|tsv)\b", MORE_ERROR)
+        self.assertEqual(names, [], "this error names a file after all")
+        self.assertIn("miRNA-Seq_data", MORE_ERROR)
+
+    def test_both_offers_are_made_and_they_differ(self):
+        """Re-checking repairs mechanically; the agent can be told what broke."""
+        self.assertIn("Check this file again", self.panel_code)
+        self.assertIn("Ask the PaintOmics AI agent", self.panel_code)
+
+    # -- the agent is given the job, not one file --------------------------
+
+    def test_the_other_files_are_summarised_for_the_agent(self):
+        self.assertIn("function siblingSummaries", self.panel_code)
+        self.assertIn("function siblingBrief", self.panel_code)
+        summaries = self.panel_code[self.panel_code.index("function siblingSummaries"):]
+        summaries = summaries[:summaries.index("function siblingBrief")]
+        self.assertIn("roleForField(field)", summaries,
+                      "every role must be summarised, not just values")
+        self.assertIn("file.slice(0, 65536)", summaries,
+                      "headers only -- the measurements stay in the browser")
+
+    def test_the_summary_is_gathered_before_the_dialog_closes(self):
+        """Closing it first would leave nothing to read the files from."""
+        hook = self.panel_code[self.panel_code.index("function attachDialogFix"):]
+        gather = hook.index("siblingSummaries(picked.input)")
+        close = hook.index("closeButton.click()", gather)
+        self.assertLess(gather, close)
+
+    def test_the_server_s_words_and_the_siblings_both_reach_the_agent(self):
+        self.assertIn("__paServerSaid", self.panel_code)
+        self.assertIn("__paSiblings", self.panel_code)
+        self.assertIn("input.__paServerSaid", self.drawer_code)
+        self.assertIn("input.__paSiblings", self.drawer_code)
+
+    # -- and the guard that stops a confident wrong answer -----------------
+
+    def test_the_design_file_is_named_as_the_authority(self):
+        """Without this the agent aligned two values files and ignored design."""
+        self.assertIn("AUTHORITY on", self.drawer_code)
+        self.assertIn("Never rename a column to make two", self.drawer_code)
+
+    def test_an_irreconcilable_job_is_asked_about_not_converted(self):
+        """The runtime has no "explain, do not convert" outcome; ask is the one
+        channel that carries an explanation, and it is already used for the
+        duplicate-identifier question."""
+        self.assertIn("ASK THE USER rather", self.drawer_code)
+        self.assertIn("one column per sample", self.drawer_code)
+
+    def test_the_brief_is_only_added_when_the_server_refused(self):
+        """A file the user picks themselves is still a per-file conversion."""
+        block = self.drawer_code[self.drawer_code.index("instructions:"):]
+        block = block[:block.index("ask:")]
+        self.assertIn("input && input.__paServerSaid", block)
+        self.assertIn(": undefined", block)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_run_failure_reaches_the_agent.py
+++ b/PaintomicsServer/src/tests/test_run_failure_reaches_the_agent.py
@@ -151,6 +151,33 @@ class RunFailureReachesTheAgentTest(unittest.TestCase):
         self.assertIn("ASK THE USER rather", self.drawer_code)
         self.assertIn("one column per sample", self.drawer_code)
 
+    def test_the_agent_is_told_it_can_rewrite_only_the_file_it_holds(self):
+        """Reported as "the AI said it fixed the problem and it fails again".
+
+        The sandbox receives exactly one file -- files: {fileKey: bytes} -- so
+        every other file is read-only context. Without this the agent offered
+        "use the contrast as-is and adjust the design to match it", an action it
+        cannot perform, then edited the one file it holds and reported success.
+
+        Measured on the reported job: MORE intersects sample names across the
+        target, the condition file and every regulator file, so renaming this
+        file's column to match the target leaves the design disagreeing, and
+        renaming it to match the design leaves the target disagreeing -- both
+        give 0 common samples. No edit to ONE file can satisfy a three-way
+        intersection, so an agent that can only edit one must say so.
+        """
+        self.assertIn("rewrite ONLY the file you were given", self.drawer_code)
+        self.assertIn("read-only", self.drawer_code)
+        # Phrases that sit inside ONE string literal: the instruction is built
+        # by concatenation, so anything spanning a `+ "` is not there to find.
+        self.assertIn("you cannot edit them", self.drawer_code)
+        self.assertIn("will fail", self.drawer_code)
+
+    def test_the_sandbox_really_does_receive_one_file(self):
+        """The premise above. If this ever becomes many, the instruction is
+        wrong and this suite should be the thing that notices."""
+        self.assertIn("f[fileKey] = bytes; return f;", self.drawer_code)
+
     def test_the_brief_is_only_added_when_the_server_refused(self):
         """A file the user picks themselves is still a per-file conversion."""
         block = self.drawer_code[self.drawer_code.index("instructions:"):]

--- a/PaintomicsServer/src/tests/test_run_failure_reaches_the_agent.py
+++ b/PaintomicsServer/src/tests/test_run_failure_reaches_the_agent.py
@@ -107,6 +107,36 @@ class RunFailureReachesTheAgentTest(unittest.TestCase):
         self.assertEqual(names, [], "this error names a file after all")
         self.assertIn("miRNA-Seq_data", MORE_ERROR)
 
+    def test_the_omic_must_be_named_as_a_subject_not_mentioned_in_prose(self):
+        """Reported as "why do these two buttons always exist".
+
+        Matching an omic NAME anywhere in the text is far too loose to stand on
+        its own -- omic names are ordinary words. The form's own refusal,
+        "Please provide at least: Gene expression /Metabolomics /Proteomics
+        data", contains "Gene expression", so a card carrying the default name
+        matched it and both buttons appeared on a dialog that names no file and
+        reports no file problem at all.
+
+        A failure that is ABOUT an omic writes it as a label -- the preparation
+        dialog builds "<omic>: <what the server said>" -- and prose does not put
+        a colon there.
+
+        Measured in Chrome with a card named "Gene expression" holding
+        myvalues.tab, after the change:
+
+            form: no data (names no file)          no buttons
+            form: field required                   no buttons
+            session expired                        no buttons
+            omic mentioned in prose                no buttons
+            names the picked file                  Check / Ask
+            "Gene expression: MORE ERROR: ..."     Check / Ask
+        """
+        matcher = self.panel_code[
+            self.panel_code.index("function pickedFileForOmicNamedIn"):]
+        matcher = matcher[:matcher.index("function pickedFileMatching")]
+        self.assertIn('.toLowerCase() + ":"', matcher,
+                      "a bare omic name is not evidence that a file failed")
+
     def test_both_offers_are_made_and_they_differ(self):
         """Re-checking repairs mechanically; the agent can be told what broke."""
         self.assertIn("Check this file again", self.panel_code)

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -90,7 +90,7 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/format-repair.js": (
         "0.1", "944c929f1496258aba56f026e7c30e4affb7052dcbc127b06982eaadff205cd2"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-panel.js": (
-        "1.9", "7198efa3a416c7527ab58602339f97df0e81a9f532c65b19f81c23c42dc56b2f"),
+        "2.0", "61ad9b03995c00f740154772420637c57e41eb653abaad6ab16fb0fd5fea2d83"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-roles.js": (
         "0.2", "4c5afdf4f9c59d167756516db823cc1fa01179f3cd7b967d137c38a78c0508dd"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js": (

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -90,15 +90,15 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/format-repair.js": (
         "0.1", "944c929f1496258aba56f026e7c30e4affb7052dcbc127b06982eaadff205cd2"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-panel.js": (
-        "3.0", "2c8fdc26fefc6247e0a67ff0a535ea879c3842a3f7417fc0bcb3d6f5d3e1abc4"),
+        "3.1", "1b2fb789d33d925c7ae482b76c0ac05b1417e7984b61f71e9321dd125461780c"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-roles.js": (
-        "0.4", "e8cfd91e96a883144b0f938901ef59753385030d22a25d2784c8f8b8c5546663"),
+        "0.5", "02fca3cace94756275993739d36deb728b1870c21be9ec5477f853828e7a67b6"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js": (
         "0.3", "d7f2846c58226fdfe334fefc68c8d6519cc4eae393265e15dd047e5babded4f3"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js": (
         "0.6", "d884a0d8344fccf966aab1219c9c70f9e29ca93a4a42e7ddf8f0852189f5ecdd"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js": (
-        "1.3", "1e4df47449d2a220171779806a93231f5ac60edc75b4e880f8a684d9573a8058"),
+        "1.4", "41be9f21d19a4471273310d905412abf67c98ad2f2734364d2fcdd54e1e4ca4b"),
     "app/view/common/Util.js": (
         "2.1", "12359b8bf746394f63a7e0a15513a4f9ac82de1a25bbaa0e91e6b2fdd7e0050e"),
     "app/view/common/OrganismSearch.js": (

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -90,7 +90,7 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/format-repair.js": (
         "0.1", "944c929f1496258aba56f026e7c30e4affb7052dcbc127b06982eaadff205cd2"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-panel.js": (
-        "2.0", "121a34ab963f355f175cc90d2cfeba31ce8f4186ed02b9fe13dd89a2af112200"),
+        "2.1", "42f520c8313691b7abee80510d7467517ecceeddcc7b2f97f64dcc50c92ca88c"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-roles.js": (
         "0.2", "4c5afdf4f9c59d167756516db823cc1fa01179f3cd7b967d137c38a78c0508dd"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js": (

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -90,7 +90,7 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/format-repair.js": (
         "0.1", "944c929f1496258aba56f026e7c30e4affb7052dcbc127b06982eaadff205cd2"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-panel.js": (
-        "2.0", "61ad9b03995c00f740154772420637c57e41eb653abaad6ab16fb0fd5fea2d83"),
+        "2.0", "121a34ab963f355f175cc90d2cfeba31ce8f4186ed02b9fe13dd89a2af112200"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-roles.js": (
         "0.2", "4c5afdf4f9c59d167756516db823cc1fa01179f3cd7b967d137c38a78c0508dd"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js": (

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -98,7 +98,7 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js": (
         "0.6", "d884a0d8344fccf966aab1219c9c70f9e29ca93a4a42e7ddf8f0852189f5ecdd"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js": (
-        "1.2", "94adb33278783c8c84fd15ae2beac897d888a2c6e963d00371f6879ae5ca95d5"),
+        "1.3", "1e4df47449d2a220171779806a93231f5ac60edc75b4e880f8a684d9573a8058"),
     "app/view/common/Util.js": (
         "2.1", "12359b8bf746394f63a7e0a15513a4f9ac82de1a25bbaa0e91e6b2fdd7e0050e"),
     "app/view/common/OrganismSearch.js": (

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -90,9 +90,9 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/format-repair.js": (
         "0.1", "944c929f1496258aba56f026e7c30e4affb7052dcbc127b06982eaadff205cd2"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-panel.js": (
-        "2.9", "786429b3408d36a28b4d1adf36e8691dcb14d29bc54ca8599b1879c2d0606ecd"),
+        "3.0", "2c8fdc26fefc6247e0a67ff0a535ea879c3842a3f7417fc0bcb3d6f5d3e1abc4"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-roles.js": (
-        "0.3", "cf16e283ebbe3f36e6be89071e83b3ba8b5696eb951fa330613116ff31b78dd8"),
+        "0.4", "e8cfd91e96a883144b0f938901ef59753385030d22a25d2784c8f8b8c5546663"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js": (
         "0.3", "d7f2846c58226fdfe334fefc68c8d6519cc4eae393265e15dd047e5babded4f3"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js": (

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -90,7 +90,7 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/format-repair.js": (
         "0.1", "944c929f1496258aba56f026e7c30e4affb7052dcbc127b06982eaadff205cd2"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-panel.js": (
-        "2.1", "42f520c8313691b7abee80510d7467517ecceeddcc7b2f97f64dcc50c92ca88c"),
+        "2.1", "adda1f328157c8ee0225c6f304d1d4a669809782b8f9f2fc0c12371d496cc185"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-roles.js": (
         "0.2", "4c5afdf4f9c59d167756516db823cc1fa01179f3cd7b967d137c38a78c0508dd"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js": (

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -90,7 +90,7 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/format-repair.js": (
         "0.1", "944c929f1496258aba56f026e7c30e4affb7052dcbc127b06982eaadff205cd2"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-panel.js": (
-        "2.2", "563453b4916e86032a36c221eeaa6c9f0387f2892f86682ebaa8d335b985d0b9"),
+        "2.3", "469ea9525eb47cf8ecdf08a1c958771b6f6be34d13c0d6be787f35c8d0055a9b"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-roles.js": (
         "0.2", "4c5afdf4f9c59d167756516db823cc1fa01179f3cd7b967d137c38a78c0508dd"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js": (

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -90,7 +90,7 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/format-repair.js": (
         "0.1", "944c929f1496258aba56f026e7c30e4affb7052dcbc127b06982eaadff205cd2"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-panel.js": (
-        "2.4", "a827cf7e64bac7cafbc9e241c85fb1b59f72f7bb2548a1f419242ec4201264fa"),
+        "2.8", "a632f62960415305011320b18e7854e3281b85fe6d1e3627f667c37d707bb9e7"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-roles.js": (
         "0.3", "cf16e283ebbe3f36e6be89071e83b3ba8b5696eb951fa330613116ff31b78dd8"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js": (
@@ -98,7 +98,7 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js": (
         "0.6", "d884a0d8344fccf966aab1219c9c70f9e29ca93a4a42e7ddf8f0852189f5ecdd"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js": (
-        "0.8", "0bf9ac82da279bb3d51e01532ae320f2258c4f5bed3d8a5679748ff9070e7448"),
+        "1.2", "94adb33278783c8c84fd15ae2beac897d888a2c6e963d00371f6879ae5ca95d5"),
     "app/view/common/Util.js": (
         "2.1", "12359b8bf746394f63a7e0a15513a4f9ac82de1a25bbaa0e91e6b2fdd7e0050e"),
     "app/view/common/OrganismSearch.js": (

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -90,7 +90,7 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/format-repair.js": (
         "0.1", "944c929f1496258aba56f026e7c30e4affb7052dcbc127b06982eaadff205cd2"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-panel.js": (
-        "2.1", "adda1f328157c8ee0225c6f304d1d4a669809782b8f9f2fc0c12371d496cc185"),
+        "2.2", "563453b4916e86032a36c221eeaa6c9f0387f2892f86682ebaa8d335b985d0b9"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-roles.js": (
         "0.2", "4c5afdf4f9c59d167756516db823cc1fa01179f3cd7b967d137c38a78c0508dd"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js": (
@@ -98,7 +98,7 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js": (
         "0.6", "d884a0d8344fccf966aab1219c9c70f9e29ca93a4a42e7ddf8f0852189f5ecdd"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js": (
-        "0.7", "241e9a48b99f6ca40f3f9d3b5dd29f27513ca38c181fb902075a0149af9ca4b3"),
+        "0.8", "0bf9ac82da279bb3d51e01532ae320f2258c4f5bed3d8a5679748ff9070e7448"),
     "app/view/common/Util.js": (
         "2.1", "12359b8bf746394f63a7e0a15513a4f9ac82de1a25bbaa0e91e6b2fdd7e0050e"),
     "app/view/common/OrganismSearch.js": (

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -90,9 +90,9 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/format-repair.js": (
         "0.1", "944c929f1496258aba56f026e7c30e4affb7052dcbc127b06982eaadff205cd2"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-panel.js": (
-        "2.3", "469ea9525eb47cf8ecdf08a1c958771b6f6be34d13c0d6be787f35c8d0055a9b"),
+        "2.4", "a827cf7e64bac7cafbc9e241c85fb1b59f72f7bb2548a1f419242ec4201264fa"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-roles.js": (
-        "0.2", "4c5afdf4f9c59d167756516db823cc1fa01179f3cd7b967d137c38a78c0508dd"),
+        "0.3", "cf16e283ebbe3f36e6be89071e83b3ba8b5696eb951fa330613116ff31b78dd8"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js": (
         "0.3", "d7f2846c58226fdfe334fefc68c8d6519cc4eae393265e15dd047e5babded4f3"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js": (

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -90,7 +90,7 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/format-repair.js": (
         "0.1", "944c929f1496258aba56f026e7c30e4affb7052dcbc127b06982eaadff205cd2"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-panel.js": (
-        "2.8", "a632f62960415305011320b18e7854e3281b85fe6d1e3627f667c37d707bb9e7"),
+        "2.9", "786429b3408d36a28b4d1adf36e8691dcb14d29bc54ca8599b1879c2d0606ecd"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-roles.js": (
         "0.3", "cf16e283ebbe3f36e6be89071e83b3ba8b5696eb951fa330613116ff31b78dd8"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js": (


### PR DESCRIPTION
## The report

From the same user as #90, the same day. She filled in a **Regulatory Omic (MORE)** panel; her files used **decimal commas** (`1,601241826` — Italian Excel). She was told nothing, and the run died on the server an hour later.

Decimal commas are the case this module was *written* for. Its own comment:

> *"Observed on the very first run-through: the strip said the numbers used decimal commas, the form was submitted anyway, and the server answered with ten identical lines of 'Perhaps you are using commas instead of dots as decimal mark?' — the exact wall of noise this module was written to replace."*

It blocks a submit over exactly that fault. **It never looked at her files.**

## Cause

```js
var VALUES_FIELD = /^omic\d+_file$/;
```

The plain, region-based and miRNA panels' convention — not MORE's, which names its five selectors `conditions`, `rnaseqaux`, `file_0`, `relevant_file_0`, `assoc_file_0`. The pattern gated **four** things: the `change` listener, whether a card gets a strip at all, the fix-it hook on the server error dialog, and the omic name.

Measured in Chrome, one file in two panels:

| panel | field name | result |
|---|---|---|
| Gene expression | `omic0_file` | ⚠ "Numbers use commas as the decimal mark" + **[Fix automatically]** |
| Regulatory Omic — MORE | `file_0_file` | `stripsOnPage: 0` |

Third instance of the same family (`[cls=omicbox]` at `PA_Step1Views.js:964`, `checkForm` in #90, `collectPickedOmicFiles` in #91).

## The fix

The **slot** is the key now, not the name — `itemId` is the one thing every panel type agrees on. And each slot is held to its **own** contract, which `format-roles.js` already models: widening the net without that would grade a two-column associations file by the values-matrix rules and reject correct work.

Three slots are exempt, each reasoned beside the table:

- `tertiaryFileSelector` — a GTF is not a delimited contract;
- `mirnaTargetsFileSelector` — the miRNA2Genes table is miRNA/gene/PLR, which is why the shipped `mirna_to_gene_associations.tab` has **three** columns and the associations contract rejects it (the exact trap `roleForFileName` already documents);
- `third`/`fourthFileSelector` — the results container, filled with server paths, where an empty `regulator_relevant_associations` file is a legitimate output.

**The new test found the first two by rejecting shipped example files** — precisely the false block this had to avoid.

Two things had to follow the wider net:

- `renderOk` read `summary.numericColumns` and `summary.idSample` unconditionally — values-only fields — so the first design file checked threw `Cannot read properties of undefined` and left a blank green strip;
- `describeProblems` knew none of the role codes, so every fault in a conditions or associations file fell through to *"The file does not match the format PaintOmics expects"* — true, and useless.

## Verification (Chrome, her own four files, MORE panel)

| slot | her file | before | after |
|---|---|---|---|
| Conditions file | `samplemetadata_miRNA.csv` | silent | ✗ *"A conditions file marks each sample with 1 or 0 in every group column; this one holds other values."* |
| Gene expression dataset | `DEGs2.txt` | silent | ⚠ decimal commas + **Fix automatically** |
| Regulators expression file | `DEmiRNA.txt` | silent | ⚠ → **one click** → ✓ *"112 rows · 1 value column"* |
| Associations file | `Targets3.txt` | silent | ✓ *"113 rows · 2 columns"* |

The conditions-file message is the diagnosis it took an hour of log-reading to reach; it now appears the instant the file is picked.

**No regression:** a plain Gene expression panel is unchanged — ✓ *"10,415 rows · 6 value columns · IDs like ENSMUSG00000000001…"*.

## Tests

`src/tests/test_input_check_covers_every_omic_slot.py` — 7 assertions:

- **every file slot the form can show** is either given a role or explicitly exempt, so a new panel cannot go blind the same way;
- **no file shipped with the example datasets is rejected by its role** — the guard against blocking valid uploads;
- the MORE slots are named explicitly, and the name pattern must not come back.

`test_validator_agrees_with_server`, `test_versioned_assets_are_bumped`, `test_example_mode_client_wiring`, `test_reset_destroys_every_job_view`, `test_organism_search` all pass; the 48 client node tests pass; `ruff check .` clean.

`format-panel.js` is hand-versioned, so `index.html` is bumped to `?v=2.0` and the digest table in `test_versioned_assets_are_bumped` updated in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)