### PR TITLE
Send the AI compound batches together, and never more than a few of them

### DIFF
--- a/PaintomicsServer/src/classes/CompoundDisambiguation/resolver.py
+++ b/PaintomicsServer/src/classes/CompoundDisambiguation/resolver.py
@@ -38,9 +38,22 @@ it, and ``pathwayAcquisitionStep2`` remains the only writer of a selection.
 
 import json
 import logging
+import os
 import re
+from concurrent.futures import ThreadPoolExecutor
 
 from src.classes.CompoundDisambiguation import prompts
+
+# Defensive: a deployment whose serverconf predates these settings must not
+# lose the servlet to an ImportError (see adding-a-serverconf-setting).
+try:
+    from src.conf.serverconf import COMPOUND_SUGGESTION_WORKERS
+except ImportError:
+    COMPOUND_SUGGESTION_WORKERS = int(os.getenv("COMPOUND_SUGGESTION_WORKERS", "3"))
+try:
+    from src.conf.serverconf import COMPOUND_SUGGESTION_MAX_SETS
+except ImportError:
+    COMPOUND_SUGGESTION_MAX_SETS = int(os.getenv("COMPOUND_SUGGESTION_MAX_SETS", "90"))
 
 #: Residual sets per gateway call. Sets are independent, so this trades prompt
 #: size against round trips: the STATegra example's 18 residuals are one call,
@@ -51,6 +64,22 @@ DEFAULT_BATCH_SIZE = 30
 #: watching a spinner; this call must give up and say so rather than hold a
 #: queue slot until the gateway decides to.
 DEFAULT_BATCH_BUDGET_SECONDS = 180
+
+#: Batches in flight at once. A run holds ONE of the site's few queue workers
+#: -- the same workers every user's step 1/2/3 run on -- and that worker is
+#: idle on I/O for the whole gateway call, so the batches, which are
+#: independent (an answer is matched by input name, never by position), go
+#: out together instead of one after another. Three, like the interpreter's
+#: own fan-out, so the gateway sees no more parallel calls than it already
+#: does.
+DEFAULT_WORKERS = max(1, int(COMPOUND_SUGGESTION_WORKERS))
+
+#: Residual sets one run will send. Without a ceiling a job with 300
+#: ambiguous names was ten sequential calls, up to half an hour on a queue
+#: worker, and PySiQ does not enforce the timeout it is handed; with one the
+#: worst case is ceil(MAX_SETS / BATCH_SIZE / WORKERS) rounds of one batch
+#: budget. The sets past it are left to the user, and told so.
+DEFAULT_MAX_SETS = max(1, int(COMPOUND_SUGGESTION_MAX_SETS))
 
 #: A selection that changes which pathways a user publishes should not change
 #: between two runs of the same job if it can be helped.
@@ -224,17 +253,36 @@ def buildClient():
     return LLMClient(AI_PROVIDERS.get(AI_LLM_PROVIDER, {}), AI_LLM_PROVIDER)
 
 
+def _leftToUser(decision, detail):
+    """The abstention entry for a set this run did not decide."""
+    return {"title": decision["title"], "keggID": None, "confidence": "", "reason": "",
+            "detail": detail, "tier": "ai", "candidates": decision.get("candidates", [])}
+
+
 def suggestCompounds(decisions, context, client=None, batchSize=DEFAULT_BATCH_SIZE,
-                     budgetSeconds=DEFAULT_BATCH_BUDGET_SECONDS, jobID=""):
+                     budgetSeconds=DEFAULT_BATCH_BUDGET_SECONDS, jobID="",
+                     workers=None, maxSets=None):
     """Ask the model to choose for every residual set, batched.
 
     @param {List} decisions, residual decisions from the ranker
     @param {Dict} context, as accepted by :func:`prompts.buildContextBlock`
     @param client, an LLMClient; built from configuration when omitted
+    @param {int} workers, batches in flight at once (DEFAULT_WORKERS)
+    @param {int} maxSets, sets this run will send (DEFAULT_MAX_SETS); the
+                 rest are returned as abstained, with a detail that says so
     @returns {Dict} {"accepted", "abstained", "rejected", "model", "batches"}
     """
     if not decisions:
         return {"accepted": [], "abstained": [], "rejected": [], "model": "", "batches": 0}
+
+    workers = max(1, int(workers if workers is not None else DEFAULT_WORKERS))
+    maxSets = max(1, int(maxSets if maxSets is not None else DEFAULT_MAX_SETS))
+    deferred = decisions[maxSets:]
+    decisions = decisions[:maxSets]
+    if deferred:
+        logging.info("COMPOUND DISAMBIGUATION - job %s: %d residual set(s); this run "
+                     "chooses for the first %d and leaves %d to the user",
+                     jobID, len(decisions) + len(deferred), maxSets, len(deferred))
 
     if client is None:
         try:
@@ -259,11 +307,8 @@ def suggestCompounds(decisions, context, client=None, batchSize=DEFAULT_BATCH_SI
 
     from src.classes.AIInterpret.llm_client import json_schema_format
 
-    accepted, abstained, rejected = [], [], []
-    batches = 0
-
-    for batch in _chunk(decisions, batchSize):
-        batches += 1
+    def runBatch(batch):
+        """One gateway call; (accepted, abstained, rejected) for its sets."""
         messages = [
             {"role": "system", "content": prompts.SYSTEM_PROMPT},
             {"role": "user", "content": prompts.buildBatchPrompt(batch, context)},
@@ -283,17 +328,26 @@ def suggestCompounds(decisions, context, client=None, batchSize=DEFAULT_BATCH_SI
             logging.warning("COMPOUND DISAMBIGUATION - batch of %d failed for job "
                             "%s (%s); those names are left to the user",
                             len(batch), jobID, ex)
-            for decision in batch:
-                abstained.append({"title": decision["title"], "keggID": None,
-                                  "confidence": "", "reason": "",
-                                  "detail": "the AI service could not be reached",
-                                  "tier": "ai", "candidates": decision.get("candidates", [])})
-            continue
+            return [], [_leftToUser(d, "the AI service could not be reached") for d in batch], []
+        return applyChoices(batch, parseChoices(reply))
 
-        batchAccepted, batchAbstained, batchRejected = applyChoices(batch, parseChoices(reply))
+    # Every batch goes out together, up to `workers` at a time, and the
+    # results are read back in the order the batches were made: the audit
+    # log below and the browser both see the sets as they were sent, however
+    # the gateway ordered its replies.
+    batchList = list(_chunk(decisions, batchSize))
+    batches = len(batchList)
+    with ThreadPoolExecutor(max_workers=min(workers, batches)) as pool:
+        results = list(pool.map(runBatch, batchList))
+
+    accepted, abstained, rejected = [], [], []
+    for batchAccepted, batchAbstained, batchRejected in results:
         accepted.extend(batchAccepted)
         abstained.extend(batchAbstained)
         rejected.extend(batchRejected)
+    for decision in deferred:
+        abstained.append(_leftToUser(
+            decision, "left for you: this run chooses for the first %d ambiguous names" % maxSets))
 
     # The audit trail. Nothing about these choices is written to the job, so
     # the log is where "which compound did the model pick for job X, and what

--- a/PaintomicsServer/src/resources/example_serverconf.py
+++ b/PaintomicsServer/src/resources/example_serverconf.py
@@ -244,6 +244,13 @@ AI_VERIFICATION_WORKERS = int(os.getenv("AI_VERIFICATION_WORKERS", "4"))
 AI_PAPERS_PER_SEARCH_TASK = int(os.getenv("AI_PAPERS_PER_SEARCH_TASK", "5"))
 AI_PAPERS_KEPT_PER_TASK = int(os.getenv("AI_PAPERS_KEPT_PER_TASK", "3"))
 AI_SEARCH_PLANNER_TEMPERATURE = float(os.getenv("AI_SEARCH_PLANNER_TEMPERATURE", "0.4"))
+# "Choose for me" on step 2: residual compound sets go to the gateway thirty
+# per call. The calls fan out over this many threads inside the one queue job
+# (they are independent; the worker is idle on I/O), and a run sends at most
+# MAX_SETS -- the rest are left to the user -- so a click can never hold a
+# queue worker for more than a few batch budgets.
+COMPOUND_SUGGESTION_WORKERS = int(os.getenv("COMPOUND_SUGGESTION_WORKERS", "3"))
+COMPOUND_SUGGESTION_MAX_SETS = int(os.getenv("COMPOUND_SUGGESTION_MAX_SETS", "90"))
 AI_SEARCH_SUBAGENT_TEMPERATURE = float(os.getenv("AI_SEARCH_SUBAGENT_TEMPERATURE", "0.2"))
 
 # ========== MORE BACKEND ==========

--- a/PaintomicsServer/src/tests/test_ai_batches_share_the_queue.py
+++ b/PaintomicsServer/src/tests/test_ai_batches_share_the_queue.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+"Choose for me" batches must not hold a queue worker one gateway call at a time.
+
+The residual sets of a job go to the gateway thirty per call. Those calls
+used to run strictly one after another, inside ONE of the four queue workers
+every user's step 1/2/3 also runs on, with no cap on how many there could be
+and a per-call budget of 180 s: a job with 300 ambiguous names was ten
+sequential calls, up to half an hour holding a worker, and four such clicks
+left no worker for anyone's analysis. The batches are independent -- an
+answer is matched to its question by input name, never by position -- and
+the worker is idle on I/O for the whole call, so they fan out over a small
+pool and a run sends at most a fixed number of sets, leaving the rest to the
+user rather than to the clock.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_ai_batches_share_the_queue
+"""
+import json
+import os
+import sys
+import threading
+import time
+import unittest
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+SERVER_ROOT = os.path.abspath(os.path.join(TESTS_DIR, "..", ".."))
+if SERVER_ROOT not in sys.path:
+    sys.path.insert(0, SERVER_ROOT)
+
+from src.classes.CompoundDisambiguation import resolver  # noqa: E402
+
+
+def _decisions(names):
+    return [{"title": name, "candidates": [{"keggID": "C%05d" % (i + 1), "names": [name]},
+                                            {"keggID": "C%05d" % (i + 101), "names": [name + " isomer"]}]}
+            for i, name in enumerate(names)]
+
+
+class FakeGateway(object):
+    """Answers every name in the batch with its first candidate, after a
+    pause, and records how many calls were in flight at once."""
+
+    model = "fake-model"
+
+    def __init__(self, delay=0.3, failFor=(), delays=None):
+        self.delay = delay
+        self.delays = delays or {}
+        self.failFor = set(failFor)
+        self.calls = []
+        self.inFlight = 0
+        self.maxInFlight = 0
+        self._lock = threading.Lock()
+
+    def complete(self, messages, **kwargs):
+        prompt = messages[-1]["content"]
+        names = [line[len("Input name: "):].strip() for line in prompt.split("\n")
+                 if line.startswith("Input name: ")]
+        with self._lock:
+            self.calls.append(names)
+            self.inFlight += 1
+            self.maxInFlight = max(self.maxInFlight, self.inFlight)
+        try:
+            time.sleep(self.delays.get(names[0], self.delay))
+            if self.failFor & set(names):
+                raise RuntimeError("gateway down")
+            return json.dumps({"choices": [
+                {"input_name": name, "kegg_id": "C%05d" % (i + 1), "confidence": "high", "reason": "first"}
+                for i, name in [(int(n.split("-")[1]) - 1, n) for n in names]]})
+        finally:
+            with self._lock:
+                self.inFlight -= 1
+
+
+class BatchesFanOutTest(unittest.TestCase):
+
+    def test_batches_run_in_parallel(self):
+        gateway = FakeGateway(delay=0.3)
+        decisions = _decisions(["name-%d" % i for i in range(1, 7)])
+        started = time.monotonic()
+        result = resolver.suggestCompounds(decisions, {}, client=gateway, batchSize=2, workers=3)
+        elapsed = time.monotonic() - started
+        self.assertEqual(result["batches"], 3)
+        self.assertEqual(len(gateway.calls), 3)
+        self.assertGreaterEqual(gateway.maxInFlight, 2, "batches ran one after another")
+        self.assertLess(elapsed, 0.75, "three 0.3 s batches took %.2f s" % elapsed)
+        self.assertEqual(len(result["accepted"]), 6)
+
+    def test_results_keep_the_order_of_the_decisions(self):
+        # The first batch is the slowest, so it finishes last; the audit log
+        # and the browser must still see the sets in the order they were sent.
+        gateway = FakeGateway(delay=0.05, delays={"name-1": 0.4})
+        decisions = _decisions(["name-%d" % i for i in range(1, 7)])
+        result = resolver.suggestCompounds(decisions, {}, client=gateway, batchSize=2, workers=3)
+        self.assertEqual([e["title"] for e in result["accepted"]],
+                         ["name-%d" % i for i in range(1, 7)])
+
+    def test_a_failing_batch_does_not_sink_the_others(self):
+        gateway = FakeGateway(delay=0.05, failFor={"name-3"})
+        decisions = _decisions(["name-%d" % i for i in range(1, 7)])
+        result = resolver.suggestCompounds(decisions, {}, client=gateway, batchSize=2, workers=3)
+        self.assertEqual(sorted(e["title"] for e in result["accepted"]),
+                         ["name-1", "name-2", "name-5", "name-6"])
+        self.assertEqual(sorted(e["title"] for e in result["abstained"]), ["name-3", "name-4"])
+        self.assertTrue(all("could not be reached" in e["detail"] for e in result["abstained"]))
+
+
+class ResidualCapTest(unittest.TestCase):
+
+    def test_a_run_sends_at_most_max_sets_and_leaves_the_rest_to_the_user(self):
+        gateway = FakeGateway(delay=0.01)
+        decisions = _decisions(["name-%d" % i for i in range(1, 6)])
+        result = resolver.suggestCompounds(decisions, {}, client=gateway, batchSize=1, workers=2, maxSets=2)
+        self.assertEqual(len(gateway.calls), 2)
+        self.assertEqual(result["batches"], 2)
+        self.assertEqual([e["title"] for e in result["accepted"]], ["name-1", "name-2"])
+        left = [e for e in result["abstained"]]
+        self.assertEqual([e["title"] for e in left], ["name-3", "name-4", "name-5"])
+        for entry in left:
+            self.assertEqual(entry["tier"], "ai")
+            self.assertIsNone(entry["keggID"])
+            self.assertIn("first 2", entry["detail"])
+            self.assertEqual(len(entry["candidates"]), 2)
+
+    def test_the_cap_and_the_pool_have_sane_defaults(self):
+        self.assertGreaterEqual(resolver.DEFAULT_WORKERS, 2)
+        self.assertLessEqual(resolver.DEFAULT_WORKERS, 4)
+        # At most a handful of batches per click: the worst case is bounded by
+        # ceil(MAX_SETS / BATCH_SIZE / WORKERS) rounds of one batch budget.
+        self.assertLessEqual(resolver.DEFAULT_MAX_SETS, 4 * resolver.DEFAULT_BATCH_SIZE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
"Choose for me" sends a job's residual compound sets to the gateway thirty per call, and those calls ran **one after another inside one of the site's four queue workers** — the same workers every user's Step 1/2/3 run on — with no cap on their number, 180 s each, and a PySiQ timeout that is never enforced. A job with 300 ambiguous names was ten sequential calls: up to half an hour holding a worker that was idle on I/O the whole time. Four such clicks and nothing could start anywhere on the site.

The batches are independent (answers are matched by input name, never by position), so:

- they go out together over a small thread pool — three, the interpreter's own fan-out width, so the gateway sees no more parallel calls than it already does — and results are read back in batch order, so the audit log and the browser see the sets as they were sent;
- a run sends at most **90 sets**; the rest come back abstained with a detail saying the run chose for the first 90, rather than being left to the clock. Worst case is now bounded at one round of one batch budget.

Both knobs live in serverconf (`COMPOUND_SUGGESTION_WORKERS`, `COMPOUND_SUGGESTION_MAX_SETS`) behind the defensive import an upgraded deployment needs.

Tests: `test_ai_batches_share_the_queue` — batches overlap (measured in-flight count), a failing batch sinks only its own sets, order is kept when the first batch is the slowest, the cap leaves the rest to the user by name, sane defaults. Neighbouring disambiguation suites and `test_release_hygiene` green; ruff clean.

Found by the review sweep of the compound-disambiguation feature (#88) on 2026-08-29; the rest of that sweep (duplicate selection across sets, the per-poll Mongo write, the `kegg_compounds` COLLSCAN) is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPYzin6921hAiHUDDR7Uxh