### PR TITLE
Keep the class map still under the cursor: overlay the hover readout instead of swapping the caption

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
@@ -6224,17 +6224,27 @@ function PA_Step3MetaboliteView() {
 			});
 		}
 
+		/* The readout goes into its own span, laid OVER the resting caption
+		   (main.css: .paClassMapReadout is position: absolute and the caption
+		   turns visibility: hidden, so it keeps its lines). It used to REPLACE
+		   the caption, and the caption is what sizes this paragraph: three
+		   lines became one, the SVG directly below rose 35px, and the mark
+		   slid out from under a cursor that had not moved -- mouseleave,
+		   caption back, map down, mouseenter, 27 times a second. Measured on
+		   PU14YF2L61 with the mouse held still on "Amino acids": 54 enter and
+		   54 leave in two seconds. Nothing above the map may change height
+		   on hover. */
 		var summary = document.getElementById("classActivityMapSummary");
 		if (!summary) return;
+		var readout = summary.querySelector(".paClassMapReadout");
 		if (!className) {
-			summary.innerHTML = summary.getAttribute("data-base") || "";
 			summary.classList.remove("paIsFocused");
+			if (readout) readout.innerHTML = "";
 			return;
 		}
 		var row = (classMapRowsCache || []).filter(function (r) { return r.name === className; })[0];
-		if (!row) return;
-		summary.classList.add("paIsFocused");
-		summary.innerHTML =
+		if (!row || !readout) return;
+		readout.innerHTML =
 			'<b>' + classMapEscape(row.name) + '</b> <span class="paClassMapMuted">'
 			+ classMapEscape(row.parent) + '</span> &nbsp; '
 			+ '<b>' + row.k + '</b>/' + row.n + ' relevant (' + Math.round(row.proportion * 100) + '%)'
@@ -6243,6 +6253,7 @@ function PA_Step3MetaboliteView() {
 				? ' &nbsp; <span class="paDirUp">▲' + row.up + '</span> <span class="paDirDown">▼' + row.down + '</span>'
 				: "")
 			+ ' &nbsp; <span class="paClassMapMuted">click to paint its compounds</span>';
+		summary.classList.add("paIsFocused");
 	};
 
 	this.drawClassMap = function () {
@@ -6489,7 +6500,8 @@ function PA_Step3MetaboliteView() {
 					+ ' and that is the bar every class is measured against';
 			}
 			summary.innerHTML =
-				'<b>' + passing + '</b> of ' + rows.length + ' classes at FDR &lt; 0.05'
+				'<span class="paClassMapBase">'
+				+ '<b>' + passing + '</b> of ' + rows.length + ' classes at FDR &lt; 0.05'
 				+ (p0 === null ? "" :
 					' &middot; ' + (userSet
 						? 'tested against <b>' + p0.toFixed(3) + '</b>, the fixed proportion you set'
@@ -6497,10 +6509,11 @@ function PA_Step3MetaboliteView() {
 						: 'tested against the rest of this job, p<sub>0</sub> = <b>' + p0.toFixed(3) + '</b>'
 							+ '<span class="paClassMapMuted">' + background + '</span>'))
 				+ (classMapHasDirection ? "" :
-					' &middot; <span class="paClassMapMuted">values never cross zero, so no direction is shown</span>');
-			/* focusClass borrows this line while a class is hovered, so keep the
-			   resting text to put back on mouseleave. */
-			summary.setAttribute("data-base", summary.innerHTML);
+					' &middot; <span class="paClassMapMuted">values never cross zero, so no direction is shown</span>')
+				/* The second span is the hover readout. focusClass fills it and
+				   lays it over the caption; the caption stays put, so the
+				   paragraph -- and the map under it -- never changes height. */
+				+ '</span><span class="paClassMapReadout"></span>';
 		}
 	};
 

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.72" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=1.73" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.15" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.6" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.7" />

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -9199,7 +9199,7 @@ div.repDetectionCard h3 {
 .paClassMapCount { fill: #44556A; font-size: 10px; }
 .paClassMapMark { cursor: pointer; }
 .paClassMapMark:hover .paClassMapDisc { stroke: #B5761F; }
-.paClassMapSummary { margin: 2px 0 10px; color: #44556A; font-size: 13px; }
+.paClassMapSummary { position: relative; margin: 2px 0 10px; color: #44556A; font-size: 13px; }
 .paClassMapWarn { color: #A51F1E; }
 .paClassMapMuted { color: #78879A; }
 /* Legend. A list, not a run-on sentence: each item is one nowrap flex child,
@@ -9240,7 +9240,19 @@ div.contentbox .paClassMapKeys li { padding-left: 0; }
 .paIsFocusing .paClassMapMark { opacity: .22; }
 .paIsFocusing .paClassMapMark.paIsFocused { opacity: 1; }
 .paClassMapMark.paIsFocused .paClassMapDisc { stroke: #B5761F; stroke-width: 3; }
-/* The caption doubles as the hover readout. */
+/* The caption doubles as the hover readout. The readout is laid OVER the
+   caption, not swapped into its place: the caption is what sizes this
+   paragraph, and the SVG sits directly under it, so a swap that changed the
+   line count moved the map out from under a resting cursor -- mouseleave,
+   swap back, mouseenter, 27 times a second, and the mark "shone". visibility,
+   not display, on the hidden caption: it must keep occupying its lines.
+   padding: inherit, because the card inset lives on `div.contentbox p` and an
+   absolute child at left: 0 sits at the padding edge -- measured 26px left of
+   the caption it stands in for. */
+.paClassMapSummary .paClassMapReadout { display: none; position: absolute; top: 0; left: 0; right: 0;
+                                        padding: inherit; box-sizing: border-box; }
+.paClassMapSummary.paIsFocused .paClassMapBase { visibility: hidden; }
+.paClassMapSummary.paIsFocused .paClassMapReadout { display: block; }
 .paClassMapSummary.paIsFocused { color: #141E2B; }
 .paDirUp { color: #0F59A9; font-weight: 600; }
 .paDirDown { color: #A51F1E; font-weight: 600; }

--- a/PaintomicsServer/src/tests/test_class_map_hover_keeps_its_caption.py
+++ b/PaintomicsServer/src/tests/test_class_map_hover_keeps_its_caption.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Hovering a mark on the metabolite class map must not move the map.
+
+Why this exists
+---------------
+Pointing at a mark on the class map (Step 3, "Metabolite class activity
+analysis") made it flash on and off for as long as the cursor stayed there.
+Reproduced in Chrome on job PU14YF2L61 with the cursor held still on the
+"Amino acids" mark, counting the mark's own events for two seconds:
+
+    mouseenter 54   mouseleave 54
+
+and the layout at every one of them, caption height / SVG top, in px:
+
+    enter 21/158  leave 56/193  enter 21/158  leave 56/193  ...
+
+The chart's caption (#classActivityMapSummary) sits directly above the SVG and
+doubles as the hover readout: focusClass() swapped the resting three-line
+sentence for a one-line readout by assigning summary.innerHTML. The paragraph
+lost two lines, the SVG rose 35px, and the mark slid out from under a cursor
+that had not moved. Chrome then dispatched mouseleave, focusClass() put the
+three lines back, the mark slid back under the cursor, mouseenter -- 27 times
+a second. The "shine" was the focus stroke toggling at that rate.
+
+The fix keeps the resting caption in the flow, where it sizes the paragraph,
+and lays the readout over it (position: absolute, the caption's text hidden
+but still occupying its lines). Nothing above the SVG changes height on
+hover, so nothing under the cursor moves.
+
+These tests run the shipped focusClass() -- the real function extracted from
+PA_Step3Views.js, not a re-implementation -- in node against a stub DOM whose
+innerHTML setter discards the children, as a browser's does. Before the fix
+the resting caption is gone after one hover; after it, it is intact.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_class_map_hover_keeps_its_caption
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+CLIENT = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), "..", "..", "..",
+    "PaintomicsClient", "public_html"))
+
+STEP3_VIEWS = os.path.join(CLIENT, "app", "view", "PathwayAcquisitionViews",
+                           "PA_Step3Views.js")
+MAIN_CSS = os.path.join(CLIENT, "resources", "css", "main.css")
+
+
+def read(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def method(source, name):
+    """The text of `this.<name> = function (...) {...}`, brace-matched."""
+    match = re.search(r"this\.%s\s*=\s*function" % re.escape(name), source)
+    if match is None:
+        raise AssertionError("%s() is not defined in %s" % (name, STEP3_VIEWS))
+    opening = source.index("{", match.end())
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[match.start():index + 1] + ";"
+    raise AssertionError("unbalanced braces in %s()" % name)
+
+
+# A DOM with exactly the behaviour the bug depends on: assigning innerHTML
+# replaces every child, so a caption that is swapped rather than overlaid
+# disappears. querySelector understands one class selector, which is all
+# focusClass() asks of it.
+STUB_DOM = r"""
+function el(cls, html) {
+    var node = {
+        cls: cls, children: [], attrs: {}, _html: html || "",
+        classList: {
+            _set: {},
+            add: function (c) { this._set[c] = true; },
+            remove: function (c) { delete this._set[c]; },
+            contains: function (c) { return !!this._set[c]; },
+            toggle: function (c, force) {
+                var on = (force === undefined) ? !this._set[c] : !!force;
+                if (on) { this._set[c] = true; } else { delete this._set[c]; }
+                return on;
+            }
+        },
+        getAttribute: function (n) { return this.attrs.hasOwnProperty(n) ? this.attrs[n] : null; },
+        setAttribute: function (n, v) { this.attrs[n] = String(v); },
+        querySelector: function (sel) {
+            var c = sel.replace(/^\./, "");
+            for (var i = 0; i < this.children.length; i++) {
+                if (this.children[i].cls === c) { return this.children[i]; }
+            }
+            return null;
+        },
+        querySelectorAll: function () { return []; }
+    };
+    Object.defineProperty(node, "innerHTML", {
+        get: function () { return this._html; },
+        set: function (v) { this._html = v; this.children = []; }
+    });
+    return node;
+}
+
+var RESTING = "<b>0</b> of 9 classes at FDR &lt; 0.05 &middot; tested against the rest of this job";
+var base = el("paClassMapBase", RESTING);
+var readout = el("paClassMapReadout", "");
+var summary = el("paClassMapSummary", "");
+summary.children = [base, readout];
+summary.attrs["data-base"] = RESTING;
+var map = el("paClassMap", "");
+
+var document = {
+    getElementById: function (id) {
+        if (id === "classActivityMapSummary") { return summary; }
+        if (id === "classActivityMap") { return map; }
+        return null;
+    }
+};
+
+var classMapRowsCache = [{
+    name: "Amino acids", parent: "Peptides", k: 0, n: 7, proportion: 0,
+    p: 1, fdr: 1, up: 0, down: 0, significant: false
+}];
+var classMapHasDirection = false;
+function classMapEscape(v) { return String(v); }
+function classMapFormatP(v) { return Number(v).toFixed(4); }
+
+var me = {};
+"""
+
+
+def run_in_node(body):
+    """Evaluate `body` with the shipped focusClass() bound to `me`."""
+    source = read(STEP3_VIEWS)
+    script = "\n".join([
+        STUB_DOM,
+        "(function () {\n" + method(source, "focusClass") + "\n}).call(me);",
+        body,
+    ])
+    directory = tempfile.mkdtemp(prefix="paintomics-classmap-")
+    try:
+        path = os.path.join(directory, "check.js")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(script)
+        completed = subprocess.run(
+            ["node", path], capture_output=True, text=True, timeout=60)
+        if completed.returncode != 0:
+            raise AssertionError("node failed:\n%s" % completed.stderr)
+        return json.loads(completed.stdout)
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+def snapshot():
+    return """
+    console.log(JSON.stringify({
+        base: summary.querySelector(".paClassMapBase") && summary.querySelector(".paClassMapBase").innerHTML,
+        readout: summary.querySelector(".paClassMapReadout") && summary.querySelector(".paClassMapReadout").innerHTML,
+        focused: summary.classList.contains("paIsFocused")
+    }));
+    """
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class FocusClassTest(unittest.TestCase):
+
+    def test_hover_leaves_the_resting_caption_in_place(self):
+        """The caption sizes the paragraph; the readout must not replace it."""
+        result = run_in_node('me.focusClass("Amino acids");' + snapshot())
+
+        self.assertIsNotNone(
+            result["base"],
+            "focusClass() replaced the caption with the readout. The caption "
+            "is what gives the paragraph its height, and the SVG sits directly "
+            "under it: a shorter readout lifts the map out from under the "
+            "cursor, Chrome fires mouseleave, the caption comes back, the map "
+            "drops, mouseenter -- 27 times a second, which is the flashing.")
+        self.assertIn("0</b> of 9 classes", result["base"])
+        self.assertTrue(result["focused"], "the summary was not marked focused")
+        self.assertIn("Amino acids", result["readout"] or "",
+                      "the readout was not written for the hovered class")
+
+    def test_unhover_clears_the_readout_and_keeps_the_caption(self):
+        result = run_in_node(
+            'me.focusClass("Amino acids"); me.focusClass(null);' + snapshot())
+
+        self.assertFalse(result["focused"])
+        self.assertEqual(result["readout"], "")
+        self.assertIn("0</b> of 9 classes", result["base"] or "")
+
+    def test_an_unknown_class_changes_nothing(self):
+        result = run_in_node('me.focusClass("No such class");' + snapshot())
+
+        self.assertFalse(result["focused"])
+        self.assertEqual(result["readout"], "")
+        self.assertIn("0</b> of 9 classes", result["base"] or "")
+
+
+class SourceStructureTest(unittest.TestCase):
+    """Holds with or without a JavaScript runtime available."""
+
+    def test_the_readout_is_laid_over_the_caption_not_in_its_flow(self):
+        """position: absolute is what keeps the paragraph's height fixed."""
+        css = read(MAIN_CSS)
+        rule = re.search(
+            r"\.paClassMapSummary\s+\.paClassMapReadout\s*\{([^}]*)\}", css)
+        self.assertIsNotNone(rule, "main.css has no .paClassMapSummary "
+                                   ".paClassMapReadout rule")
+        self.assertIn("position: absolute", rule.group(1))
+
+        hidden = re.search(
+            r"\.paClassMapSummary\.paIsFocused\s+\.paClassMapBase\s*\{([^}]*)\}", css)
+        self.assertIsNotNone(hidden, "the focused caption is never hidden")
+        # visibility keeps the lines in the layout; display: none would collapse
+        # them and bring the bug straight back.
+        self.assertIn("visibility: hidden", hidden.group(1))
+        self.assertNotIn("display", hidden.group(1))
+
+    def test_draw_class_map_builds_both_halves_of_the_caption(self):
+        source = read(STEP3_VIEWS)
+        draw = method(source, "drawClassMap")
+        for cls in ("paClassMapBase", "paClassMapReadout"):
+            self.assertTrue(cls in draw,
+                            "drawClassMap() no longer writes a .%s span" % cls)
+
+    def test_the_view_still_parses(self):
+        if shutil.which("node") is None:
+            self.skipTest("node is not installed")
+        completed = subprocess.run(
+            ["node", "--check", STEP3_VIEWS], capture_output=True, text=True,
+            timeout=60)
+        self.assertEqual(completed.returncode, 0,
+                         "%s does not parse:\n%s" % (STEP3_VIEWS, completed.stderr))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## The bug

Hovering a mark on the **Metabolite class activity analysis** map made it flash ("shine") for as long as the cursor stayed on it.

Reproduced in Chrome on job `PU14YF2L61` (mmu, gene expression + metabolomics) with the cursor held still on the "Amino acids" mark, counting the mark's own events for two seconds:

| | before | after |
|---|---|---|
| `mouseenter` / `mouseleave` in 2 s | **54 / 54** | **1 / 0** |
| caption height on enter → leave | 21 px → 56 px, every cycle | 56 px, constant |
| SVG top on enter → leave | 158 → 193, every cycle | 193, constant |

## Why

`focusClass()` swapped the caption paragraph above the map (`#classActivityMapSummary`) for the one-line hover readout by assigning `innerHTML`. That caption is what sizes the paragraph, and the SVG sits directly under it: three lines became one, the map rose 35 px, and the mark slid out from under a cursor that had not moved. Chrome fired `mouseleave`, the caption came back, the map dropped, `mouseenter` — 27 times a second. The "shine" was the focus stroke toggling at that rate.

## The fix

The caption stays in the flow in its own span (`.paClassMapBase`) and the readout is written into a second span (`.paClassMapReadout`) laid **over** it:

- `position: absolute` on the readout, so it takes no height;
- `visibility: hidden` (not `display: none`) on the caption while focused, so it keeps occupying its lines;
- `padding: inherit` on the readout, because the card inset lives on `div.contentbox p` and an absolute child at `left: 0` sat at the padding edge — measured 26 px left of the caption it stands in for.

Nothing above the map changes height on hover, so nothing under the cursor moves. `main.css` bumped to `v=1.73`; `PA_Step3Views.js` loads through `Application.loadModule` (jQuery `cache: false`) and needs no marker.

## Verified in Chrome (master worktree, :8031)

- 1 enter / 0 leave over 2 s with the mouse still; caption 56 px and SVG top 193 throughout.
- Readout text starts at exactly the caption's x/y (302 / 117); moving away restores the caption, readout emptied, `paIsFocused` removed.
- Redline HUD (`?guides=1`): all text on rail, all rows on baseline, 0 off-rail.
- Dark theme: readout inherits the focused ink (light on dark), as before.

## Test

`src/tests/test_class_map_hover_keeps_its_caption.py` runs the **shipped** `focusClass()` (extracted from `PA_Step3Views.js`, not re-implemented) in node against a stub DOM whose `innerHTML` setter discards children, as a browser's does. Before the fix the caption is gone after one hover; after it, it is intact. A structural test pins the CSS that keeps the readout out of the flow. `test_versioned_assets_are_bumped`, ruff and the vulture ratchet stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N6PT8NkNhqb1QKDfXBGe1V
