### PR TITLE
Put the Step 2 omic cards under the card that introduces them

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
@@ -1162,15 +1162,17 @@ function paFigAccent(active) {
 	return active ? "var(--pa-accent-green)" : "var(--pa-fig-faint)";
 }
 
-/* Samples: two conditions x three replicates x four metabolites. */
+/* Samples: two conditions x three replicates x four metabolites. Generic
+   condition labels, not the example dataset's own names: the figure is shown
+   for every job, and the test is not limited to a control/treatment pair. */
 function paFigPermInput() {
-	var parts = [paFigOpen(), paFigText(19, 8, "Ctr", {anchor: "middle"}), paFigText(67, 8, "Ik", {anchor: "middle"})];
-	var ctr = [0.55, 0.7, 0.45, 0.62], ik = [1, 0.9, 0.5, 0.82];
+	var parts = [paFigOpen(), paFigText(19, 8, "Control", {anchor: "middle"}), paFigText(67, 8, "Treatment", {anchor: "middle"})];
+	var control = [0.55, 0.7, 0.45, 0.62], treatment = [1, 0.9, 0.5, 0.82];
 	for (var r = 0; r < 4; r++) {
 		var y = 12 + r * 13;
 		for (var c = 0; c < 3; c++) {
-			parts.push('<rect x="' + (c * 13) + '" y="' + y + '" width="11" height="11" rx="2" fill="var(--pa-fig-cell)" opacity="' + ctr[r] + '"></rect>');
-			parts.push('<rect x="' + (48 + c * 13) + '" y="' + y + '" width="11" height="11" rx="2" fill="var(--pa-fig-cell-strong)" opacity="' + ik[r] + '"></rect>');
+			parts.push('<rect x="' + (c * 13) + '" y="' + y + '" width="11" height="11" rx="2" fill="var(--pa-fig-cell)" opacity="' + control[r] + '"></rect>');
+			parts.push('<rect x="' + (48 + c * 13) + '" y="' + y + '" width="11" height="11" rx="2" fill="var(--pa-fig-cell-strong)" opacity="' + treatment[r] + '"></rect>');
 		}
 	}
 	parts.push('</svg>');

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
@@ -132,6 +132,14 @@ function PA_Step2JobView() {
 
 		var dataDistribution = me.getModel().getDataDistributionSummaries(), aux = null;
 
+		/* The per-omic cards are collected apart from the panel array and
+		   inserted below, straight after "Multiple databases used". Pushed
+		   inline they always ended up last, because every config box that
+		   follows is spliced in at a fixed index in front of them -- so the
+		   databases card's own "The diagrams below..." pointed past the
+		   cluster and class-activity boxes at cards ~1600px further down. */
+		var omicCards = [];
+
 		var omicSummaryPanelComponents = [{
 			xtype: 'box',
 			cls: "contentbox omicSummaryBox", minHeight: 240,
@@ -275,7 +283,7 @@ function PA_Step2JobView() {
 					items: paClassActivityItems(me.getModel(), omicName)
 				});
 			}
-			omicSummaryPanelComponents.push(new PA_OmicSummaryPanel(omicName, dataDistribution[omicName], isCompoundBased).getComponent());
+			omicCards.push(new PA_OmicSummaryPanel(omicName, dataDistribution[omicName], isCompoundBased).getComponent());
 		}
 
 		if (numberOfClusters.length) {
@@ -407,6 +415,20 @@ function PA_Step2JobView() {
 				}]
 			}, {xtype: 'container', cls: 'paLayoutPad', html:'<div style="display: none;"></div>'});
 		}
+
+		/* Straight after the databases card and the layout pad that follows
+		   it, so the cards start on a fresh row of the column layout. With a
+		   single database there is no such card and they follow the two
+		   summary boxes instead. Located by id, not by a counted index: what
+		   sits in front depends on which of the config boxes this job needs. */
+		var cardsAt = 2;
+		for (var i = 0; i < omicSummaryPanelComponents.length; i++) {
+			if (omicSummaryPanelComponents[i].id === "dbs_message") {
+				cardsAt = i + 2;
+				break;
+			}
+		}
+		omicSummaryPanelComponents.splice.apply(omicSummaryPanelComponents, [cardsAt, 0].concat(omicCards));
 
 		if (me.items.length > 0) {
 			compoundsPanelHTML = me.renderCompoundsPanel();


### PR DESCRIPTION
## What

Two Step 2 fixes.

**The omic cards were separated from their own introduction.** The "Multiple databases used" card ends with *"The diagrams below combine the matched and unmatched features of all databases"* — and the diagrams were not below it. They sat ~1600px further down, past the cluster-count and class-activity boxes.

Not a styling accident. The cards are `push`ed onto the panel array inside the per-omic loop, so they land at its tail, while every config box that follows is **spliced in at a fixed index in front of them**:

```js
omicSummaryPanelComponents.splice(2, 0, dbs_message, pad);   // databases
omicSummaryPanelComponents.splice(2, 0, clusternumber_box);  // clusters
omicSummaryPanelComponents.splice(5, 0, threshold_box, pad); // class activity
```

Whatever a job needed, the cards came last. Fixed by collecting them in their own array and inserting them once the splices have run — located by `dbs_message`'s **id**, not by a counted index, since what precedes them depends on which config boxes the job has. With a single database there is no such card and they fall back to just after the two summary boxes.

**The class-activity figure borrowed one dataset's condition names.** `Ctr` / `Ik` are STATegra's own labels (control / Ikaros-induced) hard-coded into an explainer shown for *every* job. `Ik` means nothing to anyone who doesn't know that dataset, and the test isn't limited to a control/treatment pair anyway. Now reads Control / Treatment.

## Verified

Job `2c74307loY` in Chrome, on a server restarted from this branch:

- Panel order: `[0]` translation summary · `[1]` data distribution · `[2]` **Multiple databases used** · `[4-8]` the five omic cards · `[9]` clusters · `[10]` class activity.
- First card top `y=1538` against a databases-card bottom of `1519` — a 19px gap, which is the layout pad. The 2+2+1 row pairing survives.
- `paGuides`: 0 off-rail, 0 off-baseline.

Local gates: `node --check` passes, `test_versioned_assets_are_bumped.py` 5/5, `ruff check .` clean. `PA_Step2Views.js` is loaded through `Ext.Loader`, not cache-busted in index.html, so it needs no `?v=` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSxnuRvibkFWVDPh8fzD1j