### PR TITLE
Paint the source badges in the databases' own colours

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
@@ -494,51 +494,49 @@ function PA_Step3JobView() {
 	* @returns {String} the hexadecimal color code
 	**/
 	this.getClassificationColor = function(classificationID, otherColors){
-		/* The first seven are KEGG's classifications and keep their hues, which
-		   is what people recognise: C is still the blue one, H still the yellow
-		   one, and the pie, the grid stripes and the network still agree with
-		   each other. What they give up is chroma. They were an iOS system
-		   palette running to 0.265 (#C644FC) and 0.238 (#FF2D55) - against 0.135
-		   for the database badges and 0.125 for everything else here - and that
-		   is what made six discs in a quiet white card read as shouting. They
-		   now sit at 0.100-0.130, so nothing in this file is louder than
-		   anything else in it.
+		/* The first seven are KEGG's classifications and keep their hues, which is
+		   what people recognise: C is still the blue one, H still the yellow one,
+		   and the pie, the grid stripes and the network still agree with each
+		   other. Hue is the recognition; lightness and chroma are not, so those
+		   move - but only so far. An earlier cut of this generator held the hues
+		   and let lightness float, and turned #a8454d, a dark red, into a pale
+		   pink at the same angle. Same hue is not the same colour. Each of the
+		   seven now stays within 0.075 of the lightness it had.
 
-		   Their lightness moved too, and had to: #FF2D55 sat at L=0.650 and
-		   #C644FC at L=0.648, which is the lane the database badges occupy.
+		   Indices 7-35 are Reactome's, and the four in OTHER_COLORS below are cut
+		   from the same construction: every value here is chosen farthest-point
+		   first out of the OKLCH colours that render inside sRGB, sit between
+		   1.60:1 and 7.95:1 against the white page, hold chroma between 0.070 and
+		   0.131, and clear all four database badges by 0.121 in OKLab.
 
-		   Indices 7-35 are Reactome's and are new. The old tail was not a
-		   categorical palette, it was an accumulation, and it failed the one
-		   thing a category colour has to do - be visible. Measured as contrast
-		   against the white page it ran from 1.07:1 (#ffff00) to 10.34:1
-		   (#50394c): eight of the twenty-nine were effectively white discs
-		   (#ffef96 at 1.16, #deeaee at 1.23, #e3eaa7 at 1.27) and five were
-		   near-black. Since the same value paints the legend chip, the pie
-		   slice and the network node, an invisible chip meant an invisible
-		   slice - on Reactome, "Immune System" and "Hemostasis" simply had no
-		   colour. Two entries (#b9936c / #c1946a) were also near-duplicates,
-		   0.014 apart in OKLab.
+		   That last constraint is what this generation changed, and it is worth
+		   being precise about. Until now the badges sat together at one lightness,
+		   L=0.645, and this palette was drawn from two bands either side of them,
+		   L<=0.525 and L>=0.765. The 0.121 gap was a consequence of that geometry:
+		   lightness is OKLab's first coordinate, so two bands and a lane between
+		   them put a floor under the distance whatever hues the two ended up
+		   wearing. It cost the badges their brand colours. KEGG's yellow is only
+		   yellow at high lightness - at 0.645 the most saturated yellow sRGB holds
+		   is a mustard - and Reactome's blue and OmniPath's teal are nineteen
+		   degrees apart, so at a shared lightness they collapsed to 0.044 and one
+		   of them had to be pushed off brand.
 
-		   Those twenty-nine are chosen farthest-point-first out of every OKLCH
-		   colour that clears the badges, clears the seven above and renders
-		   inside sRGB, drawn from lightnesses 0.435-0.525 and 0.765-0.835.
+		   So the badges now sit at their own lightnesses and the exclusion is four
+		   points, not two bands. Four spheres of radius 0.121 remove far less of
+		   the space than two banned bands did, which is why this palette is not
+		   merely as good as the one it replaces but measurably better: the closest
+		   pair anywhere is 0.080, against 0.055 before, and the mid-lightness
+		   range the badges used to fence off is open again.
 
-		   What has to hold is the distance between ANY two of them, not between
-		   neighbours in this array: the legend renders a tree, parents with
-		   their sub-classifications nested underneath, and which
-		   classifications a job has varies, so this order is not the order
-		   anyone reads. The closest pair anywhere in the palette is 0.055,
-		   against the old 0.014; every entry lands between 1.60:1 and 8.17:1
-		   against the page; and contrastingInk() still picks each letter's ink,
-		   so every badge keeps its AA pair.
-
-		   Those band positions are not free parameters. The database badges in
-		   the summary card sit at L=0.645, between them, and the gap is what
-		   keeps a source from being confused with a category; see DB_COLORS
-		   below. Moving a band toward 0.645 closes that gap. */
-		var colors = ["#2f61a7", "#8dcd92", "#a8454d", "#e3c776", "#73c6ef", "#7b4993", "#e7a262",
-					  "#007b72", "#ffb1b2", "#00558a", "#f8ba8b", "#005e57", "#f2b1df", "#4a5900", "#d4bbfd", "#006b3d", "#aec9ff", "#6e5600", "#77dbe7", "#913546", "#88ddbd", "#86386d",
-					  "#b5d694", "#584b9a", "#acbc69", "#00647a", "#dc98d2", "#5f6900", "#b4a6f3", "#3a7c34", "#86b4f8", "#a44e26", "#5bc9ad", "#964b85", "#846600", "#5d60b0"];
+		   What has to hold is the distance between ANY two of these, not between
+		   neighbours in this array: the legend renders a tree, parents with their
+		   sub-classifications nested underneath, and which classifications a job
+		   has varies, so this order is not the order anyone reads.
+		   contrastingInk() still picks each letter's ink, and the worst badge in
+		   the file keeps its letter at 4.88:1. */
+		var colors = ["#1e5099", "#8cde95", "#8d3239", "#c7b784", "#35b0e6", "#8e57a5", "#de9046",
+					  "#fa9acf", "#8c6d08", "#37ac78", "#a78ae3", "#3982c9", "#febdb0", "#694276", "#96911a", "#6c4c09", "#935e64", "#4c8939", "#0ac2c6", "#fb908a", "#589ba5", "#c797b4",
+					  "#8bc068", "#b16db7", "#9f4b0b", "#5861a3", "#b6770b", "#94a7d5", "#fba866", "#596a24", "#739269", "#6a93e5", "#7cb398", "#e7bdfd", "#ad9365", "#8274cc"];
 		var pos = ["cellular_processes", "environmental_information_processing", "genetic_information_processing", "human_diseases", "metabolism", "organismal_systems", "overview",
 				  // Added Reactome classification
 				  "cell_cycle", "cell-cell_communication", "cellular_responses_to_external_stimuli", "chromatin_organization", "circadian_clock", "developmental_biology",
@@ -1420,56 +1418,46 @@ function PA_Step3JobView() {
 					new Odometer({el: $("#significantPathwaysTag")[0],value: 0});
 					// SUMMARY PANEL PER DATABASE
 					if (me.getModel().getDatabases().length > 1) {
-						/* A database is a source, not a category, and it was wearing
-						   the classification palette: this list used to be the first
-						   six entries of getClassificationColor()'s array, so on the
-						   very same screen the KEGG badge and the "Cellular Processes"
-						   badge were both #007AFF, OmniPath and "Environmental
-						   Information Processing" both #4CD964, Reactome and "Genetic
-						   Information Processing" both #FF2D55. Two taxonomies, one
-						   set of colours, four hundred pixels apart - and the three
-						   database discs sit alone in a white summary card with
-						   nothing to carry that much saturation, which is why they
-						   read as shouting.
+						/* A database is a source, not a category, and it used to wear the
+						   classification palette: this list was once the first six entries of
+						   getClassificationColor()'s array, so on the very same screen the KEGG
+						   badge and the "Cellular Processes" badge were both #007AFF, OmniPath
+						   and "Environmental Information Processing" both #4CD964.
 
-						   The hue now follows the database rather than its position in
-						   the list: KEGG yellow, Reactome blue, OmniPath green, which
-						   is how each of them is identified everywhere else. Under the
-						   old scheme KEGG was blue for no better reason than being
-						   index 0. MapMan takes the one remaining hue - it has to be
-						   told apart from the other three, and that is the only claim
+						   These are the databases' own colours: KEGG's yellow, OmniPath's teal,
+						   Reactome's blue, as each of them is identified everywhere else.
+						   Three are the brand value exactly. Reactome is the one that moves,
+						   and only in chroma - its #B6DEEA is at 0.045, and a 24px disc that
+						   desaturated reads as grey rather than as blue, so it is lifted to
+						   0.066 and keeps the pale character (0.042 away in OKLab). MapMan
+						   takes a hue none of the other three claims; that is the only claim
 						   being made about it.
 
-						   Hue cannot also be what separates a source from a category,
-						   because both systems now use the whole circle: there is no
-						   arrangement of four database colours and twenty-nine category
-						   colours in which every pair is distinct, and picking brand
-						   hues guarantees a gold badge shares a hue with some gold
-						   category. Lightness does the separating instead. These four
-						   sit at OKLCH L=0.645, and getClassificationColor()'s rebuilt
-						   tail is generated in two bands deliberately placed either
-						   side of them, at L<=0.525 and L>=0.775. Lightness is OKLab's
-						   first coordinate, so that gap is a floor on the distance
-						   whatever hues the two end up wearing: no category comes
-						   closer than 0.121, against 0.021 when the databases sat
-						   inside the palette's own bands.
+						   They no longer share a lightness, and that is deliberate rather than
+						   careless. Yellow has no dark form - at the L=0.645 these four used to
+						   share, the most saturated yellow in sRGB is a mustard 0.226 from
+						   KEGG's own colour - and Reactome's blue and OmniPath's teal are
+						   nineteen degrees apart in hue, which at one lightness put them 0.044
+						   from each other. Their brand lightnesses, 0.840 and 0.530, are what
+						   makes both hues usable at once: 0.312 apart.
 
-						   The KEGG seven used to be the exception, because they were
-						   fixed and could not be moved out of the way; softening them
-						   moved them into the same construction as everything else, so
-						   the floor is now uniform. No classification of any database
-						   comes within 0.121 of any badge.
+						   Hue cannot be what separates a source from a category either, because
+						   both systems use the whole circle. The separation is asserted directly
+						   instead: every one of the 40 classification colours is generated to
+						   clear all four of these by 0.121 in OKLab, and the palette test holds
+						   that floor pair by pair. Four excluded points cost the classifications
+						   less than the two banned lightness bands they replace, so the palette
+						   got better in the same move: closest pair 0.080, against 0.055.
 
-						   Keyed by name rather than by position. The old lookup was
-						   DB_COLORS[i] over whatever order the model happened to
-						   return, so Reactome was red in a three-database job and
-						   green in a two-database one; a source's identity must not
-						   move between jobs. Anything unlisted falls back to the
-						   classification palette, which is what this line did before. */
+						   Keyed by name rather than by position. The old lookup was DB_COLORS[i]
+						   over whatever order the model happened to return, so Reactome was red
+						   in a three-database job and green in a two-database one; a source's
+						   identity must not move between jobs. Anything unlisted falls back to
+						   the classification palette, which is what this line did before. */
 						var DB_COLORS = {
-							"KEGG":     "#ab8a00",
-							"Reactome": "#6a89e0",
-							"OmniPath": "#41a563",
+							"KEGG":     "#fcce00",
+							"Reactome": "#9ad5e9",
+							"OmniPath": "#027b7f",
 							"MapMan":   "#d3686e"
 						};
 						// The two count cells must stay the sole content of their id'd
@@ -1557,31 +1545,28 @@ function PA_Step3PathwayClassificationView(db = "KEGG") {
 	this.database = db;
 	this.dbid = this.database.replace(' ', '__');
 	this.highcharts = null;
-	/* Handed to getClassificationColor() for classifications the name list
-	   does not cover - which on OmniPath is most of them. Three of the four
-	   old values were near-white (#E0F8D8 at 1.13:1 against the page,
-	   #FFD3E0 at 1.34, #55EFCB at 1.44), so "Cell cycle, death and
-	   autophagy" and "Immune signalling" drew blank discs and blank pie
-	   slices.
+	/* Handed to getClassificationColor() for classifications the name list does
+	   not cover - which on OmniPath is most of them. Three of the four original
+	   values were near-white (#E0F8D8 at 1.13:1 against the page, #FFD3E0 at
+	   1.34, #55EFCB at 1.44), so "Cell cycle, death and autophagy" and "Immune
+	   signalling" drew blank discs and blank pie slices.
 
-	   These four have to clear two different things, and getting either wrong
-	   is visible on the page. They must clear the database badges, which sit
-	   at OKLCH L=0.645 - a first attempt put a green 0.028 from OmniPath's
-	   own badge, the very collision this change exists to remove. And they
-	   must clear all 36 palette entries, because a classification that takes
-	   one of these sits in the same legend as classifications that took a
-	   palette colour by name: drawing these FROM the palette instead, which
-	   was the second attempt, put "Drug ADME" and "Cell-Cell communication"
-	   on the same hex in the Reactome legend.
+	   These four are cut from the same generation as the 36 above and satisfy
+	   the same constraints - they clear every database badge by 0.121 and every
+	   palette entry by 0.080 - because a classification that takes one of these
+	   sits in the same legend as classifications that took a palette colour by
+	   name. Drawing them FROM the palette instead, which was an early attempt,
+	   put "Drug ADME" and "Cell-Cell communication" on the same hex in the
+	   Reactome legend.
 
-	   So they are their own colours, chosen from the same safe zones the
-	   palette is drawn from (L <= 0.525 or L >= 0.765, which is what staying
-	   0.12 clear of the databases in OKLab's first coordinate means) but far
-	   enough from all thirty-six to never double one. That leaves them 0.055
-	   from the nearest palette entry, 0.121 from the nearest badge, and 0.221
-	   apart from each other - which matters, because they are handed out
-	   together to consecutive rows of one legend. */
-	this.OTHER_COLORS = ["#794100", "#0073a2", "#f19690", "#49c7d3"];
+	   One thing is asked of these four that is not asked of the other 36:
+	   `otherColors.shift()` hands them out in order to CONSECUTIVE rows of one
+	   legend, so they must be far from each other and not merely far from
+	   everything. They are the four-subset of the generated tail with the
+	   largest minimum pairwise distance, 0.259 apart. A generation that simply
+	   took the last four of the farthest-point sequence left two mauves 0.083
+	   apart, side by side in the same list. */
+	this.OTHER_COLORS = ["#275d02", "#bda7ff", "#954074", "#bba737"];
 
 	/*********************************************************************
 	* OTHER FUNCTIONS
@@ -1675,7 +1660,17 @@ function PA_Step3PathwayClassificationView(db = "KEGG") {
 		/**********************************************************/
 		/* STEP 3.1 INITIALIZE VARIABLES                          */
 		/**********************************************************/
-		OTHER_COLORS = ["#794100", "#0073a2", "#f19690", "#49c7d3"];
+		/* Reset the shift-cursor: the pie above has already consumed some of these,
+		   and the selector panel below must start again from the first fallback so a
+		   classification gets the same colour in the legend as it got in the wedge.
+
+		   This line used to restate the four values as a literal. That was only ever
+		   invisible because the literal happened to equal me.OTHER_COLORS - the pie
+		   (fed from the copy taken at the top of updateObserver) and this panel were
+		   reading two different lists that happened to agree. Editing the palette in
+		   one place would have split them, and a wedge and its own legend chip would
+		   have drawn in different colours. Copied from the one source instead. */
+		OTHER_COLORS = $.extend(true, [], me.OTHER_COLORS);
 		var htmlContent = "", mainClassificationHTMLcode, secClassificationHTMLcode,
 		pathClassificationHTMLcode, color, pathwayID, temporalCodeTable, namesAux, posAux,
 		isCustomMainClass, isHiddenMainClass, isCustomSecClass, isHiddenSecClass;
@@ -1838,6 +1833,15 @@ function PA_Step3PathwayClassificationView(db = "KEGG") {
 		*/
 	this.applyVisualSettings =  function(updateSettings=true) {
 		var me = this;
+		/* One working copy per run, shared by every classification in the loop below.
+		   getClassificationColor() takes its fallback with otherColors.shift(), so
+		   passing me.OTHER_COLORS itself - which is what this did - drained the
+		   instance array permanently: after four unnamed classifications the list was
+		   empty for the rest of the session and every later one fell through to the
+		   name hash, so a pie redrawn after a filter change came back in different
+		   colours. Copying inside the loop instead would be the opposite bug, handing
+		   every classification the same first colour. */
+		var otherColors = $.extend(true, [], me.OTHER_COLORS);
 
 		/********************************************************/
 		/* STEP 1. UPDATE THE pathways Visibility               */
@@ -1885,7 +1889,7 @@ function PA_Step3PathwayClassificationView(db = "KEGG") {
 					mainClassifications.push({
 						name: mainClassificationInstance.name,
 						y: (mainVisiblePathways/pathwaysVisibility.length) * 100,
-						color: me.getParent().getClassificationColor(classificationID, me.OTHER_COLORS),
+						color: me.getParent().getClassificationColor(classificationID, otherColors),
 						drilldown: classificationID
 					});
 				}

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step4Views.js
@@ -4110,7 +4110,7 @@ function PA_Step4GlobalHeatmapView() {
 				}
 			},
 			previousWidth: 400, width: 400, minWidth: 400, html:
-			'<div class="lateralOptionsPanel-header" data-guides="ignore" style="background: #2A8368;">' +
+			'<div class="lateralOptionsPanel-header" data-guides="ignore">' +
 			'  <div class="lateralOptionsPanel-toolbar">' +
 			'    <a href="javascript:void(0)" class="toolbarOption btn-secondary helpTip" id="hideHeatmapPanelButton" title="Hide this panel"><i class="fa fa-times"></i></a>' +
 			'    <a href="javascript:void(0)" class="toolbarOption btn-secondary helpTip" id="configureHeatmapButton" title="Configure heatmap"><i class="fa fa-cogs"></i></a>' +
@@ -4811,7 +4811,7 @@ function PA_Step4DetailsView() {
 			},
 			items: [{
 				xtype: 'box', html:
-				'<div class="lateralOptionsPanel-header" data-guides="ignore" style="background: #2A8368;">' +
+				'<div class="lateralOptionsPanel-header" data-guides="ignore">' +
 				'  <div class="lateralOptionsPanel-toolbar">' +
 				'    <a class="toolbarOption btn-secondary helpTip" id="hideFeatureSetButton" title="Hide this panel"><i class="fa fa-times"></i></a>' +
 				'    <a class="toolbarOption btn-secondary helpTip" id="expandFeatureSetButton" title="Expand this panel"><i class="fa fa-expand"></i></a>' +

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.02" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.03" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.15" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.6" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.7" />

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -4022,10 +4022,28 @@ div.contentbox li {
 i.classificationNameBox {
 	margin-right: 10px;
 	border-radius: 50%;
-	/* 20px, the content box inside the 2px borders (24px border-box). At
-	   24px the line box overran the circle and the letter sat 2px low. */
-	line-height: 20px;
-	display: inline-block;
+	/* Centred by the box, not by a line-height that has to guess the box.
+
+	   This badge is 24px with a 2px border, and ExtJS puts `box-sizing:
+	   border-box` on everything (`.x-border-box *`, ext-theme-neptune-all.css),
+	   so its content box is 20px tall - not the 24px the `line-height: 24px`
+	   here was written against. A 24px line box in a 20px content box overflows
+	   downward, and the letter rendered 2.01px below the centre of its own
+	   disc: measured on the Step 3 summary card, not inferred. It read as a
+	   badge that had been nudged, which is the sort of thing that looks like
+	   sloppiness rather than a bug and so never gets reported.
+
+	   line-height cannot be the fix either - it would have to be re-derived
+	   every time the size or the border changes, and it is overridden inline in
+	   one caller already (the Highcharts legend formatter sets 20px). Flex
+	   centring does not care: the glyph is centred in whatever content box the
+	   border leaves behind, at any size, with any border, in any font. What is
+	   left is the ~0.5px by which a capital's ink sits above its line box,
+	   which is optical centring working correctly rather than a residue. */
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	line-height: 1;
 	border: 2px solid;
 	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.22);
 	font-style: normal;

--- a/PaintomicsClient/tests/palette/classification-palette.test.js
+++ b/PaintomicsClient/tests/palette/classification-palette.test.js
@@ -190,18 +190,22 @@ test("a Reactome classification clears the KEGG seven it shares a legend with", 
     }
 });
 
-test("nothing in the palette is louder than the badges", () => {
-    /* The KEGG seven were an iOS system palette at chroma up to 0.265, against
-       0.135 for the badges - six saturated discs in a quiet white card, which
-       is the complaint this whole change started from. Nothing here may exceed
-       the badges again. */
+test("nothing in the palette is louder than 0.131 chroma", () => {
+    /* The KEGG seven were once an iOS system palette at chroma up to 0.265 -
+       six saturated discs in a quiet white card, which is the complaint this
+       whole line of work started from.
+
+       The ceiling is a literal on purpose. It used to be derived as "no louder
+       than the loudest database badge", which worked only while the badges were
+       a deliberately quiet family. They are brand colours now, and KEGG's is at
+       chroma 0.177, so a derived ceiling would have quietly risen by a third and
+       let the categories get louder than the palette that was just calmed. A
+       ceiling that moves when something else moves is not a ceiling. */
     const chroma = hex => { const [, a, b] = oklab(hex); return Math.hypot(a, b); };
-    const loudestBadge = Math.max(...DATABASE.map(chroma));
     for (const fill of CLASSIFICATION.concat(OTHER)) {
         assert.ok(
-            chroma(fill) <= loudestBadge + 0.002,
-            fill + " is at chroma " + chroma(fill).toFixed(3) +
-            ", past the badges' " + loudestBadge.toFixed(3)
+            chroma(fill) <= 0.131,
+            fill + " is at chroma " + chroma(fill).toFixed(3) + ", past the palette's 0.131"
         );
     }
 });
@@ -237,34 +241,100 @@ test("a database badge is not wearing a classification colour", () => {
             !CLASSIFICATION.includes(db),
             db + " paints both a database and a pathway classification"
         );
-        /* Not merely "not identical". Both systems now use the whole hue
-           circle - KEGG's database gold shares a hue with some gold category,
+        /* Not merely "not identical". Both systems use the whole hue circle -
+           KEGG's database yellow shares a hue with some yellow category,
            necessarily - so hue cannot be what separates them and the distance
            has to be asserted rather than assumed.
 
-           One floor for the whole palette. The KEGG seven used to need a
-           looser one because they were fixed and could not be moved out of the
-           badges' way; softening them put them in the same construction as
-           everything else, so every classification now clears every badge by
-           the same structural margin. */
+           This assertion used to be a consequence of the geometry rather than a
+           check on it: the badges sat together at L=0.645 and the palette was
+           drawn from two bands either side of them, so the gap fell out of
+           OKLab's first coordinate for free. The badges wear their brand
+           lightnesses now and there are no bands, so nothing enforces this
+           except this line and the generator that satisfies it. It is the one
+           assertion in this file that a future palette cannot be regenerated
+           without. */
         for (const cls of CLASSIFICATION.concat(OTHER)) {
             assert.ok(
                 distance(db, cls) > 0.12,
                 db + " is only " + distance(db, cls).toFixed(4) + " from " + cls +
-                " - the lightness bands either side of the databases have closed up"
+                " - a source badge and a category badge on one screen in one colour"
             );
         }
     }
 });
 
-test("the databases are one quiet family, not six competing ones", () => {
-    /* Sources label the science, they are not the science. The databases sit
-       within a narrow lightness band so none of them outranks another, and all
-       of them are softer than the classification palette they used to borrow. */
-    const seen = DATABASE.map(d => contrast(d, "#ffffff"));
+test("each database badge is its own colour, not a colour near it", () => {
+    /* This replaces an assertion that the four badges sat within a narrow
+       lightness band. That band was real, and it was what made the badges
+       recognisably one family - but it also made them impossible to paint in
+       the databases' own colours, because yellow has no dark form and the
+       Reactome/OmniPath pair are nineteen degrees apart in hue and so collapse
+       to 0.044 at any shared lightness. The badges are brand-anchored now and
+       deliberately span L=0.530 to L=0.866; "one quiet family" is no longer a
+       property this file should be asserting.
+
+       What must still hold is that the four are the colours the databases
+       actually use. Pinned to the references so a later edit that drifts one
+       back toward the palette fails here rather than on the page. */
+    const BRAND = {
+        "#fcce00": "KEGG",       // brand value, exactly
+        "#027b7f": "OmniPath",   // brand value, exactly
+        "#9ad5e9": "Reactome",   // #b6deea lifted from chroma 0.045 to 0.066 - see below
+        "#d3686e": "MapMan"      // the one hue the other three do not claim
+    };
+    for (const db of DATABASE) {
+        assert.ok(BRAND[db], db + " is not one of the four database colours");
+    }
+    assert.strictEqual(DATABASE.length, Object.keys(BRAND).length);
+
+    /* Reactome is the only one that is not its brand hex, and the amount it
+       moved is the whole argument for moving it: #b6deea is at chroma 0.045,
+       and a 24px disc that desaturated reads grey rather than blue. Held to a
+       small correction so "similar to the brand" stays checkable. */
     assert.ok(
-        Math.max(...seen) - Math.min(...seen) < 1.0,
-        "database badges differ in weight: " + seen.map(v => v.toFixed(2)).join(", ")
+        distance("#9ad5e9", "#b6deea") < 0.06,
+        "the Reactome badge has drifted away from its brand reference"
+    );
+});
+
+test("two database badges are told apart from each other", () => {
+    /* They no longer share a lightness, so the thing that used to keep them
+       distinct - four hues at one L - is gone. Asserted directly instead. The
+       tightest pair is KEGG against Reactome at 0.226. */
+    for (let i = 0; i < DATABASE.length; i++) {
+        for (let j = i + 1; j < DATABASE.length; j++) {
+            const d = distance(DATABASE[i], DATABASE[j]);
+            assert.ok(
+                d > 0.15,
+                DATABASE[i] + " and " + DATABASE[j] + " are " + d.toFixed(4) + " apart"
+            );
+        }
+    }
+});
+
+test("the fallback list is read from one place, not restated", () => {
+    /* Two ways this file's colours can be correct and the page still wrong,
+       both found while regenerating the palette and both invisible until the
+       values changed:
+
+       The classification selector panel used to reset its shift-cursor by
+       restating the four fallbacks as a literal, while the pie above it read a
+       copy of me.OTHER_COLORS. Identical lists, so nothing showed - until one
+       of them was edited, at which point a pie wedge and its own legend chip
+       would have drawn in different colours.
+
+       And applyVisualSettings() passed me.OTHER_COLORS itself into a function
+       that takes its fallback with shift(), draining the instance array for the
+       rest of the session. */
+    const literals = code.match(/OTHER_COLORS\s*=\s*\[[^\]]*\]/g) || [];
+    assert.strictEqual(
+        literals.length, 1,
+        "OTHER_COLORS is written as a literal in " + literals.length + " places: " + literals.join(" | ")
+    );
+    assert.ok(
+        !/getClassificationColor\([^,)]*,\s*me\.OTHER_COLORS\s*\)/.test(code),
+        "a caller hands getClassificationColor() the instance array, which it shifts empty"
     );
 });
 


### PR DESCRIPTION
The database badges were olive, periwinkle and grass green because all four shared one lightness (L=0.645) and the classification palette was drawn from two bands either side of them. That geometry bought the 0.121 separation between a source and a category for free, and it also made the brand colours impossible: yellow has no dark form, and Reactome's blue and OmniPath's teal collapse to 0.044 at any shared lightness.

So the badges take their own lightnesses — KEGG `#fcce00` and OmniPath `#027b7f` exactly, Reactome lifted from `#b6deea`'s chroma 0.045 to 0.066 so a 24px disc reads blue rather than grey, MapMan the one hue none of the other three claims — and the exclusion becomes four points instead of two bands. The regenerated 36-entry palette is better than the one it replaces, not merely as good: closest pair 0.080 (was 0.055), contrast 1.60–7.95:1, nothing past chroma 0.131. The KEGG seven keep their hues within 0.075 of their lightness.

**Accepted cost, stated so nobody re-litigates it:** the KEGG and Reactome discs sit at roughly 1.5:1 against a white card. The letter on every badge stays ≥ 4.5:1 (the palette test asserts it for the database badges too) and the disc keeps its border and inset shadow.

Three things found on the way, each invisible until the values moved:

- The classification selector restated `OTHER_COLORS` as a second literal while the pie read `me.OTHER_COLORS`; identical lists, so nothing showed until one was edited. One source now, and the test refuses a second literal.
- `applyVisualSettings()` passed `me.OTHER_COLORS` into a function that takes its fallback with `shift()`, draining the instance array for the rest of the session. A copy per run.
- The badge letter sat 2.01px below the centre of its disc (ExtJS's `border-box` leaves a 20px content box under a 24px line-height). Centred by flex, which does not have to guess the box. Master's #105 fixed the same defect with `line-height: 20px`; this branch's rebase keeps the flex version, which holds at any size or border.

Step 4's "Global heatmap" and "Feature set overview" drop their inline `background: #2A8368` — the toolbar rule was already written for a white header, so its icons were at 1.67:1 on that green (7.73:1 now), and inline styles had kept those headers green in the dark theme.

Rebased onto master after #105 (`main.css?v=` → 2.03). Palette test: `node PaintomicsClient/tests/palette/classification-palette.test.js` — 15/15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPYzin6921hAiHUDDR7Uxh