### PR TITLE
Read both files when omics disagree on their conditions, not one at a time

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js
@@ -241,12 +241,69 @@
                 failures.push("No values matrix was produced and the manifest does not explain why.");
             }
         }
+        if (context && context.harmonise) {
+            failures = failures.concat(harmoniseFailures(context.harmonise, manifest, reports, values));
+        }
         return {
             ok: failures.length === 0,
             reports: reports,
             manifest: manifest,
             summary: failures.length ? failures.join("\n") : "All output files pass validation."
         };
+    }
+
+    /*
+     * The extra contract when several values files are converted TOGETHER so
+     * that a job's omics agree (see MAKING THE OMICS AGREE in prompts.py).
+     *
+     * The single-file grader cannot see the fault the run was refused for --
+     * every file passes on its own, they disagree with each other -- so the
+     * exit condition has to be stated here, deterministically, or the loop
+     * ends on the model's opinion that it is done: every input is answered by
+     * one values output (manifest "for": <input path>), and every values
+     * output has the same number of columns. That second rule is exactly
+     * PathwayAcquisitionJob.validateInput's, which is the check that refused
+     * the job in the first place.
+     *
+     * `harmonise.inputs` is [{path, omic}] as the sandbox saw them.
+     */
+    function harmoniseFailures(harmonise, manifest, reports, values) {
+        var failures = [];
+        var inputs = (harmonise && harmonise.inputs) || [];
+        var entries = (manifest && Array.isArray(manifest.files)) ? manifest.files : [];
+        var byInput = {};
+        entries.forEach(function (f) {
+            if (!f || !f.name || !f["for"]) return;
+            if ((reports[f.name] || {}).role !== "values") return;
+            byInput[String(f["for"])] = f.name;
+        });
+        inputs.forEach(function (input) {
+            var path = String(input.path || "");
+            var name = byInput[path] || byInput[path.replace(/^.*\//, "")];
+            if (!name) {
+                failures.push("No values file is declared for the input " + path +
+                    (input.omic ? " (" + input.omic + ")" : "") +
+                    ": every input needs one manifest entry with \"for\": \"" + path +
+                    "\" (write it back unchanged, with \"unchanged\": true, if it already has the right shape).");
+            }
+        });
+        var widths = {};
+        values.forEach(function (name) {
+            var cols = ((reports[name] || {}).summary || {}).nCols;
+            if (typeof cols !== "number") return;
+            (widths[cols] = widths[cols] || []).push(name);
+        });
+        var distinct = Object.keys(widths);
+        if (distinct.length > 1) {
+            failures.push("The values files still disagree on their number of columns: " +
+                distinct.map(function (w) {
+                    return widths[w].join(", ") + " (" + w + " columns, " + (Number(w) - 1) + " condition" +
+                           (Number(w) - 1 === 1 ? "" : "s") + ")";
+                }).join("; ") +
+                ". PaintOmics needs every omic to have the same number of condition columns; " +
+                "reduce the wider ones to the narrowest shape.");
+        }
+        return failures;
     }
 
     /*
@@ -301,7 +358,48 @@
         var history = [];
 
         var profile = options.profile || null;
-        if (!profile) {
+        /*
+         * Several inputs at once -- the values files of one job that disagree
+         * with each other. Each is profiled on its own (the profiler reads the
+         * first file it finds in /work, so it is run once per file with only
+         * that file mounted) and the model is handed the list; there is no
+         * single profile. `options.inputs` is [{key, path, omic, fileName,
+         * role, conditions}], keyed like `files`.
+         */
+        var inputs = Array.isArray(options.inputs) && options.inputs.length ? options.inputs : null;
+        var harmonise = inputs ? { inputs: inputs.map(function (i) {
+            return { path: i.path, omic: i.omic, fileName: i.fileName };
+        }) } : null;
+        if (inputs && !options.inputProfiles) {
+            step(onEvent, "profiling", "Reading your " + inputs.length + " files",
+                 "Working out each file's structure. Measurements stay on this computer; only " +
+                 "column names, counts and a few example rows describe the files.",
+                 1, maxAttempts);
+            var described = [];
+            for (var n = 0; n < inputs.length; n++) {
+                var one = {};
+                one[inputs[n].key] = files[inputs[n].key];
+                var oneRun = await sandbox.run(api.PROFILE_CODE, one);
+                var oneProfile = null;
+                if (oneRun.ok) {
+                    try { oneProfile = JSON.parse(oneRun.stdout.trim().split("\n").pop()); }
+                    catch (e) { oneProfile = null; }
+                }
+                if (!oneProfile) {
+                    emit(onEvent, { type: "failed", reason: "profile", traceback: oneRun.traceback || "The profiler returned no description." });
+                    return { ok: false, stage: "profile", traceback: oneRun.traceback || oneRun.stdout, history: history };
+                }
+                described.push(Object.assign({}, inputs[n], { profile: oneProfile }));
+                emit(onEvent, { type: "profile", profile: oneProfile, input: inputs[n] });
+            }
+            options.inputProfiles = described;
+            step(onEvent, "profiling", "Structure found", described.map(function (d) {
+                var t = (d.profile.tables || [])[0] || {};
+                var rows = t.exact ? t.exact.data_rows : t.sampled_rows;
+                return (d.omic || d.fileName) + ": " + rows + " rows × " + t.n_columns + " columns";
+            }).join(" · "), 1, maxAttempts);
+        }
+        if (!profile && !inputs) {
             step(onEvent, "profiling", "Reading your file",
                  "Working out its structure. Measurements stay on this computer; only " +
                  "column names, counts and a few example rows describe the file.",
@@ -341,6 +439,12 @@
             inputPath: options.inputPath || ("/work/" + (options.fileName || "input")),
             sampleRows: sample ? SAMPLE_ROWS : null,
             profile: profile,
+            // The list the server's build_user_message renders as "## Inputs";
+            // `key` is the sandbox's business and stays here.
+            inputs: inputs ? (options.inputProfiles || []).map(function (d) {
+                return { path: d.path, omic: d.omic, fileName: d.fileName, role: d.role || "values",
+                         conditions: d.conditions, profile: d.profile };
+            }) : undefined,
             history: history,
             answers: options.answers || {},
             instructions: options.instructions || [],
@@ -432,7 +536,7 @@
             step(onEvent, "validating", "Checking the result",
                  "Against the exact format PaintOmics accepts.", attempt, maxAttempts);
 
-            var grade = gradeOutputs(run.outputs, api, { answers: state.answers, instructions: state.instructions });
+            var grade = gradeOutputs(run.outputs, api, { answers: state.answers, instructions: state.instructions, harmonise: harmonise });
             history.push({ attempt: attempt, code: action.python, stdout: run.stdout,
                            valid: grade.ok, validation: grade.summary });
             state.history = history;
@@ -460,7 +564,7 @@
                     state.history = history;
                     continue;
                 }
-                var fullGrade = gradeOutputs(full.outputs, api, { answers: state.answers, instructions: state.instructions });
+                var fullGrade = gradeOutputs(full.outputs, api, { answers: state.answers, instructions: state.instructions, harmonise: harmonise });
                 history.push({ attempt: attempt, code: action.python, full: true,
                                stdout: full.stdout, valid: fullGrade.ok,
                                validation: fullGrade.summary });
@@ -484,7 +588,7 @@
             return { ok: true, attempts: attempt, outputs: run.outputs,
                      reports: grade.reports, manifest: grade.manifest,
                      code: action.python, stdout: run.stdout, history: history,
-                     profile: profile, answers: state.answers,
+                     profile: profile, inputProfiles: options.inputProfiles || null, answers: state.answers,
                      instructions: state.instructions };
         }
 
@@ -495,7 +599,7 @@
             reports: best ? best.reports : null,
             manifest: best ? best.manifest : null,
             code: best ? best.code : null,
-            history: history, profile: profile, answers: state.answers,
+            history: history, profile: profile, inputProfiles: options.inputProfiles || null, answers: state.answers,
             instructions: state.instructions
         };
     }

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js
@@ -306,6 +306,24 @@
         return field && field.fileInputEl ? field.fileInputEl.dom : null;
     }
 
+    /* The LIVE file input for a slot, by the field name that never changes.
+     *
+     * The DOM input does not survive a Step 1 submit: step1OnFormSubmitHandler
+     * moves the inputs into a temporary form and ExtJS's filefield re-creates
+     * fileInputEl afterwards. A drawer opened from the error dialog therefore
+     * holds a DETACHED twin of every input it was handed, and setFile on that
+     * twin writes to nothing the form will submit -- the card keeps its
+     * original file and the run fails again. Measured on the reported job:
+     * after "Submit anyway", the harmonised metabolomics file went to the twin
+     * and the live card still held the 14-column upload. So the input is
+     * resolved by name at the moment it is written, not captured when the
+     * drawer opens. */
+    function liveInputFor(fieldName) {
+        if (!fieldName || !window.Ext || !Ext.ComponentQuery) return null;
+        var field = Ext.ComponentQuery.query("filefield[name=" + fieldName + "]")[0];
+        return field && field.fileInputEl ? field.fileInputEl.dom : null;
+    }
+
     var PANEL_TYPE = {
         "gene expression": "geneexpression", "proteomics": "proteomics",
         "metabolomics": "metabolomics", "mirna-seq": "mirnaseq", "dnase-seq": "dnaseseq",
@@ -552,15 +570,40 @@
         var omicLabel = (context && context.omicType && context.omicType !== "unknown") ? context.omicType : "";
         var speciesLabel = (context && context.species && context.species !== "unknown") ? context.species : "";
 
+        /*
+         * Several files at once: the values files of ONE job that are each
+         * valid and disagree with each other on their number of conditions
+         * (see openHarmoniseDrawer). Every target keeps its own input element,
+         * file and sandbox key; the sheet is opened on the first of them.
+         */
+        var harmonise = (context && context.harmonise) || null;
+        var targets = harmonise ? harmonise.targets.map(function (t, i) {
+            return Object.assign({}, t, { key: safeName(t.file.name) || ("input" + i), bytes: null });
+        }) : [];
+        var seenKeys = {};
+        targets.forEach(function (t, i) {
+            // Two uploads may share a name; the sandbox needs distinct paths.
+            if (seenKeys[t.key]) t.key = i + "_" + t.key;
+            seenKeys[t.key] = true;
+        });
+
         // ---- header -------------------------------------------------------
         var header = el("header", "pa-convert-header");
         var mark = el("span", "pa-convert-mark");
         mark.innerHTML = typeof window.getAIMark === "function" ? window.getAIMark() : svg("thinking");
         header.appendChild(mark);
         var titles = el("div", "pa-convert-titles");
-        titles.appendChild(el("h2", "pa-convert-title", "Convert with the PaintOmics AI agent"));
+        titles.appendChild(el("h2", "pa-convert-title", harmonise
+            ? "Make the omics agree with the PaintOmics AI agent"
+            : "Convert with the PaintOmics AI agent"));
         var subject = el("p", "pa-convert-subject");
-        subject.appendChild(el("span", "pa-convert-filename", file.name));
+        if (harmonise) {
+            targets.forEach(function (t) {
+                subject.appendChild(el("span", "pa-convert-filename", t.file.name));
+            });
+        } else {
+            subject.appendChild(el("span", "pa-convert-filename", file.name));
+        }
         if (omicLabel) subject.appendChild(el("span", "pa-convert-omic", omicLabel));
         if (speciesLabel) subject.appendChild(el("span", "pa-convert-species", speciesLabel));
         titles.appendChild(subject);
@@ -853,6 +896,42 @@
         var bytes = null;
         var fileKey = safeName(file.name) || "input";
 
+        function allBytes() {
+            var f = {};
+            targets.forEach(function (t) { f[t.key] = t.bytes; });
+            return f;
+        }
+
+        /* What the agent loop needs to know about each file: where it sits
+           in the sandbox, which omic it is, and how wide the format check
+           measured it. The profiles are added by the loop itself. */
+        function harmoniseInputs() {
+            return targets.map(function (t) {
+                return { key: t.key, path: "/work/" + t.key, omic: t.omic || "",
+                         fileName: t.file.name, role: "values", conditions: t.conditions };
+            });
+        }
+
+        /* The facts the model is told up front: the refusal, when there was
+           one, and every file's width as measured here -- so it does not have
+           to infer from the profiles what the job was refused for. The rule
+           itself and how to satisfy it live in the system prompt (MAKING THE
+           OMICS AGREE). */
+        function harmoniseInstructions() {
+            var lines = [];
+            if (harmonise.serverSaid) {
+                lines.push("PaintOmics refused this job when the analysis ran. It said: " + harmonise.serverSaid);
+            }
+            lines.push("These are the values files of one run, and PaintOmics needs every one of " +
+                       "them to have the same number of condition columns. As the format check " +
+                       "measured them: " + targets.map(function (t) {
+                           return (t.omic ? t.omic + " (" + t.file.name + ")" : t.file.name) + " has " +
+                                  (t.conditions == null ? "an unknown number of condition columns"
+                                                        : plural(t.conditions, "condition column"));
+                       }).join("; ") + ".");
+            return lines;
+        }
+
         function onEvent(event) {
             if (cancelled) return;
             if (event.type === "step") {
@@ -865,6 +944,11 @@
                 pendingCode = event.code;
             } else if (event.type === "output") {
                 attachOutput(event.stdout);
+            } else if (event.type === "profile" && event.profile && event.input) {
+                // One "what the AI sees" card per input, in the order read.
+                profileShown = profileShown || event.profile;
+                anatomyHost.appendChild(renderAnatomy(event.profile,
+                    (event.input.omic ? event.input.omic + " — " : "") + event.input.fileName, providerName));
             } else if (event.type === "profile" && event.profile && !profileShown) {
                 profileShown = event.profile;
                 anatomyHost.innerHTML = "";
@@ -877,11 +961,11 @@
         provider().then(function (p) {
             if (!p || !p.success) return;
             providerName = (p.operator || p.provider || "") + (p.host ? " (" + p.host + ")" : "");
-            var meta = anatomyHost.querySelector(".pa-convert-anatomy-meta");
-            if (meta && profileShown) {
+            anatomyHost.querySelectorAll(".pa-convert-anatomy-meta").forEach(function (meta) {
+                if (!profileShown) return;
                 var chars = profileShown.description_chars ? fmtInt(profileShown.description_chars) + " characters" : "structure only";
                 meta.textContent = chars + " · sent to " + providerName;
-            }
+            });
         });
 
         async function runOnce(extra) {
@@ -894,19 +978,30 @@
                 api: api(),
                 sandbox: sandbox,
                 transport: serverTransport(),
-                files: (function () { var f = {}; f[fileKey] = bytes; return f; })(),
+                files: harmonise ? allBytes() : (function () { var f = {}; f[fileKey] = bytes; return f; })(),
+                inputs: harmonise ? harmoniseInputs() : undefined,
                 inputPath: "/work/" + fileKey,
                 fileName: file.name,
                 omicType: (context && context.omicType) || "unknown",
                 species: (context && context.species) || "unknown",
-                goal: "Convert this file into the format PaintOmics accepts, keeping every measurement it holds.",
+                goal: harmonise
+                    ? "These values files belong to one PaintOmics run and disagree on their number " +
+                      "of condition columns. Rewrite them so that they agree, keeping as much of the " +
+                      "data as possible."
+                    : "Convert this file into the format PaintOmics accepts, keeping every measurement it holds.",
                 /* When the SERVER is the one that refused, hand the agent what
                    it said. Without this the agent re-reads a file the client
                    checker already considers valid and finds nothing, because
                    the fault is one only the server can see -- a sample name
                    that does not line up with the design file, an identifier
-                   space that does not match the other omics. */
-                instructions: (input && input.__paServerSaid)
+                   space that does not match the other omics.
+
+                   The job-level conversion is the OTHER answer to the same
+                   observation: when the disagreement is between values files,
+                   every one of them is in the sandbox and the model rewrites
+                   them together, so the single-file brief below -- "you can
+                   rewrite ONLY the file you were given" -- does not apply. */
+                instructions: harmonise ? harmoniseInstructions() : (input && input.__paServerSaid)
                     ? ["PaintOmics refused this job when the analysis ran. It said: "
                        + input.__paServerSaid]
                         .concat(input.__paSiblings ? [input.__paSiblings] : [])
@@ -986,6 +1081,7 @@
             var instructions = (last.instructions || []).concat([instruction]);
             await runOnce({
                 profile: last.profile,
+                inputProfiles: last.inputProfiles || undefined,
                 instructions: instructions,
                 answers: last.answers || {},
                 accepted: last.code ? { code: last.code, manifest: last.manifest } : null
@@ -1018,7 +1114,10 @@
                 addStep({ phase: "profiling", title: "Starting the Python sandbox",
                           detail: "An isolated interpreter with no access to this page or the network." });
                 await sandbox.boot();
-                setNow("Reading your file");
+                setNow(harmonise ? "Reading your files" : "Reading your file");
+                for (var t = 0; t < targets.length; t++) {
+                    targets[t].bytes = new Uint8Array(await targets[t].file.arrayBuffer());
+                }
                 bytes = new Uint8Array(await file.arrayBuffer());
                 return await runOnce();
             } catch (err) {
@@ -1066,10 +1165,139 @@
             });
         }
 
+        /*
+         * The review of a job-level conversion: one card per omic, in the
+         * order of the form, each saying which file it started from, which
+         * output replaces it, and whether the agent left it as it was. There
+         * is nothing to choose between -- the point was to make the set
+         * agree -- so the one decision is to use the set or not.
+         */
+        function renderHarmoniseReview(result) {
+            setStage("review", "ready");
+            setNow("Ready to review");
+
+            var out = describeOutputs(result);
+            var entries = ((out.manifest && out.manifest.files) || []).filter(function (f) { return f && f.name; });
+            var forInput = {};
+            entries.forEach(function (f) { if (f["for"]) forInput[String(f["for"])] = f; });
+            var plan = targets.map(function (t) {
+                var entry = forInput["/work/" + t.key] || forInput[t.key] || forInput[t.file.name] || null;
+                var output = entry ? out.files.filter(function (f) { return f.name === entry.name; })[0] || null : null;
+                return { target: t, entry: entry, output: output };
+            });
+            var ready = plan.filter(function (p) { return p.output; });
+
+            var review = el("section", "pa-convert-review");
+            review.setAttribute("aria-label", "Review the result");
+            var head = el("div", "pa-convert-review-head");
+            head.appendChild(el("h3", "pa-convert-review-title",
+                ready.length === targets.length ? "The omics agree" : "Not every omic was answered"));
+            head.appendChild(el("span", "pa-convert-review-count",
+                plural(out.files.length, "file") + " · " + plural(result.attempts || 1, "attempt") + " · " + fmtSeconds(Date.now() - startedAt)));
+            review.appendChild(head);
+            if (out.manifest.summary) review.appendChild(el("p", "pa-convert-summary", out.manifest.summary));
+
+            plan.forEach(function (p) {
+                var unchanged = !!(p.entry && p.entry.unchanged);
+                var rcard = el("article", "pa-convert-result pa-convert-result-chosen pa-convert-target");
+                var rhead = el("header", "pa-convert-result-head");
+                var labels = el("div", "pa-convert-result-titles");
+                var title = el("div", "pa-convert-result-title");
+                title.appendChild(el("span", "pa-convert-target-omic", p.target.omic || p.target.file.name));
+                title.appendChild(document.createTextNode(" · " + p.target.file.name));
+                if (p.output && !unchanged && p.output.name !== p.target.file.name) {
+                    title.appendChild(el("span", "pa-convert-target-arrow", " → "));
+                    title.appendChild(document.createTextNode(p.output.name));
+                }
+                labels.appendChild(title);
+                var meta = p.output
+                    ? [p.output.nRows != null ? plural(p.output.nRows, "row") : null,
+                       p.output.nCols ? plural(p.output.nCols - 1, "condition") : null,
+                       (p.output.rowsIn != null && p.output.rowsOut != null && p.output.rowsIn !== p.output.rowsOut)
+                           ? fmtInt(p.output.rowsIn - p.output.rowsOut) + " rows left out" : null]
+                      .filter(Boolean).join(" · ")
+                    : "no file was produced for this omic";
+                labels.appendChild(el("div", "pa-convert-result-meta", meta));
+                rhead.appendChild(labels);
+                if (p.output) {
+                    rhead.appendChild(el("span", "pa-convert-badge", unchanged ? "Unchanged" : "Rewritten"));
+                    rhead.appendChild(iconButton("download", "Download " + p.output.name, function () {
+                        download(p.output.bytes, p.output.name);
+                    }));
+                }
+                rcard.appendChild(rhead);
+                if (p.output) {
+                    rcard.appendChild(previewTable(p.output.preview));
+                    var kept = chips("Kept", p.output.kept, "pa-convert-kept");
+                    var dropped = chips("Left out", p.output.dropped, "pa-convert-dropped");
+                    if (kept || dropped) {
+                        var cols = el("div", "pa-convert-columns");
+                        if (kept) cols.appendChild(kept);
+                        if (dropped) cols.appendChild(dropped);
+                        rcard.appendChild(cols);
+                    }
+                    if (p.output.note) rcard.appendChild(el("p", "pa-convert-result-note", p.output.note));
+                }
+                review.appendChild(rcard);
+            });
+
+            var extras = out.files.filter(function (f) {
+                return !plan.some(function (p) { return p.output === f; });
+            });
+            if (extras.length) {
+                var also = el("div", "pa-convert-extras");
+                also.appendChild(el("h4", "pa-convert-extras-title", "Also produced"));
+                extras.forEach(function (f) {
+                    also.appendChild(linkedRow(f.role === "relevant" ? "list" : "table",
+                        "<b>" + escapeHtml(f.label) + "</b>" + (f.nRows != null ? " — " + plural(f.nRows, "row") : "") +
+                        (f.note ? " (" + escapeHtml(f.note) + ")" : ""), f.bytes, f.name));
+                });
+                review.appendChild(also);
+            }
+
+            reviewHost.innerHTML = "";
+            reviewHost.appendChild(review);
+
+            var accept = el("button", "pa-convert-accept", "Use these " + plural(ready.length, "table"));
+            accept.type = "button";
+            var downloadAll = el("button", "pa-convert-dismiss", "Download all");
+            downloadAll.type = "button";
+            downloadAll.addEventListener("click", function () {
+                out.files.forEach(function (f, i) { setTimeout(function () { download(f.bytes, f.name); }, i * 150); });
+            });
+            var dismiss = el("button", "pa-convert-dismiss is-quiet", "Cancel");
+            dismiss.type = "button";
+            dismiss.addEventListener("click", cancel);
+            actions.innerHTML = "";
+            actions.appendChild(dismiss);
+            actions.appendChild(downloadAll);
+            if (ready.length === targets.length) actions.appendChild(accept);
+
+            accept.addEventListener("click", function () {
+                ready.forEach(function (p) {
+                    // A file the agent left as it was stays the user's own
+                    // upload: no provenance to record, nothing to re-check.
+                    if (p.entry && p.entry.unchanged) return;
+                    // The LIVE input, resolved now: a submit between opening the
+                    // drawer and this click will have replaced the DOM node.
+                    var input = liveInputFor(p.target.fieldName) || p.target.input;
+                    input.__paConverted = {
+                        from: p.target.file.name, original: null, fieldName: p.target.fieldName,
+                        label: p.output.label, attempts: result.attempts || 1, relevant: false,
+                        harmonised: true
+                    };
+                    setFile(input, p.output.bytes, p.output.name);
+                });
+                shutdown();
+            });
+            body.scrollTop = review.getBoundingClientRect().top - body.getBoundingClientRect().top + body.scrollTop - 10;
+        }
+
         function renderReview(result) {
             finished = true;
             freezeCurrent();
             if (!result.ok) { renderFailure(result); return; }
+            if (harmonise) { renderHarmoniseReview(result); return; }
             setStage("review", "ready");
             setNow("Ready to review");
 
@@ -1337,7 +1565,30 @@
         });
     }
 
+    /*
+     * Several values files of ONE job, converted together so that they agree.
+     *
+     * `targets` is [{input, file, fieldName, omic, conditions}] -- one per
+     * omic card, from format-panel's width guard or its error-dialog hook --
+     * and `options.serverSaid` is the server's refusal when there was one.
+     * Opened on the first target; every target's file goes into the sandbox.
+     */
+    function openHarmoniseDrawer(targets, options) {
+        var first = targets[0];
+        function fieldValue(name) {
+            if (!window.Ext || !Ext.ComponentQuery) return null;
+            var f = Ext.ComponentQuery.query("[name=" + name + "]")[0];
+            return f && f.getValue ? f.getValue() : null;
+        }
+        return openDrawer(first.input, first.file, first.fieldName, {
+            species: fieldValue("specie") || "unknown",
+            slotRole: "values",
+            harmonise: { targets: targets, serverSaid: (options && options.serverSaid) || "" }
+        });
+    }
+
     return { openDrawer: openDrawer, openConvertDrawer: openConvertDrawer,
+             openHarmoniseDrawer: openHarmoniseDrawer,
              createSandbox: createSandbox, describeOutputs: describeOutputs,
              renderAnatomy: renderAnatomy };
 });

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/InputFormat/format-panel.js
@@ -268,7 +268,10 @@
         });
     }
 
-    function setCardState(input, state) {
+    /* options.field === false: tint the card but leave the filename box
+       alone -- for a verdict about the JOB (the omics disagree) rather than
+       about this file, which is fine. */
+    function setCardState(input, state, options) {
         var component = cardComponentFor(input);
         var card = cardFor(input);
         var cardState = (state !== "err" && otherBlockedInCard(input).length) ? "err" : state;
@@ -280,6 +283,7 @@
             if (cardState) card.classList.add("pa-state-" + cardState);
         }
 
+        if (options && options.field === false) return;
         var box = filenameBoxFor(input);
         if (!box) return;
         box.classList.remove("pa-field-warn", "pa-field-err");
@@ -448,6 +452,167 @@
 
     function aiExplainer() { return AI_EXPLAINER; }
 
+    /* ------------------------------------------------------------------ *
+     * Omics that disagree on their number of conditions
+     *
+     * The per-file check passes each file on its own -- and that is the
+     * whole trouble. PathwayAcquisitionJob.validateInput fixes ONE condition
+     * count for the whole job from the first values file it reads and holds
+     * every other omic to it, so a one-column fold change beside a
+     * fourteen-column sample table is refused by the server however correct
+     * each file is. That is the 2026-08-27 guest report (job q603AOxICD):
+     * two green ticks on the form, "Expected 2 columns but found 15" from the
+     * server, and an agent that, handed either file alone, rightly found
+     * nothing to fix.
+     *
+     * So the widths are compared HERE, across the cards, the moment a second
+     * values file is checked; the cards involved say so; Run is stopped the
+     * way a known-bad file stops it; and the one action offered is the one
+     * that can fix a disagreement between files -- handing them to the agent
+     * together (openHarmoniseDrawer), not one at a time.
+     * ------------------------------------------------------------------ */
+
+    /* How many conditions the server will count for a checked values file:
+       every column after the identifier, or after chr/start/end. */
+    function conditionsOf(summary) {
+        if (!summary || typeof summary.nCols !== "number") return null;
+        return Math.max(0, summary.nCols - (summary.regionBased ? 3 : 1));
+    }
+
+    /* Remembered on the Ext filefield COMPONENT, against the file name, so a
+       file the user swaps out never speaks for the one that replaced it.
+       On the component and not on the DOM input, because the DOM input does
+       not survive a submit: step1OnFormSubmitHandler moves the inputs into a
+       temporary form and ExtJS's filefield re-creates its input afterwards,
+       so a record on the element was gone by the time the server's refusal
+       came back -- measured in Chrome: files still in every slot, and not
+       one width record left. Same reason `blocked` is keyed by field name. */
+    function recordConditions(input, file, summary) {
+        var conditions = conditionsOf(summary);
+        var record = (conditions === null) ? null
+            : { fileName: file.name, conditions: conditions };
+        var field = extFieldFor(input);
+        if (field) field.__paConditions = record;
+        input.__paConditions = record;
+    }
+
+    function forgetConditions(input) {
+        var field = extFieldFor(input);
+        if (field) field.__paConditions = null;
+        input.__paConditions = null;
+    }
+
+    /* Every values slot that holds a checked file, live. */
+    function valuesEntries() {
+        var entries = [];
+        if (!window.Ext || !Ext.ComponentQuery) return entries;
+        Ext.ComponentQuery.query("filefield").forEach(function (field) {
+            if (roleForField(field) !== "values") return;
+            var dom = field.fileInputEl && field.fileInputEl.dom;
+            var file = dom && dom.files && dom.files[0];
+            var record = field.__paConditions || (dom && dom.__paConditions);
+            if (!file || !record || record.fileName !== file.name) return;
+            entries.push({ input: dom, file: file, fieldName: field.name,
+                           omic: omicNameFor(dom, field.name), conditions: record.conditions });
+        });
+        return entries;
+    }
+
+    /* The entries, when they do not all agree; nothing otherwise. Pure over
+       its argument so the rule can be tested without a form. */
+    function widthDisagreement(entries) {
+        entries = entries || valuesEntries();
+        var seen = {};
+        entries.forEach(function (e) { seen[e.conditions] = true; });
+        return Object.keys(seen).length > 1 ? entries : [];
+    }
+
+    /* "Proteomics (vp_fc_values.tab) has 1 condition; Metabolomics
+       (lipidomica_samples.tab) has 14." */
+    function describeWidths(entries) {
+        return entries.map(function (e) {
+            return e.omic + " (" + e.file.name + ") has " + plural(e.conditions, "condition");
+        }).join("; ") + ".";
+    }
+
+    var HARMONISE_LABEL = "Make them agree with the PaintOmics AI agent";
+
+    function harmoniseButton(entries, serverSaid) {
+        var button = el("button", "pa-format-button pa-format-primary");
+        button.type = "button";
+        if (typeof window.getAIMark === "function") {
+            button.innerHTML = window.getAIMark();
+            button.appendChild(document.createTextNode(" " + HARMONISE_LABEL));
+        } else {
+            button.textContent = HARMONISE_LABEL;
+        }
+        button.addEventListener("click", function () { requestHarmonise(entries, serverSaid); });
+        return button;
+    }
+
+    /* Layer 2, for the job rather than for one file. */
+    function requestHarmonise(entries, serverSaid) {
+        var api = window.PaintomicsInputFormat;
+        if (api && api.openHarmoniseDrawer) {
+            api.openHarmoniseDrawer(entries.map(function (e) {
+                return { input: e.input, file: e.file, fieldName: e.fieldName,
+                         omic: e.omic, conditions: e.conditions };
+            }), { serverSaid: serverSaid || "" });
+            return;
+        }
+        var strip = hostFor(entries[0].input);
+        if (!strip) return;
+        renderProblem(strip, "err", "AI conversion is not enabled on this server.",
+            "Ask an administrator to enable it, or reduce the wider omic to the same " +
+            "conditions as the narrower one by hand.", []);
+    }
+
+    /* The note under a green verdict: this file's width, the others', and
+       the offer. */
+    function widthNote(entry, entries) {
+        var others = entries.filter(function (o) {
+            return o.input !== entry.input && o.conditions !== entry.conditions;
+        });
+        var note = el("div", "pa-format-width");
+        var text = el("div", "pa-format-detail");
+        text.appendChild(el("b", null, "⚠ " + plural(entry.conditions, "condition") + " here"));
+        text.appendChild(document.createTextNode(", " + others.map(function (o) {
+            return plural(o.conditions, "condition") + " in " + o.omic;
+        }).join(", ") + ". PaintOmics paints every omic on one set of conditions, so the " +
+        "server would refuse this run."));
+        note.appendChild(text);
+        var bar = el("div", "pa-format-actions");
+        bar.appendChild(harmoniseButton(entries, null));
+        note.appendChild(bar);
+        return note;
+    }
+
+    /*
+     * Re-read every card's width and say, on every card involved, whether
+     * they agree. Called after every check, because ONE file changing can
+     * put every other card in or out of agreement; the notes are rebuilt
+     * from live data each time rather than patched.
+     */
+    function syncWidthNotes() {
+        var entries = valuesEntries();
+        var disagree = widthDisagreement(entries);
+        entries.forEach(function (e) {
+            var component = cardComponentFor(e.input);
+            var host = component && component.down && component.down("[itemId=paFormatHost]");
+            var strip = host && host.getEl && host.getEl() && host.getEl().dom.firstChild;
+            if (!strip) return;
+            var old = strip.querySelector(".pa-format-width");
+            if (old) old.remove();
+            // Only a green strip carries the note: a card with a fault of its
+            // own already has a message, and the fault comes first.
+            if (!strip.classList.contains("pa-format-ok")) return;
+            var body = strip.querySelector(".pa-format-body");
+            if (disagree.length && body) body.appendChild(widthNote(e, disagree));
+            setCardState(e.input, disagree.length ? "warn" : "ok", { field: false });
+            syncCardHeight(e.input);
+        });
+    }
+
     /* What an accepted file is worth saying about it, per contract.
      *
      * Only the values summary carries numericColumns and idSample; a design
@@ -514,6 +679,7 @@
             var extras = [];
             if (converted.label) extras.push("table “" + converted.label + "”");
             if (converted.relevant) extras.push("relevant-features list attached");
+            if (converted.harmonised) extras.push("brought to the same conditions as the other omics");
             if (extras.length) what.appendChild(document.createTextNode(" (" + extras.join(", ") + ")"));
             what.appendChild(document.createTextNode("."));
             if (converted.original) {
@@ -745,6 +911,10 @@
         };
         var strip = hostFor(input);
         if (!strip) return;
+        // Whatever this slot used to hold no longer counts against the other
+        // cards' widths; the new file is counted once it has passed.
+        forgetConditions(input);
+        syncWidthNotes();
         strip.__input = input;
         strip.__field = fieldName;
         strip.__omic = omicNameFor(input, fieldName);
@@ -794,7 +964,9 @@
             var result = validate(read.rows);
             if (result.ok) {
                 clearBlocked(fieldName);
+                if (role === "values") recordConditions(input, file, result.summary);
                 renderOk(strip, result.summary, partial, input);
+                syncWidthNotes();
                 return;
             }
 
@@ -827,7 +999,10 @@
             var applyRepair = function () {
                 replaceFile(input, repaired.rows, file.name);
                 clearBlocked(fieldName);
-                renderOk(hostFor(input), validate(repaired.rows).summary, false, input);
+                var repairedSummary = validate(repaired.rows).summary;
+                if (role === "values") recordConditions(input, file, repairedSummary);
+                renderOk(hostFor(input), repairedSummary, false, input);
+                syncWidthNotes();
             };
 
             if (fixable) {
@@ -991,15 +1166,58 @@
         if (!target.closest("#submitButton")) return;
 
         var entries = liveBlocked();
-        if (!entries.length) return;
+        // A job whose omics disagree on their conditions is as certain a
+        // refusal as a file the server will reject; it is only reported once
+        // every file is individually fine, because a file fault comes first.
+        var widths = entries.length ? [] : widthDisagreement();
+        if (!entries.length && !widths.length) return;
 
         // stopImmediatePropagation, not just preventDefault: the submit is
         // wired as a jQuery/ExtJS click handler on the same element, and
         // preventDefault alone would let it run.
         event.preventDefault();
         event.stopImmediatePropagation();
-        renderBlockBanner(entries);
+        if (entries.length) renderBlockBanner(entries);
+        else renderWidthBanner(widths);
     }, true);
+
+    /* The submit-time banner for omics that disagree on their conditions:
+       the same shape as renderBlockBanner, with the job-level offer. */
+    function renderWidthBanner(entries) {
+        var input = entries[0].input;
+        var region = regionFor(input);
+        if (!region) return;
+
+        var existing = region.querySelector(".pa-format-block");
+        if (existing) existing.remove();
+
+        var banner = el("div", "pa-format-strip pa-format-err pa-format-block");
+        banner.appendChild(el("span", "pa-format-icon", "✗"));
+        var body = el("div", "pa-format-body");
+        body.appendChild(el("div", "pa-format-headline",
+            "These omics do not have the same number of conditions, so the server will refuse this run."));
+        body.appendChild(el("div", "pa-format-detail",
+            describeWidths(entries) + " PaintOmics paints every omic on one set of conditions: " +
+            "every values file needs the same number of columns, meaning the same things, in the " +
+            "same order. The PaintOmics AI agent can read these files together and bring the wider " +
+            "ones to the narrower one's shape -- you see what it computed before anything is used."));
+
+        var bar = el("div", "pa-format-actions");
+        bar.appendChild(harmoniseButton(entries, null));
+        var anyway = el("button", "pa-format-button", "Submit anyway");
+        anyway.type = "button";
+        anyway.addEventListener("click", function () {
+            banner.remove();
+            submitNow();
+        });
+        bar.appendChild(anyway);
+
+        body.appendChild(bar);
+        banner.appendChild(body);
+        region.appendChild(banner);
+        relayout(input);
+        banner.scrollIntoView({ block: "center", behavior: "smooth" });
+    }
 
     /* ------------------------------------------------------------------ *
      * The same offer, on the error the server sends back
@@ -1190,24 +1408,48 @@
            card is identifiable even though the file is not. Underscores because
            the backend substitutes them for spaces. */
         if (!picked) picked = pickedFileForOmicNamedIn(text);
-        if (!picked) return;
 
-        /* Two different offers, because they do different things and the
-           difference matters. Re-checking applies a MECHANICAL repair and is
-           only useful when the fault is one this module models. The agent can
-           be told what the server said, which is the only route open when the
-           server knows something the client checker does not -- a sample name
-           that does not line up, an identifier space that does not match. */
+        /* The refusal that is about the JOB, not about a file: the omics do
+           not have the same number of conditions. The server names the rule
+           now ("same number of conditions"); older servers say it ten times
+           as "Expected 2 columns but found 15". Either way the file it names
+           is fine, and handing that one file to the agent is exactly the
+           request that came back "nothing to fix" -- so when the cards
+           confirm the disagreement, the offer is the job-level one. */
+        var widths = /same number of conditions|expected \d+ columns but found \d+/i.test(text)
+            ? widthDisagreement() : [];
+        if (!picked && !widths.length) return;
+
+        /* One offer. There used to be two -- "Check this file again", which
+           re-ran the mechanical repair, beside the agent -- and the re-check
+           could never help from here: a file with a repairable fault is
+           stopped before submit, so a dialog can only be reached past it by
+           "Submit anyway", when the user has already declined the repair. Two
+           green buttons that do different things for the same file read as a
+           duplicate, and were reported as one. */
         var wrap = el("span", null, null);
         wrap.id = "pa-format-dialog-fix";
 
-        var ask = el("a", "button btn-secondary btn-right", "Ask the PaintOmics AI agent");
-        ask.title = "Opens the agent on this file, with what the server said.";
+        var ask = el("a", "button btn-secondary pa-dialog-ai");
+        if (typeof window.getAIMark === "function") {
+            ask.innerHTML = window.getAIMark();
+            ask.appendChild(document.createTextNode(" Ask the PaintOmics AI agent"));
+        } else {
+            ask.textContent = "Ask the PaintOmics AI agent";
+        }
+        ask.title = widths.length
+            ? "Opens the agent on every values file of this run together, with what the server said."
+            : "Opens the agent on this file, with what the server said.";
         ask.href = "#";
         ask.style.display = "inline-block";
         ask.addEventListener("click", function (event) {
             event.preventDefault();
             var serverSaid = text.replace(/\s+/g, " ").trim();
+            if (widths.length) {
+                if (typeof closeButton.click === "function") closeButton.click();
+                requestHarmonise(widths, serverSaid);
+                return;
+            }
             // Gathered BEFORE the dialog closes, while every field still holds
             // its file, so the agent starts with the whole job in front of it
             // rather than one file out of context.
@@ -1218,19 +1460,11 @@
             });
         });
 
-        var again = el("a", "button btn-secondary btn-right", "Check this file again");
-        again.title = "Re-reads the file and repairs what can be repaired mechanically.";
-        again.href = "#";
-        again.style.display = "inline-block";
-        again.addEventListener("click", function (event) {
-            event.preventDefault();
-            if (typeof closeButton.click === "function") closeButton.click();
-            check(picked.input, picked.file, picked.fieldName, true);
-        });
-
-        wrap.appendChild(again);
         wrap.appendChild(ask);
-        closeButton.parentNode.insertBefore(wrap, closeButton);
+        // First in the row: it is the action that resolves the dialog, and
+        // Report error / Close are the standing furniture.
+        var actions = closeButton.parentNode;
+        actions.insertBefore(wrap, actions.firstChild);
     }
 
     // The dialog is rendered by Util.js's showMessage, which several call sites
@@ -1298,13 +1532,27 @@
     if (typeof MutationObserver === "function") {
         var observer = new MutationObserver(function (records) {
             var found = [];
+            var removed = false;
             records.forEach(function (r) {
+                // A deleted card takes its width out of the comparison; the
+                // notes on the cards that stay are rebuilt from what is left.
+                r.removedNodes.forEach(function (n) {
+                    if (n.nodeType !== 1) return;
+                    if ((n.matches && n.matches(".omicbox")) ||
+                        (n.querySelector && n.querySelector(".omicbox"))) removed = true;
+                });
                 r.addedNodes.forEach(function (n) {
                     if (n.nodeType !== 1) return;
                     if (n.matches && n.matches(".omicbox")) found.push(n);
                     if (n.querySelectorAll) n.querySelectorAll(".omicbox").forEach(function (c) { found.push(c); });
                 });
             });
+            if (removed) {
+                (window.paDeferFrame || requestAnimationFrame)(function () {
+                    try { syncWidthNotes(); }
+                    catch (e) { if (window.console && console.warn) console.warn("[inputformat] width sync failed", e); }
+                });
+            }
             if (!found.length) return;
             /* paDeferFrame, not a bare requestAnimationFrame: Chrome throttles
                rAF to zero in a hidden tab, and a card primed in a bare frame

--- a/PaintomicsClient/public_html/app/view/common/Util.js
+++ b/PaintomicsClient/public_html/app/view/common/Util.js
@@ -520,7 +520,9 @@ function showMessage(title, data) {
             $("#messageDialogTitle").html(title);
         }
         $("#messageDialogBody").html(message.replace(/\n/g, "</br>"));
-        $("#hiddenMessageDialogBody").text(extra);
+        // `hidden` is the half of a server message that is for the log rather
+        // than the reader (see splitServerError); it travels with the report.
+        $("#hiddenMessageDialogBody").text([data.hidden || "", extra].filter(Boolean).join("\n"));
 
         // The bar replaces the spinner rather than joining it - two things
         // moving at once to say the same "still working" is noise.
@@ -619,9 +621,13 @@ function showMessage(title, data) {
                 '   </div>' +
                 ' </div>' +
                 ' <p id="messageDialogSpin" ><img src="resources/images/loadingpaintomics2.gif"></img></p>' +
-                ' <div style="text-align:center; margin-top:10px;">' +
-                '   <a id="reportErrorButton" class="button btn-warning" id="messageDialogButton"><i class="fa fa-bug"></i> Report error</a>' +
-                '   <a id="messageDialogButton" class="button btn-default" id="messageDialogButton">Close</a>' +
+                // A flex row (main.css .messageDialogActions), not a centred
+                // run of floats: with a third action -- the AI offer that
+                // format-panel.js adds on a file error -- the floats wrapped
+                // into a ragged 2x2 block with the offer on its own line.
+                ' <div id="messageDialogActions" class="messageDialogActions">' +
+                '   <a id="reportErrorButton" class="button btn-warning"><i class="fa fa-bug"></i> Report error</a>' +
+                '   <a id="messageDialogButton" class="button btn-default">Close</a>' +
                 " </div>" +
                 "</div>",
             listeners: {
@@ -796,14 +802,40 @@ function ajaxErrorHandler(responseObj) {
     var serverSide = !!(err.extra && (err.extra.file_name || err.extra.exc_type));
     var adminLink = "If the error persists, please contact the " +
         "<a href='mailto:paintomicsai@gmail.com' target='_blank'> administrator</a>.";
+    var halves = splitServerError(err.message);
 
     showErrorMessage("Oops..Internal error!", {
-        message: err.message + "</br>" + (serverSide
+        message: halves.readable + "</br>" + (serverSide
             ? "This happened on the server, so retrying in the browser will not help. " + adminLink
             : "Try running it in private mode or clear your web cache in your browser.</br>" + adminLink),
         extra: err.extra,
+        hidden: halves.technical,
         showButton: true
     });
+}
+
+/*
+ * The two halves of a servlet error.
+ *
+ * ServerErrorManager prefixes every message with where it was raised --
+ *
+ *     Exception: AT PathwayAcquisitionServlet.py: pathwayAcquisitionStep1_PART2.
+ *     ERROR MESSAGE: Errors detected in input files, ...
+ *
+ * -- which is for the log. The dialog printed the whole line, so the person
+ * who pressed Run read a Python file name and a function before the sentence
+ * that was written for them (the 2026-08-27 screenshot opens with exactly
+ * that). The readable half goes on screen; the prefix goes to the hidden body
+ * that "Report error" already sends, so the report loses nothing. Same split
+ * UserController, JobController and convert-drawer already make on their own
+ * paths.
+ */
+function splitServerError(message) {
+    var raw = String(message || "");
+    var at = raw.indexOf("ERROR MESSAGE:");
+    if (at === -1) return { readable: raw, technical: "" };
+    return { readable: raw.slice(at + "ERROR MESSAGE:".length).trim() || raw,
+             technical: raw.slice(0, at).trim() };
 }
 
 function extJSErrorHandler(form, responseObj) {
@@ -827,8 +859,10 @@ function extJSErrorHandler(form, responseObj) {
         return;
     }
 
+    var halves = splitServerError(err.message);
     showErrorMessage("Oops..Internal error!", {
-        message: err.message + "</br>Please try again later.</br>If the error persists, please contact your web <a href='mailto:paintomicsai@gmail.com' target='_blank'> administrator</a>.",
+        message: halves.readable + "</br>Please try again later.</br>If the error persists, please contact your web <a href='mailto:paintomicsai@gmail.com' target='_blank'> administrator</a>.",
+        hidden: halves.technical,
         showButton: true
     });
 }

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,9 +39,9 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.71" />
-	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.14" />
-	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.5" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.72" />
+	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.15" />
+	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.6" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.7" />
 	<!-- Shared chrome for both of Step 3's graph surfaces. Before more-network.css,
 	     which layers this view's own legend and layout on top of it. -->
@@ -127,7 +127,7 @@
 	<!--SCRIPTS FOR SERVER CONNECTION CONFIGURATION-->
 	<script type="text/javascript" src="resources/ServerConfiguration.js?v=1.5"></script>
 	<!--CUSTOM SENCHA EXTENSIONS-->
-	<script type="text/javascript" src="app/view/common/Util.js?v=2.3"></script>
+	<script type="text/javascript" src="app/view/common/Util.js?v=2.4"></script>
 	<script type="text/javascript" src="app/view/common/ExtJS_extensions.js?v=0.7"></script>
 	<script type="text/javascript" src="app/view/common/OrganismSearch.js?v=1.0"></script>
 	<script type="text/javascript" src="app/view/common/upload/Panel.js?v=0.2"></script>
@@ -141,11 +141,11 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-reader.js?v=0.1"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-validator.js?v=0.2"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-repair.js?v=0.1"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=3.1"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-panel.js?v=3.3"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/format-roles.js?v=0.5"></script>
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js?v=0.3"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.6"></script>
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=1.4"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js?v=0.7"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js?v=1.6"></script>
 	<!--MORE REGULATOR–TARGET NETWORK VIEW -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3RegTargetNetworkView.js?v=0.7"></script>
 	<!--OMNIPATH PATHWAY NETWORK VIEW (OmniPath ships no diagram; its pathways render as graphs) -->

--- a/PaintomicsClient/public_html/resources/css/inputconvert.css
+++ b/PaintomicsClient/public_html/resources/css/inputconvert.css
@@ -1012,3 +1012,8 @@
     top: 0;
     border: 0;
 }
+
+/* The job-level review: one card per omic, titled by the omic first, then
+   the file it started from and the file that replaces it. */
+.pa-convert-target-omic { color: var(--cv-omic, var(--pa-accent-blue, #19589E)); }
+.pa-convert-target-arrow { color: var(--pa-ink-muted, #595959); font-weight: 400; }

--- a/PaintomicsClient/public_html/resources/css/inputformat.css
+++ b/PaintomicsClient/public_html/resources/css/inputformat.css
@@ -385,3 +385,23 @@ input[type="text"].pa-field-err {
     .po-upload-ai-specs { flex-direction: column; align-items: flex-start; gap: 12px; }
     .po-upload-ai a.po-download-example { margin-left: 0; }
 }
+
+/* ------------------------------------------------------------------------
+   Omics that disagree on their number of conditions.
+
+   Each file is fine; the job is not. PaintOmics paints every omic on one set
+   of conditions, so a one-column fold change beside a fourteen-column sample
+   table is refused by the server however correct each file is. The note sits
+   under the green verdict of every card involved, in the warning colour, and
+   carries the one action that can fix a disagreement BETWEEN files: handing
+   them to the agent together.
+   ------------------------------------------------------------------------ */
+.pa-format-width {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px dashed var(--pa-border, #D4D4D8);
+}
+.pa-format-width .pa-format-detail {
+    color: var(--pa-accent-orange, #AD5022);
+}
+.pa-format-width .pa-format-actions { margin-top: 8px; }

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -2589,6 +2589,28 @@ body > .x-mask {
 }
 #messageDialog .button{float: none;}
 
+/* The dialog's button row. It was a centred inline run of floated buttons,
+   which wrapped into a ragged 2x2 block the moment a third action was added:
+   format-panel.js puts the AI offer on a file error, and it landed on its own
+   line under "Report error", aligned to nothing. A flex row keeps every action
+   on one line while there is room and wraps them evenly when there is not, and
+   DOM order is display order, so the offer can go first. */
+#messageDialog .messageDialogActions {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	align-items: center;
+	gap: 8px;
+	margin-top: 14px;
+}
+#messageDialog .messageDialogActions .button {
+	margin: 0;
+}
+#messageDialog .messageDialogActions .po-ai-mark {
+	margin-right: 4px;
+	vertical-align: -0.15em;
+}
+
 /** SIGMA TOOLTIP OPTIONS **/
 .sigma-tooltip {
 	width: 200px;

--- a/PaintomicsServer/src/classes/InputConvert/prompts.py
+++ b/PaintomicsServer/src/classes/InputConvert/prompts.py
@@ -27,7 +27,10 @@ It is Python, not JSON: write True, False and None, never true, false or
 null, and build /out/manifest.json with json.dump.
 
 The input is ONE FILE, and its exact path is given below under "Input path".
-That path is a file, not a directory -- do not append anything to it.
+That path is a file, not a directory -- do not append anything to it. When the
+message lists SEVERAL inputs instead (a "## Inputs" section), read the section
+MAKING THE OMICS AGREE below: every listed path is a file, and you write one
+output for each.
 
 Return ONE JSON object, nothing else, matching one of these three shapes:
 
@@ -269,6 +272,47 @@ in real user data.
   treat the first data column as the identifier. European CSVs use ";" as the
   separator and "," as the decimal mark (sep=";", decimal=",").
 
+MAKING THE OMICS AGREE (several inputs)
+
+When the message lists several inputs, they are the values files of the omics
+of ONE PaintOmics run, and the run was refused because PaintOmics paints every
+omic on the same conditions: every values file must have the SAME NUMBER of
+condition columns, with column k meaning the same condition in every file.
+Each file is valid on its own -- the format check passed all of them -- so do
+not look for a fault inside one file. They disagree with EACH OTHER, and your
+job is to rewrite them so that they agree, losing as little as possible:
+
+- Find the omic with the FEWEST condition columns and what those columns mean:
+  one fold change or ratio for one contrast; a log fold change per contrast;
+  one mean per condition; one value per replicate sample.
+- Bring every wider omic to THAT shape by DERIVING the same quantities from
+  its own columns. Deriving is allowed here, and only here: the mean of a
+  condition's replicates; the ratio of two condition means when the narrow
+  omic holds plain ratios (values around 1, all positive); log2 of that ratio
+  when it holds log fold changes (values around 0, signed). Use group means the
+  file already carries (media_c, mean_T, avg_ctrl ...) before computing any,
+  and take the direction (treated over control) from the narrow omic's own
+  header when it says. Say exactly what you computed, and from which columns,
+  in the file's note and in the summary.
+- Never widen the narrow omic: no nan padding, no duplicated columns, no
+  invented condition. Never rescale a file that already has the right shape --
+  the narrowest omic is normally written back UNCHANGED, and you say so.
+- Name the output condition columns identically across the files (the same
+  "T_vs_C" in every file), in the same order.
+- Ask (a "question" action) when the data cannot settle it: which samples
+  form which group when the names do not say; which direction the contrast
+  runs when neither header says; which conditions correspond when two
+  per-sample omics have different sample sets. Put the option the headers
+  suggest first. Two per-sample omics with different numbers of samples cannot
+  be aligned by sample: reduce both to one mean per condition and say so, or
+  ask when the conditions do not correspond.
+
+Write ONE values file per input, and give every manifest entry the input it
+replaces: "for": "<that input's path exactly as listed>". An input you leave
+as it is still gets an entry and is still written to /out/ unchanged, with
+"unchanged": true. Every output must have the same number of columns; the
+validator refuses the set until they do, and tells you which one differs.
+
 You will be told what went wrong after each attempt: a Python traceback, or the
 validator's report on the files you produced. Fix the specific problem named.
 """
@@ -289,11 +333,30 @@ def build_user_message(state):
     # instead: the instruction never reached the model at all.
     if state.get("goal"):
         parts.append("goal: %s" % state["goal"])
-    if state.get("inputPath"):
-        parts.append("Input path: %s" % state["inputPath"])
-    parts += ["omic type: %s" % state.get("omicType", "unknown"),
-              "species: %s" % state.get("species", "unknown"),
-              "file name: %s" % state.get("fileName", "unknown")]
+    # Several inputs: the values files of one job that disagree with each
+    # other (see MAKING THE OMICS AGREE in the system prompt). Each is listed
+    # with the omic it belongs to and its own profile; there is no single
+    # "Input path" and no single "What the file looks like".
+    inputs = [i for i in (state.get("inputs") or []) if isinstance(i, dict)]
+    if inputs:
+        parts.append("species: %s" % state.get("species", "unknown"))
+        parts += ["", "## Inputs (%d files of one run; read MAKING THE OMICS AGREE)" % len(inputs)]
+        for k, entry in enumerate(inputs, 1):
+            width = entry.get("conditions")
+            parts += ["", "### Input %d: %s" % (k, entry.get("path", "?")),
+                      "omic: %s" % entry.get("omic", "unknown"),
+                      "file name: %s" % entry.get("fileName", "unknown"),
+                      "role: %s" % entry.get("role", "values")]
+            if width is not None:
+                parts.append("condition columns: %s" % width)
+            parts += ["What it looks like:",
+                      json.dumps(entry.get("profile", {}), indent=1)[:24000]]
+    else:
+        if state.get("inputPath"):
+            parts.append("Input path: %s" % state["inputPath"])
+        parts += ["omic type: %s" % state.get("omicType", "unknown"),
+                  "species: %s" % state.get("species", "unknown"),
+                  "file name: %s" % state.get("fileName", "unknown")]
 
     instructions = [str(i).strip() for i in (state.get("instructions") or []) if str(i).strip()]
     if instructions:
@@ -310,8 +373,9 @@ def build_user_message(state):
         if accepted.get("manifest"):
             parts += ["Its manifest:", json.dumps(accepted["manifest"])[:3000]]
 
-    parts += ["", "## What the file looks like",
-              json.dumps(state.get("profile", {}), indent=1)[:60000]]
+    if not inputs:
+        parts += ["", "## What the file looks like",
+                  json.dumps(state.get("profile", {}), indent=1)[:60000]]
 
     answers = state.get("answers") or {}
     if answers:

--- a/PaintomicsServer/src/classes/JobInstances/PathwayAcquisitionJob.py
+++ b/PaintomicsServer/src/classes/JobInstances/PathwayAcquisitionJob.py
@@ -495,6 +495,9 @@ class PathwayAcquisitionJob(Job):
         error = ""
 
         nConditions = -1
+        # Which omic fixed nConditions for the whole job. A file that disagrees
+        # with it is told so by name -- see _conditionsDisagreement.
+        self._conditionsFixedBy = None
 
         # Establish nConditions from the first available data file
         all_omics = self.geneBasedInputOmics + self.compoundBasedInputOmics
@@ -519,6 +522,7 @@ class PathwayAcquisitionJob(Job):
                                 try:
                                     float(line[1])
                                     nConditions = len(line)
+                                    self._rememberConditionsFixedBy(inputOmic, nConditions)
                                     break
                                 except ValueError:
                                     continue
@@ -539,6 +543,49 @@ class PathwayAcquisitionJob(Job):
                 "[b]Errors detected in input files, please fix the following issues and try again:[/b][br]" + error)
 
         return True
+
+    def _rememberConditionsFixedBy(self, inputOmic, nConditions):
+        """Record the omic whose values file set the job-wide condition count."""
+        self._conditionsFixedBy = {
+            "omicName": inputOmic.get("omicName") or "the first omic",
+            "file": inputOmic.get("inputDataFile") or "",
+            "nConditions": nConditions,
+        }
+
+    @staticmethod
+    def _conditionCount(nColumns):
+        """'1 condition column' / '14 condition columns' from a line width."""
+        conditions = max(0, int(nColumns) - 1)
+        return "%d condition column%s" % (conditions, "" if conditions == 1 else "s")
+
+    def _conditionsDisagreement(self, inputOmic, fileWidth):
+        """The one sentence a uniformly-wider (or narrower) omic is refused with.
+
+        PaintOmics paints every omic on ONE set of conditions, so validateInput
+        fixes nConditions from the first values file it reads and every other
+        omic must match it. A job whose omics are individually well-formed but
+        of different widths -- one fold-change column beside twelve samples and
+        two means, the shape of the 2026-08-27 guest report -- used to be
+        refused with ten copies of "Line N: Expected 2 columns but found 15",
+        which names neither the rule nor the omic the 2 came from. The reader
+        was left to guess which file was "wrong", when neither is: they
+        disagree with each other.
+
+        Returns None when the disagreement is not with ANOTHER omic (the width
+        was fixed by this very file, so the file is ragged and the per-line
+        report is the right one), or when nothing fixed it at all.
+        """
+        fixedBy = getattr(self, "_conditionsFixedBy", None)
+        if not fixedBy or fixedBy.get("file") == inputOmic.get("inputDataFile"):
+            return None
+        return ("Every omic in one run must have the same number of conditions: "
+                "[b]" + str(fixedBy["omicName"]) + "[/b] (" + str(fixedBy["file"]) + ") has "
+                + self._conditionCount(fixedBy["nConditions"]) + ", but [b]"
+                + str(inputOmic.get("omicName") or "this omic") + "[/b] ("
+                + str(inputOmic.get("inputDataFile") or "") + ") has "
+                + self._conditionCount(fileWidth) + ". Bring them to the same "
+                "conditions -- for instance one fold change per contrast in both -- "
+                "or run them as separate analyses.\n")
 
     def validateFile(self, inputOmic, nConditions, error):
         """
@@ -698,6 +745,11 @@ class PathwayAcquisitionJob(Job):
             with open(valuesFileName, newline='', encoding='utf-8-sig' ) as inputDataFile:
                 nLine = -1
                 erroneousLines = {}
+                # The width faults on their own, and every width this file's
+                # data lines had, so that a file that is uniformly a different
+                # width from the job can be told apart from a ragged one.
+                widthFaults = {}
+                widthsSeen = set()
                 for line in csv_reader(inputDataFile, delimiter=values_delimiter):
                     nLine = nLine + 1
                     # TODO: HACER ALGO CON EL HEADER?
@@ -715,6 +767,7 @@ class PathwayAcquisitionJob(Job):
                             erroneousLines[nLine] = "Expected at least 2 columns, but found one."
                             break
                         nConditions = len(line)
+                        self._rememberConditionsFixedBy(inputOmic, nConditions)
 
                     # *************************************************************************
                     # STEP 2.2 CHECK IF IT EXCEEDS THE MAX NUMBER OF FEATURES ALLOWED
@@ -728,9 +781,12 @@ class PathwayAcquisitionJob(Job):
                     # **************************************************************************************
                     # STEP 2.3 IF LINE LENGTH DOES NOT MATCH WITH EXPECTED NUMBER OF CONDITIONS, ADD ERROR
                     # **************************************************************************************
+                    if len(line) > 0:
+                        widthsSeen.add(len(line))
                     if nConditions != len(line) and len(line) > 0:
-                        erroneousLines[nLine] = "Expected " + str(nConditions) + " columns but found " + str(
+                        widthFaults[nLine] = "Expected " + str(nConditions) + " columns but found " + str(
                             len(line)) + ";"
+                        erroneousLines[nLine] = widthFaults[nLine]
 
                     # **************************************************************************************
                     # STEP 2.4 IF CONTAINS NOT VALID VALUES, ADD ERROR
@@ -749,6 +805,23 @@ class PathwayAcquisitionJob(Job):
                         break
 
             inputDataFile.close()
+
+            # A file whose every line (of the ten read before the cap) is the
+            # SAME width, and that width is not the job's, is not a broken
+            # file: it is a well-formed omic that disagrees with another one.
+            # Say that once, by name, instead of ten times by line number. A
+            # file whose widths vary is ragged and keeps the per-line report;
+            # so does a value fault on any of those lines.
+            if widthFaults and len(widthsSeen) == 1:
+                disagreement = self._conditionsDisagreement(inputOmic, next(iter(widthsSeen)))
+                if disagreement is not None:
+                    for k, fault in widthFaults.items():
+                        rest = erroneousLines.get(k, "").replace(fault, "", 1)
+                        if rest.strip():
+                            erroneousLines[k] = rest
+                        else:
+                            erroneousLines.pop(k, None)
+                    error += disagreement
 
             # *************************************************************************
             # STEP 3. CHECK THE ERRORS AND RETURN

--- a/PaintomicsServer/src/tests/test_harmonise_grader.py
+++ b/PaintomicsServer/src/tests/test_harmonise_grader.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""When several omics are converted together, the grader holds them to the
+rule the server will apply, not to the model's opinion.
+
+The behaviour this guards
+-------------------------
+The conversion loop's exit condition is the validator. That was enough while
+one file was converted at a time: the validator is pinned to the server's own
+per-file loop. It is not enough for the job-level conversion that makes two
+omics agree, because the fault the run was refused for is not in any one file
+-- `PathwayAcquisitionJob.validateInput` requires every values file to have the
+same number of columns, and the per-file grader cannot see two files at once.
+
+Without this a model could write one beautiful file, leave the other as it
+was, declare itself done, and the loop would accept it -- and the run would
+fail again in the same place. Measured before this existed: "the AI said it
+fixed the problem and it fails again" is the report this whole feature answers.
+
+So `gradeOutputs(outputs, api, {harmonise: {inputs: [...]}})` adds two
+deterministic checks, run in node against the shipped source:
+
+  * every input is answered by ONE values output, declared in the manifest
+    with "for": <input path>;
+  * every values output has the same number of columns.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_harmonise_grader
+"""
+import io
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+JS_DIR = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), "..", "..", "..", "PaintomicsClient", "public_html",
+    "app", "view", "PathwayAcquisitionViews", "InputFormat"))
+
+SCRIPT = r"""
+const path = require("path");
+const DIR = %(dir)s;
+const API = Object.assign({},
+    require(path.join(DIR, "format-reader.js")),
+    require(path.join(DIR, "format-validator.js")),
+    require(path.join(DIR, "format-roles.js")));
+const AGENT = require(path.join(DIR, "convert-agent.js"));
+
+const enc = (s) => new TextEncoder().encode(s);
+const table = (header, rows) => enc([header].concat(rows).map(r => r.join("\t")).join("\n") + "\n");
+
+const narrow = table(["proteinID", "FC"], [["P1", "1.5"], ["P2", "0.7"], ["P3", "2.0"]]);
+const wideIn = table(["Label", "C_1", "C_2", "T_1", "T_2"],
+                     [["LPE 18:0", "1", "2", "3", "4"], ["LPI 18:0", "2", "2", "5", "5"]]);
+const wideOut = table(["Label", "T_vs_C"], [["LPE 18:0", "2.33"], ["LPI 18:0", "2.5"]]);
+
+const INPUTS = [{path: "/work/vp_fc_values.tab", omic: "Proteomics"},
+                {path: "/work/lipidomica_samples.tab", omic: "Metabolomics"}];
+const manifest = (files) => enc(JSON.stringify({summary: "s", files: files}));
+
+const grade = (outputs) => {
+    const g = AGENT.gradeOutputs(outputs, API, {harmonise: {inputs: INPUTS}});
+    return {ok: g.ok, summary: g.summary};
+};
+const out = {};
+
+// Both inputs answered, both one condition wide: accepted.
+out.agree = grade({
+    "manifest.json": manifest([
+        {name: "vp_fc_values.tab", role: "values", "for": "/work/vp_fc_values.tab", unchanged: true},
+        {name: "lipids_t_vs_c.tab", role: "values", "for": "/work/lipidomica_samples.tab"}]),
+    "vp_fc_values.tab": narrow, "lipids_t_vs_c.tab": wideOut});
+
+// The wide one written back as it was: still 5 columns against 2.
+out.still_disagree = grade({
+    "manifest.json": manifest([
+        {name: "vp_fc_values.tab", role: "values", "for": "/work/vp_fc_values.tab", unchanged: true},
+        {name: "lipidomica_samples.tab", role: "values", "for": "/work/lipidomica_samples.tab", unchanged: true}]),
+    "vp_fc_values.tab": narrow, "lipidomica_samples.tab": wideIn});
+
+// One input answered, the other forgotten.
+out.one_missing = grade({
+    "manifest.json": manifest([
+        {name: "lipids_t_vs_c.tab", role: "values", "for": "/work/lipidomica_samples.tab"}]),
+    "lipids_t_vs_c.tab": wideOut});
+
+// Answered by basename rather than the full path: accepted.
+out.by_basename = grade({
+    "manifest.json": manifest([
+        {name: "a.tab", role: "values", "for": "vp_fc_values.tab", unchanged: true},
+        {name: "b.tab", role: "values", "for": "lipidomica_samples.tab"}]),
+    "a.tab": narrow, "b.tab": wideOut});
+
+// No harmonise context: the single-file grader is unchanged and accepts a
+// lone valid file.
+const single = AGENT.gradeOutputs({
+    "manifest.json": manifest([{name: "a.tab", role: "values"}]), "a.tab": narrow}, API, {});
+out.single = {ok: single.ok, summary: single.summary};
+
+console.log(JSON.stringify(out));
+"""
+
+
+def run_node(script):
+    directory = tempfile.mkdtemp(prefix="paintomics-harmonise-")
+    try:
+        path = os.path.join(directory, "check.js")
+        with io.open(path, "w", encoding="utf-8") as handle:
+            handle.write(script)
+        done = subprocess.run(["node", path], capture_output=True, text=True, timeout=120)
+        if done.returncode != 0:
+            raise AssertionError("node failed:\n%s" % done.stderr)
+        return json.loads(done.stdout)
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class HarmoniseGraderTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.r = run_node(SCRIPT % {"dir": json.dumps(JS_DIR)})
+
+    def test_agreeing_outputs_are_accepted(self):
+        self.assertTrue(self.r["agree"]["ok"], self.r["agree"]["summary"])
+
+    def test_outputs_that_still_disagree_are_refused_by_width(self):
+        case = self.r["still_disagree"]
+        self.assertFalse(case["ok"])
+        self.assertIn("still disagree on their number of columns", case["summary"])
+        self.assertIn("lipidomica_samples.tab (5 columns, 4 conditions)", case["summary"])
+        self.assertIn("vp_fc_values.tab (2 columns, 1 condition)", case["summary"])
+
+    def test_an_unanswered_input_is_refused_by_name(self):
+        case = self.r["one_missing"]
+        self.assertFalse(case["ok"])
+        self.assertIn("No values file is declared for the input /work/vp_fc_values.tab (Proteomics)",
+                      case["summary"])
+
+    def test_a_basename_answers_an_input(self):
+        self.assertTrue(self.r["by_basename"]["ok"], self.r["by_basename"]["summary"])
+
+    def test_the_single_file_grader_is_unchanged(self):
+        self.assertTrue(self.r["single"]["ok"], self.r["single"]["summary"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_harmonise_prompt.py
+++ b/PaintomicsServer/src/tests/test_harmonise_prompt.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Several inputs reach the model as one job, with the rule they broke.
+
+The behaviour this guards
+-------------------------
+The converter was per-file: one profile, one "Input path", one script. The
+failure that reached a guest on 2026-08-27 (job q603AOxICD) is not in any one
+file -- a one-column proteomics fold change beside a fourteen-column lipidomics
+table, each valid alone, refused together because PaintOmics paints every omic
+on the same conditions. Handed either file, with the other's header as
+context, the agent rightly found nothing to fix and said so; the user read
+that as "the AI fix does not work".
+
+So `build_user_message` now takes `state["inputs"]`: every values file of the
+job, each with its omic, its width and its own profile, rendered under one
+"## Inputs" heading; and the system prompt carries a section that states the
+rule and how to satisfy it -- reduce the wider omic to the narrower one's
+shape by deriving (means, ratios) from its own columns, never pad, ask when the
+data cannot settle the grouping or the direction, and declare every output
+with "for": <input path>.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_harmonise_prompt
+"""
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from src.classes.InputConvert.prompts import SYSTEM_PROMPT, build_user_message
+
+
+def _twoInputs():
+    return {
+        "goal": "Make these omics agree.",
+        "species": "ecb",
+        "inputs": [
+            {"path": "/work/vp_fc_values.tab", "omic": "Proteomics", "fileName": "vp_fc_values.tab",
+             "role": "values", "conditions": 1,
+             "profile": {"tables": [{"name": "(single table)", "n_columns": 2}]}},
+            {"path": "/work/lipidomica_samples.tab", "omic": "Metabolomics",
+             "fileName": "lipidomica_samples.tab", "role": "values", "conditions": 14,
+             "profile": {"tables": [{"name": "(single table)", "n_columns": 15}]}},
+        ],
+        "instructions": ["PaintOmics refused this job. It said: Every omic in one run must "
+                         "have the same number of conditions."],
+    }
+
+
+class SystemPromptTest(unittest.TestCase):
+
+    def test_the_rule_is_stated_with_its_remedy(self):
+        section = SYSTEM_PROMPT[SYSTEM_PROMPT.index("MAKING THE OMICS AGREE"):]
+        self.assertIn("SAME NUMBER of\ncondition columns", section)
+        self.assertIn("FEWEST condition columns", section)
+        self.assertIn("Deriving is allowed here, and only here", section)
+        self.assertIn("Never widen the narrow omic", section)
+        self.assertIn('"for": "<that input\'s path exactly as listed>"', section)
+        self.assertIn('"unchanged": true', section)
+
+    def test_ratio_versus_log_ratio_is_decided_by_the_narrow_omic(self):
+        """The reported proteomics FC is a plain ratio (values up to 1000, all
+        positive); a log2 of the lipid means would not have matched it."""
+        section = SYSTEM_PROMPT[SYSTEM_PROMPT.index("MAKING THE OMICS AGREE"):]
+        self.assertIn("plain ratios", section)
+        self.assertIn("log2 of that ratio", section)
+
+    def test_the_single_file_paragraph_points_at_the_section(self):
+        self.assertIn("read the section\nMAKING THE OMICS AGREE", SYSTEM_PROMPT)
+
+
+class UserMessageTest(unittest.TestCase):
+
+    def test_every_input_is_listed_with_its_omic_and_width(self):
+        message = build_user_message(_twoInputs())
+        self.assertIn("## Inputs (2 files of one run", message)
+        self.assertIn("### Input 1: /work/vp_fc_values.tab", message)
+        self.assertIn("omic: Proteomics", message)
+        self.assertIn("condition columns: 1", message)
+        self.assertIn("### Input 2: /work/lipidomica_samples.tab", message)
+        self.assertIn("omic: Metabolomics", message)
+        self.assertIn("condition columns: 14", message)
+
+    def test_each_input_carries_its_own_profile(self):
+        message = build_user_message(_twoInputs())
+        self.assertIn('"n_columns": 2', message)
+        self.assertIn('"n_columns": 15', message)
+
+    def test_the_single_file_headings_are_absent(self):
+        """One "Input path" and one "What the file looks like" would tell the
+        model there is one file, which is the misreading being fixed."""
+        message = build_user_message(_twoInputs())
+        self.assertNotIn("Input path:", message)
+        self.assertNotIn("## What the file looks like", message)
+
+    def test_the_servers_words_still_reach_it(self):
+        message = build_user_message(_twoInputs())
+        self.assertIn("PaintOmics refused this job", message)
+
+    def test_a_single_file_state_is_unchanged(self):
+        message = build_user_message({"inputPath": "/work/a.tab", "fileName": "a.tab",
+                                      "omicType": "Gene expression", "profile": {"x": 1}})
+        self.assertIn("Input path: /work/a.tab", message)
+        self.assertIn("## What the file looks like", message)
+        self.assertNotIn("## Inputs", message)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_mixed_width_omics_are_named.py
+++ b/PaintomicsServer/src/tests/test_mixed_width_omics_are_named.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Two well-formed omics of different widths are refused by NAME, once.
+
+The behaviour this guards
+-------------------------
+PaintOmics paints every omic on one set of conditions, so
+`PathwayAcquisitionJob.validateInput` fixes `nConditions` from the first
+values file it reads and then holds every other omic to it. That rule is
+right. What it said was not: a guest on 2026-08-27 (job q603AOxICD) submitted a
+proteomics table of `proteinID, FC` beside a lipidomics table of twelve samples
+and two means, and was refused with
+
+    Errors detected while processing lipidomica_samples.tab:
+      Line 1:Expected 2 columns but found 15;
+      Line 2:Expected 2 columns but found 15;
+      ... (ten of them)
+    Too many errors detected while processing lipidomica_samples.tab, skipping remaining lines...
+
+-- which names neither the rule nor the omic the "2" came from, and blames a
+file that has nothing wrong with it. The client's per-file check had passed
+both files with a green tick, so from where the user stood the server had
+refused a valid file for no reason. Reproduced locally and on paintomics.uv.es.
+
+Now the ten lines become one sentence that names both omics, both files and
+both widths. Everything else is unchanged: a file whose OWN lines vary in width
+is ragged, and still gets its per-line report; the file that fixed the width
+can only be ragged, never "disagreeing with itself".
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_mixed_width_omics_are_named
+"""
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from src.classes.JobInstances.PathwayAcquisitionJob import PathwayAcquisitionJob
+from src.tests import fake_omics
+
+
+class _JobCase(unittest.TestCase):
+
+    def setUp(self):
+        self._tmpRoot = tempfile.mkdtemp(prefix="paintomics_widths_") + "/"
+        self.job = PathwayAcquisitionJob(jobID="widths", userID=None,
+                                         CLIENT_TMP_DIR=self._tmpRoot)
+        self.inputDir = self.job.getInputDir()
+        os.makedirs(self.inputDir, exist_ok=True)
+        self.job.geneBasedInputOmics = []
+        self.job.compoundBasedInputOmics = []
+
+    def tearDown(self):
+        shutil.rmtree(self._tmpRoot, ignore_errors=True)
+
+    def _error(self):
+        try:
+            self.job.validateInput()
+            return ""
+        except Exception as exc:
+            return str(exc)
+
+
+class MixedWidthOmicsAreNamedTest(_JobCase):
+
+    def _reportedCase(self):
+        """Proteomics id+FC (2 columns) beside Metabolomics id+14 (15 columns)."""
+        proteomics = fake_omics.proteomicsFile(self.inputDir, "vp_fc_values.tab",
+                                               nFeatures=12, nConditions=1)
+        lipids = fake_omics.metabolomicsFile(self.inputDir, "lipidomica_samples.tab",
+                                             nFeatures=12, nConditions=14)
+        self.job.geneBasedInputOmics = [
+            fake_omics.omicInput(proteomics, omicName="Proteomics")]
+        self.job.compoundBasedInputOmics = [
+            fake_omics.omicInput(lipids, omicName="Metabolomics")]
+
+    def test_the_rule_and_both_omics_are_named(self):
+        self._reportedCase()
+        error = self._error()
+        self.assertIn("same number of conditions", error)
+        self.assertIn("[b]Proteomics[/b] (vp_fc_values.tab) has 1 condition column", error)
+        self.assertIn("[b]Metabolomics[/b] (lipidomica_samples.tab) has 14 condition columns", error)
+
+    def test_the_per_line_wall_is_gone(self):
+        self._reportedCase()
+        error = self._error()
+        self.assertNotIn("Expected 2 columns but found 15", error)
+        self.assertNotIn("Too many errors", error)
+        self.assertNotIn("[li]", error)
+
+    def test_order_does_not_change_who_is_named_first(self):
+        """The omic that fixed the width is always the reference, whichever
+        loop it sits in: with the wide file first the narrow one disagrees."""
+        lipids = fake_omics.geneExpressionFile(self.inputDir, "wide.tab",
+                                               nFeatures=12, nConditions=14)
+        proteomics = fake_omics.metabolomicsFile(self.inputDir, "narrow.tab",
+                                                 nFeatures=12, nConditions=1)
+        self.job.geneBasedInputOmics = [fake_omics.omicInput(lipids, omicName="Gene expression")]
+        self.job.compoundBasedInputOmics = [fake_omics.omicInput(proteomics, omicName="Metabolomics")]
+        error = self._error()
+        self.assertIn("[b]Gene expression[/b] (wide.tab) has 14 condition columns, but "
+                      "[b]Metabolomics[/b] (narrow.tab) has 1 condition column", error)
+
+    def test_a_ragged_file_keeps_its_per_line_report(self):
+        """Varying widths inside ONE file are a broken file, not a disagreement."""
+        first = fake_omics.geneExpressionFile(self.inputDir, "first.tab", nConditions=3)
+        ragged = fake_omics.raggedFile(self.inputDir, "ragged.tab", nConditions=3)
+        self.job.geneBasedInputOmics = [
+            fake_omics.omicInput(first, omicName="Gene expression"),
+            fake_omics.omicInput(ragged, omicName="Proteomics")]
+        error = self._error()
+        self.assertIn("Expected 4 columns but found 3", error)
+        self.assertNotIn("same number of conditions", error)
+
+    def test_the_file_that_fixed_the_width_cannot_disagree_with_itself(self):
+        ragged = fake_omics.raggedFile(self.inputDir, "ragged.tab", nConditions=3)
+        self.job.geneBasedInputOmics = [fake_omics.omicInput(ragged, omicName="Gene expression")]
+        error = self._error()
+        self.assertIn("Expected 4 columns but found 3", error)
+        self.assertNotIn("same number of conditions", error)
+
+    def test_a_value_fault_on_a_disagreeing_line_is_still_reported(self):
+        """Collapsing the width fault must not swallow a different fault on
+        the same line."""
+        first = fake_omics.geneExpressionFile(self.inputDir, "first.tab", nConditions=1)
+        bad = fake_omics.nonNumericValuesFile(self.inputDir, "bad.tab", nConditions=3)
+        self.job.geneBasedInputOmics = [
+            fake_omics.omicInput(first, omicName="Gene expression"),
+            fake_omics.omicInput(bad, omicName="Proteomics")]
+        error = self._error()
+        self.assertIn("same number of conditions", error)
+        self.assertIn("Line contains invalid values or symbols", error)
+        self.assertNotIn("Expected 2 columns but found 4", error)
+
+    def test_agreeing_omics_are_still_accepted(self):
+        a = fake_omics.geneExpressionFile(self.inputDir, "a.tab", nConditions=3)
+        b = fake_omics.metabolomicsFile(self.inputDir, "b.tab", nConditions=3)
+        self.job.geneBasedInputOmics = [fake_omics.omicInput(a, omicName="Gene expression")]
+        self.job.compoundBasedInputOmics = [fake_omics.omicInput(b, omicName="Metabolomics")]
+        self.assertEqual(self._error(), "")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_repair_clears_the_submit_block.py
+++ b/PaintomicsServer/src/tests/test_repair_clears_the_submit_block.py
@@ -89,10 +89,17 @@ function clearBlocked(fieldName) { calls.push('clearBlocked:' + fieldName);
 function renderOk() { calls.push('renderOk'); }
 function hostFor() { return {}; }
 function validate() { return { ok: true, summary: { nRows: 112 } }; }
+// The width guard collaborators applyRepair gained: a values file records its
+// condition count after a repair so the cross-omic comparison stays current.
+// In the browser these are the enclosing check()'s `role` argument and two
+// module functions; extracted alone, the harness must supply them.
+function recordConditions() { calls.push('recordConditions'); }
+function syncWidthNotes() { calls.push('syncWidthNotes'); }
 
 const input = {};
 const fieldName = 'omic0_file';
 const file = { name: 'DEGs2.txt' };
+const role = 'values';
 const repaired = { rows: [['#gene', 'v'], ['Cp', '-1.86']] };
 
 %(apply_repair)s

--- a/PaintomicsServer/src/tests/test_run_failure_reaches_the_agent.py
+++ b/PaintomicsServer/src/tests/test_run_failure_reaches_the_agent.py
@@ -137,10 +137,45 @@ class RunFailureReachesTheAgentTest(unittest.TestCase):
         self.assertIn('.toLowerCase() + ":"', matcher,
                       "a bare omic name is not evidence that a file failed")
 
-    def test_both_offers_are_made_and_they_differ(self):
-        """Re-checking repairs mechanically; the agent can be told what broke."""
-        self.assertIn("Check this file again", self.panel_code)
+    def test_one_offer_the_agent_and_not_a_mechanical_re_check(self):
+        """"Check this file again" is gone from the dialog.
+
+        It re-ran the mechanical repair, and from the dialog that could never
+        help: a file with a repairable fault is stopped BEFORE submit, so the
+        dialog is only reached past it by "Submit anyway" -- when the user has
+        already declined the repair. Two green buttons for the same file read
+        as a duplicate, and were reported as one (2026-08-27 screenshot)."""
+        self.assertNotIn("Check this file again", self.panel_code)
         self.assertIn("Ask the PaintOmics AI agent", self.panel_code)
+
+    # -- a refusal about the JOB opens the agent on the whole job ----------
+
+    def test_a_width_disagreement_routes_to_the_job_level_agent(self):
+        """The 2026-08-27 guest report: Proteomics id+FC beside Metabolomics
+        id+14 samples, each file valid, refused together. Handed either file
+        alone the agent rightly finds nothing to fix, so the dialog's offer
+        for that class hands over EVERY values file of the run."""
+        hook = self.panel_code[self.panel_code.index("function attachDialogFix"):]
+        self.assertIn("same number of conditions|expected", hook)
+        self.assertIn("widthDisagreement()", hook)
+        self.assertIn("requestHarmonise(widths, serverSaid)", hook)
+        # And the per-file route is still there for every other failure.
+        self.assertIn("siblingSummaries(picked.input)", hook)
+
+    def test_the_job_level_route_reaches_the_drawer(self):
+        self.assertIn("function requestHarmonise", self.panel_code)
+        self.assertIn("openHarmoniseDrawer", self.panel_code)
+        self.assertIn("function openHarmoniseDrawer", self.drawer_code)
+        self.assertIn("openHarmoniseDrawer: openHarmoniseDrawer", self.drawer_code)
+
+    def test_in_the_job_level_mode_every_file_is_in_the_sandbox(self):
+        """The single-file brief ("rewrite ONLY the file you were given") is
+        true of the single-file mode and false of this one, so the drawer
+        must not send it here: every target's bytes go in, and the agent
+        loop is told which input is which."""
+        self.assertIn("files: harmonise ? allBytes()", self.drawer_code)
+        self.assertIn("inputs: harmonise ? harmoniseInputs()", self.drawer_code)
+        self.assertIn("instructions: harmonise ? harmoniseInstructions()", self.drawer_code)
 
     # -- the agent is given the job, not one file --------------------------
 

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -90,22 +90,22 @@ PUBLISHED = {
     "app/view/PathwayAcquisitionViews/InputFormat/format-repair.js": (
         "0.1", "944c929f1496258aba56f026e7c30e4affb7052dcbc127b06982eaadff205cd2"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-panel.js": (
-        "3.1", "1b2fb789d33d925c7ae482b76c0ac05b1417e7984b61f71e9321dd125461780c"),
+        "3.3", "995e88fbe45955de2991e51aecd814d624d22371b66afaf5ce20795a4284d7f2"),
     "app/view/PathwayAcquisitionViews/InputFormat/format-roles.js": (
         "0.5", "02fca3cace94756275993739d36deb728b1870c21be9ec5477f853828e7a67b6"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-profiler.js": (
         "0.3", "d7f2846c58226fdfe334fefc68c8d6519cc4eae393265e15dd047e5babded4f3"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-agent.js": (
-        "0.6", "d884a0d8344fccf966aab1219c9c70f9e29ca93a4a42e7ddf8f0852189f5ecdd"),
+        "0.7", "f7046f6383282d5a3e45b96519c9191bb639bd732ffbf225b08b09f5da867d87"),
     "app/view/PathwayAcquisitionViews/InputFormat/convert-drawer.js": (
-        "1.4", "41be9f21d19a4471273310d905412abf67c98ad2f2734364d2fcdd54e1e4ca4b"),
+        "1.6", "9bda68bffafde80c9ef414db497109b09acb81a813d0a67f8128c196a911427f"),
     # v=2.2 makes fitPlotPanel measure the figures it drew instead of the
     # height:100% wrapper it drew them into. The old reading was a function of
     # the panel height it was computing, so the panel could only grow: a
     # 40-compound metabolite class pinned it at the 820 cap and every smaller
     # class after that kept the cap as blank space.
     "app/view/common/Util.js": (
-        "2.3", "d9d16f7e672d480ed107e06d6bfcd1ae66e64e5238d1971f7816fd958eebe5a0"),
+        "2.4", "567f6bb041e2d3be89490b9b76a01940ff7865c45a97a902922ab88de605dd8f"),
     "app/view/common/OrganismSearch.js": (
         "1.0", "7903626835e7703bdb6a1e31b78e3ca00539eee23b8fa67a37524cd9cc4d2e7f"),
     "app/view/common/ExtJS_extensions.js": (


### PR DESCRIPTION
## The problem

A guest submitted a one-column proteomics fold change beside a fourteen-column lipidomics table (job `q603AOxICD`). Each file is well formed and the per-file check — client and server — passes both. But PaintOmics paints every omic on **one** set of conditions, so `validateInput` fixes `nConditions` from the first values file and refused the run with ten copies of `Line N: Expected 2 columns but found 15`, naming neither the rule nor the omic the "2" came from.

Handed either file alone, the AI converter rightly found nothing to fix — **the files are not wrong, they disagree with each other.** That is why the earlier "AI fix" never helped and the re-run failed in the same place.

## What changed

1. **Server message** — a file whose data lines are *uniformly* a different width than the job is refused with one sentence naming the rule, both omics, both files and both widths, instead of a per-line wall. A genuinely ragged file keeps its per-line report.
2. **Client width guard** (`format-panel.js`) — each values file's condition count is recorded on its Ext field (the DOM input doesn't survive a Step 1 submit), compared across the cards, shown under every card involved, and stops the submit with a banner — the same certainty as a file the server will reject.
3. **Job-level AI conversion** — every values file goes into the sandbox *together*; the model reduces the wider omics to the narrowest one's shape by **deriving** the same quantities from their own columns (a ratio, a log ratio, a mean), never padding, and asks when the data can't settle it. The grader enforces one-output-per-input and equal widths **deterministically**, so the loop can't exit on the model's opinion. The review writes each result back into its own card.
4. **Dialog cleanup** — the failure dialog shows only the readable half of a servlet error (the `AT <file>.py:` prefix goes to the hidden body that Report error already sends); the buttons are a flex row; and it offers **one** action — the agent — dropping the duplicate **Check this file again** (it re-ran a repair that can't help once the form has already been submitted).

## Verification

Driven end-to-end in Chrome against a worktree server:

- width notes on both cards + the submit-time banner
- "Submit anyway" → the readable server refusal + a single **Ask the PaintOmics AI agent** (job-level)
- the conversion reduced the 14-column lipidomics to a single `T_vs_C = media_t/media_c` matching the 1-column proteomics FC, kept the proteomics file, and **Use these 2 tables** replaced both files (metabolomics 29045 → 3407 B)
- the widths then agreed and **the run reached Step 2** (low feature mapping is the data's own description-word / lipid-name problem, not this change)

New tests: `test_mixed_width_omics_are_named` (server message), `test_harmonise_prompt` (the "## Inputs" payload + prompt section), `test_harmonise_grader` (node — the deterministic one-per-input + equal-width exit condition); `test_run_failure_reaches_the_agent` updated for the removed button and the job-level route. All affected suites + the versioned-assets drift guard pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7jivrJ8YZAaeLkXYHY27p