### PR TITLE
Say that nothing matched, instead of crashing the metagenes step over an empty file

### DIFF
--- a/PaintomicsServer/src/classes/JobInstances/PathwayAcquisitionJob.py
+++ b/PaintomicsServer/src/classes/JobInstances/PathwayAcquisitionJob.py
@@ -118,6 +118,84 @@ def _metagenesParallelism():
         return 3
 
 
+def mappedTotal(omicSummary):
+    """The number of features an omic mapped, from its omicSummary.
+
+    First position: a dictionary per database ("Total" is the maximum) for
+    gene-based omics, a bare int for compound-based ones. Shared with
+    getMappedRatios, which used to carry this rule alone.
+    """
+    if not omicSummary:
+        return 0
+    first = omicSummary[0]
+    if isinstance(first, int):
+        return first
+    if isinstance(first, dict):
+        total = first.get("Total")
+        if total is None:
+            total = next(iter(first.values()), 0)
+        try:
+            return int(total or 0)
+        except (TypeError, ValueError):
+            return 0
+    return 0
+
+
+def hasDataRows(path):
+    """Whether a mapping file holds at least one non-blank line."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                if line.strip():
+                    return True
+    except OSError:
+        return False
+    return False
+
+
+_ENSEMBL_VERSIONED = re.compile(r"^ENS[A-Z]*[GTP]\d{5,}\.\d+$")
+
+
+def explainEmptyMapping(organism, geneOmics, sampleUnmatchedFor):
+    """Why step 2 has nothing to work on, or None.
+
+    An omic whose identifiers matched nothing passed step 1 as a success
+    (omicSummary {KEGG: 0}) and then step 2 died INSIDE R -- generateMetaGenes.R
+    was handed an empty <omic>_matched.txt and reported "no lines available in
+    input", which reached the user as a metagenes failure. Measured on three
+    real files (2026-08-27): a GEO count matrix with versioned Ensembl ids
+    (ENSMUSG00000102693.2), PacBio transcript ids, and a human file run as
+    mouse. None of them is a metagenes problem; all three are "nothing
+    matched", and that is what this says, with the identifiers in question.
+    """
+    if not geneOmics:
+        return None
+    if any(mappedTotal(omic.get("omicSummary")) > 0 for omic in geneOmics):
+        return None
+    parts, samples = [], []
+    for omic in geneOmics:
+        name = omic.get("omicName") or "omic"
+        summary = omic.get("omicSummary") or []
+        unmatched = summary[1] if len(summary) > 1 and isinstance(summary[1], int) else None
+        sample = list(sampleUnmatchedFor(name) or [])[:3]
+        samples.extend(sample)
+        parts.append("'%s'%s%s" % (
+            name,
+            (" (%d identifiers)" % unmatched) if unmatched is not None else "",
+            (", e.g. " + ", ".join(sample)) if sample else ""))
+    lines = ["None of the identifiers in your data matched %s's KEGG genes: %s "
+             "matched 0, so there is nothing to analyse." % (organism, "; ".join(parts))]
+    if samples and all(_ENSEMBL_VERSIONED.match(x) for x in samples):
+        lines.append("These carry an Ensembl version suffix (the .%s in %s); KEGG "
+                     "knows them without it, so strip the suffix and run again."
+                     % (samples[0].rsplit(".", 1)[1], samples[0]))
+    else:
+        lines.append("Check the organism you chose and the kind of identifier "
+                     "in the first column: the mapping summary on this page "
+                     "says which identifiers PaintOmics recognised.")
+    return " ".join(lines)
+
+
 def _runMetagenesScripts(omicNames, databases, commands):
     """
     Run one generateMetaGenes.R per (omic, database) -- `commands[(omic, db)]`
@@ -330,6 +408,33 @@ class PathwayAcquisitionJob(Job):
 
         return self.description
 
+    def sampleUnmatched(self, omicName, limit=3):
+        """The first identifiers of <omic>_unmatched.txt in the mapping zip."""
+        try:
+            with zipFile(self.getOutputDir() + "/mapping_results_" + self.getJobID() + ".zip") as mappingZip:
+                member = omicName + "_unmatched.txt"
+                if member not in mappingZip.namelist():
+                    return []
+                sample = []
+                with mappingZip.open(member) as handle:
+                    for raw in handle:
+                        first = raw.decode("utf-8", "replace").split("\t")[0].strip()
+                        if first and not first.startswith("#"):
+                            sample.append(first)
+                        if len(sample) >= limit:
+                            break
+                return sample
+        except Exception:
+            return []
+
+    def explainEmptyMapping(self, selectedCompounds=None):
+        """See explainEmptyMapping(): None unless every gene-based omic mapped
+        nothing and no compound was selected either."""
+        if selectedCompounds:
+            return None
+        return explainEmptyMapping(self.getOrganism(), self.getGeneBasedInputOmics(),
+                                   self.sampleUnmatched)
+
     def getMappedRatios(self):
         # Calculate the mapped/unmapped ratio of each omic
         mapped_ratios = {}
@@ -342,12 +447,7 @@ class PathwayAcquisitionJob(Job):
             # Compounds omics only have one value (no dict)
             # Lazy fallback: .get(key, expr) evaluates expr even when the key
             # exists, and an empty dict made list({}.values())[0] raise.
-            if isinstance(omicSummary[0], int):
-                totalMapped = omicSummary[0]
-            else:
-                totalMapped = omicSummary[0].get("Total")
-                if totalMapped is None:
-                    totalMapped = next(iter(omicSummary[0].values()), 0)
+            totalMapped = mappedTotal(omicSummary)
 
             # Second position: considering total if it exists
             totalUnmapped = omicSummary[1]
@@ -2161,6 +2261,35 @@ class PathwayAcquisitionJob(Job):
             for member in mappingZip.namelist():
                 if member in wanted:
                     mappingZip.extract(member, path=self.getTemporalDir())
+
+        # An omic that matched nothing has an empty <omic>_matched.txt, and
+
+        # generateMetaGenes.R read it as "no lines available in input" -- a
+
+        # crash reported to the user as a metagenes failure. There is nothing
+
+        # to cluster; the omic is skipped here and step 2 says why (see
+
+        # explainEmptyMapping) when it was the only one.
+
+        eligible = []
+
+        for inputOmic in filtered_omics:
+
+            matchedFile = self.getTemporalDir() + "/" + inputOmic.get("omicName") + "_matched.txt"
+
+            if hasDataRows(matchedFile):
+
+                eligible.append(inputOmic)
+
+            else:
+
+                logging.warning("STEP2 - omic '%s' matched no feature; metagenes skipped.",
+
+                                inputOmic.get("omicName"))
+
+        filtered_omics = eligible
+
 
         # STEP 2. GENERATE THE DATA FOR EACH OMIC DATA TYPE
 

--- a/PaintomicsServer/src/servlets/PathwayAcquisitionServlet.py
+++ b/PaintomicsServer/src/servlets/PathwayAcquisitionServlet.py
@@ -587,6 +587,12 @@ def pathwayAcquisitionStep2_PART2(jobID, userID, selectedCompounds, clusterNumbe
         jobInstance.updateSubmitedCompoundsList(selectedCompounds)
         logging.info("STEP2 - UPDATING SELECTED COMPOUNDS LIST...DONE")
 
+        # Nothing matched anywhere: say so now, in the user's identifiers,
+        # rather than let the metagenes step fail inside R over an empty file.
+        emptyMapping = jobInstance.explainEmptyMapping(selectedCompounds)
+        if emptyMapping:
+            raise UserWarning(emptyMapping)
+
         logging.info("STEP2 - GENERATING PATHWAYS INFORMATION...")
         JobProgress.enter(jobID, "pathways")
         summary = jobInstance.generatePathwaysList()

--- a/PaintomicsServer/src/tests/test_zero_matched_omic_says_so.py
+++ b/PaintomicsServer/src/tests/test_zero_matched_omic_says_so.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""An omic that matched nothing is refused with its identifiers, not a crash in R.
+
+Measured 2026-08-27 on three real files pushed through steps 1-3 over HTTP:
+a GEO count matrix with versioned Ensembl ids (ENSMUSG00000102693.2), a PacBio
+transcript table and a human file run as mouse. All three passed step 1 as a
+success with `omicSummary {KEGG: 0}` and then step 2 failed inside
+generateMetaGenes.R -- "no lines available in input" -- because the metagenes
+step was handed an empty <omic>_matched.txt. The user read that as a
+metagenes bug; it was "nothing matched".
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_zero_matched_omic_says_so
+"""
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+os.environ.setdefault("PAINTOMICS_KEGG_DATA", tempfile.mkdtemp(prefix="kegg-"))
+os.environ.setdefault("PAINTOMICS_CLIENT_TMP", tempfile.mkdtemp(prefix="client-"))
+
+from src.classes.JobInstances.PathwayAcquisitionJob import (  # noqa: E402
+    explainEmptyMapping, hasDataRows, mappedTotal)
+
+
+def omic(name, mapped, unmapped):
+    return {"omicName": name, "omicSummary": [{"KEGG": mapped, "Total": mapped}, unmapped]}
+
+
+class ZeroMatchedOmicSaysSoTest(unittest.TestCase):
+
+    def test_mapped_total_reads_both_summary_shapes(self):
+        self.assertEqual(mappedTotal([{"KEGG": 12, "Total": 15}, 3]), 15)
+        self.assertEqual(mappedTotal([{"KEGG": 12}, 3]), 12)
+        self.assertEqual(mappedTotal([18, 4]), 18)
+        self.assertEqual(mappedTotal([{}, 0]), 0)
+        self.assertEqual(mappedTotal(None), 0)
+
+    def test_an_omic_that_matched_something_is_not_refused(self):
+        self.assertIsNone(explainEmptyMapping("mmu", [omic("Gene expression", 0, 100),
+                                                        omic("Proteomics", 5, 20)],
+                                              lambda name: []))
+
+    def test_no_gene_omic_is_not_refused(self):
+        self.assertIsNone(explainEmptyMapping("mmu", [], lambda name: []))
+
+    def test_nothing_matched_names_the_identifiers(self):
+        message = explainEmptyMapping(
+            "mmu", [omic("Gene expression", 0, 11116)],
+            lambda name: ["PB.1.1", "PB.1.2", "PB.2.1"])
+        self.assertIn("matched mmu's KEGG genes", message)
+        self.assertIn("'Gene expression' (11116 identifiers), e.g. PB.1.1, PB.1.2, PB.2.1", message)
+        self.assertIn("Check the organism", message)
+
+    def test_a_versioned_ensembl_id_gets_the_suffix_hint(self):
+        message = explainEmptyMapping(
+            "mmu", [omic("Gene expression", 0, 56953)],
+            lambda name: ["ENSMUSG00000102693.2", "ENSMUSG00000064842.3", "ENSMUSG00000051951.6"])
+        self.assertIn("Ensembl version suffix", message)
+        self.assertIn(".2 in ENSMUSG00000102693.2", message)
+
+    def test_has_data_rows(self):
+        directory = tempfile.mkdtemp(prefix="matched-")
+        try:
+            empty = os.path.join(directory, "a_matched.txt")
+            open(empty, "w").close()
+            blank = os.path.join(directory, "b_matched.txt")
+            with open(blank, "w") as handle:
+                handle.write("\n\n")
+            full = os.path.join(directory, "c_matched.txt")
+            with open(full, "w") as handle:
+                handle.write("11416\tGene expression\t1.0\n")
+            self.assertFalse(hasDataRows(empty))
+            self.assertFalse(hasDataRows(blank))
+            self.assertTrue(hasDataRows(full))
+            self.assertFalse(hasDataRows(os.path.join(directory, "missing.txt")))
+        finally:
+            shutil.rmtree(directory, ignore_errors=True)
+
+    def test_the_servlet_asks_before_the_pathways(self):
+        source = open(os.path.join(os.path.dirname(__file__), "..", "servlets",
+                                   "PathwayAcquisitionServlet.py")).read()
+        asks = source.index("jobInstance.explainEmptyMapping(selectedCompounds)")
+        pathways = source.index("summary = jobInstance.generatePathwaysList()")
+        self.assertLess(asks, pathways)
+
+    def test_the_metagenes_step_skips_an_empty_matched_file(self):
+        source = open(os.path.join(os.path.dirname(__file__), "..", "classes",
+                                   "JobInstances", "PathwayAcquisitionJob.py")).read()
+        self.assertIn("if hasDataRows(matchedFile):", source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

An omic whose identifiers match **0** KEGG genes passed Step 1 as a success (`omicSummary {KEGG: 0}`) and then Step 2 died inside `generateMetaGenes.R` with `no lines available in input`, because the metagenes step handed Rscript an empty `<omic>_matched.txt`. The user saw a metagenes failure; the cause was "nothing matched".

Found by pushing 22 real-world files from the test corpus through Steps 1–3 over HTTP: a GEO count matrix keyed by **versioned Ensembl ids** (`ENSMUSG00000102693.2`), a PacBio transcript table and a human file run as mouse all failed this way.

## Fix

- `generateMetagenesList` skips an omic whose matched file holds no row (the handler already skipped two other degenerate-data messages from R).
- Step 2 refuses **before the pathways** when every gene-based omic mapped nothing and no compound was selected, naming the omic, its identifier count and its first three identifiers — and, when all of them carry an Ensembl version suffix, saying that KEGG knows them without it.
- `mappedTotal()` is the one reading of `omicSummary`, shared with `getMappedRatios`.

## Measured

| file | before | after |
|---|---|---|
| GSE312614 (ENSMUSG…​.2) | Step 2 R crash after 12 s | 2 s: "None of the identifiers … matched mmu's KEGG genes: 'Gene expression' (56953 identifiers), e.g. ENSMUSG00000102693.2 … These carry an Ensembl version suffix (the .2 …); KEGG knows them without it" |
| tappAS PB transcripts | R crash | "… e.g. PB.1.1, PB.10.1 … Check the organism you chose and the kind of identifier" |
| human ENSG as mmu | R crash | same shape |
| ath logFC, mmu DEGs1 (controls) | Step 3 OK | Step 3 OK |

`test_zero_matched_omic_says_so.py`: 8 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)