### PR TITLE
Put Browse inside the file field, with a caret for the menu

### DIFF
--- a/PaintomicsClient/public_html/app/view/DataManagementViews/DM_MyDataView.js
+++ b/PaintomicsClient/public_html/app/view/DataManagementViews/DM_MyDataView.js
@@ -920,6 +920,11 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 	fieldLabel: "label",
 	namePrefix: "filefield",
 	buttonText: "Browse...",
+	/* The drawn width of the in-field control, per label: measured once on
+	   the first row that can be measured and reused by every other row. */
+	statics: {
+		measuredWidths: {}
+	},
 	/* "required" or "optional": whether the job needs this file. Every file row on
 	   Step 1 sets it, so a row that says nothing is a row somebody forgot, not a
 	   row with nothing to say. Shown as the asterisk in the label; conditional
@@ -956,12 +961,14 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 	},
 	/* Two doors, one state. The widget's own lock (example rows, through
 	   setDisabled) and the path field's own disabled state (a panel switching
-	   the row off through the field or its container) each grey the control
-	   out; either is enough, and a container enable cascade -- the miRNA
-	   correlation box, the Region-based own-associations toggle -- cannot lift
-	   the widget's lock, which is how example rows once came back to life. */
+	   the row off through the field or its container; read from the field, not
+	   mirrored) each grey the control out; either is enough, and a container
+	   enable cascade -- the miRNA correlation box, the Region-based
+	   own-associations toggle -- cannot lift the widget's lock, which is how
+	   example rows once came back to life. */
 	applyBrowseState: function() {
-		var off = !!(this.browseLocked || this.fieldDisabled);
+		var field = this.queryById("visiblePathField");
+		var off = !!(this.browseLocked || (field && field.disabled));
 		var buttons = this.browseButtons || [];
 		var i;
 		for (i = 0; i < buttons.length; i++) {
@@ -1045,8 +1052,11 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 		caret.on("mousedown", function() {
 			me.menuWasOpen = me.optionsMenu.isVisible();
 		});
-		caret.on("click", function() {
-			me.toggleOptionsMenu();
+		caret.on("click", function(e) {
+			/* A keyboard activation is a click with no mousedown before it
+			   (detail 0); a press released off the caret leaves the flag stale,
+			   so the keyboard does not read it. */
+			me.toggleOptionsMenu(!!(e.browserEvent && e.browserEvent.detail === 0));
 		});
 		caret.on("keydown", function(e) {
 			if (e.getKey() === e.DOWN) {
@@ -1073,28 +1083,36 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 		   measures 0 here, so a zero is never written, and the field's resize
 		   -- which fires when that container is shown and laid out -- measures
 		   again; an unchanged figure is not written back. */
+		var widths = me.self.measuredWidths;
 		var measure = function() {
-			var width = control.getWidth();
+			/* Every row on the page shares one label and one font, so one drawn
+			   control answers for all of them: the first figure is kept and the
+			   other rows read it instead of forcing a layout each. */
+			var width = widths[me.buttonText] || control.getWidth();
 			var padding = (width + 2) + "px";
-			if (width > 0) {
-				if (field.inputEl.getStyle("padding-right") !== padding) {
-					field.inputEl.setStyle("padding-right", padding);
-				}
-				field.un("resize", measure);
+			if (width <= 0) {
+				return false;
 			}
+			widths[me.buttonText] = width;
+			if (field.inputEl.getStyle("padding-right") !== padding) {
+				field.inputEl.setStyle("padding-right", padding);
+			}
+			field.un("resize", measure);
+			return true;
 		};
-		measure();
-		field.on("resize", measure);
+		if (!measure()) {
+			field.on("resize", measure);
+		}
 		/* The web font can land after the first paint and change the width. */
 		if (document.fonts && document.fonts.ready) {
 			document.fonts.ready.then(function() {
 				if (!me.isDestroyed && field.rendered) {
+					delete widths[me.buttonText];
 					measure();
 				}
 			});
 		}
 		me.setRequiredTag(me.requiredTag);
-		me.fieldDisabled = !!field.disabled;
 		me.applyBrowseState();
 	},
 	/* The field label as words, for the caret's name: four rows on one card
@@ -1106,9 +1124,9 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 	showOptionsMenu: function() {
 		this.optionsMenu.showBy(this.browseCaret, "tr-br?");
 	},
-	toggleOptionsMenu: function() {
+	toggleOptionsMenu: function(keyboard) {
 		var menu = this.optionsMenu;
-		var wasOpen = this.menuWasOpen;
+		var wasOpen = !keyboard && this.menuWasOpen;
 		this.menuWasOpen = false;
 		if (wasOpen || menu.isVisible()) {
 			menu.hide();
@@ -1204,14 +1222,13 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 					/* Panels disable a row through the field or its container
 					   (`down('container').setDisabled(...)`), and the container
 					   cascade reaches form fields and buttons only. The control
-					   follows the field's own events -- as its own flag, so the
-					   enable that follows cannot lift a lock set through setDisabled. */
+					   follows the field's own events and reads the field's own disabled
+					   state, so the enable that follows cannot lift a lock set through
+					   setDisabled. */
 					disable: function() {
-						me.fieldDisabled = true;
 						me.applyBrowseState();
 					},
 					enable: function() {
-						me.fieldDisabled = false;
 						me.applyBrowseState();
 					}
 				},

--- a/PaintomicsClient/public_html/app/view/DataManagementViews/DM_MyDataView.js
+++ b/PaintomicsClient/public_html/app/view/DataManagementViews/DM_MyDataView.js
@@ -945,18 +945,27 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 		this.queryById("visiblePathField").setRawValue("");
 		this.queryById("originField").setValue("");
 	},
-	/* Greys the in-field control out and takes it out of the tab order. The
+	/* Locks the in-field control: greyed out and out of the tab order. The
 	   read-only path field itself stays enabled: a disabled input is dropped
 	   from the form post, and its text should stay readable. Remembered so a
 	   call made before the field is rendered (the example scenarios disable
 	   their rows straight away) still lands once wireBrowse() runs. */
 	setDisabled: function(disabled) {
-		var field = this.queryById("visiblePathField");
-		var buttons = (field && field.rendered) ? field.bodyEl.query(".po-browse button") : [];
+		this.browseLocked = !!disabled;
+		return this.applyBrowseState();
+	},
+	/* Two doors, one state. The widget's own lock (example rows, through
+	   setDisabled) and the path field's own disabled state (a panel switching
+	   the row off through the field or its container) each grey the control
+	   out; either is enough, and a container enable cascade -- the miRNA
+	   correlation box, the Region-based own-associations toggle -- cannot lift
+	   the widget's lock, which is how example rows once came back to life. */
+	applyBrowseState: function() {
+		var off = !!(this.browseLocked || this.fieldDisabled);
+		var buttons = this.browseButtons || [];
 		var i;
-		this.browseDisabled = !!disabled;
 		for (i = 0; i < buttons.length; i++) {
-			buttons[i].disabled = this.browseDisabled;
+			buttons[i].disabled = off;
 		}
 		return this;
 	},
@@ -1021,31 +1030,36 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 		if (!control || !text || !caret) {
 			return;
 		}
+		me.browseCaret = caret;
+		me.browseButtons = [text.dom, caret.dom];
 		text.dom.textContent = me.buttonText;
 		caret.set({"aria-label": "More options for " + me.rowName()});
 		text.on("click", function() {
 			me.openFilePicker();
 		});
+		/* Ext.menu.Manager hides every open menu on a document mousedown. The
+		   caret's own mousedown must not reach it, or the click that follows
+		   would show the menu straight back; with that stopped, the click is a
+		   plain toggle on what is visible. */
+		caret.on("mousedown", function(e) {
+			e.stopPropagation();
+		});
 		caret.on("click", function() {
-			me.toggleOptionsMenu(caret);
+			me.toggleOptionsMenu();
 		});
 		caret.on("keydown", function(e) {
 			if (e.getKey() === e.DOWN) {
 				e.stopEvent();
-				me.showOptionsMenu(caret);
+				me.showOptionsMenu();
 			}
 		});
-		/* Ext.menu.Manager hides every open menu on the mousedown that precedes
-		   a click on the caret; without remembering when that happened, the
-		   click would show the menu straight back. The split button kept the
-		   same 250 ms grace, and gave focus back to itself when its menu hid. */
+		/* The split button gave focus back to itself when its menu hid. */
 		me.optionsMenu.on({
 			show: function() {
 				caret.set({"aria-expanded": "true"});
 			},
 			hide: function() {
 				caret.set({"aria-expanded": "false"});
-				me.menuHiddenAt = Ext.Date.now();
 				if (!caret.dom.disabled) {
 					caret.focus();
 				}
@@ -1057,33 +1071,35 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 		   a hidden container (the Region-based panel's own-associations rows)
 		   measures 0 here, so a zero is never written, and the field's resize
 		   -- which fires when that container is shown and laid out -- measures
-		   again. */
+		   again; an unchanged figure is not written back. */
 		var measure = function() {
-			if (control.getWidth() > 0) {
-				field.inputEl.setStyle("padding-right", (control.getWidth() + 2) + "px");
+			var width = control.getWidth();
+			var padding = (width + 2) + "px";
+			if (width > 0 && field.inputEl.getStyle("padding-right") !== padding) {
+				field.inputEl.setStyle("padding-right", padding);
 			}
 		};
 		measure();
 		field.on("resize", measure);
 		me.setRequiredTag(me.requiredTag);
-		me.setDisabled(me.browseDisabled);
+		me.fieldDisabled = !!field.disabled;
+		me.applyBrowseState();
 	},
 	/* The field label as words, for the caret's name: four rows on one card
 	   would otherwise all announce as "More options". Six shipped labels carry
-	   a <br>, which JobController's plainFieldText strips. */
+	   a <br>, so the markup comes out. */
 	rowName: function() {
-		var label = String(this.fieldLabel);
-		return (typeof plainFieldText === "function") ? plainFieldText(label) : label;
+		return String(this.fieldLabel).replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").replace(/^ | $/g, "");
 	},
-	showOptionsMenu: function(caret) {
-		this.optionsMenu.showBy(caret, "tr-br?");
+	showOptionsMenu: function() {
+		this.optionsMenu.showBy(this.browseCaret, "tr-br?");
 	},
-	toggleOptionsMenu: function(caret) {
+	toggleOptionsMenu: function() {
 		var menu = this.optionsMenu;
 		if (menu.isVisible()) {
 			menu.hide();
-		} else if (Ext.Date.now() - (this.menuHiddenAt || 0) > 250) {
-			this.showOptionsMenu(caret);
+		} else {
+			this.showOptionsMenu();
 		}
 	},
 	beforeDestroy: function() {
@@ -1174,12 +1190,15 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 					/* Panels disable a row through the field or its container
 					   (`down('container').setDisabled(...)`), and the container
 					   cascade reaches form fields and buttons only. The control
-					   follows the field's own events, so every door ends here. */
+					   follows the field's own events -- as its own flag, so the
+					   enable that follows cannot lift a lock set through setDisabled. */
 					disable: function() {
-						me.setDisabled(true);
+						me.fieldDisabled = true;
+						me.applyBrowseState();
 					},
 					enable: function() {
-						me.setDisabled(false);
+						me.fieldDisabled = false;
+						me.applyBrowseState();
 					}
 				},
 				style: {

--- a/PaintomicsClient/public_html/app/view/DataManagementViews/DM_MyDataView.js
+++ b/PaintomicsClient/public_html/app/view/DataManagementViews/DM_MyDataView.js
@@ -1037,12 +1037,13 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 		text.on("click", function() {
 			me.openFilePicker();
 		});
-		/* Ext.menu.Manager hides every open menu on a document mousedown. The
-		   caret's own mousedown must not reach it, or the click that follows
-		   would show the menu straight back; with that stopped, the click is a
-		   plain toggle on what is visible. */
-		caret.on("mousedown", function(e) {
-			e.stopPropagation();
+		/* Ext.menu.Manager hides every open menu on a document mousedown, so
+		   the click that follows a press on the caret would show its own menu
+		   straight back. The press records whether the menu was open -- the
+		   caret's listener runs before the document's -- and still propagates:
+		   combos and tooltips close on that same document mousedown. */
+		caret.on("mousedown", function() {
+			me.menuWasOpen = me.optionsMenu.isVisible();
 		});
 		caret.on("click", function() {
 			me.toggleOptionsMenu();
@@ -1075,12 +1076,23 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 		var measure = function() {
 			var width = control.getWidth();
 			var padding = (width + 2) + "px";
-			if (width > 0 && field.inputEl.getStyle("padding-right") !== padding) {
-				field.inputEl.setStyle("padding-right", padding);
+			if (width > 0) {
+				if (field.inputEl.getStyle("padding-right") !== padding) {
+					field.inputEl.setStyle("padding-right", padding);
+				}
+				field.un("resize", measure);
 			}
 		};
 		measure();
 		field.on("resize", measure);
+		/* The web font can land after the first paint and change the width. */
+		if (document.fonts && document.fonts.ready) {
+			document.fonts.ready.then(function() {
+				if (!me.isDestroyed && field.rendered) {
+					measure();
+				}
+			});
+		}
 		me.setRequiredTag(me.requiredTag);
 		me.fieldDisabled = !!field.disabled;
 		me.applyBrowseState();
@@ -1096,7 +1108,9 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 	},
 	toggleOptionsMenu: function() {
 		var menu = this.optionsMenu;
-		if (menu.isVisible()) {
+		var wasOpen = this.menuWasOpen;
+		this.menuWasOpen = false;
+		if (wasOpen || menu.isVisible()) {
 			menu.hide();
 		} else {
 			this.showOptionsMenu();

--- a/PaintomicsClient/public_html/app/view/DataManagementViews/DM_MyDataView.js
+++ b/PaintomicsClient/public_html/app/view/DataManagementViews/DM_MyDataView.js
@@ -922,7 +922,8 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 	buttonText: "Browse...",
 	/* "required" or "optional": whether the job needs this file. Every file row on
 	   Step 1 sets it, so a row that says nothing is a row somebody forgot, not a
-	   row with nothing to say. Conditional rows flip it with setRequiredTag(). */
+	   row with nothing to say. Shown as the asterisk in the label; conditional
+	   rows flip it with setRequiredTag(). */
 	requiredTag: null,
 	labelAlign: "right",
 	labelWidth: 200,
@@ -944,18 +945,20 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 		this.queryById("visiblePathField").setRawValue("");
 		this.queryById("originField").setValue("");
 	},
-	/* Greys the in-field control out and makes it ignore clicks; the read-only
-	   path field stays readable. Remembered so a call made before the field is
-	   rendered (the example scenarios disable their rows straight away) still
-	   lands once wireBrowse() runs. */
+	/* Greys the in-field control out and takes it out of the tab order. The
+	   read-only path field itself stays enabled: a disabled input is dropped
+	   from the form post, and its text should stay readable. Remembered so a
+	   call made before the field is rendered (the example scenarios disable
+	   their rows straight away) still lands once wireBrowse() runs. */
 	setDisabled: function(disabled) {
 		var field = this.queryById("visiblePathField");
-		var control = (field && field.rendered) ? field.bodyEl.down(".po-browse") : null;
+		var buttons = (field && field.rendered) ? field.bodyEl.query(".po-browse button") : [];
+		var i;
 		this.browseDisabled = !!disabled;
-		if (control) {
-			control[disabled ? "addCls" : "removeCls"]("po-browse-disabled");
-			control.set({"aria-disabled": disabled ? "true" : "false"});
+		for (i = 0; i < buttons.length; i++) {
+			buttons[i].disabled = this.browseDisabled;
 		}
+		return this;
 	},
 	openFilePicker: function() {
 		this.queryById("fileField").fileInputEl.el.dom.click();
@@ -963,10 +966,16 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 	/* The menu behind the caret: the three entries the split button used to
 	   carry, plus whatever the panel adds through extraButtons. Built once and
 	   torn down with the widget -- a menu renders to the document body and would
-	   otherwise outlive the row it belongs to. */
+	   otherwise outlive the row it belongs to.
+
+	   The widget is named as the menu's owner. The extraButtons handlers (the
+	   Region-based panel's GTF picker, the miRNA panel's "other omic" picker)
+	   climb `this.up("myFilesSelectorButton")` from the menu item, and
+	   Menu.getRefOwner walks parentMenu -> ownerButton -> ownerCt; the split
+	   button used to be that owner, and an ownerless menu dead-ends the walk. */
 	buildOptionsMenu: function() {
 		var me = this;
-		return new Ext.menu.Menu({
+		var menu = new Ext.menu.Menu({
 			items: [
 				{
 					text: 'Upload file from my PC',
@@ -993,58 +1002,92 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 				}
 			].concat(me.extraButtons || [])
 		});
+		menu.ownerButton = me;
+		return menu;
 	},
-	/* Attaches the in-field control once the path field is rendered: the text
-	   opens the picker, the caret opens the menu under itself. An anchor answers
-	   Enter on its own; Space is what a button answers, so it is added here. */
+	/* Attaches the in-field control once the path field is rendered. The text
+	   opens the picker; the caret opens the menu under itself (Down arrow too,
+	   as the split button did) and closes it again on a second press. */
 	wireBrowse: function(field) {
 		var me = this;
+		var control = field.bodyEl.down(".po-browse");
 		var text = field.bodyEl.down(".po-browse-text");
 		var caret = field.bodyEl.down(".po-browse-caret");
-		if (!text || !caret) {
+		if (!control || !text || !caret) {
 			return;
 		}
-		text.on("click", function(e) {
-			e.stopEvent();
-			if (!me.browseDisabled) {
-				me.openFilePicker();
-			}
+		text.dom.textContent = me.buttonText;
+		caret.set({"aria-label": "More options for " + me.rowName()});
+		text.on("click", function() {
+			me.openFilePicker();
 		});
-		caret.on("click", function(e) {
-			e.stopEvent();
-			if (!me.browseDisabled) {
-				me.optionsMenu.showBy(caret, "tr-br?");
-			}
+		caret.on("click", function() {
+			me.toggleOptionsMenu(caret);
 		});
-		field.bodyEl.on("keydown", function(e, target) {
-			if (e.getKey() === e.SPACE) {
+		caret.on("keydown", function(e) {
+			if (e.getKey() === e.DOWN) {
 				e.stopEvent();
-				target.click();
+				me.showOptionsMenu(caret);
 			}
-		}, me, {delegate: ".po-browse a"});
-		if (me.browseDisabled) {
-			me.setDisabled(true);
+		});
+		/* Ext.menu.Manager hides every open menu on the mousedown that precedes
+		   a click on the caret; without remembering when that happened, the
+		   click would show the menu straight back. The split button kept the
+		   same 250 ms grace, and gave focus back to itself when its menu hid. */
+		me.optionsMenu.on({
+			show: function() {
+				caret.set({"aria-expanded": "true"});
+			},
+			hide: function() {
+				caret.set({"aria-expanded": "false"});
+				me.menuHiddenAt = Ext.Date.now();
+				if (!caret.dom.disabled) {
+					caret.focus();
+				}
+			}
+		});
+		/* The stylesheet's padding-right is a guess for the first paint; the
+		   control's real width depends on the text and the font, so measure it
+		   once it is drawn and let the input end exactly where it begins. */
+		field.inputEl.setStyle("padding-right", (control.getWidth() + 2) + "px");
+		me.setRequiredTag(me.requiredTag);
+		me.setDisabled(me.browseDisabled);
+	},
+	/* The field label without its trailing colon, for the caret's name: four
+	   rows on one card would otherwise all announce as "More options". */
+	rowName: function() {
+		return Ext.String.trim(String(this.fieldLabel || "this file").replace(/:\s*$/, "")) || "this file";
+	},
+	showOptionsMenu: function(caret) {
+		this.optionsMenu.showBy(caret, "tr-br?");
+	},
+	toggleOptionsMenu: function(caret) {
+		var menu = this.optionsMenu;
+		if (menu.isVisible()) {
+			menu.hide();
+		} else if (Ext.Date.now() - (this.menuHiddenAt || 0) > 250) {
+			this.showOptionsMenu(caret);
 		}
 	},
-	onDestroy: function() {
-		if (this.optionsMenu) {
-			this.optionsMenu.destroy();
-		}
+	beforeDestroy: function() {
+		Ext.destroy(this.optionsMenu);
 		this.callParent(arguments);
 	},
-	markInvalid: function(errorMessage) {
-		return this.queryById("visiblePathField").markInvalid(errorMessage);
-	},
-	buildRequiredTag: function(tag) {
-		return '<span class="po-file-tag' + (tag === "required" ? " po-file-tag-required" : "") + '">' + tag + '</span>';
-	},
-	/* For the rows whose requiredness is a consequence of a choice made elsewhere
-	   on the card -- the correlation checkbox on a miRNA panel, say. The caller
-	   passes the same expression the validator reads, so the two cannot drift. */
+	/* Shows or hides the requiredness mark in the label. The mark is always
+	   rendered (afterLabelTextTpl on the path field) and this only toggles it,
+	   so the rows whose requiredness is a consequence of a choice made elsewhere
+	   on the card -- the correlation checkbox on a miRNA panel, say -- can flip
+	   after render. The caller passes the same expression the validator reads,
+	   so the two cannot drift. Remembered when called before render; wireBrowse()
+	   applies it. */
 	setRequiredTag: function(tag) {
-		var box = this.queryById("requiredTag");
-		if (box && box.rendered) {
-			box.update(this.buildRequiredTag(tag));
+		var field = this.queryById("visiblePathField");
+		var mark = (field && field.rendered && field.labelEl) ? field.labelEl.down(".po-required") : null;
+		this.requiredTag = tag;
+		if (mark) {
+			/* setDisplayed, not setVisible: the latter keeps the box (visibility:
+			   hidden) and an optional row would show a gap before its colon. */
+			mark.setDisplayed(tag === "required");
 		}
 		return this;
 	},
@@ -1077,32 +1120,55 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 				labelWidth: me.labelWidth,
 				readOnly: true,
 				fieldLabel: me.fieldLabel,
+				/* The requiredness mark, after the words and before the colon, the way
+				   every form reader expects: a red asterisk for a row the job needs,
+				   nothing for an optional one. It used to be the word "required" or
+				   "optional" after the Browse button. Rendered by the label template
+				   rather than written into fieldLabel, so the label text the refusal
+				   dialog quotes stays the plain words; the mark carries the word for
+				   readers that cannot see it. setRequiredTag() shows or hides it. ExtJS puts
+				   this template after the separator, so the separator is blank and the
+				   colon is written here, after the mark: "Data file *:". */
+				labelSeparator: "",
+				afterLabelTextTpl: '<span class="po-required">' +
+					'<span class="po-required-mark" role="img" aria-label="required">*</span>' +
+					'</span>:',
 				cls: "po-file-path",
 				/* The Browse control is part of the field. "Browse..." at the field's
 				   right edge opens the file picker; the caret beside it opens the menu
 				   that used to hang off a split button standing next to the field as a
 				   second bordered box. The field's own template renders it, so it sits
 				   inside the one border the row has, and wireBrowse() attaches the
-				   handlers once the field is on the page. */
+				   handlers once the field is on the page.
+
+				   Native buttons on purpose: Enter and Space, the disabled attribute
+				   (out of the tab order, click-inert) and non-navigation come with the
+				   element, and the dark theme's blanket anchor colour never applies.
+				   The text is written in wireBrowse(), not here: afterSubTpl is an
+				   XTemplate, and a brace in buttonText would read as a placeholder. */
 				afterSubTpl: '<span class="po-browse">' +
-					'<a class="po-browse-text" href="javascript:void(0)" role="button">' + me.buttonText + '</a>' +
-					'<a class="po-browse-caret" href="javascript:void(0)" role="button" aria-haspopup="true" aria-label="More options for this file"></a>' +
+					'<button type="button" class="po-browse-text"></button>' +
+					'<button type="button" class="po-browse-caret" aria-haspopup="true" aria-expanded="false"></button>' +
 					'</span>',
 				listeners: {
 					afterrender: function(field) {
 						me.wireBrowse(field);
+					},
+					/* Panels disable a row through the field or its container
+					   (`down('container').setDisabled(...)`), and the container
+					   cascade reaches form fields and buttons only. The control
+					   follows the field's own events, so every door ends here. */
+					disable: function() {
+						me.setDisabled(true);
+					},
+					enable: function() {
+						me.setDisabled(false);
 					}
 				},
 				style: {
 					"margin-right": "3px"
 				}
-			}, (me.requiredTag ? {
-				xtype: "box",
-				itemId: "requiredTag",
-				width: 56,
-				margin: "0 0 0 8",
-				html: me.buildRequiredTag(me.requiredTag)
-			} : null), (me.helpTip !== undefined ? {
+			}, (me.helpTip !== undefined ? {
 				xtype: "label",
 				html: '<span class="helpTip" style="float:right;" title="' + this.helpTip + '""></span>'
 			} : null)]

--- a/PaintomicsClient/public_html/app/view/DataManagementViews/DM_MyDataView.js
+++ b/PaintomicsClient/public_html/app/view/DataManagementViews/DM_MyDataView.js
@@ -944,8 +944,93 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 		this.queryById("visiblePathField").setRawValue("");
 		this.queryById("originField").setValue("");
 	},
+	/* Greys the in-field control out and makes it ignore clicks; the read-only
+	   path field stays readable. Remembered so a call made before the field is
+	   rendered (the example scenarios disable their rows straight away) still
+	   lands once wireBrowse() runs. */
 	setDisabled: function(disabled) {
-		this.queryById("optionsButton").setDisabled(disabled);
+		var field = this.queryById("visiblePathField");
+		var control = (field && field.rendered) ? field.bodyEl.down(".po-browse") : null;
+		this.browseDisabled = !!disabled;
+		if (control) {
+			control[disabled ? "addCls" : "removeCls"]("po-browse-disabled");
+			control.set({"aria-disabled": disabled ? "true" : "false"});
+		}
+	},
+	openFilePicker: function() {
+		this.queryById("fileField").fileInputEl.el.dom.click();
+	},
+	/* The menu behind the caret: the three entries the split button used to
+	   carry, plus whatever the panel adds through extraButtons. Built once and
+	   torn down with the widget -- a menu renders to the document body and would
+	   otherwise outlive the row it belongs to. */
+	buildOptionsMenu: function() {
+		var me = this;
+		return new Ext.menu.Menu({
+			items: [
+				{
+					text: 'Upload file from my PC',
+					handler: function() {
+						me.openFilePicker();
+					}
+				}, {
+					text: 'Use a file from My Data',
+					disabled: (Ext.util.Cookies.get("userID") === null),
+					handler: function() {
+						var _callback = function(selectedItem) {
+							if (selectedItem !== null) {
+								me.clearValue();
+								me.setValue(selectedItem[0].get("fileName"));
+							}
+						};
+						Ext.widget("myFilesSelectorDialog").showDialog(_callback);
+					}
+				}, {
+					text: 'Clear selection',
+					handler: function() {
+						me.clearValue();
+					}
+				}
+			].concat(me.extraButtons || [])
+		});
+	},
+	/* Attaches the in-field control once the path field is rendered: the text
+	   opens the picker, the caret opens the menu under itself. An anchor answers
+	   Enter on its own; Space is what a button answers, so it is added here. */
+	wireBrowse: function(field) {
+		var me = this;
+		var text = field.bodyEl.down(".po-browse-text");
+		var caret = field.bodyEl.down(".po-browse-caret");
+		if (!text || !caret) {
+			return;
+		}
+		text.on("click", function(e) {
+			e.stopEvent();
+			if (!me.browseDisabled) {
+				me.openFilePicker();
+			}
+		});
+		caret.on("click", function(e) {
+			e.stopEvent();
+			if (!me.browseDisabled) {
+				me.optionsMenu.showBy(caret, "tr-br?");
+			}
+		});
+		field.bodyEl.on("keydown", function(e, target) {
+			if (e.getKey() === e.SPACE) {
+				e.stopEvent();
+				target.click();
+			}
+		}, me, {delegate: ".po-browse a"});
+		if (me.browseDisabled) {
+			me.setDisabled(true);
+		}
+	},
+	onDestroy: function() {
+		if (this.optionsMenu) {
+			this.optionsMenu.destroy();
+		}
+		this.callParent(arguments);
 	},
 	markInvalid: function(errorMessage) {
 		return this.queryById("visiblePathField").markInvalid(errorMessage);
@@ -969,6 +1054,7 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 	initComponent: function() {
 		var me = this;
 
+		me.optionsMenu = me.buildOptionsMenu();
 		me.items = [{
 			xtype: "container",
 			layout: {
@@ -991,45 +1077,24 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 				labelWidth: me.labelWidth,
 				readOnly: true,
 				fieldLabel: me.fieldLabel,
+				cls: "po-file-path",
+				/* The Browse control is part of the field. "Browse..." at the field's
+				   right edge opens the file picker; the caret beside it opens the menu
+				   that used to hang off a split button standing next to the field as a
+				   second bordered box. The field's own template renders it, so it sits
+				   inside the one border the row has, and wireBrowse() attaches the
+				   handlers once the field is on the page. */
+				afterSubTpl: '<span class="po-browse">' +
+					'<a class="po-browse-text" href="javascript:void(0)" role="button">' + me.buttonText + '</a>' +
+					'<a class="po-browse-caret" href="javascript:void(0)" role="button" aria-haspopup="true" aria-label="More options for this file"></a>' +
+					'</span>',
+				listeners: {
+					afterrender: function(field) {
+						me.wireBrowse(field);
+					}
+				},
 				style: {
 					"margin-right": "3px"
-				}
-			}, {
-				xtype: "splitbutton",
-				itemId: "optionsButton",
-				text: me.buttonText,
-				maxHeight: 24,
-				menu: new Ext.menu.Menu({
-					items: [
-						// these will render as dropdown menu items when the arrow is clicked:
-						{
-							text: 'Upload file from my PC',
-							scope: me,
-							handler: function() {
-								me.queryById("fileField").fileInputEl.el.dom.click();
-							}
-						}, {
-							text: 'Use a file from My Data',
-							disabled: (Ext.util.Cookies.get("userID") === null),
-							handler: function() {
-								var _callback = function(selectedItem) {
-									if (selectedItem !== null) {
-										me.clearValue();
-										me.setValue(selectedItem[0].get("fileName"));
-									}
-								};
-								Ext.widget("myFilesSelectorDialog").showDialog(_callback);
-							}
-						}, {
-							text: 'Clear selection',
-							handler: function() {
-								me.clearValue();
-							}
-						}
-					].concat(me.extraButtons)
-				}),
-				handler: function() {
-					this.showMenu();
 				}
 			}, (me.requiredTag ? {
 				xtype: "box",

--- a/PaintomicsClient/public_html/app/view/DataManagementViews/DM_MyDataView.js
+++ b/PaintomicsClient/public_html/app/view/DataManagementViews/DM_MyDataView.js
@@ -963,6 +963,11 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 	openFilePicker: function() {
 		this.queryById("fileField").fileInputEl.el.dom.click();
 	},
+	/* The panels mark a row that is missing its file through the widget; a
+	   Container has no markInvalid of its own, so it lands on the path field. */
+	markInvalid: function(errorMessage) {
+		return this.queryById("visiblePathField").markInvalid(errorMessage);
+	},
 	/* The menu behind the caret: the three entries the split button used to
 	   carry, plus whatever the panel adds through extraButtons. Built once and
 	   torn down with the widget -- a menu renders to the document body and would
@@ -1048,15 +1053,27 @@ Ext.define('Paintomics.view.common.MyFilesSelectorButton', {
 		});
 		/* The stylesheet's padding-right is a guess for the first paint; the
 		   control's real width depends on the text and the font, so measure it
-		   once it is drawn and let the input end exactly where it begins. */
-		field.inputEl.setStyle("padding-right", (control.getWidth() + 2) + "px");
+		   and let the input end exactly where it begins. A row rendered inside
+		   a hidden container (the Region-based panel's own-associations rows)
+		   measures 0 here, so a zero is never written, and the field's resize
+		   -- which fires when that container is shown and laid out -- measures
+		   again. */
+		var measure = function() {
+			if (control.getWidth() > 0) {
+				field.inputEl.setStyle("padding-right", (control.getWidth() + 2) + "px");
+			}
+		};
+		measure();
+		field.on("resize", measure);
 		me.setRequiredTag(me.requiredTag);
 		me.setDisabled(me.browseDisabled);
 	},
-	/* The field label without its trailing colon, for the caret's name: four
-	   rows on one card would otherwise all announce as "More options". */
+	/* The field label as words, for the caret's name: four rows on one card
+	   would otherwise all announce as "More options". Six shipped labels carry
+	   a <br>, which JobController's plainFieldText strips. */
 	rowName: function() {
-		return Ext.String.trim(String(this.fieldLabel || "this file").replace(/:\s*$/, "")) || "this file";
+		var label = String(this.fieldLabel);
+		return (typeof plainFieldText === "function") ? plainFieldText(label) : label;
 	},
 	showOptionsMenu: function(caret) {
 		this.optionsMenu.showBy(caret, "tr-br?");

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -384,7 +384,10 @@ var STATEGRA_EXPERIMENT_DESIGN = "STATegra multi-omics time-course experiment in
 *
 * setDisabled here greys out the Browse control inside the field and takes it
 * out of the tab order -- the widget's whole interactive surface; the field
-* itself stays enabled so the text can be read, copied and still posted.
+* itself stays enabled so the text can be read, copied and still posted. (A
+* row its panel switches off, like the miRNA associations row under the
+* correlation box, is disabled through the field instead, which also drops it
+* from the post; the control follows that door too.)
 */
 function setExampleLabel(field, text) {
 	if (!field) { return; }
@@ -2303,7 +2306,7 @@ function PA_Step1JobView() {
 							margin: "10 20 10 10",
 							layout: {type: 'vbox',align: "stretch"},
 							items: [
-								{xtype: 'box',html: '<div class="content"><h5><i class="fa fa-info-circle"></i> Help</h5><p>Drag <i>omics</i> from <b>Available omics</b> to <b>Selected omics</b>, or click the <i class="fa fa-plus-circle"></i> button.</p><p>Remove any you do not need with <span class="po-nowrap"><i class="fa fa-trash"></i>.</span></p><p><span class="po-required-mark" aria-hidden="true">*</span> marks the files the job needs; the rest are optional.</p><p>Files are checked as you pick them; the <b>PaintOmics AI agent</b> converts any that are not in PaintOmics’ format.</p><p>When you are done, click <b>Run PaintOmics</b> in the top-right corner.</p></div>'}
+								{xtype: 'box',html: '<div class="content"><h5><i class="fa fa-info-circle"></i> Help</h5><p>Drag <i>omics</i> from <b>Available omics</b> to <b>Selected omics</b>, or click the <i class="fa fa-plus-circle"></i> button.</p><p>Remove any you do not need with <span class="po-nowrap"><i class="fa fa-trash"></i>.</span></p><p><span class="po-required-mark" role="img" aria-label="asterisk">*</span> marks the files the job needs; the rest are optional.</p><p>Files are checked as you pick them; the <b>PaintOmics AI agent</b> converts any that are not in PaintOmics’ format.</p><p>When you are done, click <b>Run PaintOmics</b> in the top-right corner.</p></div>'}
 							]
 						}]
 					}					

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -382,8 +382,9 @@ var STATEGRA_EXPERIMENT_DESIGN = "STATegra multi-omics time-course experiment in
 * example submissions never reach saveFiles -- the servlets resolve their files
 * from the manifest and ignore the form entirely.
 *
-* setDisabled here disables the Browse button, which is the widget's whole
-* interactive surface; the text stays selectable so it can be read and copied.
+* setDisabled here greys out the Browse control inside the field and takes it
+* out of the tab order -- the widget's whole interactive surface; the field
+* itself stays enabled so the text can be read, copied and still posted.
 */
 function setExampleLabel(field, text) {
 	if (!field) { return; }
@@ -2302,7 +2303,7 @@ function PA_Step1JobView() {
 							margin: "10 20 10 10",
 							layout: {type: 'vbox',align: "stretch"},
 							items: [
-								{xtype: 'box',html: '<div class="content"><h5><i class="fa fa-info-circle"></i> Help</h5><p>Drag <i>omics</i> from <b>Available omics</b> to <b>Selected omics</b>, or click the <i class="fa fa-plus-circle"></i> button.</p><p>Remove any you do not need with <span class="po-nowrap"><i class="fa fa-trash"></i>.</span></p><p>Files are checked as you pick them; the <b>PaintOmics AI agent</b> converts any that are not in PaintOmics’ format.</p><p>When you are done, click <b>Run PaintOmics</b> in the top-right corner.</p></div>'}
+								{xtype: 'box',html: '<div class="content"><h5><i class="fa fa-info-circle"></i> Help</h5><p>Drag <i>omics</i> from <b>Available omics</b> to <b>Selected omics</b>, or click the <i class="fa fa-plus-circle"></i> button.</p><p>Remove any you do not need with <span class="po-nowrap"><i class="fa fa-trash"></i>.</span></p><p><span class="po-required-mark" aria-hidden="true">*</span> marks the files the job needs; the rest are optional.</p><p>Files are checked as you pick them; the <b>PaintOmics AI agent</b> converts any that are not in PaintOmics’ format.</p><p>When you are done, click <b>Run PaintOmics</b> in the top-right corner.</p></div>'}
 							]
 						}]
 					}					

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.04" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.05" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.15" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.6" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.7" />
@@ -48,7 +48,7 @@
 	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=2.3" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
 	<link rel="stylesheet" type="text/css" href="resources/css/evidence-overlay.css?v=1.0" />
-	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=1.32" />
+	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=1.33" />
 
 	<!-- Theme, resolved before the first paint.
 	     Deliberately inline and here rather than in Util.js: the stylesheets

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.05" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.06" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.15" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.6" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.7" />
@@ -48,7 +48,7 @@
 	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=2.3" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
 	<link rel="stylesheet" type="text/css" href="resources/css/evidence-overlay.css?v=1.0" />
-	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=1.33" />
+	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=1.34" />
 
 	<!-- Theme, resolved before the first paint.
 	     Deliberately inline and here rather than in Util.js: the stylesheets

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.06" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.07" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.15" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.6" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.7" />

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.07" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.08" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.15" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.6" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.7" />

--- a/PaintomicsClient/public_html/resources/css/dark.css
+++ b/PaintomicsClient/public_html/resources/css/dark.css
@@ -2029,3 +2029,18 @@
 :root[data-theme="dark"] #threshold_box .paClassPill-off { background: rgba(255, 255, 255, 0.08) !important; color: #A1B0C0; }
 :root[data-theme="dark"] #threshold_box .paClassPillDot { background: #7DD87F !important; }
 :root[data-theme="dark"] .metaboliteHead > h3.metaboliteTitle { color: #E3EAF2; }
+
+/* The Browse control inside every Step 1 file field (main.css .po-browse) is
+   muted ink, not a link, but the blanket anchor rule above paints any <a> in
+   the link blue. Restated here at the same specificity so the control keeps
+   the field's ink in the dark theme too; hover brings it up to the control
+   ink exactly as in the light theme. */
+[data-theme="dark"] .po-browse a {
+  color: inherit;
+}
+[data-theme="dark"] .po-browse a:hover {
+  color: var(--pa-ink-strong, #FFFFFF);
+}
+[data-theme="dark"] .po-browse-caret {
+  border-left-color: var(--pa-border, rgba(255, 255, 255, 0.14));
+}

--- a/PaintomicsClient/public_html/resources/css/dark.css
+++ b/PaintomicsClient/public_html/resources/css/dark.css
@@ -1553,8 +1553,6 @@
 	border-color: var(--pa-border-control-hover);
 }
 [data-theme="dark"] .omicbox a.x-btn .x-btn-inner { color: var(--pa-btn-default-ink); }
-[data-theme="dark"] .omicbox a.x-btn .x-btn-wrap::after { border-top-color: var(--pa-ink-label); }
-[data-theme="dark"] .omicbox a.x-btn .x-btn-wrap::before { border-left-color: var(--pa-border-control); }
 [data-theme="dark"] .fieldBox,
 [data-theme="dark"] .container { background-color: var(--pa-surface); }
 [data-theme="dark"] .dragHerePanel {
@@ -2029,18 +2027,3 @@
 :root[data-theme="dark"] #threshold_box .paClassPill-off { background: rgba(255, 255, 255, 0.08) !important; color: #A1B0C0; }
 :root[data-theme="dark"] #threshold_box .paClassPillDot { background: #7DD87F !important; }
 :root[data-theme="dark"] .metaboliteHead > h3.metaboliteTitle { color: #E3EAF2; }
-
-/* The Browse control inside every Step 1 file field (main.css .po-browse) is
-   muted ink, not a link, but the blanket anchor rule above paints any <a> in
-   the link blue. Restated here at the same specificity so the control keeps
-   the field's ink in the dark theme too; hover brings it up to the control
-   ink exactly as in the light theme. */
-[data-theme="dark"] .po-browse a {
-  color: inherit;
-}
-[data-theme="dark"] .po-browse a:hover {
-  color: var(--pa-ink-strong, #FFFFFF);
-}
-[data-theme="dark"] .po-browse-caret {
-  border-left-color: var(--pa-border, rgba(255, 255, 255, 0.14));
-}

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -198,7 +198,7 @@ root {
      own fill - which is why the green and red button fills do not constrain
      the choice. */
   --pa-focus-ring: #0A84FF;
-  --pa-status-error: #C84D2F;   /* the refusal dialog's ink; the asterisk on a required row */
+  --pa-status-error: #C84D2F;   /* the refusal dialog's ink and the asterisk on a required row */
 
   /* Surfaces and controls ----------------------------------------------------
      The app had three corner radii in play - 2px on cards, 3px on form fields,
@@ -2548,7 +2548,7 @@ body > .x-mask {
 	border-top-color: rgb(211, 96, 68);
 }
 #messageDialog.errorDialog h4 {
-	color: #C84D2F; /* was rgb(211,96,68) - 3.80:1 on the dialog's white fill */
+	color: var(--pa-status-error, #C84D2F); /* was rgb(211,96,68) - 3.80:1 on the dialog's white fill */
 }
 #messageDialog.warningDialog {
 	border-top-color: #CB7505;
@@ -7667,6 +7667,12 @@ a.po-ghost-action > i.fa {
   color: var(--pa-ink-muted);
   opacity: 0.45;
   cursor: default;
+}
+/* A row switched off by its panel (the miRNA associations row when the
+   correlation box is ticked) is disabled through the field, which Neptune
+   already fades to .3; the control's own fade would stack on top of it. */
+.x-item-disabled .po-browse button:disabled {
+  opacity: 1;
 }
 
 /* The "Request an organism" dialog, opened by the pill above.

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -198,6 +198,7 @@ root {
      own fill - which is why the green and red button fills do not constrain
      the choice. */
   --pa-focus-ring: #0A84FF;
+  --pa-status-error: #C84D2F;   /* the refusal dialog's ink; the asterisk on a required row */
 
   /* Surfaces and controls ----------------------------------------------------
      The app had three corner radii in play - 2px on cards, 3px on form fields,
@@ -7038,34 +7039,6 @@ div.omicSummaryBox.expandedBox, div.metaboliteBox.expandedBox{
   color: #3F3F46;
   font-weight: 500;
 }
-/* The split arrow and its divider come from the Neptune sprite, drawn light for
-   a dark button - on white they disappear, and with them the only sign that
-   this button opens a menu. Drawn here instead, so they follow the text colour
-   rather than the theme image. */
-.omicbox a.x-btn .x-btn-wrap {
-  background-image: none;
-  position: relative;
-}
-.omicbox a.x-btn .x-btn-wrap::after {
-  content: "";
-  position: absolute;
-  right: 8px;
-  top: 50%;
-  margin-top: -2px;
-  border-left: 4px solid transparent;
-  border-right: 4px solid transparent;
-  border-top: 5px solid #71717A;
-  pointer-events: none;
-}
-.omicbox a.x-btn .x-btn-wrap::before {
-  content: "";
-  position: absolute;
-  right: 21px;
-  top: 4px;
-  bottom: 4px;
-  border-left: 1px solid var(--pa-border);
-  pointer-events: none;
-}
 /* About / How It Works Section */
 .po-about-section {
   padding: 0;
@@ -7602,22 +7575,20 @@ a.po-ghost-action > i.fa {
   color: var(--pa-ink-muted);
 }
 
-/* The same note, one per file row on Step 1: does the job need this file or not.
-   It sits after the Browse button, in the 24px the row already has, so no card
-   grows by a pixel. "required" is the one that has to be read, so it carries the
-   weight; "optional" is a background fact and steps back. Both are qualifiers
-   next to the field, not badges -- a form with 28 pills on it reads as an alarm. */
-.po-file-tag {
-  font-size: 11px;
-  font-weight: 400;
-  color: var(--pa-ink-muted);
-  opacity: 0.72;
-  line-height: 24px;
-  white-space: nowrap;
-}
-.po-file-tag-required {
+/* The requiredness mark, in every file row's label after the words and
+   before the colon: a red asterisk for a row the job needs, nothing for an
+   optional one -- the convention every form reader already knows. It replaces
+   the word "required" or "optional" that sat after each Browse button; the
+   card's help column says once what the asterisk means. */
+.po-required-mark {
+  color: var(--pa-status-error, #C84D2F);
   font-weight: 600;
-  opacity: 1;
+}
+/* A hair of air between the words and the mark, in the labels only: the
+   legend in the help column starts with the mark and sits on the column's
+   rail. */
+.x-form-item-label .po-required-mark {
+  margin-left: 2px;
 }
 
 /* Browse lives inside the file field.
@@ -7630,14 +7601,17 @@ a.po-ghost-action > i.fa {
    The control is now rendered by the path field itself (afterSubTpl), sitting
    at the field's right edge as quiet text: "Browse..." opens the file picker,
    the caret beside it opens the same menu. The field keeps its one border, the
-   input leaves room for the control so a long file name never runs under it,
-   and the tag and help tip stay where they were. The colour is the same muted
-   ink as the tag; hover and focus bring it up to the control ink so it still
-   reads as something that can be pressed. */
-.po-file-path .x-form-item-body {
-  position: relative;
-}
+   input leaves room for the control so a long file name is clipped before it
+   rather than running under it, and the tag and help tip stay where they were.
+   Neptune already positions .x-form-item-body, which is the containing block.
+   The colour is the same muted ink as the tag; hover and keyboard focus bring
+   it up to the control ink so it still reads as something that can be
+   pressed. The two controls are native buttons, so Enter, Space, the disabled
+   attribute and the global focus ring all come for free. */
 .po-file-path .x-form-text {
+  /* A guess for the first paint; wireBrowse() measures the drawn control and
+     sets the exact figure, so a longer label or another font cannot let the
+     file name run underneath. */
   padding-right: 92px;
 }
 .po-browse {
@@ -7652,44 +7626,47 @@ a.po-ghost-action > i.fa {
   line-height: 1;
   color: var(--pa-ink-muted);
   white-space: nowrap;
+  -webkit-user-select: none;
   user-select: none;
 }
-.po-browse a {
-  color: inherit;
-  text-decoration: none;
+.po-browse button {
   display: inline-flex;
   align-items: center;
   height: 18px;
+  padding: 0;
+  border: 0;
   border-radius: 3px;
+  background: none;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
 }
-.po-browse a:hover {
+.po-browse button:hover,
+.po-browse button:focus-visible {
   color: var(--pa-ink-control, #3F3F46);
 }
-.po-browse a:focus-visible {
-  outline: 2px solid var(--pa-focus-ring, #0A84FF);
-  outline-offset: 1px;
-}
-.po-browse-text {
+.po-browse .po-browse-text {
   padding: 0 6px;
 }
 /* The caret is its own target, separated from the text by a hairline, so the
    menu and the picker cannot be confused for one another. */
-.po-browse-caret {
+.po-browse .po-browse-caret {
   width: 18px;
   justify-content: center;
   margin-left: 2px;
   border-left: 1px solid var(--pa-border, rgba(24, 24, 27, 0.10));
   border-radius: 0 3px 3px 0;
 }
-.po-browse-caret::after {
+.po-browse .po-browse-caret::after {
   content: "";
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
   border-top: 5px solid currentColor;
 }
-.po-browse-disabled {
+.po-browse button:disabled {
+  color: var(--pa-ink-muted);
   opacity: 0.45;
-  pointer-events: none;
+  cursor: default;
 }
 
 /* The "Request an organism" dialog, opened by the pill above.

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -198,7 +198,7 @@ root {
      own fill - which is why the green and red button fills do not constrain
      the choice. */
   --pa-focus-ring: #0A84FF;
-  --pa-status-error: #C84D2F;   /* the refusal dialog's ink and the asterisk on a required row */
+  --pa-status-error-ink: #C84D2F;   /* the refusal dialog's ink and the asterisk on a required row; dark.css keeps --pa-status-error for fills */
 
   /* Surfaces and controls ----------------------------------------------------
      The app had three corner radii in play - 2px on cards, 3px on form fields,
@@ -2548,7 +2548,7 @@ body > .x-mask {
 	border-top-color: rgb(211, 96, 68);
 }
 #messageDialog.errorDialog h4 {
-	color: var(--pa-status-error, #C84D2F); /* was rgb(211,96,68) - 3.80:1 on the dialog's white fill */
+	color: var(--pa-status-error-ink, #C84D2F); /* was rgb(211,96,68) - 3.80:1 on the dialog's white fill */
 }
 #messageDialog.warningDialog {
 	border-top-color: #CB7505;
@@ -7581,7 +7581,7 @@ a.po-ghost-action > i.fa {
    the word "required" or "optional" that sat after each Browse button; the
    card's help column says once what the asterisk means. */
 .po-required-mark {
-  color: var(--pa-status-error, #C84D2F);
+  color: var(--pa-status-error-ink, #C84D2F);
   font-weight: 600;
 }
 /* A hair of air between the words and the mark, in the labels only: the
@@ -7669,8 +7669,13 @@ a.po-ghost-action > i.fa {
   cursor: default;
 }
 /* A row switched off by its panel (the miRNA associations row when the
-   correlation box is ticked) is disabled through the field, which Neptune
-   already fades to .3; the control's own fade would stack on top of it. */
+   correlation box is ticked) is disabled through the field. Neptune fades
+   that row's label and input to .3 but not the control, which sits beside
+   the input in the body cell: the control fades to the same .3 itself, and
+   its buttons' own .45 does not stack on top. */
+.x-item-disabled .po-browse {
+  opacity: 0.3;
+}
 .x-item-disabled .po-browse button:disabled {
   opacity: 1;
 }

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -7620,6 +7620,78 @@ a.po-ghost-action > i.fa {
   opacity: 1;
 }
 
+/* Browse lives inside the file field.
+
+   Every file row used to be two boxes side by side: the read-only path field
+   and, beside it, a bordered ExtJS split button reading "Browse...", with the
+   upload / My Data / clear menu behind its arrow. Two borders per row, three
+   controls with the tag, and the card's right edge set by the widest of them.
+
+   The control is now rendered by the path field itself (afterSubTpl), sitting
+   at the field's right edge as quiet text: "Browse..." opens the file picker,
+   the caret beside it opens the same menu. The field keeps its one border, the
+   input leaves room for the control so a long file name never runs under it,
+   and the tag and help tip stay where they were. The colour is the same muted
+   ink as the tag; hover and focus bring it up to the control ink so it still
+   reads as something that can be pressed. */
+.po-file-path .x-form-item-body {
+  position: relative;
+}
+.po-file-path .x-form-text {
+  padding-right: 92px;
+}
+.po-browse {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  bottom: 1px;
+  display: flex;
+  align-items: center;
+  padding: 0 4px 0 6px;
+  font-size: 12px;
+  line-height: 1;
+  color: var(--pa-ink-muted);
+  white-space: nowrap;
+  user-select: none;
+}
+.po-browse a {
+  color: inherit;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  height: 18px;
+  border-radius: 3px;
+}
+.po-browse a:hover {
+  color: var(--pa-ink-control, #3F3F46);
+}
+.po-browse a:focus-visible {
+  outline: 2px solid var(--pa-focus-ring, #0A84FF);
+  outline-offset: 1px;
+}
+.po-browse-text {
+  padding: 0 6px;
+}
+/* The caret is its own target, separated from the text by a hairline, so the
+   menu and the picker cannot be confused for one another. */
+.po-browse-caret {
+  width: 18px;
+  justify-content: center;
+  margin-left: 2px;
+  border-left: 1px solid var(--pa-border, rgba(24, 24, 27, 0.10));
+  border-radius: 0 3px 3px 0;
+}
+.po-browse-caret::after {
+  content: "";
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid currentColor;
+}
+.po-browse-disabled {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
 /* The "Request an organism" dialog, opened by the pill above.
 
    One line of introduction and two fields, so the body needs nothing but a

--- a/PaintomicsServer/src/tests/test_step1_browse_lives_inside_the_field.py
+++ b/PaintomicsServer/src/tests/test_step1_browse_lives_inside_the_field.py
@@ -115,9 +115,8 @@ class BrowseLivesInsideTheFieldTest(unittest.TestCase):
         control follows the field's own disable/enable events."""
         self.assertRegex(self.field, r"\bdisable:\s*function")
         self.assertRegex(self.field, r"\benable:\s*function")
-        set_disabled = between(self.widget, "setDisabled: function(disabled)",
-                               "openFilePicker: function")
-        self.assertIn(".disabled = ", set_disabled,
+        apply = between(self.widget, "applyBrowseState: function()", "\n\t},")
+        self.assertIn(".disabled = ", apply,
                       "the native disabled attribute is the one carrier")
 
     def test_the_widget_still_forwards_mark_invalid(self):
@@ -136,21 +135,24 @@ class BrowseLivesInsideTheFieldTest(unittest.TestCase):
         under Browse once the row is shown. Measure only a drawn control and
         again when the field is laid out."""
         wire = between(self.widget, "wireBrowse: function(field)", "\n\t},")
-        self.assertRegex(wire, r"\bwidth\s*>\s*0", "guard the zero measurement")
+        self.assertRegex(wire, r"\bwidth\s*<=\s*0", "guard the zero measurement")
         self.assertRegex(wire, r"[\"']resize[\"']", "re-measure on the field's resize")
-        self.assertIn('un("resize"', wire, "stop re-measuring once a figure has landed")
+        self.assertRegex(wire, r"if \(!measure\(\)\)", "listen for resize only until a figure has landed")
         self.assertIn("document.fonts", wire, "the web font can land after the first measurement")
+        self.assertIn("measuredWidths", self.widget, "one figure per label for every row on the page")
 
     def test_a_container_enable_cannot_lift_the_example_lock(self):
         """Example rows are locked through the widget's setDisabled; a panel
         that disables and re-enables the row's container (the miRNA
         correlation box, the Region-based own-associations toggle) fires the
         field's enable, which must not unlock them. Two flags, one state."""
-        self.assertIn("applyBrowseState: function()", self.widget)
-        self.assertRegex(self.widget, r"browseLocked\s*\|\|\s*this\.fieldDisabled")
+        apply = between(self.widget, "applyBrowseState: function()", "\n\t},")
+        self.assertIn("browseLocked", apply)
+        # The field's own disabled state, not a mirror of it kept in step by hand.
+        self.assertRegex(apply, r"field\s*&&\s*field\.disabled")
         listeners = between(self.field, "listeners: {", "\n\t\t\t\t},")
         self.assertNotIn("setDisabled(false)", listeners)
-        self.assertIn("fieldDisabled = false", listeners)
+        self.assertEqual(listeners.count("applyBrowseState()"), 2, "disable and enable both re-apply")
 
     def test_the_caret_toggles_its_menu_without_a_timer(self):
         """Ext.menu.Manager hides every menu on a document mousedown, so a
@@ -162,7 +164,10 @@ class BrowseLivesInsideTheFieldTest(unittest.TestCase):
         wire = between(self.widget, "wireBrowse: function(field)", "\n\t},")
         self.assertRegex(wire, r"[\"']mousedown[\"'][^}]*menuWasOpen\s*=")
         self.assertNotIn("stopPropagation", wire)
-        toggle = between(self.widget, "toggleOptionsMenu: function()", "\n\t},")
+        # A press released off the caret never becomes a click and would leave
+        # the flag stale; a keyboard activation (detail 0) must not read it.
+        self.assertIn("detail === 0", wire)
+        toggle = between(self.widget, "toggleOptionsMenu: function(keyboard)", "\n\t},")
         self.assertIn("menuWasOpen", toggle)
         self.assertIn("isVisible()", toggle)
 

--- a/PaintomicsServer/src/tests/test_step1_browse_lives_inside_the_field.py
+++ b/PaintomicsServer/src/tests/test_step1_browse_lives_inside_the_field.py
@@ -80,7 +80,7 @@ def path_field_config(widget):
     return between(widget, 'itemId: "visiblePathField"', "xtype: 'filefield'")
 
 
-class BrowseLivesInsideTheField(unittest.TestCase):
+class BrowseLivesInsideTheFieldTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -136,8 +136,30 @@ class BrowseLivesInsideTheField(unittest.TestCase):
         under Browse once the row is shown. Measure only a drawn control and
         again when the field is laid out."""
         wire = between(self.widget, "wireBrowse: function(field)", "\n\t},")
-        self.assertRegex(wire, r"getWidth\(\)[^;]*>\s*0|>\s*0[^;]*getWidth", "guard the zero measurement")
+        self.assertRegex(wire, r"\bwidth\s*>\s*0", "guard the zero measurement")
         self.assertRegex(wire, r"[\"']resize[\"']", "re-measure on the field's resize")
+
+    def test_a_container_enable_cannot_lift_the_example_lock(self):
+        """Example rows are locked through the widget's setDisabled; a panel
+        that disables and re-enables the row's container (the miRNA
+        correlation box, the Region-based own-associations toggle) fires the
+        field's enable, which must not unlock them. Two flags, one state."""
+        self.assertIn("applyBrowseState: function()", self.widget)
+        self.assertRegex(self.widget, r"browseLocked\s*\|\|\s*this\.fieldDisabled")
+        listeners = between(self.field, "listeners: {", "\n\t\t\t\t},")
+        self.assertNotIn("setDisabled(false)", listeners)
+        self.assertIn("fieldDisabled = false", listeners)
+
+    def test_the_caret_toggles_its_menu_without_a_timer(self):
+        """Ext.menu.Manager hides every menu on a document mousedown; the
+        caret's own mousedown must not reach it, and then a plain
+        isVisible() toggle is deterministic -- no grace period a slow press
+        can outlast."""
+        wire = between(self.widget, "wireBrowse: function(field)", "\n\t},")
+        self.assertRegex(wire, r"[\"']mousedown[\"'][^}]*stopPropagation")
+        toggle = between(self.widget, "toggleOptionsMenu: function()", "\n\t},")
+        self.assertIn("isVisible()", toggle)
+        self.assertNotIn("menuHiddenAt", self.widget)
 
     def test_the_menu_still_offers_the_three_actions(self):
         for entry in ("Upload file from my PC", "Use a file from My Data",

--- a/PaintomicsServer/src/tests/test_step1_browse_lives_inside_the_field.py
+++ b/PaintomicsServer/src/tests/test_step1_browse_lives_inside_the_field.py
@@ -120,10 +120,35 @@ class BrowseLivesInsideTheField(unittest.TestCase):
         self.assertIn(".disabled = ", set_disabled,
                       "the native disabled attribute is the one carrier")
 
+    def test_the_widget_still_forwards_mark_invalid(self):
+        """Eleven Step 1 validators call markInvalid() on the widget (a
+        Container, which has none of its own) to mark a row that is missing
+        its file; the forwarder to the path field must survive any rewrite
+        of the widget or every such refusal throws instead of marking."""
+        self.assertIn('up("myFilesSelectorButton")', self.step1)
+        self.assertIn('.markInvalid("Please, provide', self.step1)
+        forwarder = between(self.widget, "markInvalid: function(errorMessage)", "\n\t},")
+        self.assertIn('queryById("visiblePathField").markInvalid(errorMessage)', forwarder)
+
+    def test_the_control_is_measured_when_it_is_actually_drawn(self):
+        """A row rendered inside a hidden container measures 0 at afterrender;
+        writing that into the input's padding would let the file name run
+        under Browse once the row is shown. Measure only a drawn control and
+        again when the field is laid out."""
+        wire = between(self.widget, "wireBrowse: function(field)", "\n\t},")
+        self.assertRegex(wire, r"getWidth\(\)[^;]*>\s*0|>\s*0[^;]*getWidth", "guard the zero measurement")
+        self.assertRegex(wire, r"[\"']resize[\"']", "re-measure on the field's resize")
+
     def test_the_menu_still_offers_the_three_actions(self):
         for entry in ("Upload file from my PC", "Use a file from My Data",
                       "Clear selection"):
             self.assertIn(entry, self.widget)
+
+    def test_a_row_disabled_through_its_container_fades_once(self):
+        """Neptune fades a disabled field (.x-item-disabled, opacity .3) and
+        the control fades its disabled buttons (.45); stacked, the control
+        all but vanishes on the miRNA associations row."""
+        self.assertRegex(self.css, r"\.x-item-disabled\s+\.po-browse\s+button:disabled\s*\{[^}]*opacity:\s*1")
 
     def test_the_stylesheet_puts_browse_inside_the_field(self):
         self.assertRegex(self.css, r"\.po-browse\s*\{[^}]*position:\s*absolute")

--- a/PaintomicsServer/src/tests/test_step1_browse_lives_inside_the_field.py
+++ b/PaintomicsServer/src/tests/test_step1_browse_lives_inside_the_field.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Browse is a quiet control inside the file field, not a button beside it.
+
+The behaviour this guards
+-------------------------
+Every file row on Step 1 is a `myFilesSelectorButton`: a read-only path field
+followed, until now, by an ExtJS split button reading "Browse..." with a menu
+behind its arrow (upload from my PC / use a file from My Data / clear). The
+button sat outside the field as a second, bordered box, so each row read as two
+controls plus a tag, and the card's right edge was set by the widest of them.
+
+Now "Browse..." is text at the right edge of the field itself, with a small
+caret next to it that opens the same menu. The field keeps its single border;
+the required/optional tag and the help tip stay where they were. Nothing is
+lost: the file picker opens from the text, the three menu entries open from
+the caret, and `setDisabled()` still greys the control out.
+
+What is tested is the source the browser loads: the widget no longer builds a
+split button, the path field renders the control through `afterSubTpl`, and the
+stylesheet positions it inside the field and makes room for it.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_step1_browse_lives_inside_the_field
+"""
+import os
+import re
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CLIENT_ROOT = os.path.normpath(
+    os.path.join(HERE, "..", "..", "..", "PaintomicsClient", "public_html"))
+MY_DATA_VIEW = os.path.join(
+    CLIENT_ROOT, "app", "view", "DataManagementViews", "DM_MyDataView.js")
+MAIN_CSS = os.path.join(CLIENT_ROOT, "resources", "css", "main.css")
+
+
+def read(path):
+    with open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def widget_source(source):
+    """The text of `Ext.define('Paintomics.view.common.MyFilesSelectorButton'`
+    up to the next Ext.define."""
+    start = source.index("Ext.define('Paintomics.view.common.MyFilesSelectorButton'")
+    end = source.find("Ext.define(", start + 1)
+    return source[start:end if end != -1 else len(source)]
+
+
+class BrowseLivesInsideTheField(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.widget = widget_source(read(MY_DATA_VIEW))
+        cls.css = read(MAIN_CSS)
+
+    def test_the_widget_no_longer_builds_a_button_beside_the_field(self):
+        self.assertNotIn('xtype: "splitbutton"', self.widget)
+        self.assertNotIn("xtype: 'splitbutton'", self.widget)
+
+    def test_the_path_field_renders_browse_and_caret_inside_itself(self):
+        field = re.search(r'itemId:\s*"visiblePathField".*?\n\t\t\t\}', self.widget, re.S)
+        self.assertIsNotNone(field, "visiblePathField config not found")
+        config = field.group(0)
+        self.assertIn("afterSubTpl", config)
+        self.assertIn('class="po-browse-text"', config)
+        self.assertIn('class="po-browse-caret"', config)
+
+    def test_the_menu_still_offers_the_three_actions(self):
+        for entry in ("Upload file from my PC", "Use a file from My Data",
+                      "Clear selection"):
+            self.assertIn(entry, self.widget)
+
+    def test_disabling_still_reaches_the_control(self):
+        """setDisabled() used to disable the split button; it must still do
+        something visible now that there is no button."""
+        self.assertIn("setDisabled: function(disabled)", self.widget)
+        self.assertIn("po-browse-disabled", self.widget)
+
+    def test_the_stylesheet_puts_browse_inside_the_field(self):
+        self.assertIn(".po-browse {", self.css)
+        self.assertRegex(self.css, r"\.po-browse\s*\{[^}]*position:\s*absolute")
+        self.assertRegex(
+            self.css, r"\.po-file-path \.x-form-text\s*\{[^}]*padding-right",
+            "the input must leave room for the control at its right edge")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/PaintomicsServer/src/tests/test_step1_browse_lives_inside_the_field.py
+++ b/PaintomicsServer/src/tests/test_step1_browse_lives_inside_the_field.py
@@ -138,6 +138,8 @@ class BrowseLivesInsideTheFieldTest(unittest.TestCase):
         wire = between(self.widget, "wireBrowse: function(field)", "\n\t},")
         self.assertRegex(wire, r"\bwidth\s*>\s*0", "guard the zero measurement")
         self.assertRegex(wire, r"[\"']resize[\"']", "re-measure on the field's resize")
+        self.assertIn('un("resize"', wire, "stop re-measuring once a figure has landed")
+        self.assertIn("document.fonts", wire, "the web font can land after the first measurement")
 
     def test_a_container_enable_cannot_lift_the_example_lock(self):
         """Example rows are locked through the widget's setDisabled; a panel
@@ -151,15 +153,18 @@ class BrowseLivesInsideTheFieldTest(unittest.TestCase):
         self.assertIn("fieldDisabled = false", listeners)
 
     def test_the_caret_toggles_its_menu_without_a_timer(self):
-        """Ext.menu.Manager hides every menu on a document mousedown; the
-        caret's own mousedown must not reach it, and then a plain
-        isVisible() toggle is deterministic -- no grace period a slow press
-        can outlast."""
+        """Ext.menu.Manager hides every menu on a document mousedown, so a
+        click on the caret would show its menu straight back. The caret's
+        mousedown records whether the menu was open (element listeners run
+        before the document's) and still propagates -- combos and tooltips
+        listen to the same document mousedown to close -- and the click
+        shows the menu only if it was not open."""
         wire = between(self.widget, "wireBrowse: function(field)", "\n\t},")
-        self.assertRegex(wire, r"[\"']mousedown[\"'][^}]*stopPropagation")
+        self.assertRegex(wire, r"[\"']mousedown[\"'][^}]*menuWasOpen\s*=")
+        self.assertNotIn("stopPropagation", wire)
         toggle = between(self.widget, "toggleOptionsMenu: function()", "\n\t},")
+        self.assertIn("menuWasOpen", toggle)
         self.assertIn("isVisible()", toggle)
-        self.assertNotIn("menuHiddenAt", self.widget)
 
     def test_the_menu_still_offers_the_three_actions(self):
         for entry in ("Upload file from my PC", "Use a file from My Data",
@@ -167,9 +172,10 @@ class BrowseLivesInsideTheFieldTest(unittest.TestCase):
             self.assertIn(entry, self.widget)
 
     def test_a_row_disabled_through_its_container_fades_once(self):
-        """Neptune fades a disabled field (.x-item-disabled, opacity .3) and
-        the control fades its disabled buttons (.45); stacked, the control
-        all but vanishes on the miRNA associations row."""
+        """Neptune fades a disabled row's label and input to .3 but not the
+        control, which is the input's sibling: the control fades to the same
+        .3 itself, and its buttons' own .45 does not stack on top."""
+        self.assertRegex(self.css, r"\.x-item-disabled\s+\.po-browse\s*\{[^}]*opacity:\s*0?\.3")
         self.assertRegex(self.css, r"\.x-item-disabled\s+\.po-browse\s+button:disabled\s*\{[^}]*opacity:\s*1")
 
     def test_the_stylesheet_puts_browse_inside_the_field(self):
@@ -186,12 +192,6 @@ class BrowseLivesInsideTheFieldTest(unittest.TestCase):
                              "%s still draws the split arrow" % name)
             self.assertNotIn("a.x-btn .x-btn-wrap::before", sheet,
                              "%s still draws the split divider" % name)
-
-    def test_dark_theme_needs_no_restatement(self):
-        """Native buttons are not caught by dark.css's blanket anchor rule and
-        the control reads theme tokens, so a second copy to keep in sync
-        would only ever drift."""
-        self.assertNotIn(".po-browse", self.dark)
 
 
 if __name__ == "__main__":

--- a/PaintomicsServer/src/tests/test_step1_browse_lives_inside_the_field.py
+++ b/PaintomicsServer/src/tests/test_step1_browse_lives_inside_the_field.py
@@ -40,7 +40,6 @@ Usage:
     python -m src.tests.test_step1_browse_lives_inside_the_field
 """
 import os
-import re
 import unittest
 
 HERE = os.path.dirname(os.path.abspath(__file__))

--- a/PaintomicsServer/src/tests/test_step1_browse_lives_inside_the_field.py
+++ b/PaintomicsServer/src/tests/test_step1_browse_lives_inside_the_field.py
@@ -11,13 +11,29 @@ controls plus a tag, and the card's right edge was set by the widest of them.
 
 Now "Browse..." is text at the right edge of the field itself, with a small
 caret next to it that opens the same menu. The field keeps its single border;
-the required/optional tag and the help tip stay where they were. Nothing is
-lost: the file picker opens from the text, the three menu entries open from
-the caret, and `setDisabled()` still greys the control out.
+the required/optional tag and the help tip stay where they were.
 
-What is tested is the source the browser loads: the widget no longer builds a
-split button, the path field renders the control through `afterSubTpl`, and the
-stylesheet positions it inside the field and makes room for it.
+What the split button did for free, and the review of the first cut found
+missing, is pinned here as contracts between files:
+
+- The menu must have an owner. The Region-based and miRNA panels add entries
+  through `extraButtons` whose handlers climb `this.up("myFilesSelectorButton")`
+  from the menu item; an ownerless `Ext.menu.Menu` dead-ends that walk and the
+  GTF / other-omic pickers throw instead of filling the row.
+- Disabling the row's field must disable the control. Panels disable the
+  widget's inner container (`down('container').setDisabled(...)`), which
+  cascades to form fields and buttons only; the control listens to the path
+  field's own disable/enable so every door converges on one mechanism.
+- The controls are native `<button type="button">`s: Enter and Space, the
+  `disabled` attribute (out of the tab order, click-inert) and non-navigation
+  come with the element, and the dark theme's blanket anchor colour rule
+  never touches them -- so dark.css needs no restatement to keep in sync.
+- The split-arrow rules hand-drawn for the old buttons go with them; left
+  behind they painted a fake menu caret on the MORE panel's plain button.
+
+What is tested is the source the browser loads, in the style of the other
+Step 1 tests; the runtime behaviour was verified in Chrome and is described
+in the commit.
 
 Usage:
     cd PaintomicsServer
@@ -32,7 +48,10 @@ CLIENT_ROOT = os.path.normpath(
     os.path.join(HERE, "..", "..", "..", "PaintomicsClient", "public_html"))
 MY_DATA_VIEW = os.path.join(
     CLIENT_ROOT, "app", "view", "DataManagementViews", "DM_MyDataView.js")
+STEP1_VIEWS = os.path.join(
+    CLIENT_ROOT, "app", "view", "PathwayAcquisitionViews", "PA_Step1Views.js")
 MAIN_CSS = os.path.join(CLIENT_ROOT, "resources", "css", "main.css")
+DARK_CSS = os.path.join(CLIENT_ROOT, "resources", "css", "dark.css")
 
 
 def read(path):
@@ -40,12 +59,26 @@ def read(path):
         return handle.read()
 
 
+def between(source, start_marker, end_marker):
+    """The text from the first `start_marker` to the next `end_marker`."""
+    start = source.index(start_marker)
+    end = source.index(end_marker, start)
+    return source[start:end]
+
+
 def widget_source(source):
-    """The text of `Ext.define('Paintomics.view.common.MyFilesSelectorButton'`
-    up to the next Ext.define."""
-    start = source.index("Ext.define('Paintomics.view.common.MyFilesSelectorButton'")
-    end = source.find("Ext.define(", start + 1)
-    return source[start:end if end != -1 else len(source)]
+    """`Ext.define('Paintomics.view.common.MyFilesSelectorButton'` up to the
+    next Ext.define."""
+    return between(
+        source,
+        "Ext.define('Paintomics.view.common.MyFilesSelectorButton'",
+        "Ext.define('Paintomics.view.common.MyFilesSelectorDialog'")
+
+
+def path_field_config(widget):
+    """The visiblePathField config: from its itemId to the hidden filefield
+    that follows it in the widget's items."""
+    return between(widget, 'itemId: "visiblePathField"', "xtype: 'filefield'")
 
 
 class BrowseLivesInsideTheField(unittest.TestCase):
@@ -53,37 +86,66 @@ class BrowseLivesInsideTheField(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.widget = widget_source(read(MY_DATA_VIEW))
+        cls.field = path_field_config(cls.widget)
+        cls.step1 = read(STEP1_VIEWS)
         cls.css = read(MAIN_CSS)
+        cls.dark = read(DARK_CSS)
 
     def test_the_widget_no_longer_builds_a_button_beside_the_field(self):
         self.assertNotIn('xtype: "splitbutton"', self.widget)
         self.assertNotIn("xtype: 'splitbutton'", self.widget)
 
-    def test_the_path_field_renders_browse_and_caret_inside_itself(self):
-        field = re.search(r'itemId:\s*"visiblePathField".*?\n\t\t\t\}', self.widget, re.S)
-        self.assertIsNotNone(field, "visiblePathField config not found")
-        config = field.group(0)
-        self.assertIn("afterSubTpl", config)
-        self.assertIn('class="po-browse-text"', config)
-        self.assertIn('class="po-browse-caret"', config)
+    def test_the_path_field_renders_native_buttons_inside_itself(self):
+        self.assertIn("afterSubTpl", self.field)
+        self.assertIn('<button type="button" class="po-browse-text"', self.field)
+        self.assertIn('<button type="button" class="po-browse-caret"', self.field)
+        self.assertNotIn("<a ", self.field, "anchors bring link drag, "
+                         "link context menus and the dark anchor colour")
+
+    def test_the_menu_can_be_climbed_from_its_items(self):
+        """The panels' extraButtons handlers reach the widget with
+        `this.up("myFilesSelectorButton")` from a menu item, which walks
+        parentMenu -> ownerButton -> ownerCt; the menu must name the widget
+        as its owner or those handlers throw."""
+        self.assertIn('up("myFilesSelectorButton")', self.step1,
+                      "the contract this test guards no longer exists")
+        self.assertIn(".ownerButton = me", self.widget)
+
+    def test_disabling_the_field_disables_the_control(self):
+        """Callers disable the row through the field or its container; the
+        control follows the field's own disable/enable events."""
+        self.assertRegex(self.field, r"\bdisable:\s*function")
+        self.assertRegex(self.field, r"\benable:\s*function")
+        set_disabled = between(self.widget, "setDisabled: function(disabled)",
+                               "openFilePicker: function")
+        self.assertIn(".disabled = ", set_disabled,
+                      "the native disabled attribute is the one carrier")
 
     def test_the_menu_still_offers_the_three_actions(self):
         for entry in ("Upload file from my PC", "Use a file from My Data",
                       "Clear selection"):
             self.assertIn(entry, self.widget)
 
-    def test_disabling_still_reaches_the_control(self):
-        """setDisabled() used to disable the split button; it must still do
-        something visible now that there is no button."""
-        self.assertIn("setDisabled: function(disabled)", self.widget)
-        self.assertIn("po-browse-disabled", self.widget)
-
     def test_the_stylesheet_puts_browse_inside_the_field(self):
-        self.assertIn(".po-browse {", self.css)
         self.assertRegex(self.css, r"\.po-browse\s*\{[^}]*position:\s*absolute")
         self.assertRegex(
             self.css, r"\.po-file-path \.x-form-text\s*\{[^}]*padding-right",
             "the input must leave room for the control at its right edge")
+        self.assertNotIn(".po-file-path .x-form-item-body", self.css,
+                         "Neptune already positions .x-form-item-body")
+
+    def test_the_split_arrow_rules_went_with_the_split_button(self):
+        for name, sheet in (("main.css", self.css), ("dark.css", self.dark)):
+            self.assertNotIn("a.x-btn .x-btn-wrap::after", sheet,
+                             "%s still draws the split arrow" % name)
+            self.assertNotIn("a.x-btn .x-btn-wrap::before", sheet,
+                             "%s still draws the split divider" % name)
+
+    def test_dark_theme_needs_no_restatement(self):
+        """Native buttons are not caught by dark.css's blanket anchor rule and
+        the control reads theme tokens, so a second copy to keep in sync
+        would only ever drift."""
+        self.assertNotIn(".po-browse", self.dark)
 
 
 if __name__ == "__main__":

--- a/PaintomicsServer/src/tests/test_step1_file_rows_say_required_or_optional.py
+++ b/PaintomicsServer/src/tests/test_step1_file_rows_say_required_or_optional.py
@@ -11,6 +11,15 @@ somebody forgot, not a row with nothing to say, so this test refuses it. The
 rows whose requiredness follows a choice made elsewhere on the card flip it
 with setRequiredTag() from the same expression the validator reads.
 
+How it is shown: the convention every form reader already knows. A required
+row carries a red asterisk after its label ("Data file *:") and an optional
+row carries nothing -- the words "required" / "optional" that used to sit
+after the Browse button are gone, and the card's help column says once what
+the asterisk means. The label template renders the mark (afterLabelTextTpl),
+so the label text the refusal dialog quotes stays the plain words; the mark
+itself carries the word "required" (role="img") for readers that cannot see
+it.
+
 Usage:
     cd PaintomicsServer
     python -m src.tests.test_step1_file_rows_say_required_or_optional
@@ -94,20 +103,44 @@ class EveryFileRowIsTaggedTest(unittest.TestCase):
         self.assertIn('queryById("secondaryAssociationFileSelector").setRequiredTag(corrEnabled ? "optional" : "required")', handler)
         self.assertIn('queryById("rnaseqauxFileSelector").setRequiredTag(corrEnabled ? "required" : "optional")', handler)
 
+    def test_the_help_column_says_once_what_the_asterisk_means(self):
+        """One legend per form, next to the rows, instead of a word per row."""
+        self.assertIn('po-required-mark', self.source)
+        self.assertRegex(self.source, r"marks? (the )?files? (the job|this job|a job) needs",
+                         "the help text must explain the asterisk")
+
 
 class TheTagIsOneComponentTest(unittest.TestCase):
 
-    def test_the_selector_renders_and_updates_the_tag(self):
+    def test_the_selector_renders_the_mark_in_its_label(self):
         source = read(MY_DATA_VIEW)
         self.assertIn("requiredTag: null", source)
-        self.assertIn("buildRequiredTag: function(tag)", source)
+        self.assertIn("afterLabelTextTpl", source)
         self.assertIn("setRequiredTag: function(tag)", source)
-        self.assertIn('itemId: "requiredTag"', source)
+        # The mark is part of the label, not a box after the Browse button.
+        self.assertIn('class="po-required-mark" role="img" aria-label="required">*<', source)
+        # After the words and before the colon: ExtJS emits the template after
+        # its separator, so the separator is blank and the colon is in the
+        # template.
+        self.assertIn('labelSeparator: "",', source)
+        self.assertIn("'</span>:',", source)
+        self.assertNotIn('itemId: "requiredTag"', source)
+        self.assertNotIn("buildRequiredTag", source)
+        self.assertNotIn("po-file-tag", source)
 
-    def test_required_carries_the_weight_in_css(self):
+    def test_flipping_the_tag_shows_or_hides_the_mark(self):
+        """The conditional miRNA rows flip after render; the mark is always in
+        the label and the setter only shows or hides it."""
+        source = read(MY_DATA_VIEW)
+        setter = source[source.index("setRequiredTag: function(tag)"):]
+        setter = setter[:setter.index("\n\t},") + 4]
+        self.assertIn('setDisplayed(tag === "required")', setter)
+
+    def test_the_mark_is_red_and_the_words_are_gone(self):
         css = read(MAIN_CSS)
-        self.assertIn(".po-file-tag {", css)
-        self.assertIn(".po-file-tag-required {", css)
+        self.assertRegex(css, r"\.po-required-mark\s*\{[^}]*var\(--pa-status-error")
+        self.assertNotIn(".po-file-tag {", css)
+        self.assertNotIn(".po-file-tag-required {", css)
 
 
 if __name__ == "__main__":

--- a/PaintomicsServer/src/tests/test_step1_file_rows_say_required_or_optional.py
+++ b/PaintomicsServer/src/tests/test_step1_file_rows_say_required_or_optional.py
@@ -139,12 +139,15 @@ class TheTagIsOneComponentTest(unittest.TestCase):
 
     def test_the_mark_is_red_and_the_words_are_gone(self):
         css = read(MAIN_CSS)
-        self.assertRegex(css, r"\.po-required-mark\s*\{[^}]*var\(--pa-status-error")
-        # The token is named after the refusal dialog's ink, so the dialog
-        # reads it too -- one source of truth for the colour.
+        # dark.css keeps --pa-status-error for fills and --pa-status-error-ink
+        # for text; the mark is text, and the light sheet declares the ink.
+        self.assertRegex(css, r"--pa-status-error-ink:\s*#")
+        self.assertRegex(css, r"\.po-required-mark\s*\{[^}]*var\(--pa-status-error-ink")
+        # The token is the refusal dialog's ink, so the dialog reads it too --
+        # one source of truth for the colour.
         dialog = css[css.index("#messageDialog.errorDialog h4 {"):]
         dialog = dialog[:dialog.index("}")]
-        self.assertIn("var(--pa-status-error", dialog)
+        self.assertIn("var(--pa-status-error-ink", dialog)
         self.assertNotIn(".po-file-tag {", css)
         self.assertNotIn(".po-file-tag-required {", css)
 

--- a/PaintomicsServer/src/tests/test_step1_file_rows_say_required_or_optional.py
+++ b/PaintomicsServer/src/tests/test_step1_file_rows_say_required_or_optional.py
@@ -105,9 +105,10 @@ class EveryFileRowIsTaggedTest(unittest.TestCase):
 
     def test_the_help_column_says_once_what_the_asterisk_means(self):
         """One legend per form, next to the rows, instead of a word per row."""
-        self.assertIn('po-required-mark', self.source)
-        self.assertRegex(self.source, r"marks? (the )?files? (the job|this job|a job) needs",
-                         "the help text must explain the asterisk")
+        legend = re.search(r'<p><span class="po-required-mark"[^>]*>\*</span> marks the files the job needs[^<]*</p>', self.source)
+        self.assertIsNotNone(legend, "the help text must explain the asterisk")
+        # Read aloud, the sentence needs its subject: the mark names itself.
+        self.assertIn('role="img" aria-label="asterisk"', legend.group(0))
 
 
 class TheTagIsOneComponentTest(unittest.TestCase):
@@ -122,8 +123,8 @@ class TheTagIsOneComponentTest(unittest.TestCase):
         # After the words and before the colon: ExtJS emits the template after
         # its separator, so the separator is blank and the colon is in the
         # template.
-        self.assertIn('labelSeparator: "",', source)
-        self.assertIn("'</span>:',", source)
+        self.assertRegex(source, r'labelSeparator:\s*""')
+        self.assertRegex(source, r"</span>:['\"]")
         self.assertNotIn('itemId: "requiredTag"', source)
         self.assertNotIn("buildRequiredTag", source)
         self.assertNotIn("po-file-tag", source)
@@ -133,12 +134,17 @@ class TheTagIsOneComponentTest(unittest.TestCase):
         the label and the setter only shows or hides it."""
         source = read(MY_DATA_VIEW)
         setter = source[source.index("setRequiredTag: function(tag)"):]
-        setter = setter[:setter.index("\n\t},") + 4]
+        setter = setter[:setter.index("return this;")]
         self.assertIn('setDisplayed(tag === "required")', setter)
 
     def test_the_mark_is_red_and_the_words_are_gone(self):
         css = read(MAIN_CSS)
         self.assertRegex(css, r"\.po-required-mark\s*\{[^}]*var\(--pa-status-error")
+        # The token is named after the refusal dialog's ink, so the dialog
+        # reads it too -- one source of truth for the colour.
+        dialog = css[css.index("#messageDialog.errorDialog h4 {"):]
+        dialog = dialog[:dialog.index("}")]
+        self.assertIn("var(--pa-status-error", dialog)
         self.assertNotIn(".po-file-tag {", css)
         self.assertNotIn(".po-file-tag-required {", css)
 

--- a/scripts/ci/vulture_baseline.txt
+++ b/scripts/ci/vulture_baseline.txt
@@ -253,7 +253,6 @@ PaintomicsServer/src/tests/test_pathway_evidence_sources.py: unused class 'React
 PaintomicsServer/src/tests/test_pathway_evidence_sources.py: unused class 'TranslatedSource' (60% confidence)
 PaintomicsServer/src/tests/test_quote_source_covers_full_text.py: unused class 'QuoteSourceCoversFullText' (60% confidence)
 PaintomicsServer/src/tests/test_reactome_matches_get_symbol_names.py: unused class 'ReactomeMatchesGetSymbolNames' (60% confidence)
-PaintomicsServer/src/tests/test_step1_browse_lives_inside_the_field.py: unused class 'BrowseLivesInsideTheField' (60% confidence)
 PaintomicsServer/src/tests/test_svg_export_is_sandboxed.py: unused method 'testEntityDefinitionsAreRefused' (60% confidence)
 PaintomicsServer/src/tests/test_svg_export_is_sandboxed.py: unused method 'testLegitimateExportStillRenders' (60% confidence)
 PaintomicsServer/src/tests/test_svg_export_is_sandboxed.py: unused method 'testLocalFileIsNotReadIntoTheRender' (60% confidence)

--- a/scripts/ci/vulture_baseline.txt
+++ b/scripts/ci/vulture_baseline.txt
@@ -253,6 +253,7 @@ PaintomicsServer/src/tests/test_pathway_evidence_sources.py: unused class 'React
 PaintomicsServer/src/tests/test_pathway_evidence_sources.py: unused class 'TranslatedSource' (60% confidence)
 PaintomicsServer/src/tests/test_quote_source_covers_full_text.py: unused class 'QuoteSourceCoversFullText' (60% confidence)
 PaintomicsServer/src/tests/test_reactome_matches_get_symbol_names.py: unused class 'ReactomeMatchesGetSymbolNames' (60% confidence)
+PaintomicsServer/src/tests/test_step1_browse_lives_inside_the_field.py: unused class 'BrowseLivesInsideTheField' (60% confidence)
 PaintomicsServer/src/tests/test_svg_export_is_sandboxed.py: unused method 'testEntityDefinitionsAreRefused' (60% confidence)
 PaintomicsServer/src/tests/test_svg_export_is_sandboxed.py: unused method 'testLegitimateExportStillRenders' (60% confidence)
 PaintomicsServer/src/tests/test_svg_export_is_sandboxed.py: unused method 'testLocalFileIsNotReadIntoTheRender' (60% confidence)


### PR DESCRIPTION
## What

Every file row on Step 1 was two boxes side by side: the read-only path field and a bordered ExtJS split button reading "Browse..." with the upload / My Data / clear menu behind its arrow — plus the word "required" or "optional" after it.

Now:

- **"Browse..."** is quiet text at the field's right edge and opens the file picker; a small **caret** beside it opens the same `Ext.menu.Menu` (built once per widget, the widget is its owner, destroyed with it). Both are native `<button type="button">`s.
- **Required rows carry a red asterisk** after the label and before the colon (`Data file *:`); optional rows carry nothing; the help column says once what the asterisk means. The mark is rendered by the label template, so the label text the refusal dialog quotes stays the plain words, and it carries `required` as its accessible name.

## What five review rounds added

1. Ownerless menu broke the GTF / other-omic picker callbacks (`up()` chain) → the widget is `ownerButton`; container-level disable didn't reach anchors → the control follows the field's `disable`/`enable`; dead Space delegate → native buttons; focus return, Down arrow, `aria-expanded`, per-row caret name; the old split-arrow CSS painted a fake caret on the MORE panel's button → retired.
2. **The rewrite had dropped the widget's `markInvalid` forwarder** (eleven validators call it) → restored; measure only a drawn control and again on resize; dialog reads the status token; the legend's asterisk names itself.
3. **A container enable cascade lifted the example lock** (stategra-mirna) → the lock and the field's own disabled state are combined in `applyBrowseState()`; the caret's toggle is deterministic.
4. The "fade once" rule had removed the only fade (Neptune fades the label and input, not the sibling control) → the control fades to .3 itself; stopping the caret's mousedown starved other document listeners (open combos stayed open) → the press records whether the menu was open and still propagates; `--pa-status-error-ink` for text, as dark.css already does.
5. A press released off the caret left the flag stale for a later keyboard activation → keyboard clicks (detail 0) ignore it; the control's width is measured once per label for every row and re-measured when the web font is ready.

## Tests

`test_step1_browse_lives_inside_the_field.py` (12) and the updated `test_step1_file_rows_say_required_or_optional.py` (9) pin the cross-file contracts above; the `?v=` bump test and the vulture ratchet are green (`main.css` 2.04→2.08, `dark.css` 1.32→1.34; two baseline rows fewer).

## Verified in Chrome (branch server, light + dark)

Caret menu and the GTF row's item resolving the widget; correlation box disables the associations row (control at .3, buttons at 1) and moves the asterisk; a row with only a relevant file is refused as "Data file: Please, provide a Data file." with the row marked; the stategra-mirna and region-based examples keep their rows locked through their toggles; with the organism picker open, a press on a caret collapses the picker and opens the menu; press-and-click closes it, keyboard opens it even after a press released elsewhere; example mode disables every row; MORE's plain button has no fake caret; alignment guides 0 off-rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWQK1bJxPbwTWiFeisDPie