### PR TITLE
Say on every Step 1 file row whether the job needs it

### DIFF
--- a/PaintomicsClient/public_html/app/view/DataManagementViews/DM_MyDataView.js
+++ b/PaintomicsClient/public_html/app/view/DataManagementViews/DM_MyDataView.js
@@ -920,6 +920,10 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 	fieldLabel: "label",
 	namePrefix: "filefield",
 	buttonText: "Browse...",
+	/* "required" or "optional": whether the job needs this file. Every file row on
+	   Step 1 sets it, so a row that says nothing is a row somebody forgot, not a
+	   row with nothing to say. Conditional rows flip it with setRequiredTag(). */
+	requiredTag: null,
 	labelAlign: "right",
 	labelWidth: 200,
 	margin: "5px 0px",
@@ -945,6 +949,19 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 	},
 	markInvalid: function(errorMessage) {
 		return this.queryById("visiblePathField").markInvalid(errorMessage);
+	},
+	buildRequiredTag: function(tag) {
+		return '<span class="po-file-tag' + (tag === "required" ? " po-file-tag-required" : "") + '">' + tag + '</span>';
+	},
+	/* For the rows whose requiredness is a consequence of a choice made elsewhere
+	   on the card -- the correlation checkbox on a miRNA panel, say. The caller
+	   passes the same expression the validator reads, so the two cannot drift. */
+	setRequiredTag: function(tag) {
+		var box = this.queryById("requiredTag");
+		if (box && box.rendered) {
+			box.update(this.buildRequiredTag(tag));
+		}
+		return this;
 	},
 	/***********************************************************************
 	* COMPONENT DECLARATION
@@ -1014,7 +1031,13 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 				handler: function() {
 					this.showMenu();
 				}
-			}, (me.helpTip !== undefined ? {
+			}, (me.requiredTag ? {
+				xtype: "box",
+				itemId: "requiredTag",
+				width: 56,
+				margin: "0 0 0 8",
+				html: me.buildRequiredTag(me.requiredTag)
+			} : null), (me.helpTip !== undefined ? {
 				xtype: "label",
 				html: '<span class="helpTip" style="float:right;" title="' + this.helpTip + '""></span>'
 			} : null)]

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -2561,6 +2561,7 @@ function OmicSubmittingPanel(nElem, options) {
 							})
 						}, {
 							xtype: "myFilesSelectorButton",
+							requiredTag: "required",
 							fieldLabel: 'Data file',
 							namePrefix: this.namePrefix,
 							itemId: "mainFileSelector",
@@ -2587,6 +2588,7 @@ function OmicSubmittingPanel(nElem, options) {
 							helpTip: "Specify the type of data for uploaded file (Gene Expression file, Proteomic quatification,...)."
 						}, {
 							xtype: "myFilesSelectorButton",
+							requiredTag: "optional",
 							fieldLabel: 'Relevant features file',
 							namePrefix: this.namePrefix + '_relevant',
 							itemId: "secondaryFileSelector",
@@ -2623,6 +2625,7 @@ function OmicSubmittingPanel(nElem, options) {
 							   build that list. Optional, and the panel is still
 							   valid without it. */
 							xtype: "myFilesSelectorButton",
+							requiredTag: "optional",
 							fieldLabel: 'Experimental design',
 							namePrefix: this.namePrefix + '_design',
 							itemId: "designFileSelector",
@@ -2938,6 +2941,7 @@ function RegionBasedOmicSubmittingPanel(nElem, options) {
 					})
 				}, {
 					xtype: "myFilesSelectorButton",
+					requiredTag: "required",
 					fieldLabel: 'Data file',
 					namePrefix: this.namePrefix,
 					itemId: "mainFileSelector",
@@ -2952,6 +2956,7 @@ function RegionBasedOmicSubmittingPanel(nElem, options) {
 					helpTip: "Specify the type of data for uploaded file (Gene Expression file, Proteomic quatification,...)."
 				}, {
 					xtype: "myFilesSelectorButton",
+					requiredTag: "optional",
 					fieldLabel: 'Relevant features file',
 					namePrefix: this.namePrefix + '_relevant',
 					itemId: "secondaryFileSelector",
@@ -3039,6 +3044,7 @@ function RegionBasedOmicSubmittingPanel(nElem, options) {
 					})
 				}, {
 					xtype: "myFilesSelectorButton",
+					requiredTag: "required",
 					fieldLabel: 'Data file',
 					namePrefix: this.namePrefix,
 					itemId: "mainFileSelector",
@@ -3053,6 +3059,7 @@ function RegionBasedOmicSubmittingPanel(nElem, options) {
 					helpTip: "Specify the type of data for uploaded file (Gene Expression file, Proteomic quatification,...)."
 				}, {
 					xtype: "myFilesSelectorButton",
+					requiredTag: "optional",
 					fieldLabel: 'Relevant features file',
 					namePrefix: this.namePrefix + '_relevant',
 					itemId: "secondaryFileSelector",
@@ -3067,12 +3074,14 @@ function RegionBasedOmicSubmittingPanel(nElem, options) {
 					helpTip: "Specify the type of data for uploaded file (Relevant Genes list, Relevant proteins list,...)."
 				}, {
 					xtype: "myFilesSelectorButton",
+					requiredTag: "required",
 					fieldLabel: 'Associations file',
 					namePrefix: this.namePrefix + '_associations',
 					itemId: "mainAssociationFileSelector",
 					helpTip: "Upload the 2 column association file associating genes with features or choose it from your data folder."
 				}, {
 					xtype: "myFilesSelectorButton",
+					requiredTag: "optional",
 					fieldLabel: 'Relevant associations file',
 					namePrefix: this.namePrefix + '_relevant_associations',
 					itemId: "secondaryAssociationFileSelector",
@@ -3167,7 +3176,8 @@ function RegionBasedOmicSubmittingPanel(nElem, options) {
 				/*REGIONS FILE*/
 				{
 					xtype: "myFilesSelectorButton",
-					fieldLabel: 'Regions file <br>(BED + Quantification)',
+					requiredTag: "required",
+					fieldLabel: 'Regions file',
 					namePrefix: this.namePrefix,
 					itemId: "mainFileSelector",
 					helpTip: "Upload the regions file (BED format + Quantification) or choose it from your data folder."
@@ -3182,6 +3192,7 @@ function RegionBasedOmicSubmittingPanel(nElem, options) {
 				/*RELEVANT REGIONS FILE*/
 				{
 					xtype: "myFilesSelectorButton",
+					requiredTag: "optional",
 					fieldLabel: "Relevant regions file",
 					namePrefix: this.namePrefix + '_relevant',
 					itemId: "secondaryFileSelector",
@@ -3197,6 +3208,7 @@ function RegionBasedOmicSubmittingPanel(nElem, options) {
 				/*ANNOTATIONS FILE*/
 				{
 					xtype: "myFilesSelectorButton",
+					requiredTag: "required",
 					fieldLabel: "Annotations file (GTF)",
 					namePrefix: this.namePrefix + '_annotations',
 					itemId: "tertiaryFileSelector",
@@ -3489,6 +3501,16 @@ function RegionBasedOmicSubmittingPanel(nElem, options) {
 			if (component.queryById("tertiaryFileSelector") && component.queryById("tertiaryFileSelector").getValue() === "") {
 				valid = false;
 				component.queryById("tertiaryFileSelector").markInvalid("Please, provide a GTF file.");
+			}
+			/* Only reachable from "Provide own associations lists", because
+			   mainAssociationFileSelector exists only in itemsContainerAssociations.
+			   That mode is the user saying "I will supply the mapping myself"; with
+			   no file, Job.parseAssociationsFile returns an empty dict and the omic
+			   maps to nothing -- a job that succeeds and means nothing. The row is
+			   tagged "required", so this is what makes the tag true. */
+			if (component.queryById("mainAssociationFileSelector") && component.queryById("mainAssociationFileSelector").getValue() === "") {
+				valid = false;
+				component.queryById("mainAssociationFileSelector").markInvalid("Please, provide an associations file, or untick \"Provide own associations lists\".");
 			}
 
 			if (this.queryById("reportOptionsContainer").query("checkboxfield[checked=true]") < 1) {
@@ -3785,6 +3807,7 @@ function MiRNAOmicSubmittingPanel(nElem, options) {
 					})
 				}, {
 					xtype: "myFilesSelectorButton",
+					requiredTag: "required",
 					fieldLabel: 'Data file',
 					namePrefix: this.namePrefix,
 					itemId: "mainFileSelector",
@@ -3799,6 +3822,7 @@ function MiRNAOmicSubmittingPanel(nElem, options) {
 					helpTip: "Specify the type of data for uploaded file (Gene Expression file, Proteomic quatification,...)."
 				}, {
 					xtype: "myFilesSelectorButton",
+					requiredTag: "optional",
 					fieldLabel: 'Relevant features file',
 					namePrefix: this.namePrefix + '_relevant',
 					itemId: "secondaryFileSelector",
@@ -3813,6 +3837,7 @@ function MiRNAOmicSubmittingPanel(nElem, options) {
 					helpTip: "Specify the type of data for uploaded file (Relevant Genes list, Relevant proteins list,...)."
 				}, {
 					xtype: "myFilesSelectorButton",
+					requiredTag: "optional",
 					fieldLabel: 'Regulator associations file',
 					namePrefix: this.namePrefix + '_associations',
 					itemId: "thirdFileSelector",
@@ -3827,6 +3852,7 @@ function MiRNAOmicSubmittingPanel(nElem, options) {
 					helpTip: "Specify the type of data for uploaded file (Relevant Genes list, Relevant proteins list,...)."
 				}, {
 					xtype: "myFilesSelectorButton",
+					requiredTag: "optional",
 					fieldLabel: 'Regulator relevant associations file',
 					namePrefix: this.namePrefix + '_relevant_associations',
 					itemId: "fourthFileSelector",
@@ -3929,7 +3955,8 @@ function MiRNAOmicSubmittingPanel(nElem, options) {
 				/*miRNA FILE*/
 				{
 					xtype: "myFilesSelectorButton",
-					fieldLabel: 'Regulators expression file <br>(ie: miRNA expression)',
+					requiredTag: "required",
+					fieldLabel: 'Regulators expression file',
 					namePrefix: this.namePrefix,
 					itemId: "mainFileSelector",
 					helpTip: "Upload the quantification file (i.e. miRNA Quantification) or choose it from your data folder. See above the accepted format for the file."
@@ -3944,7 +3971,8 @@ function MiRNAOmicSubmittingPanel(nElem, options) {
 				/*RELEVANT miRNA FILE*/
 				{
 					xtype: "myFilesSelectorButton",
-					fieldLabel: "Relevant regulators file<br> (optional)",
+					requiredTag: "optional",
+					fieldLabel: 'Relevant regulators file',
 					namePrefix: this.namePrefix + '_relevant',
 					itemId: "secondaryFileSelector",
 					helpTip: "Upload the list of relevant (differentially expressed) features (TAB format) or choose it from your data folder. See above the accepted format for the file."
@@ -3978,6 +4006,7 @@ function MiRNAOmicSubmittingPanel(nElem, options) {
 				/*TARGETS FILE*/
 				{
 					xtype: "myFilesSelectorButton",
+					requiredTag: "required",
 					fieldLabel: "Associations file",
 					namePrefix: this.namePrefix + '_associations',
 					itemId: "mirnaTargetsFileSelector",
@@ -4009,7 +4038,8 @@ function MiRNAOmicSubmittingPanel(nElem, options) {
 				},
 				{
 					xtype: "myFilesSelectorButton",
-					fieldLabel: 'Relevant associations file<br>(optional)',
+					requiredTag: "required",
+					fieldLabel: 'Relevant associations file',
 					namePrefix: this.namePrefix + '_relevant_associations',
 					itemId: "secondaryAssociationFileSelector",
 					helpTip: "Upload the 2 column list of relevant associations (gene - feature) or choose it from your data folder."
@@ -4045,7 +4075,8 @@ function MiRNAOmicSubmittingPanel(nElem, options) {
 						},
 						{
 							xtype: "myFilesSelectorButton",
-							fieldLabel: "Gene expression dataset"/*<br> (optional)"*/,
+							requiredTag: "optional",
+							fieldLabel: 'Gene expression dataset',
 							namePrefix: this.namePrefix + '_rnaseqaux',
 							extraButtons: [{
 								text: 'Use a file from other omic',
@@ -4254,9 +4285,21 @@ function MiRNAOmicSubmittingPanel(nElem, options) {
 				// });
 
 				$("#" + me.namePrefix + "_corrOptions").change(function() {
-					// $("#" + me.namePrefix + "_mapRegions").prop('disabled', $(this).is(':checked'));
-					me.getComponent().queryById("secondaryAssociationFileSelector").down('container').setDisabled($(this).is(':checked'));
-					me.getComponent().queryById("itemsContainerCorrOptions").setDisabled(! $(this).is(':checked'));
+					var corrEnabled = $(this).is(':checked');
+					// $("#" + me.namePrefix + "_mapRegions").prop('disabled', corrEnabled);
+					me.getComponent().queryById("secondaryAssociationFileSelector").down('container').setDisabled(corrEnabled);
+					me.getComponent().queryById("itemsContainerCorrOptions").setDisabled(! corrEnabled);
+
+					/* Two of the rows on this card are required only because of this
+					   checkbox, so their tag is driven by the checkbox -- and by the same
+					   reading of it that isValid() makes a few lines above. Correlation on:
+					   the panel needs the gene expression file and derives the relevant
+					   associations itself. Correlation off: it needs the associations list.
+					   Written into the label instead, one of the two would always be wrong;
+					   that is what 'Relevant associations file (optional)' was, a label that
+					   said optional over a field that refused the form. */
+					me.getComponent().queryById("secondaryAssociationFileSelector").setRequiredTag(corrEnabled ? "optional" : "required");
+					me.getComponent().queryById("rnaseqauxFileSelector").setRequiredTag(corrEnabled ? "required" : "optional");
 				});
 
 				$(this.getEl().dom).find("a.deleteOmicBox").click(function() {
@@ -4430,6 +4473,7 @@ function MORESubmittingPanel(nElem, options) {
 				},
 				{
 					xtype: "myFilesSelectorButton",
+					requiredTag: "required",
 					fieldLabel: 'Conditions file',
 					namePrefix: 'conditions',
 					itemId: "conditionsFileSelector",
@@ -4441,6 +4485,7 @@ function MORESubmittingPanel(nElem, options) {
 				},
 				{
 					xtype: "myFilesSelectorButton",
+					requiredTag: "required",
 					fieldLabel: "Gene expression dataset",
 					namePrefix: 'rnaseqaux',
 					itemId: "rnaseqauxFileSelector",
@@ -4485,6 +4530,7 @@ function MORESubmittingPanel(nElem, options) {
 				},
 				{
 					xtype: "myFilesSelectorButton",
+					requiredTag: "required",
 					fieldLabel: 'Regulators expression file',
 					namePrefix: 'file_0',
 					itemId: "mainFileSelector",
@@ -4492,13 +4538,15 @@ function MORESubmittingPanel(nElem, options) {
 				},
 				{
 					xtype: "myFilesSelectorButton",
-					fieldLabel: 'Relevant regulators file<br>(optional)',
+					requiredTag: "optional",
+					fieldLabel: 'Relevant regulators file',
 					namePrefix: 'relevant_file_0',
 					itemId: "moreRelevantFileSelector",
 					helpTip: "Upload the list of relevant (differentially expressed) features (TAB format) or choose it from your data folder. See above the accepted format for the file."
 				},
 				{
 					xtype: "myFilesSelectorButton",
+					requiredTag: "optional",
 					fieldLabel: 'Associations file',
 					namePrefix: 'assoc_file_0',
 					itemId: "moreAssociationsFileSelector",
@@ -4566,6 +4614,7 @@ function MORESubmittingPanel(nElem, options) {
 							},
 							{
 								xtype: "myFilesSelectorButton",
+								requiredTag: "required",
 								fieldLabel: 'Regulators expression file',
 								namePrefix: 'file_' + i,
 								/* The same itemIds as the first regulator's
@@ -4582,13 +4631,15 @@ function MORESubmittingPanel(nElem, options) {
 							},
 							{
 								xtype: "myFilesSelectorButton",
-								fieldLabel: 'Relevant regulators file<br>(optional)',
+								requiredTag: "optional",
+								fieldLabel: 'Relevant regulators file',
 								namePrefix: 'relevant_file_' + i,
 								itemId: "moreRelevantFileSelector",
 								helpTip: "Upload the list of relevant (differentially expressed) features (TAB format) or choose it from your data folder. See above the accepted format for the file."
 							},
 							{
 								xtype: "myFilesSelectorButton",
+								requiredTag: "optional",
 								fieldLabel: 'Associations file',
 								namePrefix: 'assoc_file_' + i,
 								itemId: "moreAssociationsFileSelector",

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.03" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.04" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.15" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.6" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.7" />

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -7602,6 +7602,24 @@ a.po-ghost-action > i.fa {
   color: var(--pa-ink-muted);
 }
 
+/* The same note, one per file row on Step 1: does the job need this file or not.
+   It sits after the Browse button, in the 24px the row already has, so no card
+   grows by a pixel. "required" is the one that has to be read, so it carries the
+   weight; "optional" is a background fact and steps back. Both are qualifiers
+   next to the field, not badges -- a form with 28 pills on it reads as an alarm. */
+.po-file-tag {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--pa-ink-muted);
+  opacity: 0.72;
+  line-height: 24px;
+  white-space: nowrap;
+}
+.po-file-tag-required {
+  font-weight: 600;
+  opacity: 1;
+}
+
 /* The "Request an organism" dialog, opened by the pill above.
 
    One line of introduction and two fields, so the body needs nothing but a

--- a/PaintomicsServer/src/tests/test_step1_file_rows_say_required_or_optional.py
+++ b/PaintomicsServer/src/tests/test_step1_file_rows_say_required_or_optional.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Every file row on Step 1 says whether the job needs it.
+
+The labels used to carry it in words -- "Relevant associations file
+(optional)" over a field that refused the form when the correlation box was
+off -- and most rows said nothing at all. Each `myFilesSelectorButton` now
+declares `requiredTag: "required" | "optional"`; a row without one is a row
+somebody forgot, not a row with nothing to say, so this test refuses it. The
+rows whose requiredness follows a choice made elsewhere on the card flip it
+with setRequiredTag() from the same expression the validator reads.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_step1_file_rows_say_required_or_optional
+"""
+import os
+import re
+import sys
+import unittest
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+SERVER_ROOT = os.path.abspath(os.path.join(TESTS_DIR, "..", ".."))
+CLIENT_ROOT = os.path.abspath(os.path.join(SERVER_ROOT, "..", "PaintomicsClient", "public_html"))
+if SERVER_ROOT not in sys.path:
+    sys.path.insert(0, SERVER_ROOT)
+
+STEP1_VIEWS = os.path.join(CLIENT_ROOT, "app", "view", "PathwayAcquisitionViews", "PA_Step1Views.js")
+MY_DATA_VIEW = os.path.join(CLIENT_ROOT, "app", "view", "DataManagementViews", "DM_MyDataView.js")
+MAIN_CSS = os.path.join(CLIENT_ROOT, "resources", "css", "main.css")
+
+
+def read(path):
+    with open(path, "r") as handle:
+        return handle.read()
+
+
+def _fileRows(source):
+    """(line number, the item's text up to its closing brace) for every live
+    myFilesSelectorButton item; commented-out rows are skipped."""
+    rows = []
+    # Block comments are blanked (not removed, so line numbers hold): the
+    # miRNA panel keeps one retired row inside /* ... */.
+    source = re.sub(r"/\*.*?\*/", lambda m: re.sub(r"[^\n]", " ", m.group()), source, flags=re.S)
+    for match in re.finditer(r'xtype:\s*"myFilesSelectorButton"', source):
+        lineStart = source.rfind("\n", 0, match.start()) + 1
+        line = source[lineStart:match.start()]
+        if line.lstrip().startswith("//") or line.lstrip().startswith("*"):
+            continue
+        # The item's own braces: walk to the brace that closes the object
+        # this xtype sits in.
+        depth = 1
+        i = match.end()
+        while i < len(source) and depth > 0:
+            depth += {"{": 1, "}": -1}.get(source[i], 0)
+            i += 1
+        rows.append((source.count("\n", 0, match.start()) + 1, source[match.start():i]))
+    return rows
+
+
+class EveryFileRowIsTaggedTest(unittest.TestCase):
+
+    def setUp(self):
+        self.source = read(STEP1_VIEWS)
+        self.rows = _fileRows(self.source)
+
+    def test_there_are_file_rows_to_check(self):
+        self.assertGreater(len(self.rows), 20)
+
+    def test_every_file_row_declares_a_tag(self):
+        untagged = [line for line, text in self.rows if "requiredTag:" not in text]
+        self.assertEqual(untagged, [], "file rows without a requiredTag at lines %s" % untagged)
+
+    def test_a_tag_is_required_or_optional(self):
+        for line, text in self.rows:
+            match = re.search(r'requiredTag:\s*"([^"]+)"', text)
+            if match:
+                self.assertIn(match.group(1), ("required", "optional"), "line %d" % line)
+
+    def test_the_experimental_design_row_is_optional(self):
+        """The job runs without it -- the binomial route -- and the server
+        reads it only when present (JobInformationManager: `_design_file`)."""
+        design = [text for line, text in self.rows if 'itemId: "designFileSelector"' in text]
+        self.assertEqual(len(design), 1)
+        self.assertIn('requiredTag: "optional"', design[0])
+
+    def test_the_mirna_rows_that_depend_on_the_correlation_box_flip_together(self):
+        """Correlation on: the gene expression file is needed and the relevant
+        associations are derived; off: the list is needed. Both flips sit in
+        the one change handler, driven by the same reading the validator makes."""
+        handler = self.source[self.source.find('_corrOptions").change('):]
+        handler = handler[:handler.find("});") + 3]
+        self.assertIn('queryById("secondaryAssociationFileSelector").setRequiredTag(corrEnabled ? "optional" : "required")', handler)
+        self.assertIn('queryById("rnaseqauxFileSelector").setRequiredTag(corrEnabled ? "required" : "optional")', handler)
+
+
+class TheTagIsOneComponentTest(unittest.TestCase):
+
+    def test_the_selector_renders_and_updates_the_tag(self):
+        source = read(MY_DATA_VIEW)
+        self.assertIn("requiredTag: null", source)
+        self.assertIn("buildRequiredTag: function(tag)", source)
+        self.assertIn("setRequiredTag: function(tag)", source)
+        self.assertIn('itemId: "requiredTag"', source)
+
+    def test_required_carries_the_weight_in_css(self):
+        css = read(MAIN_CSS)
+        self.assertIn(".po-file-tag {", css)
+        self.assertIn(".po-file-tag-required {", css)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Every `myFilesSelectorButton` on Step 1 — 28 rows across the omic, region, miRNA and MORE panels — now carries a small **required** / optional note after its Browse button, in the 24px the row already has. The labels used to carry it in words, and only sometimes; "Relevant associations file (optional)" sat over a field that refused the form when the correlation box was off.

- `MyFilesSelectorButton` takes `requiredTag` and can flip it with `setRequiredTag()`; the two miRNA rows whose requiredness follows the correlation checkbox flip from the same reading of it the validator makes.
- The region panel's own-associations row is tagged required **and made so**: with no file the omic mapped to nothing and the job succeeded meaning nothing; `isValid` now refuses it.
- MORE / miRNA association rows stay optional, matching the server (NULL to R; the parser is guarded).
- #105's new Experimental-design row is tagged optional (the binomial route runs without it).
- `test_step1_file_rows_say_required_or_optional` refuses any file row without a tag, pins the design row as optional and the miRNA flip.

This is the working tree that had been sitting on the stale `feat/ai-compound-disambiguation` branch, re-based onto master: its checkForm / refusal-message half was already on master via #90 (and master's copy of `test_step1_drops_empty_omic_panels` is the newer one), so only the tag feature is here.

Verified in Chrome on :8061 with `?guides=1`: tags render on both default panels and the design row; HUD reports all text on rail, all rows on baseline. `main.css?v=` → 2.04.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NPYzin6921hAiHUDDR7Uxh