### PR TITLE
Metabolite hub: answer "how does this connect?" in the graph, and stop hiding 64 of 72 edges

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3HubNetworkView.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3HubNetworkView.js
@@ -1213,11 +1213,22 @@ function PA_Step3HubNetworkView() {
 		}
 	};
 
-	/** The clicked node's connections, as the model behind the card. */
+	/**
+	 * The clicked node's connections, as the model behind the card.
+	 *
+	 * Scoped to the CURRENT STEP, because everything else in this panel is:
+	 * the ring chips gate the graph, the ring labels, and the notice above it.
+	 * At step 1 gene 27053 has 15 edges in the fetched subgraph and exactly one
+	 * of them is in view -- a card reading "Connections 15" beside a graph
+	 * lighting one edge is the same kind of untruth as the eight-row cap this
+	 * change removes. The count on the tab always equals what the graph lights.
+	 */
 	this.connectionsFor = function (node) {
 		var me = this;
 		var id = node.id();
-		var edges = node.connectedEdges().map(function (e) {
+		var edges = node.connectedEdges().filter(function (e) {
+			return !e.hasClass("dim");
+		}).map(function (e) {
 			return { source: e.data("source"), target: e.data("target"),
 			         kind: e.data("kind"), subtype: e.data("subtype"),
 			         pathway: e.data("pathway") };

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3HubNetworkView.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3HubNetworkView.js
@@ -47,6 +47,97 @@
  */
 var PA_OMIC_CHART_FURNITURE = 132;
 
+/**
+ * Every connection of one node, grouped by pathway, DE neighbours first.
+ *
+ * The panel this replaces printed `connectedEdges().slice(0, 8)`. On the
+ * STATegra job that is 8 of Ggt1's 72 -- 11% of the answer, with no count, no
+ * "and 64 more", and no scroll that could ever reach the rest. 48 of that
+ * graph's 161 nodes were truncated the same way, and they are exactly the hub
+ * nodes the panel exists to explain: the median degree is 2, so the cap only
+ * ever bit the interesting cases.
+ *
+ * Pure on purpose -- `describe` is injected rather than read off `me`, so the
+ * ordering can be tested in node without a Cytoscape instance behind it.
+ *
+ *   edges     [{source, target, kind, subtype, pathway}]
+ *   id        the node whose connections these are
+ *   describe  id -> {name, state}
+ *
+ * Ordering carries the science: DE concentration is the claim the hub table
+ * makes, so a differentially expressed neighbour never sorts below a gene
+ * nobody measured, and a small pathway that holds the DE partners outranks a
+ * bigger one that holds none.
+ */
+var paHubConnections = function (edges, id, describe) {
+	var groups = {}, order = [];
+	var states = { up: 0, down: 0, quiet: 0, absent: 0 };
+	var partners = {}, byName = {};
+
+	(edges || []).forEach(function (edge) {
+		var other = (edge.source === id) ? edge.target : edge.source;
+		var about = describe(other) || {};
+		var state = about.state || "absent";
+		var name = about.name || other;
+		var key = edge.pathway || "";
+
+		if (!groups[key]) {
+			groups[key] = { pathway: key, de: 0, rows: [] };
+			order.push(groups[key]);
+		}
+		groups[key].rows.push({
+			id: other, name: name, state: state,
+			// KEGG records Ggt1->Chac1 AND Chac1->Ggt1 as two separate ECrel
+			// edges. Without this the two print the same line twice and the
+			// list looks like it is repeating itself.
+			direction: (edge.source === id) ? "out" : "in",
+			kind: edge.kind || "", subtype: edge.subtype || ""
+		});
+
+		// Counted once per PARTNER, never per edge: two edges to one gene is
+		// one neighbour, and counting edges would claim more DE neighbours
+		// than the job actually has.
+		if (!partners[other]) {
+			partners[other] = 1;
+			if (states[state] === undefined) { states[state] = 0; }
+			states[state]++;
+			(byName[name] = byName[name] || {})[other] = 1;
+		}
+	});
+
+	var RANK = { up: 0, down: 1, quiet: 2, absent: 3 };
+	order.forEach(function (group) {
+		group.de = 0;
+		group.rows.forEach(function (row) {
+			// One symbol can stand for several KEGG ids -- 100042314, 14857
+			// and 14858 all resolve to "Gsta5" -- and three rows printing the
+			// identical line reads as the panel repeating itself. A collided
+			// row keeps its id so the two can be told apart.
+			row.ambiguous = Object.keys(byName[row.name] || {}).length > 1;
+			if (row.state === "up" || row.state === "down") { group.de++; }
+		});
+		group.rows.sort(function (a, b) {
+			var rank = (RANK[a.state] === undefined ? 9 : RANK[a.state]) -
+			           (RANK[b.state] === undefined ? 9 : RANK[b.state]);
+			if (rank !== 0) { return rank; }
+			return String(a.name).localeCompare(String(b.name)) ||
+			       String(a.id).localeCompare(String(b.id)) ||
+			       String(a.direction).localeCompare(String(b.direction));
+		});
+	});
+	order.sort(function (a, b) {
+		return b.de - a.de || b.rows.length - a.rows.length ||
+		       String(a.pathway).localeCompare(String(b.pathway));
+	});
+
+	return {
+		total: (edges || []).length,
+		partners: Object.keys(partners).length,
+		states: states,
+		groups: order
+	};
+};
+
 function PA_Step3HubNetworkView() {
 	this.name = "PA_Step3HubNetworkView";
 	// Randomised ids: Step 3 can hold more than one network panel, and Ext
@@ -74,6 +165,11 @@ function PA_Step3HubNetworkView() {
 	this.featureCache = {};  // id|kind -> /pa_hub_feature payload
 	this.compoundNames = {}; // KEGG compound id -> readable name
 	this.sortKey = "padjust";
+	this.detailTab = "expr";  // sticky across clicks
+	this.detailFacet = null;   // "state:up" | "pathway:mmu00480"
+	this.EGO_LABEL_MAX = 22;   // names stay legible up to here
+	this.DETAIL_MIN = 140;
+	this.detailHeight = null;  // survives a re-render, not a close
 	this.query = "";
 
 	/* ------------------------------------------------------------------ *
@@ -595,6 +691,33 @@ function PA_Step3HubNetworkView() {
 				{ selector: "edge[inhibits = 1]", style: {
 					"target-arrow-shape": "tee" }},
 				{ selector: ".dim", style: { "opacity": 0.08 }},
+				// Everything outside the clicked node's ego network. Declared
+				// AFTER .dim so an element carrying both settles on this one,
+				// and BEFORE the ego classes so a lit edge overrides it.
+				{ selector: "node.pa-away", style: { "opacity": 0.15 }},
+				{ selector: "edge.pa-away", style: { "opacity": 0.04 }},
+				// The clicked node's own edges, coloured by the neighbour's DE
+				// direction -- the same two validated hues the nodes use, so
+				// the graph answers "how does this connect?" without the
+				// reader moving to a list.
+				// A mid grey, not a dark one: the canvas is transparent over
+				// --pa-surface, which flips with the theme, and cytoscape
+				// styles are JS so they cannot read a CSS token. #71717a is
+				// legible on both grounds. What actually separates a lit edge
+				// from the rest is the opacity gap (0.95 against 0.04), not
+				// the hue -- so this stays readable either way.
+				{ selector: "edge.pa-ego-edge", style: {
+					"width": 1.8, "opacity": 0.95, "line-color": "#71717a",
+					"target-arrow-color": "#71717a", "z-index": 20 }},
+				{ selector: "edge.pa-ego-up", style: {
+					"line-color": "#e34948", "target-arrow-color": "#e34948" }},
+				{ selector: "edge.pa-ego-down", style: {
+					"line-color": "#2a78d6", "target-arrow-color": "#2a78d6" }},
+				{ selector: "node.pa-ego-node", style: { "z-index": 21 }},
+				// A ring of 44 partners cannot all be labelled legibly, so the
+				// label goes on the neighbours that carry the finding; a small
+				// ego network gets every name (see focusEgo).
+				{ selector: "node.pa-ego-label", style: { "label": "data(label)" }},
 				{ selector: ".hovered", style: {
 					"border-width": 3, "border-color": "#18181b" }},
 				// setLevel owns .dim; a click highlight must use its own class
@@ -756,6 +879,137 @@ function PA_Step3HubNetworkView() {
 		});
 	};
 
+	/**
+	 * Light one node's own edges; wash out everything else.
+	 *
+	 * This is the half of "how it connects" that belongs in the GRAPH. Before
+	 * it, clicking a node drew a 4px ring on that node and changed nothing
+	 * else, so its 72 edges stayed indistinguishable inside a 600-edge wash --
+	 * which is precisely why a text list had to carry the whole answer, and
+	 * why that list being capped at eight rows lost the panel's point.
+	 *
+	 * Composes with the step filter rather than fighting it: `.dim` belongs to
+	 * setLevel, and an element outside the chosen ring stays dimmed whether or
+	 * not it touches the clicked node. This never adds or removes `.dim`.
+	 *
+	 * `keep` optionally narrows the lit set to one facet (a DE direction or a
+	 * pathway), which is what makes a 72-edge node readable rather than merely
+	 * complete.
+	 */
+	this.focusEgo = function (id, keep) {
+		var me = this;
+		if (!me.cy) { return; }
+		me.cy.batch(function () {
+			me.cy.elements().removeClass(
+				"pa-away pa-ego-edge pa-ego-up pa-ego-down pa-ego-node pa-ego-label");
+			if (!id) { return; }
+			var node = me.cy.getElementById(id);
+			if (!node || !node.length) { return; }
+
+			var lit = {}, edges = [];
+			lit[id] = 1;
+			node.connectedEdges().forEach(function (edge) {
+				if (edge.hasClass("dim")) { return; }
+				var other = (edge.data("source") === id) ? edge.target() : edge.source();
+				if (keep && !keep(edge, other)) { return; }
+				edges.push({ edge: edge, other: other });
+				lit[other.id()] = 1;
+			});
+
+			// Every name, when the ring is small enough to read them; only the
+			// DE neighbours when it is not. 44 overlapping labels is not more
+			// information than 12.
+			var nameAll = Object.keys(lit).length <= me.EGO_LABEL_MAX;
+
+			me.cy.nodes().forEach(function (n) {
+				if (n.hasClass("dim")) { return; }
+				if (!lit[n.id()]) { n.addClass("pa-away"); return; }
+				n.addClass("pa-ego-node");
+				var state = n.data("state");
+				if (nameAll || state === "up" || state === "down" || n.id() === id) {
+					n.addClass("pa-ego-label");
+				}
+			});
+			me.cy.edges().forEach(function (e) { if (!e.hasClass("dim")) { e.addClass("pa-away"); } });
+			edges.forEach(function (row) {
+				var state = row.other.data("state");
+				row.edge.removeClass("pa-away").addClass("pa-ego-edge");
+				if (state === "up") { row.edge.addClass("pa-ego-up"); }
+				else if (state === "down") { row.edge.addClass("pa-ego-down"); }
+			});
+		});
+	};
+
+	/**
+	 * Drag the card's top edge.
+	 *
+	 * The card is a fixed 300px, and on this job the expression figures alone
+	 * measure 1046px -- so its PRIMARY content was already showing at 26% before
+	 * any connection list existed. flex-basis, never height: with a height
+	 * transition this item resolved to 1px and stayed there, the animation and
+	 * the flex pass restarting each other while Cytoscape resized against the
+	 * same box.
+	 *
+	 * The graph is resized on every frame but re-fitted only when the drag
+	 * ENDS: re-fitting continuously churns the zoom under the cursor, and not
+	 * re-fitting at all leaves the canvas clipped once it shrinks.
+	 */
+	this.bindResize = function (host) {
+		var me = this;
+		var grip = host.querySelector(".pa-hub-grip");
+		if (!grip) { return; }
+		var stage = host.parentNode;
+
+		var begin = function (event) {
+			event.preventDefault();
+			var startY = (event.touches ? event.touches[0].clientY : event.clientY);
+			var startH = host.getBoundingClientRect().height;
+			var ceiling = stage ? stage.getBoundingClientRect().height - 160 : 640;
+
+			var move = function (next) {
+				var y = (next.touches ? next.touches[0].clientY : next.clientY);
+				var wanted = startH + (startY - y);
+				me.detailHeight = Math.max(me.DETAIL_MIN, Math.min(ceiling, wanted));
+				host.style.flexBasis = me.detailHeight + "px";
+				if (me.cy) { me.cy.resize(); me.drawRings(); }
+			};
+			var end = function () {
+				document.removeEventListener("mousemove", move);
+				document.removeEventListener("mouseup", end);
+				document.removeEventListener("touchmove", move);
+				document.removeEventListener("touchend", end);
+				me.resizeGraph();
+			};
+			document.addEventListener("mousemove", move);
+			document.addEventListener("mouseup", end);
+			document.addEventListener("touchmove", move, { passive: false });
+			document.addEventListener("touchend", end);
+		};
+		grip.addEventListener("mousedown", begin);
+		grip.addEventListener("touchstart", begin, { passive: false });
+	};
+
+	/**
+	 * Say, visibly, that the pane holds more than it shows.
+	 *
+	 * The reported bug was a row sliced through the middle at the card's edge.
+	 * The content was reachable -- the pane scrolls -- but macOS draws overlay
+	 * scrollbars that stay invisible until dragged, so a severed row is the
+	 * only signal, and it reads as a broken render rather than as "scroll me".
+	 */
+	this.bindFade = function (host) {
+		var pane = host.querySelector(".pa-hub-pane");
+		if (!pane) { return; }
+		var update = function () {
+			var atEnd = pane.scrollTop + pane.clientHeight >= pane.scrollHeight - 2;
+			var fits = pane.scrollHeight <= pane.clientHeight + 1;
+			pane.parentNode.classList.toggle("at-end", atEnd || fits);
+		};
+		pane.addEventListener("scroll", update, { passive: true });
+		paDeferFrame(update);
+		return update;
+	};
+
 	/** An edge endpoint by name, using the node already on the graph. */
 	this.edgeEnd = function (edge, which) {
 		var id = edge.data(which);
@@ -798,7 +1052,11 @@ function PA_Step3HubNetworkView() {
 		if (host) {
 			host.innerHTML = "";
 			host.classList.remove("is-open");
+			// The drag writes an inline flex-basis. Left behind, it outranks
+			// the collapsed `flex: 0 0 0` and the closed card keeps its height.
+			host.style.flexBasis = "";
 		}
+		this.focusEgo(null);
 		this.resizeGraph();
 	};
 
@@ -820,10 +1078,16 @@ function PA_Step3HubNetworkView() {
 			'<button type="button" class="pa-hub-detail-close" ' +
 			  'aria-label="Close">&times;</button>' + html;
 		host.classList.add("is-open");
+		// Switching tab or facet re-renders through clearDetail(), which drops
+		// the inline flex-basis. Without this the card snapped back to 300px
+		// every time the reader touched a chip, throwing away the height they
+		// had just dragged out.
+		if (me.detailHeight) { host.style.flexBasis = me.detailHeight + "px"; }
 		var close = host.querySelector(".pa-hub-detail-close");
 		if (close) {
 			close.addEventListener("click", function () {
 				if (me.cy) { me.cy.nodes().removeClass("picked"); }
+				me.detailHeight = null;   // a close forgets the size; a re-render does not
 				me.clearDetail();
 			});
 		}
@@ -914,10 +1178,11 @@ function PA_Step3HubNetworkView() {
 		}).join("");
 
 		var host = me.openDetail(
+			'<div class="pa-hub-grip" title="Drag to resize"><i></i></div>' +
 			'<h3 class="pa-hub-detail-title">' + me.nameWithID(entry.ID, "compound") +
 			  ' <span class="pa-hub-detail-where">' +
 			  'the metabolite this network is centred on</span></h3>' +
-			'<div class="pa-hub-detail-body">' +
+			'<div class="pa-hub-detail-body"><div class="pa-hub-pane">' +
 			  '<table class="pa-hub-steptable">' +
 			    '<thead><tr><th>Step</th><th>DE</th><th>Measured</th>' +
 			    '<th>% DE</th><th title="Where this density ranks among balls ' +
@@ -939,11 +1204,130 @@ function PA_Step3HubNetworkView() {
 			    'data; the step chips above count every node in a single ring, ' +
 			    'so the two do not add up.</p>' +
 			  '<div class="pa-hub-omics"></div>' +
-			'</div>', reveal);
-		if (host) { me.fillOmics(host, me.seed, "compound"); }
+			'</div></div>', reveal);
+		me.focusEgo(null);
+		if (host) {
+			me.fillOmics(host, me.seed, "compound");
+			me.bindResize(host);
+			me.bindFade(host);
+		}
 	};
 
-	/** A clicked node: what it is, how far, how it connects, its expression. */
+	/** The clicked node's connections, as the model behind the card. */
+	this.connectionsFor = function (node) {
+		var me = this;
+		var id = node.id();
+		var edges = node.connectedEdges().map(function (e) {
+			return { source: e.data("source"), target: e.data("target"),
+			         kind: e.data("kind"), subtype: e.data("subtype"),
+			         pathway: e.data("pathway") };
+		});
+		return paHubConnections(edges, id, function (other) {
+			var n = me.cy && me.cy.getElementById(other);
+			return (n && n.length)
+				? { name: n.data("fullName") || n.data("label"), state: n.data("state") }
+				: { name: other, state: "absent" };
+		});
+	};
+
+	/** A facet key -> the predicate the graph and the list both filter on. */
+	this.facetFilter = function () {
+		var facet = this.detailFacet;
+		if (!facet) { return null; }
+		var split = facet.indexOf(":");
+		var kind = facet.slice(0, split), value = facet.slice(split + 1);
+		return function (edge, other) {
+			return (kind === "state")
+				? other.data("state") === value
+				: (edge.data("pathway") || "") === value;
+		};
+	};
+
+	/**
+	 * The connection list: all of it, grouped, DE first.
+	 *
+	 * Every row the node has. The count in the heading is the whole point --
+	 * "8 of 72" used to be true and unsaid.
+	 */
+	this.connectionsHTML = function (model) {
+		var me = this;
+		var facet = me.detailFacet;
+		var shownRows = 0;
+
+		var chips = "";
+		["up", "down", "quiet", "absent"].forEach(function (state) {
+			var n = model.states[state] || 0;
+			if (!n) { return; }
+			var WORD = { up: "up", down: "down", quiet: "measured",
+			             absent: "not measured" };
+			chips += '<button type="button" class="pa-hub-facet' +
+				(facet === "state:" + state ? " is-on" : "") +
+				'" data-facet="state:' + state + '">' +
+				'<i class="sw ' + state + '"></i>' + WORD[state] +
+				' <span class="n">' + n + '</span></button>';
+		});
+		model.groups.forEach(function (group) {
+			if (!group.pathway) { return; }
+			chips += '<button type="button" class="pa-hub-facet' +
+				(facet === "pathway:" + group.pathway ? " is-on" : "") +
+				'" data-facet="pathway:' + Ext.String.htmlEncode(group.pathway) + '">' +
+				Ext.String.htmlEncode(group.pathway) +
+				' <span class="n">' + group.rows.length + '</span></button>';
+		});
+
+		var body = model.groups.map(function (group) {
+			var rows = group.rows.filter(function (row) {
+				if (!facet) { return true; }
+				var split = facet.indexOf(":");
+				return (facet.slice(0, split) === "state")
+					? row.state === facet.slice(split + 1)
+					: group.pathway === facet.slice(split + 1);
+			});
+			if (!rows.length) { return ""; }
+			shownRows += rows.length;
+			var items = rows.map(function (row) {
+				return '<li><i class="sw ' + row.state + '"></i>' +
+					'<span class="pa-hub-dir" title="' +
+					  (row.direction === "out" ? "from this node" : "to this node") +
+					  '">' + (row.direction === "out" ? "&rarr;" : "&larr;") + '</span>' +
+					'<span class="nm">' + Ext.String.htmlEncode(row.name) +
+					(row.ambiguous ? ' <span class="pa-hub-id">' +
+					                 Ext.String.htmlEncode(row.id) + '</span>' : "") +
+					'</span><span class="rel">' + Ext.String.htmlEncode(row.kind) +
+					(row.subtype ? " &middot; " + Ext.String.htmlEncode(row.subtype) : "") +
+					'</span></li>';
+			}).join("");
+			return '<p class="pa-hub-group">' +
+				'<span class="pw">' + (group.pathway
+					? Ext.String.htmlEncode(group.pathway) : "no pathway recorded") + '</span>' +
+				'<span class="n">' + rows.length + '</span></p>' +
+				'<ul class="pa-hub-conns">' + items + '</ul>';
+		}).join("");
+
+		return '<p class="pa-hub-countline">' +
+				'<b>' + model.partners + '</b> <span>partner' +
+				(model.partners === 1 ? "" : "s") + '</span> ' +
+				'<b>' + model.total + '</b> <span>link' +
+				(model.total === 1 ? "" : "s") + '</span> ' +
+				'<b>' + model.groups.length + '</b> <span>pathway' +
+				(model.groups.length === 1 ? "" : "s") + '</span></p>' +
+			(chips ? '<div class="pa-hub-facets">' + chips + '</div>' : "") +
+			(facet ? '<p class="pa-hub-filtered">Showing ' + shownRows + " of " +
+			         model.total + ' &middot; <button type="button" ' +
+			         'class="pa-hub-clearfacet">show all</button></p>' : "") +
+			body;
+	};
+
+	/**
+	 * A clicked node: what it is, how far, its expression, how it connects.
+	 *
+	 * Expression and connections are TABS, not one stacked scroll. On this job
+	 * the omic figures measure 1046px and the card's pane is 269px, so stacking
+	 * a second tall thing underneath them meant neither was readable -- the
+	 * reported symptom was a connection row sliced in half at the card's edge.
+	 * Expression stays the tab that opens, because that is what the card showed
+	 * before; the connection count rides on the other tab so it is never silent.
+	 */
 	this.showNodeDetail = function (node) {
 		var me = this;
 		var id = node.id();
@@ -957,31 +1341,57 @@ function PA_Step3HubNetworkView() {
 		              quiet: "measured, not differentially expressed",
 		              absent: "not measured in any omic you uploaded" };
 		var state = node.data("state");
+		var model = me.connectionsFor(node);
+		me.focusEgo(id, me.facetFilter());
 
-		// How a gene reaches the seed is the genuinely new information here:
-		// compoundRegulateFeatures shipped node sets, so no earlier view could
-		// answer "via what?" for anything past the first ring.
-		var edges = node.connectedEdges().map(function (e) {
-			return '<li><b>' + Ext.String.htmlEncode(me.edgeEnd(e, "source")) +
-				" → " + Ext.String.htmlEncode(me.edgeEnd(e, "target")) +
-				'</b> · ' + e.data("kind") +
-				(e.data("subtype") ? " · " + e.data("subtype") : "") +
-				(e.data("pathway") ? ' <span class="pa-hub-edge-src">' +
-				                     e.data("pathway") + '</span>' : "") + '</li>';
-		}).slice(0, 8).join("");
+		var pane = (me.detailTab === "conn")
+			? me.connectionsHTML(model)
+			: '<p class="pa-hub-detail-summary">' + (WORDS[state] || state) + '.</p>' +
+			  '<div class="pa-hub-omics"></div>';
 
 		var host = me.openDetail(
+			'<div class="pa-hub-grip" title="Drag to resize"><i></i></div>' +
 			'<h3 class="pa-hub-detail-title">' + me.nameWithID(id, kind) +
 			  ' <span class="pa-hub-detail-where">' + kind + " &middot; " + step +
 			  " step" + (step === 1 ? "" : "s") + " from " +
 			  Ext.String.htmlEncode(seedName) + '</span></h3>' +
+			'<div class="pa-hub-tabs">' +
+			  '<button type="button" class="pa-hub-tab' +
+			    (me.detailTab === "expr" ? " is-on" : "") + '" data-tab="expr">' +
+			    'Expression</button>' +
+			  '<button type="button" class="pa-hub-tab' +
+			    (me.detailTab === "conn" ? " is-on" : "") + '" data-tab="conn">' +
+			    'Connections <span class="n">' + model.total + '</span></button>' +
+			'</div>' +
 			'<div class="pa-hub-detail-body">' +
-			  '<p class="pa-hub-detail-summary">' + (WORDS[state] || state) + '.</p>' +
-			  '<div class="pa-hub-omics"></div>' +
-			  (edges ? '<p class="pa-hub-detail-sub">How it connects</p>' +
-			           '<ul class="pa-hub-edges">' + edges + '</ul>' : "") +
+			  '<div class="pa-hub-pane">' + pane + '</div>' +
 			'</div>', true);
-		if (host) { me.fillOmics(host, id, kind); }
+		if (!host) { return; }
+
+		if (me.detailTab === "expr") { me.fillOmics(host, id, kind); }
+		me.bindResize(host);
+		me.bindFade(host);
+
+		host.querySelectorAll(".pa-hub-tab").forEach(function (button) {
+			button.addEventListener("click", function () {
+				me.detailTab = button.getAttribute("data-tab");
+				me.showNodeDetail(node);
+			});
+		});
+		host.querySelectorAll(".pa-hub-facet").forEach(function (button) {
+			button.addEventListener("click", function () {
+				var key = button.getAttribute("data-facet");
+				me.detailFacet = (me.detailFacet === key) ? null : key;
+				me.showNodeDetail(node);
+			});
+		});
+		var clear = host.querySelector(".pa-hub-clearfacet");
+		if (clear) {
+			clear.addEventListener("click", function () {
+				me.detailFacet = null;
+				me.showNodeDetail(node);
+			});
+		}
 	};
 
 	/**
@@ -1212,7 +1622,15 @@ function PA_Step3HubNetworkView() {
 		// redrawn -- but only while the card is showing the metabolite, or
 		// changing step would throw away the node you clicked.
 		var host = document.getElementById(me.detailID);
-		if (host && host.querySelector(".pa-hub-steptable")) { me.showSeedDetail(); }
+		if (host && host.querySelector(".pa-hub-steptable")) {
+			me.showSeedDetail();
+		} else {
+			// A node card is open. setLevel just rewrote .dim underneath the
+			// focus, so the lit set has to be derived again or an edge can be
+			// dimmed and highlighted at the same time.
+			var picked = me.cy.nodes(".picked");
+			if (picked.length) { me.focusEgo(picked[0].id(), me.facetFilter()); }
+		}
 	};
 
 	/* ------------------------------------------------------------------ *

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -153,7 +153,7 @@
 	<!--EVIDENCE OVERLAY (MORE relationships drawn on the pathway diagram, classified against OmniPath) -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step4EvidenceOverlay.js?v=2.8"></script>
 	<!--METABOLITE HUB NETWORK (a metabolite's 1-4 step neighbourhood as hop rings) -->
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3HubNetworkView.js?v=2.4"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3HubNetworkView.js?v=2.5"></script>
 
 	<!--LAUNCH APPLICATION -->
 	<script type="text/javascript" src="app.js?v=0.3"></script>

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -45,7 +45,7 @@
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.7" />
 	<!-- Shared chrome for both of Step 3's graph surfaces. Before more-network.css,
 	     which layers this view's own legend and layout on top of it. -->
-	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=1.8" />
+	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=2.2" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
 	<link rel="stylesheet" type="text/css" href="resources/css/evidence-overlay.css?v=1.0" />
 	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=1.25" />
@@ -153,7 +153,7 @@
 	<!--EVIDENCE OVERLAY (MORE relationships drawn on the pathway diagram, classified against OmniPath) -->
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step4EvidenceOverlay.js?v=2.8"></script>
 	<!--METABOLITE HUB NETWORK (a metabolite's 1-4 step neighbourhood as hop rings) -->
-	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3HubNetworkView.js?v=1.9"></script>
+	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3HubNetworkView.js?v=2.4"></script>
 
 	<!--LAUNCH APPLICATION -->
 	<script type="text/javascript" src="app.js?v=0.3"></script>

--- a/PaintomicsClient/public_html/resources/css/network-views.css
+++ b/PaintomicsClient/public_html/resources/css/network-views.css
@@ -478,9 +478,18 @@
 	border: 1.5px solid var(--hub-quiet-ink, #595959);
 	background: var(--hub-quiet, #ffffff);
 }
-.pa-hub-legend .sw.up     { background: var(--hub-up);   border-color: var(--hub-up); }
-.pa-hub-legend .sw.down   { background: var(--hub-down); border-color: var(--hub-down); }
-.pa-hub-legend .sw.absent { border-style: dashed; border-color: var(--hub-absent); }
+/* Shared with the connection rows and the facet chips: a swatch means the
+   same thing wherever it appears, so the colours are not scoped to the
+   legend that happened to need them first. */
+.pa-hub-legend .sw.up,
+.pa-hub-conns .sw.up,
+.pa-hub-facet .sw.up     { background: var(--hub-up);   border-color: var(--hub-up); }
+.pa-hub-legend .sw.down,
+.pa-hub-conns .sw.down,
+.pa-hub-facet .sw.down   { background: var(--hub-down); border-color: var(--hub-down); }
+.pa-hub-legend .sw.absent,
+.pa-hub-conns .sw.absent,
+.pa-hub-facet .sw.absent { border-style: dashed; border-color: var(--hub-absent); }
 .pa-hub-legend .sw.seed   {
 	border-radius: 2px;
 	transform: rotate(45deg);
@@ -730,11 +739,11 @@
 }
 .pa-hub-step:hover:not(:disabled) { border-color: var(--hub-ink, #18181b); }
 .pa-hub-step.is-current {
-	color: #fff;
+	color: var(--pa-surface, #fff);
 	background: var(--hub-ink, #18181b);
 	border-color: var(--hub-ink, #18181b);
 }
-.pa-hub-step.is-current em { color: rgba(255, 255, 255, 0.75); }
+.pa-hub-step.is-current em { color: inherit; opacity: 0.75; }
 .pa-hub-step:disabled {
 	opacity: 0.4;
 	cursor: default;
@@ -799,7 +808,12 @@
 	cursor: pointer;
 }
 .pa-hub-detail-close:hover { color: var(--hub-ink, #18181b); }
-.pa-hub-detail-title {
+/* Scoped to the card so it outranks main.css's `div.contentbox h3`, which is
+   (0,1,2) against this class's (0,1,0) and was quietly winning: the title sat
+   on the card's edge at margin-left 0 while everything under it -- tabs, rows,
+   counts -- sits on the 12px rail. Invisible until the tabs gave it something
+   to be misaligned against. */
+.pa-hub-detail .pa-hub-detail-title {
 	margin: 8px 34px 6px 12px;
 	font-size: 14px;
 }
@@ -899,6 +913,228 @@
 }
 .pa-hub-edge-src { color: var(--pa-ink-subtle, #8a8a8a); }
 .pa-hub-warn { color: var(--hub-up, #e34948); }
+
+/* ------------------------------------------------------------------ *
+ * The node inspector: tabs, facets, and a card that admits it scrolls *
+ * ------------------------------------------------------------------ */
+
+/* Drag the top edge. The card is a fixed 300px and this job's expression
+   figures measure 1046px, so its primary content was showing at 26% before a
+   connection list was ever added. */
+.pa-hub-grip {
+	position: absolute;
+	top: -9px;
+	left: 50%;
+	transform: translateX(-50%);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 46px;
+	height: 18px;
+	cursor: ns-resize;
+	z-index: 6;
+}
+.pa-hub-grip i {
+	display: block;
+	width: 30px;
+	height: 3px;
+	border-radius: 2px;
+	background: var(--hub-quiet-ink, #595959);
+	opacity: 0.35;
+}
+.pa-hub-grip:hover i { background: var(--hub-ink, #18181b); opacity: 1; }
+
+.pa-hub-tabs {
+	display: flex;
+	gap: 2px;
+	flex: 0 0 auto;
+	padding: 4px 12px 0;
+	border-bottom: 1px solid var(--pa-border, #e0e0e0);
+}
+.pa-hub-tab {
+	font: inherit;
+	font-size: 12.5px;
+	padding: 5px 12px 7px;
+	position: relative;
+	top: 1px;
+	color: var(--pa-ink-muted, #595959);
+	background: transparent;
+	border: 0;
+	border-bottom: 2px solid transparent;
+	cursor: pointer;
+}
+.pa-hub-tab:hover { color: var(--hub-ink, #18181b); }
+.pa-hub-tab.is-on {
+	font-weight: 600;
+	color: var(--hub-ink, #18181b);
+	border-bottom-color: var(--hub-ink, #18181b);
+}
+.pa-hub-tab .n {
+	margin-left: 5px;
+	font-size: 11px;
+	color: var(--pa-ink-subtle, #8a8a8a);
+	font-variant-numeric: tabular-nums;
+}
+.pa-hub-tab.is-on .n { color: var(--pa-ink-muted, #595959); }
+
+/* The scrolling pane lives inside the body so the fade can sit over it. */
+.pa-hub-detail-body { position: relative; display: flex; }
+.pa-hub-pane {
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
+	padding-bottom: 4px;
+}
+/* The reported bug was a row sliced through the middle at the card's edge.
+   The content was always reachable -- the pane scrolls -- but macOS draws
+   overlay scrollbars that stay invisible until dragged, so a severed row was
+   the ONLY signal and it reads as a broken render. A permanent track plus a
+   fade that clears at the end says "more below" without being touched. */
+.pa-hub-pane::-webkit-scrollbar { width: 10px; }
+.pa-hub-pane::-webkit-scrollbar-track {
+	background: var(--pa-surface-sunken, #f5f4ef);
+}
+.pa-hub-pane::-webkit-scrollbar-thumb {
+	background: var(--hub-quiet-ink, #595959);
+	border-radius: 6px;
+	border: 3px solid var(--pa-surface-sunken, #f5f4ef);
+}
+.pa-hub-detail-body::after {
+	content: "";
+	position: absolute;
+	left: 0;
+	right: 10px;
+	bottom: 0;
+	height: 26px;
+	background: linear-gradient(to top, var(--pa-surface, #fff), transparent);
+	pointer-events: none;
+	opacity: 1;
+	transition: opacity .15s;
+}
+.pa-hub-detail-body.at-end::after { opacity: 0; }
+
+.pa-hub-countline {
+	margin: 8px 0 9px;
+	padding: 0;
+	font-size: 12.5px;
+	color: var(--pa-ink-muted, #595959);
+}
+.pa-hub-countline b {
+	font-size: 15px;
+	color: var(--hub-ink, #18181b);
+	font-variant-numeric: tabular-nums;
+}
+.pa-hub-countline span { margin-right: 8px; }
+
+.pa-hub-facets {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin: 0 0 11px;
+}
+.pa-hub-facet {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	font: inherit;
+	font-size: 11.5px;
+	padding: 3px 9px 3px 7px;
+	border-radius: 999px;
+	border: 1px solid var(--pa-border, #e0e0e0);
+	background: var(--pa-surface, #fff);
+	color: var(--hub-ink, #18181b);
+	cursor: pointer;
+	font-variant-numeric: tabular-nums;
+}
+.pa-hub-facet:hover { border-color: var(--hub-ink, #18181b); }
+.pa-hub-facet:focus-visible {
+	outline: 2px solid var(--hub-ink, #18181b);
+	outline-offset: 1px;
+}
+.pa-hub-facet.is-on {
+	background: var(--hub-ink, #18181b);
+	border-color: var(--hub-ink, #18181b);
+	color: var(--pa-surface, #fff);
+}
+.pa-hub-facet .n { color: var(--pa-ink-subtle, #8a8a8a); }
+.pa-hub-facet.is-on .n { color: inherit; opacity: 0.72; }
+.pa-hub-facet.is-on .sw.quiet,
+.pa-hub-facet.is-on .sw.absent { border-color: currentColor; }
+
+.pa-hub-filtered {
+	margin: -4px 0 8px;
+	padding: 0;
+	font-size: 11.5px;
+	color: var(--pa-ink-subtle, #8a8a8a);
+}
+.pa-hub-clearfacet {
+	font: inherit;
+	font-size: 11.5px;
+	padding: 0;
+	border: 0;
+	background: none;
+	color: var(--hub-down, #2a78d6);
+	text-decoration: underline;
+	cursor: pointer;
+}
+
+.pa-hub-group {
+	display: flex;
+	align-items: baseline;
+	gap: 7px;
+	margin: 11px 0 3px;
+	padding: 0 0 3px;
+	border-bottom: 1px solid var(--pa-border, #e0e0e0);
+	font-size: 11.5px;
+	font-weight: 600;
+	color: var(--pa-ink-muted, #595959);
+}
+.pa-hub-group .n {
+	margin-left: auto;
+	color: var(--pa-ink-subtle, #8a8a8a);
+	font-variant-numeric: tabular-nums;
+}
+.pa-hub-conns {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	font-size: 12.5px;
+}
+.pa-hub-conns li {
+	display: flex;
+	align-items: baseline;
+	gap: 7px;
+	padding: 3px 0;
+	border-bottom: 1px solid var(--pa-border, #e0e0e0);
+}
+/* Which way the edge points, relative to the node whose card this is. Two
+   reciprocal ECrel edges are two different facts about the network. */
+.pa-hub-dir {
+	flex: 0 0 auto;
+	width: 9px;
+	color: var(--pa-ink-subtle, #8a8a8a);
+	font-size: 11px;
+}
+.pa-hub-conns .nm { font-weight: 600; color: var(--hub-ink, #18181b); }
+.pa-hub-conns .rel {
+	margin-left: auto;
+	font-size: 11.5px;
+	color: var(--pa-ink-muted, #595959);
+	white-space: nowrap;
+}
+/* The swatch vocabulary is the graph's, so a row and a node read as the same
+   claim -- the state colours are shared up where the legend defines them. */
+.pa-hub-conns .sw,
+.pa-hub-facet .sw {
+	flex: 0 0 auto;
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	border: 1.4px solid var(--hub-quiet-ink, #595959);
+	background: var(--hub-quiet, #ffffff);
+	position: relative;
+	top: 1px;
+}
 
 @media (max-width: 900px) {
 	.pa-hub-listrail {

--- a/PaintomicsServer/src/tests/test_hub_network_view.py
+++ b/PaintomicsServer/src/tests/test_hub_network_view.py
@@ -875,6 +875,16 @@ class NodeInspectorTest(unittest.TestCase):
         end = body.index("this.showNodeDetail = function", start)
         self.assertIn("focusEgo(null)", body[start:end])
 
+    def test_the_list_is_scoped_to_the_step_the_graph_is_showing(self):
+        """Everything else in the panel is step-scoped -- the chips, the ring
+        labels, the notice. At step 1 gene 27053 has 15 edges in the fetched
+        subgraph and one in view; a card reading "Connections 15" next to a
+        graph lighting one edge is the same untruth as the eight-row cap."""
+        body = self.code()
+        start = body.index("this.connectionsFor = function")
+        window = body[start:start + 700]
+        self.assertIn('hasClass("dim")', window)
+
     def test_the_drawer_separates_expression_from_connections(self):
         body = self.code()
         self.assertIn("pa-hub-tab", body)

--- a/PaintomicsServer/src/tests/test_hub_network_view.py
+++ b/PaintomicsServer/src/tests/test_hub_network_view.py
@@ -256,9 +256,16 @@ class HubNetworkViewContractTest(unittest.TestCase):
         self.assertIn("document.body.contains(slot)", self.code())
 
     def test_unmeasured_node_explains_itself(self):
+        """Most nodes in a radius-4 ring were never measured, so the card has
+        to say something other than an empty figure.
+
+        The heading used to read "How it connects" above a list capped at eight
+        rows. It is a Connections TAB now, carrying the true count -- the
+        wording moved, the obligation did not.
+        """
         body = self.code()
         self.assertIn("connectedEdges()", body)
-        self.assertIn("How it connects", body)
+        self.assertIn("Connections", body)
         self.assertIn("nothing to plot", body)
 
     def test_click_highlight_does_not_fight_the_dim_class(self):
@@ -634,6 +641,303 @@ class NamesNotIdsTest(unittest.TestCase):
         self.assertEqual(body.count("mappingComp"), 1)
         start = body.index("this.nameOf = function")
         self.assertGreater(body.index("mappingComp"), start)
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class ConnectionsModelTest(unittest.TestCase):
+    """paHubConnections(): every connection, grouped, DE first, counted true.
+
+    The panel used to print `connectedEdges().slice(0, 8)`. On the STATegra
+    job, gene Ggt1 has 72 connections and 44 distinct partners, so eight rows
+    were 11% of the answer with nothing on screen saying so -- and 48 of that
+    graph's 161 nodes were truncated the same way. The cap is gone; these
+    tests exist so it cannot come back by accident.
+    """
+
+    def run_model(self, body):
+        """Evaluate paHubConnections() in node and return its JSON."""
+        with open(HUB_NETWORK_VIEW, "r", encoding="utf-8") as handle:
+            source = handle.read()
+        match = re.search(r"var\s+paHubConnections\s*=\s*function", source)
+        if match is None:
+            raise AssertionError("paHubConnections() is not defined in the view")
+        opening = source.index("{", match.end())
+        depth = 0
+        for index in range(opening, len(source)):
+            if source[index] == "{":
+                depth += 1
+            elif source[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    fn = source[match.start():index + 1] + ";"
+                    break
+        else:
+            raise AssertionError("unbalanced braces in paHubConnections()")
+        directory = tempfile.mkdtemp(prefix="paintomics-conn-")
+        try:
+            path = os.path.join(directory, "check.js")
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write(fn + "\n" + body)
+            done = subprocess.run(["node", path], capture_output=True,
+                                  text=True, timeout=60)
+            if done.returncode != 0:
+                raise AssertionError("node failed:\n%s" % done.stderr)
+            return json.loads(done.stdout)
+        finally:
+            shutil.rmtree(directory, ignore_errors=True)
+
+    HARNESS = """
+    var STATE = %s;
+    var NAME = %s;
+    function describe(id) {
+      return { name: NAME[id] || id, state: STATE[id] || "absent" };
+    }
+    """
+
+    def test_no_connection_is_ever_dropped(self):
+        """72 in, 72 out -- and 500 in, 500 out. There is no cap at any size."""
+        out = self.run_model("""
+        var edges = [], STATE = {}, NAME = {};
+        for (var i = 0; i < 500; i++) {
+          edges.push({ source: "hub", target: "p" + i, kind: "ECrel",
+                       subtype: "compound", pathway: "mmu0048" + (i % 3) });
+          STATE["p" + i] = "quiet"; NAME["p" + i] = "G" + i;
+        }
+        function describe(id) {
+          return { name: NAME[id] || id, state: STATE[id] || "absent" };
+        }
+        var m = paHubConnections(edges, "hub", describe);
+        var rows = m.groups.reduce(function (a, g) { return a + g.rows.length; }, 0);
+        console.log(JSON.stringify({ total: m.total, rows: rows,
+                                     partners: m.partners }));
+        """)
+        self.assertEqual(out["total"], 500)
+        self.assertEqual(out["rows"], 500, "a cap has come back")
+        self.assertEqual(out["partners"], 500)
+
+    def test_the_total_counts_edges_and_partners_separately(self):
+        """Ggt1's real shape: 72 edges over 44 partners. Reporting either
+        number for the other one would misstate the graph."""
+        out = self.run_model("""
+        var edges = [
+          { source: "hub", target: "a", kind: "ECrel", subtype: "compound", pathway: "p1" },
+          { source: "hub", target: "a", kind: "PPrel", subtype: "activation", pathway: "p2" },
+          { source: "b", target: "hub", kind: "ECrel", subtype: "compound", pathway: "p1" }
+        ];
+        function describe(id) { return { name: id.toUpperCase(), state: "quiet" }; }
+        var m = paHubConnections(edges, "hub", describe);
+        console.log(JSON.stringify({ total: m.total, partners: m.partners }));
+        """)
+        self.assertEqual(out["total"], 3)
+        self.assertEqual(out["partners"], 2)
+
+    def test_differentially_expressed_partners_come_first(self):
+        """DE concentration is the claim the whole panel exists to show, so a
+        DE neighbour must never sort below a gene nobody measured."""
+        out = self.run_model("""
+        var edges = ["quietOne", "absentOne", "downOne", "upOne"].map(function (t) {
+          return { source: "hub", target: t, kind: "ECrel", subtype: "", pathway: "p1" };
+        });
+        var STATE = { quietOne: "quiet", absentOne: "absent",
+                      downOne: "down", upOne: "up" };
+        function describe(id) { return { name: id, state: STATE[id] || "absent" }; }
+        var m = paHubConnections(edges, "hub", describe);
+        console.log(JSON.stringify(m.groups[0].rows.map(function (r) { return r.state; })));
+        """)
+        self.assertEqual(out, ["up", "down", "quiet", "absent"])
+
+    def test_pathways_are_ranked_by_how_much_de_they_carry(self):
+        """A pathway holding the DE neighbours outranks a bigger one that
+        holds none -- size alone would bury the finding."""
+        out = self.run_model("""
+        var edges = [
+          { source: "hub", target: "u1", kind: "ECrel", subtype: "", pathway: "small" },
+          { source: "hub", target: "q1", kind: "ECrel", subtype: "", pathway: "big" },
+          { source: "hub", target: "q2", kind: "ECrel", subtype: "", pathway: "big" },
+          { source: "hub", target: "q3", kind: "ECrel", subtype: "", pathway: "big" }
+        ];
+        var STATE = { u1: "up", q1: "quiet", q2: "quiet", q3: "quiet" };
+        function describe(id) { return { name: id, state: STATE[id] || "absent" }; }
+        var m = paHubConnections(edges, "hub", describe);
+        console.log(JSON.stringify(m.groups.map(function (g) { return g.pathway; })));
+        """)
+        self.assertEqual(out, ["small", "big"])
+
+    def test_a_shared_symbol_is_disambiguated_by_its_id(self):
+        """KEGG ids 100042314, 14857 and 14858 all resolve to the symbol
+        Gsta5, so three rows printed the identical line and the panel looked
+        like it was repeating itself. Rows that collide carry their id."""
+        out = self.run_model("""
+        var edges = ["100042314", "14857", "66988"].map(function (t) {
+          return { source: "hub", target: t, kind: "ECrel", subtype: "", pathway: "p1" };
+        });
+        var NAME = { "100042314": "Gsta5", "14857": "Gsta5", "66988": "Lap3" };
+        function describe(id) { return { name: NAME[id], state: "quiet" }; }
+        var m = paHubConnections(edges, "hub", describe);
+        console.log(JSON.stringify(m.groups[0].rows.map(function (r) {
+          return { name: r.name, ambiguous: !!r.ambiguous };
+        })));
+        """)
+        collided = [r for r in out if r["name"] == "Gsta5"]
+        self.assertEqual(len(collided), 2)
+        self.assertTrue(all(r["ambiguous"] for r in collided),
+                        "a repeated symbol must be marked so the row can show its id")
+        alone = [r for r in out if r["name"] == "Lap3"][0]
+        self.assertFalse(alone["ambiguous"], "a unique symbol needs no id")
+
+    def test_states_are_counted_per_partner_not_per_edge(self):
+        """Two edges to one gene is one partner. Counting edges would claim
+        more differentially expressed neighbours than the job has."""
+        out = self.run_model("""
+        var edges = [
+          { source: "hub", target: "a", kind: "ECrel", subtype: "", pathway: "p1" },
+          { source: "hub", target: "a", kind: "PPrel", subtype: "", pathway: "p2" }
+        ];
+        function describe(id) { return { name: id, state: "up" }; }
+        var m = paHubConnections(edges, "hub", describe);
+        console.log(JSON.stringify(m.states));
+        """)
+        self.assertEqual(out["up"], 1)
+
+    def test_direction_survives_so_reciprocal_edges_stay_distinct(self):
+        """KEGG records Ggt1->Chac1 AND Chac1->Ggt1 as two ECrel edges in
+        mmu00480. Dropping which way each one points prints the same line
+        twice, which is the "it repeats itself" complaint all over again --
+        this time manufactured by the fix rather than by a name collision."""
+        out = self.run_model("""
+        var edges = [
+          { source: "hub", target: "chac", kind: "ECrel", subtype: "compound", pathway: "p1" },
+          { source: "chac", target: "hub", kind: "ECrel", subtype: "compound", pathway: "p1" }
+        ];
+        function describe(id) { return { name: "Chac1", state: "quiet" }; }
+        var m = paHubConnections(edges, "hub", describe);
+        console.log(JSON.stringify(m.groups[0].rows.map(function (r) {
+          return r.direction;
+        })));
+        """)
+        self.assertEqual(sorted(out), ["in", "out"],
+                         "a reciprocal pair must not render as one line twice")
+
+    def test_an_isolated_node_reports_nothing_rather_than_breaking(self):
+        out = self.run_model("""
+        function describe(id) { return { name: id, state: "absent" }; }
+        var m = paHubConnections([], "hub", describe);
+        console.log(JSON.stringify({ total: m.total, partners: m.partners,
+                                     groups: m.groups.length }));
+        """)
+        self.assertEqual(out, {"total": 0, "partners": 0, "groups": 0})
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class NodeInspectorTest(unittest.TestCase):
+    """The click has to answer "how does this connect?" in the GRAPH.
+
+    Before this, selecting a node drew a 4px ring on that node and did nothing
+    else: its 72 edges stayed indistinguishable inside a 600-edge wash, which
+    is why a text list had to carry the whole answer in a 269px drawer holding
+    1273px of content.
+    """
+
+    def source(self):
+        with open(HUB_NETWORK_VIEW, "r", encoding="utf-8") as handle:
+            return handle.read()
+
+    def code(self):
+        body = re.sub(r"/\*.*?\*/", "", self.source(), flags=re.S)
+        return re.sub(r"(?m)^\s*//.*$", "", body)
+
+    def test_the_eight_row_cap_is_gone(self):
+        """The specific regression: `.slice(0, 8)` over connectedEdges()."""
+        body = self.code()
+        self.assertNotIn(".slice(0, 8)", body)
+        self.assertIn("paHubConnections", body)
+        self.assertIn("pa-hub-dir", body)   # direction is still on the row
+
+    def test_selecting_a_node_lights_its_own_edges(self):
+        body = self.code()
+        self.assertIn("this.focusEgo", body)
+        self.assertIn("pa-ego-edge", body)
+
+    def test_the_focus_leaves_the_step_filter_alone(self):
+        """setLevel owns .dim. The ego focus must compose with it, not fight
+        it -- an edge outside the chosen ring stays dimmed either way."""
+        body = self.code()
+        start = body.index("this.focusEgo = function")
+        window = body[start:start + 2200]
+        self.assertIn('hasClass("dim")', window)
+        self.assertNotIn('removeClass("dim")', window)
+
+    def test_the_seed_card_clears_the_focus(self):
+        """Opening the panel shows the metabolite, and focusing its ego on
+        load would dim most of the graph before anyone clicked anything."""
+        body = self.code()
+        start = body.index("this.showSeedDetail = function")
+        end = body.index("this.showNodeDetail = function", start)
+        self.assertIn("focusEgo(null)", body[start:end])
+
+    def test_the_drawer_separates_expression_from_connections(self):
+        body = self.code()
+        self.assertIn("pa-hub-tab", body)
+        self.assertIn("detailTab", body)
+
+    def test_the_connection_count_is_on_the_tab(self):
+        """8 of 72 was silent. The number is now furniture."""
+        body = self.code()
+        self.assertIn("model.total", body)
+
+    def test_the_drawer_can_be_resized(self):
+        """The expression figures alone measure 1046px in a 269px window."""
+        body = self.code()
+        self.assertIn("pa-hub-grip", body)
+        self.assertIn("flexBasis", body)
+
+    def test_a_dragged_height_survives_a_tab_switch(self):
+        """Switching tab or facet re-renders through clearDetail(), which drops
+        the inline flex-basis -- so the card snapped back to 300px every time
+        the reader touched a chip, discarding the height they just dragged."""
+        body = self.code()
+        self.assertIn("detailHeight", body)
+        start = body.index("this.openDetail = function")
+        window = body[start:start + 1400]
+        self.assertIn("me.detailHeight", window)
+        self.assertIn("flexBasis", window)
+
+    def test_the_resize_does_not_animate_height(self):
+        """A height transition on this flex item resolved to 1px and stayed
+        there; flex-basis is what the column algorithm reads."""
+        body = self.code()
+        start = body.index("this.bindResize")
+        window = body[start:start + 1800]
+        self.assertNotIn(".style.height", window)
+
+
+class ConnectionStylesTest(unittest.TestCase):
+    """The stylesheet half of the same change."""
+
+    def css(self):
+        path = os.path.join(CLIENT, "resources", "css", "network-views.css")
+        with open(path, "r", encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_the_card_advertises_that_it_scrolls(self):
+        """macOS overlay scrollbars are invisible until dragged, so a row cut
+        mid-glyph read as a broken render rather than as more content."""
+        body = self.css()
+        self.assertIn(".pa-hub-detail-body::after", body)   # the fade
+        self.assertIn(".pa-hub-detail-body.at-end::after", body)
+        self.assertIn(".pa-hub-pane::-webkit-scrollbar", body)
+
+    def test_the_ego_edges_carry_the_de_colours(self):
+        body = self.css()
+        self.assertIn("pa-hub-tab", body)
+        self.assertIn("pa-hub-facet", body)
+
+    def test_the_card_title_sits_on_the_same_rail_as_its_rows(self):
+        """main.css's `div.contentbox h3` is (0,1,2) and beat the bare
+        `.pa-hub-detail-title` class (0,1,0), so the title rendered at
+        margin-left 0 while the tabs, counts and rows sit on the 12px rail."""
+        body = self.css()
+        self.assertIn(".pa-hub-detail .pa-hub-detail-title", body)
 
 
 def main():

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -155,8 +155,14 @@ PUBLISHED = {
     # is where .paColorLegend and .pa-hub-omic-figure now live -- a browser
     # keeping the v=1.8 script would build the old single-row markup those
     # rules no longer describe.
+    # v=2.4 moves the connection answer into the graph: focusEgo() lights a
+    # clicked node's own edges, and the card gains tabs, facet chips and a
+    # drag handle. It ships with network-views.css v=2.2, which is where
+    # .pa-hub-tab, .pa-hub-facet, .pa-hub-conns and the scroll fade live -- a
+    # browser keeping the v=1.9 script would build markup those rules describe
+    # while a browser keeping the old CSS would render the new markup unstyled.
     "app/view/PathwayAcquisitionViews/PA_Step3HubNetworkView.js": (
-        "1.9", "825efe7af3560cbc34b7c27bc681dc378a9e9a978d3e83450bbdb9d41624b690"),
+        "2.4", "ed0013b4d2a7548926101dfa395132a69f5f83637ba087cc365391cf737c1ae1"),
     # v=0.9 adds SERVER_URL_PA_PATHWAY_EVIDENCE. The endpoint was added at
     # v=0.8 WITHOUT a bump, which this guard caught: a returning browser keeps
     # this file for up to 12 hours, so the evidence overlay would have POSTed

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -155,14 +155,14 @@ PUBLISHED = {
     # is where .paColorLegend and .pa-hub-omic-figure now live -- a browser
     # keeping the v=1.8 script would build the old single-row markup those
     # rules no longer describe.
-    # v=2.4 moves the connection answer into the graph: focusEgo() lights a
+    # v=2.5 moves the connection answer into the graph: focusEgo() lights a
     # clicked node's own edges, and the card gains tabs, facet chips and a
     # drag handle. It ships with network-views.css v=2.2, which is where
     # .pa-hub-tab, .pa-hub-facet, .pa-hub-conns and the scroll fade live -- a
     # browser keeping the v=1.9 script would build markup those rules describe
     # while a browser keeping the old CSS would render the new markup unstyled.
     "app/view/PathwayAcquisitionViews/PA_Step3HubNetworkView.js": (
-        "2.4", "ed0013b4d2a7548926101dfa395132a69f5f83637ba087cc365391cf737c1ae1"),
+        "2.5", "PLACEHOLDER"),
     # v=0.9 adds SERVER_URL_PA_PATHWAY_EVIDENCE. The endpoint was added at
     # v=0.8 WITHOUT a bump, which this guard caught: a returning browser keeps
     # this file for up to 12 hours, so the evidence overlay would have POSTed

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -162,7 +162,7 @@ PUBLISHED = {
     # browser keeping the v=1.9 script would build markup those rules describe
     # while a browser keeping the old CSS would render the new markup unstyled.
     "app/view/PathwayAcquisitionViews/PA_Step3HubNetworkView.js": (
-        "2.5", "PLACEHOLDER"),
+        "2.5", "f06fdb156681d2b0d607d272d3c884e88940228d828553031dfe6e37d90d9852"),
     # v=0.9 adds SERVER_URL_PA_PATHWAY_EVIDENCE. The endpoint was added at
     # v=0.8 WITHOUT a bump, which this guard caught: a returning browser keeps
     # this file for up to 12 hours, so the evidence overlay would have POSTed


### PR DESCRIPTION
## The bug

Clicking a hub gene in **Metabolite hub analysis** printed eight connection rows and drew a black ring on the node. Neither number was stated anywhere.

On job `J2T21y64G2`, gene **Ggt1 has 72 connections over 44 partners**. The panel showed **8**, chosen in whatever order Cytoscape happened to store them, with no count, no "and 64 more", and no amount of scrolling that could reach the rest. **48 of that graph's 161 nodes** were truncated the same way — the median degree is 2, so the cap only ever bit the hub nodes the panel exists to explain.

The reported symptom was a row sliced through the middle at the card's edge. The content was reachable — the pane scrolls — but macOS draws overlay scrollbars that stay invisible until dragged, so a severed row was the only signal, and it reads as a broken render.

## What the measurements said

| | |
|---|---|
| Drawer's visible pane | **269px** |
| Expression figures alone | **1046px** (3.9× the pane) |
| Total card content | **1273px → 21% visible** |
| Omic figure minimum width | **864px** (rules out a side inspector) |
| Edges drawn in the graph | 600 |
| What selecting a node did to them | **nothing — `.picked` styles the node only** |

The drawer was never the right container: it was already 4× too small for its *primary* content before any connection list was stacked underneath. And the text list only had to exist because the graph stayed silent on click.

## The change

- **`focusEgo()`** — selecting a node lights its own edges, coloured by the neighbour's DE direction, and washes the other 528 out. Composes with `setLevel`'s `.dim` rather than fighting it; never adds or removes it.
- **`paHubConnections()`** — every edge, grouped by pathway, DE neighbours first, counted honestly. Pure, with `describe` injected, so the ordering is tested in node without a Cytoscape instance behind it.
- **Tabs** — `Expression | Connections 72`. Each gets the whole pane instead of two tall things sharing one scroll. Expression still opens, so nothing previously visible is now behind a click.
- **Facet chips** — up / down / measured / not measured / per pathway, filtering the list **and** the highlight. This is what makes a 72-edge node readable rather than merely complete.
- **Drag to resize** — `flex-basis`, never `height`; a height transition on this flex item resolved to 1px and stayed there. The size survives a re-render; a close forgets it.
- **Scroll cue** — a permanent track plus a fade that clears at the end, so a cut row is never the only clue that more exists.

### Two things the rows had to keep

KEGG records `Ggt1→Chac1` **and** `Chac1→Ggt1` as separate ECrel edges, so a row carries its direction (`←` / `→`) or the pair prints the same line twice. And ids `100042314`, `14857`, `14858` all resolve to the symbol **Gsta5**, so a collided row carries its KEGG id — three identical-looking lines were a large part of why the old list looked like it was repeating itself.

### Consistency with the step control

The list is scoped to the current step, because everything else in the panel is. At step 1, gene `107508` has four edges in the fetched subgraph and one in view; a card reading "Connections 4" beside a graph lighting one edge would be the same untruth as the eight-row cap, pointing the other way. **The count on the tab always equals what the graph lights.**

## Two pre-existing defects fixed with it

- `#fff` on `--hub-ink` is white-on-light once `dark.css` flips that token. The **step chips have carried this since they were written**; on a `--hub-ink` plate the readable ink is `--pa-surface`, since both invert together.
- `main.css`'s `div.contentbox h3` (0,1,2) was quietly beating `.pa-hub-detail-title` (0,1,0), so the card title sat at `margin-left: 0` while everything under it sits on the 12px rail. Invisible until the tabs gave it something to be misaligned against.

## Verification

Driven in Chrome on `J2T21y64G2` / Ggt1, not inferred from the diff:

- 72 edges lit, 528 washed out
- 72 of 72 rows listed; counts `44 partners · 72 links · 3 pathways`
- a facet narrowing **both** graph and list to 10 of 72
- a dragged height (555px) surviving a tab switch
- the last row fully visible at the end of the scroll, fade cleared
- all six card elements on the 12px rail
- dark theme: chip `#E7E8EA` on ink `#1E1F23`, fade ending at `rgba(0,0,0,0)` — no white haze
- close collapses to 0, clears the inline basis and the focus

**Tests:** 82/82 in `test_hub_network_view.py` (17 new), ruff clean, versioned-asset digests recorded at `v=2.5` / `v=2.2`.

Full suite: 272 suites, 266 pass, 5 inherited from master. One suite flagged as introduced — `test_retention_matches_the_promise` — was traced to a stale gitignored `conf/serverconf.py` copied into the worktree during setup (it predates #65 and lacks `MAX_GUEST_JOB_DAYS`); with the template's values it passes. **This branch introduces no failures** and touches no Python outside two test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WM9HFZCuQkAWyzZngd9dUX