### PR TITLE
Calm the whole Step 3 palette, and make every category visible

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
@@ -494,9 +494,51 @@ function PA_Step3JobView() {
 	* @returns {String} the hexadecimal color code
 	**/
 	this.getClassificationColor = function(classificationID, otherColors){
-		var colors = ["#007AFF",  "#4CD964", "#FF2D55", "#FFCD02", "#5AC8FB", "#C644FC", "#FF9500",
-					  "#6b5b95", "#b2ad7f", "#a2b9bc", "#b5e7a0", "#b9936c", "#d6cbd3", "#eca1a6", "#bdcebe", "#e3eaa7", "#c1946a", "#034f84", "#92a8d1", "#deeaee", "#ffef96", "#50394c",
-					  "#618685", "#c1502e", "#7a3b2e", "#99ffcc", "#ffff00", "#990033", "#990099", "#994d00", "#269900", "#009999", "#008888", "#007777", "#006666", "#005555"];
+		/* The first seven are KEGG's classifications and keep their hues, which
+		   is what people recognise: C is still the blue one, H still the yellow
+		   one, and the pie, the grid stripes and the network still agree with
+		   each other. What they give up is chroma. They were an iOS system
+		   palette running to 0.265 (#C644FC) and 0.238 (#FF2D55) - against 0.135
+		   for the database badges and 0.125 for everything else here - and that
+		   is what made six discs in a quiet white card read as shouting. They
+		   now sit at 0.100-0.130, so nothing in this file is louder than
+		   anything else in it.
+
+		   Their lightness moved too, and had to: #FF2D55 sat at L=0.650 and
+		   #C644FC at L=0.648, which is the lane the database badges occupy.
+
+		   Indices 7-35 are Reactome's and are new. The old tail was not a
+		   categorical palette, it was an accumulation, and it failed the one
+		   thing a category colour has to do - be visible. Measured as contrast
+		   against the white page it ran from 1.07:1 (#ffff00) to 10.34:1
+		   (#50394c): eight of the twenty-nine were effectively white discs
+		   (#ffef96 at 1.16, #deeaee at 1.23, #e3eaa7 at 1.27) and five were
+		   near-black. Since the same value paints the legend chip, the pie
+		   slice and the network node, an invisible chip meant an invisible
+		   slice - on Reactome, "Immune System" and "Hemostasis" simply had no
+		   colour. Two entries (#b9936c / #c1946a) were also near-duplicates,
+		   0.014 apart in OKLab.
+
+		   Those twenty-nine are chosen farthest-point-first out of every OKLCH
+		   colour that clears the badges, clears the seven above and renders
+		   inside sRGB, drawn from lightnesses 0.435-0.525 and 0.765-0.835.
+
+		   What has to hold is the distance between ANY two of them, not between
+		   neighbours in this array: the legend renders a tree, parents with
+		   their sub-classifications nested underneath, and which
+		   classifications a job has varies, so this order is not the order
+		   anyone reads. The closest pair anywhere in the palette is 0.055,
+		   against the old 0.014; every entry lands between 1.60:1 and 8.17:1
+		   against the page; and contrastingInk() still picks each letter's ink,
+		   so every badge keeps its AA pair.
+
+		   Those band positions are not free parameters. The database badges in
+		   the summary card sit at L=0.645, between them, and the gap is what
+		   keeps a source from being confused with a category; see DB_COLORS
+		   below. Moving a band toward 0.645 closes that gap. */
+		var colors = ["#2f61a7", "#8dcd92", "#a8454d", "#e3c776", "#73c6ef", "#7b4993", "#e7a262",
+					  "#007b72", "#ffb1b2", "#00558a", "#f8ba8b", "#005e57", "#f2b1df", "#4a5900", "#d4bbfd", "#006b3d", "#aec9ff", "#6e5600", "#77dbe7", "#913546", "#88ddbd", "#86386d",
+					  "#b5d694", "#584b9a", "#acbc69", "#00647a", "#dc98d2", "#5f6900", "#b4a6f3", "#3a7c34", "#86b4f8", "#a44e26", "#5bc9ad", "#964b85", "#846600", "#5d60b0"];
 		var pos = ["cellular_processes", "environmental_information_processing", "genetic_information_processing", "human_diseases", "metabolism", "organismal_systems", "overview",
 				  // Added Reactome classification
 				  "cell_cycle", "cell-cell_communication", "cellular_responses_to_external_stimuli", "chromatin_organization", "circadian_clock", "developmental_biology",
@@ -1378,7 +1420,58 @@ function PA_Step3JobView() {
 					new Odometer({el: $("#significantPathwaysTag")[0],value: 0});
 					// SUMMARY PANEL PER DATABASE
 					if (me.getModel().getDatabases().length > 1) {
-						var DB_COLORS = ["#007AFF",  "#4CD964", "#FF2D55", "#FFCD02", "#5AC8FB", "#C644FC"];
+						/* A database is a source, not a category, and it was wearing
+						   the classification palette: this list used to be the first
+						   six entries of getClassificationColor()'s array, so on the
+						   very same screen the KEGG badge and the "Cellular Processes"
+						   badge were both #007AFF, OmniPath and "Environmental
+						   Information Processing" both #4CD964, Reactome and "Genetic
+						   Information Processing" both #FF2D55. Two taxonomies, one
+						   set of colours, four hundred pixels apart - and the three
+						   database discs sit alone in a white summary card with
+						   nothing to carry that much saturation, which is why they
+						   read as shouting.
+
+						   The hue now follows the database rather than its position in
+						   the list: KEGG yellow, Reactome blue, OmniPath green, which
+						   is how each of them is identified everywhere else. Under the
+						   old scheme KEGG was blue for no better reason than being
+						   index 0. MapMan takes the one remaining hue - it has to be
+						   told apart from the other three, and that is the only claim
+						   being made about it.
+
+						   Hue cannot also be what separates a source from a category,
+						   because both systems now use the whole circle: there is no
+						   arrangement of four database colours and twenty-nine category
+						   colours in which every pair is distinct, and picking brand
+						   hues guarantees a gold badge shares a hue with some gold
+						   category. Lightness does the separating instead. These four
+						   sit at OKLCH L=0.645, and getClassificationColor()'s rebuilt
+						   tail is generated in two bands deliberately placed either
+						   side of them, at L<=0.525 and L>=0.775. Lightness is OKLab's
+						   first coordinate, so that gap is a floor on the distance
+						   whatever hues the two end up wearing: no category comes
+						   closer than 0.121, against 0.021 when the databases sat
+						   inside the palette's own bands.
+
+						   The KEGG seven used to be the exception, because they were
+						   fixed and could not be moved out of the way; softening them
+						   moved them into the same construction as everything else, so
+						   the floor is now uniform. No classification of any database
+						   comes within 0.121 of any badge.
+
+						   Keyed by name rather than by position. The old lookup was
+						   DB_COLORS[i] over whatever order the model happened to
+						   return, so Reactome was red in a three-database job and
+						   green in a two-database one; a source's identity must not
+						   move between jobs. Anything unlisted falls back to the
+						   classification palette, which is what this line did before. */
+						var DB_COLORS = {
+							"KEGG":     "#ab8a00",
+							"Reactome": "#6a89e0",
+							"OmniPath": "#41a563",
+							"MapMan":   "#d3686e"
+						};
 						// The two count cells must stay the sole content of their id'd
 						// element -- the pathway filters refresh them with .html(number)
 						// (see the $("#foundPathwaysTag_" + dbname) calls above), so any
@@ -1403,7 +1496,12 @@ function PA_Step3JobView() {
 
 						for (var i = 0; i < me.getModel().getDatabases().length; i++) {
 							var database = me.getModel().getDatabases()[i];
-							var db_color = (i < DB_COLORS.length) ? DB_COLORS[i] : "#000000";
+							/* A database installed after this list was written still
+							   needs a colour, and #000000 was not one: a black disc
+							   reads as disabled next to three coloured ones. Deferring
+							   to the classification palette's name hash gives it a
+							   stable colour drawn from a vetted band instead. */
+							var db_color = DB_COLORS[database] || me.getClassificationColor(database);
 
 							table_html +=
 							'<tr>' +
@@ -1459,7 +1557,31 @@ function PA_Step3PathwayClassificationView(db = "KEGG") {
 	this.database = db;
 	this.dbid = this.database.replace(' ', '__');
 	this.highcharts = null;
-	this.OTHER_COLORS = ["#FF9500", "#E0F8D8", "#55EFCB", "#FFD3E0"];
+	/* Handed to getClassificationColor() for classifications the name list
+	   does not cover - which on OmniPath is most of them. Three of the four
+	   old values were near-white (#E0F8D8 at 1.13:1 against the page,
+	   #FFD3E0 at 1.34, #55EFCB at 1.44), so "Cell cycle, death and
+	   autophagy" and "Immune signalling" drew blank discs and blank pie
+	   slices.
+
+	   These four have to clear two different things, and getting either wrong
+	   is visible on the page. They must clear the database badges, which sit
+	   at OKLCH L=0.645 - a first attempt put a green 0.028 from OmniPath's
+	   own badge, the very collision this change exists to remove. And they
+	   must clear all 36 palette entries, because a classification that takes
+	   one of these sits in the same legend as classifications that took a
+	   palette colour by name: drawing these FROM the palette instead, which
+	   was the second attempt, put "Drug ADME" and "Cell-Cell communication"
+	   on the same hex in the Reactome legend.
+
+	   So they are their own colours, chosen from the same safe zones the
+	   palette is drawn from (L <= 0.525 or L >= 0.765, which is what staying
+	   0.12 clear of the databases in OKLab's first coordinate means) but far
+	   enough from all thirty-six to never double one. That leaves them 0.055
+	   from the nearest palette entry, 0.121 from the nearest badge, and 0.221
+	   apart from each other - which matters, because they are handed out
+	   together to consecutive rows of one legend. */
+	this.OTHER_COLORS = ["#794100", "#0073a2", "#f19690", "#49c7d3"];
 
 	/*********************************************************************
 	* OTHER FUNCTIONS
@@ -1553,7 +1675,7 @@ function PA_Step3PathwayClassificationView(db = "KEGG") {
 		/**********************************************************/
 		/* STEP 3.1 INITIALIZE VARIABLES                          */
 		/**********************************************************/
-		OTHER_COLORS = ["#FF9500", "#E0F8D8", "#55EFCB", "#FFD3E0"];
+		OTHER_COLORS = ["#794100", "#0073a2", "#f19690", "#49c7d3"];
 		var htmlContent = "", mainClassificationHTMLcode, secClassificationHTMLcode,
 		pathClassificationHTMLcode, color, pathwayID, temporalCodeTable, namesAux, posAux,
 		isCustomMainClass, isHiddenMainClass, isCustomSecClass, isHiddenSecClass;

--- a/PaintomicsClient/tests/palette/classification-palette.test.js
+++ b/PaintomicsClient/tests/palette/classification-palette.test.js
@@ -1,0 +1,322 @@
+/*
+ * The pathway palettes are plain literals inside an ExtJS view, so there is no
+ * module to require. The view is read as text and the three arrays are pulled
+ * out of it, which is the point: this asserts the values that actually ship.
+ *
+ * What it guards is the defect these tests were written for - a category colour
+ * that cannot be seen. The palette that lived here before ran from 1.07:1 to
+ * 10.34:1 against the white page, and since one value paints the legend badge,
+ * the pie slice and the network node at once, the eight entries under 2:1 meant
+ * Reactome classifications like "Immune System" and "Hemostasis" drew a white
+ * disc on white, a white wedge in the pie and a white dot in the network.
+ */
+const test = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const VIEW = path.join(
+    __dirname, "..", "..", "public_html", "app", "view",
+    "PathwayAcquisitionViews", "PA_Step3Views.js"
+);
+const source = fs.readFileSync(VIEW, "utf8");
+
+/* The comments in this view quote the code they replaced, so a search for an
+   old expression finds the prose describing why it went. Assertions about what
+   the file *does* run against the comment-free text. */
+const code = source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/^[ \t]*\/\/.*$/gm, " ");
+
+/* ---------------------------------------------------------------- helpers */
+
+function channel(c) {
+    return (c <= 0.04045) ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+/* Same relative luminance Util.js uses to choose the badge ink. */
+function luminance(hex) {
+    const p = [1, 3, 5].map(i => channel(parseInt(hex.substr(i, 2), 16) / 255));
+    return 0.2126 * p[0] + 0.7152 * p[1] + 0.0722 * p[2];
+}
+
+function contrast(a, b) {
+    const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+    return (hi + 0.05) / (lo + 0.05);
+}
+
+/* contrastingInk() picks whichever of black or white contrasts better, so the
+   ink a badge will actually get is the better of the two ratios. */
+function inkContrast(fill) {
+    return Math.max(contrast(fill, "#000000"), contrast(fill, "#ffffff"));
+}
+
+/* Perceptual distance, so "these two are different colours" is a claim about
+   what a reader can see rather than about the hex digits. */
+function oklab(hex) {
+    const [r, g, b] = [1, 3, 5].map(i => channel(parseInt(hex.substr(i, 2), 16) / 255));
+    const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+    const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+    const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+    return [
+        0.2104542553 * l + 0.7936177850 * m - 0.0040720468 * s,
+        1.9779984951 * l - 2.4285922050 * m + 0.4505937099 * s,
+        0.0259040371 * l + 0.7827717662 * m - 0.8086757660 * s
+    ];
+}
+
+function distance(a, b) {
+    const [x, y] = [oklab(a), oklab(b)];
+    return Math.hypot(x[0] - y[0], x[1] - y[1], x[2] - y[2]);
+}
+
+function hexesIn(block) {
+    return (block.match(/#[0-9a-fA-F]{6}/g) || []).map(h => h.toLowerCase());
+}
+
+/* ------------------------------------------------------------ extraction */
+
+/* The literal must be the one that opens right after the marker. Scanning for
+   the next `{` anywhere would happily walk past an array and pick up some
+   unrelated object further down the file, and every assertion below would then
+   pass against colours that are not the ones being read - a guard that cannot
+   fail is worse than no guard. */
+function slice(startMarker, open, close) {
+    const from = source.indexOf(startMarker);
+    assert.notStrictEqual(from, -1, "cannot find " + startMarker + " in PA_Step3Views.js");
+    const begin = source.indexOf(open, from);
+    const between = source.slice(from + startMarker.length, begin);
+    assert.ok(
+        begin !== -1 && /^[\s=]*$/.test(between),
+        startMarker + " is no longer followed by a '" + open + "' literal"
+    );
+    const end = source.indexOf(close, begin);
+    assert.notStrictEqual(end, -1, "unterminated literal after " + startMarker);
+    return source.slice(begin, end + 1);
+}
+
+const CLASSIFICATION = hexesIn(slice("var colors =", "[", "]"));
+const DATABASE_BLOCK = slice("var DB_COLORS =", "{", "}");
+const DATABASE = hexesIn(DATABASE_BLOCK);
+const OTHER = hexesIn(slice("this.OTHER_COLORS =", "[", "]"));
+
+assert.ok(CLASSIFICATION.length > 30, "read only " + CLASSIFICATION.length + " classification colours");
+assert.ok(DATABASE.length >= 3, "read only " + DATABASE.length + " database colours");
+assert.ok(OTHER.length >= 3, "read only " + OTHER.length + " fallback colours");
+
+/* The seven KEGG classifications are deliberately untouched - users read them
+   off the Category Distribution pie and the pathway grid at the same time. The
+   rebuilt Reactome tail starts after them. */
+const KEGG_HEAD = 7;
+const TAIL = CLASSIFICATION.slice(KEGG_HEAD);
+
+/* ---------------------------------------------------------------- tests */
+
+test("the classification palette has one colour per classification name", () => {
+    const names = source
+        .slice(source.indexOf("this.getClassificationColor = function"))
+        .match(/var pos = \[[\s\S]*?\]\.indexOf/)[0];
+    const count = (names.match(/"/g).length) / 2;
+    assert.strictEqual(
+        CLASSIFICATION.length, count,
+        "a name without a colour reads colors[undefined]; a colour without a name is unreachable"
+    );
+});
+
+test("every classification badge gets a letter that passes AA", () => {
+    for (const fill of CLASSIFICATION.concat(OTHER, DATABASE)) {
+        assert.ok(
+            inkContrast(fill) >= 4.5,
+            fill + " leaves the badge letter at " + inkContrast(fill).toFixed(2) + ":1"
+        );
+    }
+});
+
+test("no Reactome classification is invisible against the page", () => {
+    /* The floor is the weakest colour the KEGG head is allowed to keep
+       (#FFCD02 at 1.50:1), so the tail can never be worse than the set that
+       was explicitly kept. In practice its lightest band clears 1.85:1, just
+       above #4CD964. */
+    for (const fill of TAIL.concat(OTHER)) {
+        const seen = contrast(fill, "#ffffff");
+        assert.ok(
+            seen >= 1.5,
+            fill + " is " + seen.toFixed(2) + ":1 against the white page - it draws a blank " +
+            "badge, a blank pie slice and a blank network node"
+        );
+    }
+});
+
+test("no classification colour is a near-black blot", () => {
+    for (const fill of TAIL) {
+        const seen = contrast(fill, "#ffffff");
+        assert.ok(seen <= 8.0, fill + " is " + seen.toFixed(2) + ":1 - it reads as ink, not as a category");
+    }
+});
+
+test("two classifications in one legend are told apart", () => {
+    let worst = { d: Infinity };
+    for (let i = 0; i < TAIL.length; i++) {
+        for (let j = i + 1; j < TAIL.length; j++) {
+            const d = distance(TAIL[i], TAIL[j]);
+            if (d < worst.d) worst = { d: d, a: TAIL[i], b: TAIL[j] };
+        }
+    }
+    /* The old palette held #b9936c and #c1946a, 0.014 apart - two tans nobody
+       could separate. */
+    assert.ok(
+        worst.d > 0.03,
+        worst.a + " and " + worst.b + " are " + worst.d.toFixed(4) + " apart in OKLab"
+    );
+});
+
+test("a Reactome classification clears the KEGG seven it shares a legend with", () => {
+    /* The Reactome and OmniPath legends both contain "Metabolism", which is a
+       KEGG name and so takes KEGG's colour. A Reactome entry landing beside it
+       in the same legend is the same defect as any other duplicate - an early
+       cut put #79c5f3 0.025 from the old #5AC8FB, two light blues three rows
+       apart in the Reactome list. */
+    const HEAD = CLASSIFICATION.slice(0, KEGG_HEAD);
+    for (const fill of TAIL) {
+        let worst = { d: Infinity };
+        for (const h of HEAD) {
+            const d = distance(fill, h);
+            if (d < worst.d) worst = { d: d, h: h };
+        }
+        assert.ok(
+            worst.d > 0.05,
+            fill + " is " + worst.d.toFixed(4) + " from the KEGG colour " + worst.h
+        );
+    }
+});
+
+test("nothing in the palette is louder than the badges", () => {
+    /* The KEGG seven were an iOS system palette at chroma up to 0.265, against
+       0.135 for the badges - six saturated discs in a quiet white card, which
+       is the complaint this whole change started from. Nothing here may exceed
+       the badges again. */
+    const chroma = hex => { const [, a, b] = oklab(hex); return Math.hypot(a, b); };
+    const loudestBadge = Math.max(...DATABASE.map(chroma));
+    for (const fill of CLASSIFICATION.concat(OTHER)) {
+        assert.ok(
+            chroma(fill) <= loudestBadge + 0.002,
+            fill + " is at chroma " + chroma(fill).toFixed(3) +
+            ", past the badges' " + loudestBadge.toFixed(3)
+        );
+    }
+});
+
+test("any two colours that can share a legend are told apart", () => {
+    /* Deliberately not an adjacency test. The order of this array is NOT the
+       order a reader sees: the legend renders a tree, parents with their
+       sub-classifications nested underneath, and which classifications a job
+       has varies. So any two entries can end up next to each other and the
+       floor has to hold for every pair, not for consecutive ones. Measured on
+       a KEGG+OmniPath+Reactome job the closest pair actually rendered in one
+       legend is 0.0555. */
+    const ALL = CLASSIFICATION.concat(OTHER);
+    let worst = { d: Infinity };
+    for (let i = 0; i < ALL.length; i++) {
+        for (let j = i + 1; j < ALL.length; j++) {
+            const d = distance(ALL[i], ALL[j]);
+            if (d < worst.d) worst = { d: d, a: ALL[i], b: ALL[j] };
+        }
+    }
+    assert.ok(
+        worst.d > 0.05,
+        worst.a + " and " + worst.b + " are " + worst.d.toFixed(4) + " apart in OKLab"
+    );
+});
+
+test("a database badge is not wearing a classification colour", () => {
+    /* The reported bug: DB_COLORS was the first six entries of the
+       classification palette, so on one screen the KEGG badge and the
+       "Cellular Processes" badge were both #007AFF. */
+    for (const db of DATABASE) {
+        assert.ok(
+            !CLASSIFICATION.includes(db),
+            db + " paints both a database and a pathway classification"
+        );
+        /* Not merely "not identical". Both systems now use the whole hue
+           circle - KEGG's database gold shares a hue with some gold category,
+           necessarily - so hue cannot be what separates them and the distance
+           has to be asserted rather than assumed.
+
+           One floor for the whole palette. The KEGG seven used to need a
+           looser one because they were fixed and could not be moved out of the
+           badges' way; softening them put them in the same construction as
+           everything else, so every classification now clears every badge by
+           the same structural margin. */
+        for (const cls of CLASSIFICATION.concat(OTHER)) {
+            assert.ok(
+                distance(db, cls) > 0.12,
+                db + " is only " + distance(db, cls).toFixed(4) + " from " + cls +
+                " - the lightness bands either side of the databases have closed up"
+            );
+        }
+    }
+});
+
+test("the databases are one quiet family, not six competing ones", () => {
+    /* Sources label the science, they are not the science. The databases sit
+       within a narrow lightness band so none of them outranks another, and all
+       of them are softer than the classification palette they used to borrow. */
+    const seen = DATABASE.map(d => contrast(d, "#ffffff"));
+    assert.ok(
+        Math.max(...seen) - Math.min(...seen) < 1.0,
+        "database badges differ in weight: " + seen.map(v => v.toFixed(2)).join(", ")
+    );
+});
+
+test("a database colour is keyed by name, not by position", () => {
+    /* Keyed by index, Reactome was red in a three-database job and green in a
+       two-database one. */
+    assert.match(DATABASE_BLOCK, /"KEGG"\s*:/);
+    assert.match(DATABASE_BLOCK, /"Reactome"\s*:/);
+    assert.match(DATABASE_BLOCK, /"OmniPath"\s*:/);
+    assert.ok(
+        !/DB_COLORS\[i\]|DB_COLORS\.length/.test(code),
+        "DB_COLORS is being read positionally again"
+    );
+});
+
+test("an unlisted database still gets a colour", () => {
+    /* The fallback used to be #000000, which reads as a disabled badge beside
+       three coloured ones. */
+    assert.ok(!/DB_COLORS\S*\s*\?[^:]*:\s*"#000000"/.test(code),
+        "an unlisted database falls back to a black disc again");
+    assert.ok(/DB_COLORS\[database\]\s*\|\|\s*me\.getClassificationColor\(database\)/.test(code),
+        "the fallback to the classification palette is gone");
+});
+
+test("the fallback list collides with nothing it can appear beside", () => {
+    /* A classification that takes an OTHER_COLOR sits in the same legend as
+       classifications that took a palette colour by name, so these four must
+       clear all 36 - taking them FROM the palette put "Drug ADME" and
+       "Cell-Cell communication" on one hex in the Reactome legend. */
+    for (const fill of OTHER) {
+        let worst = { d: Infinity };
+        for (const cls of CLASSIFICATION) {
+            const d = distance(fill, cls);
+            if (d < worst.d) worst = { d: d, cls: cls };
+        }
+        assert.ok(
+            worst.d > 0.045,
+            fill + " is " + worst.d.toFixed(4) + " from the palette colour " + worst.cls +
+            " - two classifications in one legend would wear it"
+        );
+    }
+    let worst = { d: Infinity };
+    for (let i = 0; i < OTHER.length; i++) {
+        for (let j = i + 1; j < OTHER.length; j++) {
+            const d = distance(OTHER[i], OTHER[j]);
+            if (d < worst.d) worst = { d: d, a: OTHER[i], b: OTHER[j] };
+        }
+    }
+    /* They are handed out together, to consecutive classifications in one
+       legend, so these four in particular have to be far apart. */
+    assert.ok(
+        worst.d > 0.15,
+        worst.a + " and " + worst.b + " are " + worst.d.toFixed(4) + " apart in OKLab"
+    );
+});


### PR DESCRIPTION
## What you reported

The three pathway-database badges — **K** / **O** / **R** in the Pathways summary card — read as too strong.

They were the same palette as the categories. `DB_COLORS` was literally the first six entries of `getClassificationColor()`, so on one screen, four hundred pixels apart:

| | database badge | KEGG category badge |
|---|---|---|
| blue `#007AFF` | **K** KEGG | **C** Cellular Processes |
| green `#4CD964` | **O** OmniPath | **E** Environmental Information Processing |
| red `#FF2D55` | **R** Reactome | **G** Genetic Information Processing |

## The badges

The hue now follows the database — **KEGG yellow, Reactome blue, OmniPath green** — which is how each is identified everywhere else. Under the old scheme KEGG was blue for no better reason than being index 0 of a list it had no business sharing.

| | before | after |
|---|---|---|
| KEGG | `#007AFF` blue | `#ab8a00` gold |
| Reactome | `#FF2D55` red | `#6a89e0` blue |
| OmniPath | `#4CD964` green | `#41a563` green |
| MapMan | *(unlisted → black)* | `#d3686e` |

**Keyed by name, not by position.** `DB_COLORS[i]` over whatever order the model returned made Reactome red in a three-database job and green in a two-database one. A database nobody listed now falls through to the classification hash rather than to `#000000`, which read as a disabled badge beside three coloured ones.

## The KEGG categories

Softened rather than kept. They were an iOS system palette running to chroma **0.265** (`#C644FC`) and **0.238** (`#FF2D55`) — against 0.135 for the badges and 0.125 for everything else here. That, not the hue, is what made a quiet white card shout.

| | before | after | |
|---|---|---|---|
| C Cellular Processes | `#007AFF` | `#2f61a7` | electric blue → muted navy |
| E Environmental Info | `#4CD964` | `#8dcd92` | neon green → soft green |
| G Genetic Info | `#FF2D55` | `#a8454d` | hot pink-red → brick |
| H Human Diseases | `#FFCD02` | `#e3c776` | pure yellow → soft gold |
| M Metabolism | `#5AC8FB` | `#73c6ef` | sky blue → calmer sky |
| O Organismal Systems | `#C644FC` | `#7b4993` | magenta → plum |
| — Overview | `#FF9500` | `#e7a262` | orange → apricot |

They keep their hues, so C is still the blue one and H still the yellow one, and the pie, the grid stripes and the network still agree with each other. **Max chroma anywhere in the file: 0.265 → 0.131.** Nothing is louder than anything else now.

## Why lightness separates sources from categories

Hue can't do it once both systems use the whole circle — there is no arrangement of 4 badge colours and 36 category colours in which every pair is distinct. So badges sit at OKLCH **L=0.645** and every category is drawn from either side.

Softening the KEGG seven also removed an exception: `#FF2D55` and `#C644FC` sat at L=0.650 and L=0.648, *inside* the badge lane, and had to be tolerated because they were fixed. They aren't any more.

```
any category -> any badge, closest approach    0.021  ->  0.121   (uniform, no exception)
```

## The invisible categories

The Reactome tail was not a categorical palette but an accumulation, and it failed the one thing a category colour has to do:

```
contrast vs page   1.07 .. 10.34   ->   1.60 .. 8.17     8 invisible, 5 near-black -> 0
closest pair       0.0135          ->   0.0552           in OKLab
```

`#ffef96` at **1.16:1**, `#deeaee` at 1.23, `#e3eaa7` at 1.27. One value paints the legend chip, the pie slice *and* the network node, so "Immune System" and "Hemostasis" had no colour anywhere.

`OTHER_COLORS` had the same fault and took three attempts, the first two failing **on the page, not in the diff**: one put a green 0.028 from OmniPath's own badge; one drawn from the palette put "Drug ADME" and "Cell-Cell communication" on one hex in the Reactome legend.

## Tests

`PaintomicsClient/tests/palette/classification-palette.test.js` — 13 cases, run by the existing `sh PaintomicsClient/tests/run.sh`, no dependencies. It reads the literals out of the shipped view.

One of them started out asserting the wrong thing: an adjacency test on the array order, when the legend actually renders a *tree* (parents with sub-classifications nested) whose order the array doesn't determine. Caught by measuring the running page against the test's own claim; it now asserts the global pairwise floor, which is what actually has to hold.

13/13 pass. Against `master`, 5 fail with the original defects, and reverting `DB_COLORS` to an array fails the extraction loudly rather than passing vacuously.

## Verified in Chrome

Job `56pfV2jIno` (mmu, KEGG + OmniPath + Reactome), light and dark, measured on the live DOM:

| | light | dark |
|---|---|---|
| databases | 3.09–3.35 vs page | 4.91–5.32 vs surface |
| KEGG | 1.65–6.53 | 2.52–9.95 |
| OmniPath | 1.73–8.17 | 2.01–9.51 |
| Reactome | 1.60–8.17 | 2.01–10.29 |

Minimum badge ink 5.11 (AA needs 4.5). No blank chips in any legend. Also confirmed: the enrichment table's 1009 source-chip cells and its 32 classification stripes, and the Reactome network node fills. No app console errors.

## Not fixed here

- `format-roles.test.js` › "a design file rejects a sample in two conditions at once" fails on `master` too. Unrelated, untouched.
- A classification outside the name list still gets its colour by *arrival order* (`OTHER_COLORS.shift()`) then by name hash — two mechanisms, the first position-dependent the way `DB_COLORS[i]` was. Every value either can reach is now vetted, so the visible defect is gone, but unifying them is worth its own change.
- Old exported figures and screenshots will not match the new palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRBLhhw3Dmfko6YyhEjBvU