### PR TITLE
Count metabolites in the pathway network, not only genes

### DIFF
--- a/PaintomicsClient/public_html/app.js
+++ b/PaintomicsClient/public_html/app.js
@@ -49,8 +49,12 @@ if (debugging === true)
  * this a browser that opened a job before an upgrade never asked again --
  * the hub view's checkSchema() learned that the hard way.
  *   2: globalExpressionData carries sampleValues / sampleRelevant.
+ *   3: every pathway carries totalGenes / totalCompounds, the denominator of
+ *      the network's "min features in pathway" filter. Without them the filter
+ *      falls back to the installed gene-only count, which is what made a
+ *      metabolomics-only job draw an empty network.
  */
-var PA_JOB_CACHE_SCHEMA = 2;
+var PA_JOB_CACHE_SCHEMA = 3;
 
 function openPaintomicsDB() {
     var db = new Dexie("paintomics");

--- a/PaintomicsClient/public_html/app/model/PathwayModels.js
+++ b/PaintomicsClient/public_html/app/model/PathwayModels.js
@@ -48,6 +48,14 @@ function Pathway(ID) {
     //GRAPHICAL INFORMATION
     this.graphicalOptions = null;
     this.totalFeatures = null;
+    //HOW MANY FEATURES OF EACH KIND THE PATHWAY CONTAINS, filled by the server
+    //while it matches. The network's "min features in pathway" filter divides
+    //by these; the number it used instead, total_features in the installed
+    //pathways_network.json, counts GENES only, so a compound-only job divided
+    //matched compounds by the pathway's gene count and drew nothing. Null on
+    //jobs stored before this existed - see paNetworkCoverageTotal.
+    this.totalGenes = null;
+    this.totalCompounds = null;
 
     this.selected = false;
     this.visible = true;
@@ -167,6 +175,12 @@ function Pathway(ID) {
 	this.getAllAdjustedSignificanceValues = function() {
 		return jQuery.extend({}, this.getAdjustedSignificanceValues(), this.getAdjustedCombinedSignificanceValues());
 	};
+    this.getTotalGenes = function () {
+        return this.totalGenes;
+    };
+    this.getTotalCompounds = function () {
+        return this.totalCompounds;
+    };
     this.setTotalFeatures = function (totalFeatures) {
         this.totalFeatures = totalFeatures;
     };
@@ -216,6 +230,12 @@ function Pathway(ID) {
         }
         if (jsonObject.matchedCompounds !== undefined) {
             this.matchedCompounds = jsonObject.matchedCompounds;
+        }
+        if (jsonObject.totalGenes !== undefined) {
+            this.totalGenes = jsonObject.totalGenes;
+        }
+        if (jsonObject.totalCompounds !== undefined) {
+            this.totalCompounds = jsonObject.totalCompounds;
         }
         if (jsonObject.metagenes !== undefined) {
             this.metagenes = jsonObject.metagenes;

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
@@ -148,9 +148,15 @@ function PA_Step3JobView() {
 		   coverage filter divides by the pathway's features OF THESE CLASSES,
 		   and starts at a threshold these classes can reach - see
 		   paNetworkCoverageTotal and paNetworkDefaultMinFeatures. */
+		var hasCompoundOmics = (this.getModel().getCompoundBasedInputOmics() || []).length > 0;
 		this.omicClasses = {
-			genes: (this.getModel().getGeneBasedInputOmics() || []).length > 0,
-			compounds: (this.getModel().getCompoundBasedInputOmics() || []).length > 0
+			/* `|| !hasCompoundOmics` mirrors clusters.py::_omic_classes: a job
+			   that records no omic at all is read as gene-based, which is what
+			   every such job has always been treated as. Without it the
+			   denominator would be unknown for both classes, the filter would
+			   switch itself off, and the slider would still read 50%. */
+			genes: (this.getModel().getGeneBasedInputOmics() || []).length > 0 || !hasCompoundOmics,
+			compounds: hasCompoundOmics
 		};
 
 		/********************************************************/
@@ -432,9 +438,9 @@ function PA_Step3JobView() {
 			this.visualOptions[db][propertyName] = value;
 		}
 	};
-	/* Which feature classes the job measured, {genes, compounds}. Set in
-	   loadModel; defaults to genes-only so a view used before a model is
-	   attached behaves the way it always has. */
+	/* Which feature classes the job measured, {genes, compounds}. Always
+	   replaced by loadModel; this initialiser only keeps the field defined for
+	   a view read before a model is attached. */
 	this.omicClasses = {genes: true, compounds: false};
 	this.getOmicClasses = function() {
 		return this.omicClasses;
@@ -2048,22 +2054,34 @@ function paNetworkLabelInk() {
 * gene-based job divides by the pathway's genes, exactly as it always has; a
 * metabolomics job divides by its compounds; a job with both divides by both.
 *
-* Three sources, in order of authority:
+* The installed node still decides WHETHER the filter applies; the job's counts
+* only correct WHAT it divides by. `total_features` absent or zero is how a
+* database says it has never had a coverage filter, because `total_features *
+* minFeatures > matched` could not be true either way: OmniPath ships no such
+* field at all, every one of MapMan's 70 bins carries 0 (the installer counts
+* only 20-character gene ids), and so do 220 of mmu's 584 KEGG maps. Handing
+* those a denominator out of the job's own counts would switch a 50% filter on
+* for the first time - on ath MapMan bins holding 21,446 genes, and on OmniPath
+* pathways with a median of 20 - which is this bug again, moved to another
+* database.
+*
+* Two sources for the denominator, in order of authority:
 *  1. the job's own pathway, which the server fills from the full feature sets
 *     it already holds while matching - correct on every existing install;
-*  2. the installed network node, for jobs stored before (1) existed;
-*  3. nothing, which returns null and disables the filter rather than
-*     inventing a denominator. OmniPath ships no totals at all, and hiding a
-*     whole network over a number nobody knows is the worse failure.
+*  2. the installed network node, for jobs stored before (1) existed.
 *
 * @param {Object} pathwayCounts {genes, compounds} from the job's pathway
 * @param {Object} nodeData the installed node's data (total_features is GENES)
 * @param {Object} omicClasses {genes, compounds} - what the job submitted
-* @returns {Number|null}
+* @returns {Number|null} null means "no coverage filter here"
 */
 var paNetworkCoverageTotal = function (pathwayCounts, nodeData, omicClasses) {
 	var counts = pathwayCounts || {}, node = nodeData || {};
 	var total = 0, known = false;
+
+	if (!(typeof node.total_features === "number" && node.total_features > 0)) {
+		return null;
+	}
 
 	var take = function (primary, fallback) {
 		/* 0 is a real answer: a pathway with no compounds cannot be covered by
@@ -2082,6 +2100,12 @@ var paNetworkCoverageTotal = function (pathwayCounts, nodeData, omicClasses) {
 	if (omicClasses.compounds) {
 		take(counts.compounds, node.total_compounds);
 	}
+	/* A submitted class whose total is unknown - a job stored before the counts
+	   existed, on a species not yet reinstalled - contributes nothing to the
+	   denominator while its matches still count in the numerator, so coverage
+	   can read high. That is precisely what this filter did for every job
+	   before this change, and reproducing it is the point: an old job must
+	   draw the network it drew yesterday. */
 	return known ? total : null;
 };
 

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step3Views.js
@@ -144,6 +144,15 @@ function PA_Step3JobView() {
 		var pathways = this.getModel().getPathways();
 		var databases = this.getModel().getDatabases();
 
+		/* Which kinds of feature this job actually measured. The network's
+		   coverage filter divides by the pathway's features OF THESE CLASSES,
+		   and starts at a threshold these classes can reach - see
+		   paNetworkCoverageTotal and paNetworkDefaultMinFeatures. */
+		this.omicClasses = {
+			genes: (this.getModel().getGeneBasedInputOmics() || []).length > 0,
+			compounds: (this.getModel().getCompoundBasedInputOmics() || []).length > 0
+		};
+
 		/********************************************************/
 		/* STEP 2.1.A LOAD VISUAL OPTIONS IF ANY                */
 		/********************************************************/
@@ -152,7 +161,8 @@ function PA_Step3JobView() {
 			//GENERAL OPTIONS
 			pathwaysVisibility: [],
 			//OPTIONS FOR NETWORK
-			minFeatures: 0.50,
+			minFeatures: paNetworkDefaultMinFeatures(this.omicClasses.genes,
+			                                         this.omicClasses.compounds),
 			minPValue: 0.05,
 			/* 0.10, not 0.90.
 			   Every other statement of this default in the application says
@@ -421,6 +431,13 @@ function PA_Step3JobView() {
 		} else {
 			this.visualOptions[db][propertyName] = value;
 		}
+	};
+	/* Which feature classes the job measured, {genes, compounds}. Set in
+	   loadModel; defaults to genes-only so a view used before a model is
+	   attached behaves the way it always has. */
+	this.omicClasses = {genes: true, compounds: false};
+	this.getOmicClasses = function() {
+		return this.omicClasses;
 	};
 	this.getClassificationData = function(db = null){
 		return (db == null) ? this.classificationData : this.classificationData[db];
@@ -2014,6 +2031,162 @@ function paNetworkLabelInk() {
 	return (ink !== "") ? ink : "#000";
 }
 
+/**
+* How many features the "Min features in pathway" slider measures a pathway
+* against - the denominator of the coverage the node filter compares to.
+*
+* It used to be `elem.data.total_features`, which the installer fills from the
+* pathway's GENE list alone (`len(gene_ids)`, `pathway2gene.list`, the
+* 20-character MapMan ids). The numerator has always been matched genes PLUS
+* matched compounds, so the filter divided one kind of thing by another. On a
+* compound-only job that is fatal: the numerator holds no genes at all and the
+* denominator is the pathway's whole gene set, so nothing can clear the bar.
+* Measured on a mmu STATegra metabolomics job, 137 of the 141 matched pathways
+* were dropped by this line alone and the network drew nothing.
+*
+* So count the classes the input actually contains, and nothing else. A
+* gene-based job divides by the pathway's genes, exactly as it always has; a
+* metabolomics job divides by its compounds; a job with both divides by both.
+*
+* Three sources, in order of authority:
+*  1. the job's own pathway, which the server fills from the full feature sets
+*     it already holds while matching - correct on every existing install;
+*  2. the installed network node, for jobs stored before (1) existed;
+*  3. nothing, which returns null and disables the filter rather than
+*     inventing a denominator. OmniPath ships no totals at all, and hiding a
+*     whole network over a number nobody knows is the worse failure.
+*
+* @param {Object} pathwayCounts {genes, compounds} from the job's pathway
+* @param {Object} nodeData the installed node's data (total_features is GENES)
+* @param {Object} omicClasses {genes, compounds} - what the job submitted
+* @returns {Number|null}
+*/
+var paNetworkCoverageTotal = function (pathwayCounts, nodeData, omicClasses) {
+	var counts = pathwayCounts || {}, node = nodeData || {};
+	var total = 0, known = false;
+
+	var take = function (primary, fallback) {
+		/* 0 is a real answer: a pathway with no compounds cannot be covered by
+		   a metabolomics input. Only null/undefined/NaN mean "not known". */
+		var value = (typeof primary === "number" && !isNaN(primary)) ? primary :
+		            ((typeof fallback === "number" && !isNaN(fallback)) ? fallback : null);
+		if (value !== null) {
+			total += value;
+			known = true;
+		}
+	};
+
+	if (omicClasses.genes) {
+		take(counts.genes, node.total_features);
+	}
+	if (omicClasses.compounds) {
+		take(counts.compounds, node.total_compounds);
+	}
+	return known ? total : null;
+};
+
+/**
+* Where the "Min features in pathway" slider starts.
+*
+* 50% is a transcriptomics number: an RNA-seq experiment measures very nearly
+* every gene a pathway contains, so half of them is a bar worth clearing. A
+* metabolomics platform measures a few hundred compounds out of KEGG's ~19000,
+* and covers about a tenth of any one pathway - the median on the mmu STATegra
+* metabolomics job was 10.1%, and at 50% only 6 of its 140 pathways cleared the
+* coverage bar against 75 at 10%. Holding every job to the gene number hands a
+* compound-only user a blank canvas by default.
+*
+* Only the default moves. A saved visual setting is a user's own choice and is
+* left alone.
+*
+* @param {Boolean} hasGeneOmics
+* @param {Boolean} hasCompoundOmics
+* @returns {Number}
+*/
+var paNetworkDefaultMinFeatures = function (hasGeneOmics, hasCompoundOmics) {
+	return (!hasGeneOmics && hasCompoundOmics) ? 0.10 : 0.50;
+};
+
+/**
+* The "Shared biological features" edges, derived from the job's own matched
+* features.
+*
+* The install file ships an 's' edge for every pathway pair sharing a GENE, and
+* the view then recomputes the weight it draws from the matched genes AND
+* compounds. So the file only ever decided which pairs were allowed to exist,
+* and it decided it on genes: two pathways joined solely by their metabolites
+* could not be connected however much they shared. Deriving the pairs here
+* instead needs no reinstall, and is exactly equivalent for gene-based jobs -
+* a shipped pair with no shared MATCHED feature scores zero and was already
+* being dropped by the threshold below.
+*
+* Sorensen-Dice over the pooled matched features: S = 2|AnB| / (|A| + |B|).
+*
+* O(n^2) pair tests over the drawn nodes, each a set lookup per feature of the
+* smaller pathway. n is the node count after filtering (~600 at the very most,
+* usually far fewer), so this is milliseconds; sets are built once per pathway
+* rather than per pair.
+*
+* @param {Array} pathwayIDs the ids that became nodes
+* @param {Object} featuresByID id -> {genes: [...], compounds: [...]} matched
+* @param {Number} minSimilarity the "Min shared features" threshold
+* @returns {Array} cytoscape-style edge data, class 's'
+*/
+var paNetworkSharedFeatureEdges = function (pathwayIDs, featuresByID, minSimilarity) {
+	var edges = [], sets = {}, sizes = {}, drawable = [];
+
+	for (var i = 0; i < pathwayIDs.length; i++) {
+		var id = pathwayIDs[i], matched = featuresByID[id];
+		if (matched === undefined) {
+			continue;
+		}
+		/* Genes and compounds go into one set, prefixed so that a gene and a
+		   compound that happen to share an identifier are not counted as one
+		   shared feature. */
+		var pooled = {}, size = 0, feature;
+		for (var g = 0; g < matched.genes.length; g++) {
+			feature = "g:" + matched.genes[g];
+			if (pooled[feature] === undefined) { pooled[feature] = 1; size++; }
+		}
+		for (var c = 0; c < matched.compounds.length; c++) {
+			feature = "c:" + matched.compounds[c];
+			if (pooled[feature] === undefined) { pooled[feature] = 1; size++; }
+		}
+		/* A pathway with no matched feature has no similarity to anything and
+		   would put a zero in the Dice denominator. */
+		if (size > 0) {
+			sets[id] = pooled;
+			sizes[id] = size;
+			drawable.push(id);
+		}
+	}
+
+	for (var a = 0; a < drawable.length; a++) {
+		var source = drawable[a], sourceSet = sets[source];
+		for (var b = a + 1; b < drawable.length; b++) {
+			var target = drawable[b];
+			/* Walk the smaller of the two, look up in the larger. */
+			var small = sizes[source] <= sizes[target] ? sourceSet : sets[target];
+			var large = small === sourceSet ? sets[target] : sourceSet;
+			var shared = 0;
+			for (var key in small) {
+				if (large[key] !== undefined) {
+					shared++;
+				}
+			}
+			if (shared === 0) {
+				continue;
+			}
+			var similarity = 2 * shared / (sizes[source] + sizes[target]);
+			if (similarity >= minSimilarity) {
+				edges.push({id: source + "-" + target, source: source,
+				            target: target, weight: similarity, "class": "s"});
+			}
+		}
+	}
+	return edges;
+};
+
 function PA_Step3PathwayNetworkView(db = "KEGG") {
 	/**
 	* About this view: this view (PA_Step3PathwayNetworkView) is used to visualize
@@ -2068,6 +2241,7 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 			visualOptions.colorBy = "classification";
 		}
 		var indexedPathways = this.getParent().getIndexedPathways(this.database);
+		var omicClasses = this.getParent().getOmicClasses();
 		var CLUSTERS = {};
 		var TOTAL_CLUSTERS = this.getModel().getClusterNumber()[this.database];
 
@@ -2160,7 +2334,16 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 			}
 
 			matchedPathway.setTotalFeatures(matchedPathway.getMatchedGenes().length + matchedPathway.getMatchedCompounds().length);
-			if (elem.data.total_features * visualOptions.minFeatures > matchedPathway.getTotalFeatures() || pValue > visualOptions.minPValue){
+			/* The denominator counts the feature classes the job actually
+			   submitted, NOT elem.data.total_features - which is the pathway's
+			   gene count, and made this line divide matched compounds by genes.
+			   null means no total is known for any submitted class, and the
+			   coverage filter is skipped rather than guessed at. */
+			var coverageTotal = paNetworkCoverageTotal(
+				{genes: matchedPathway.getTotalGenes(),
+				 compounds: matchedPathway.getTotalCompounds()},
+				elem.data, omicClasses);
+			if ((coverageTotal !== null && coverageTotal * visualOptions.minFeatures > matchedPathway.getTotalFeatures()) || pValue > visualOptions.minPValue){
 				ignoredPathways[elem.data.id] = true;
 				continue;
 			}
@@ -2243,51 +2426,60 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 		}
 		/********************************************************/
 		/* STEP 2. GENERATE EDGES                               */
+		/*                                                      */
+		/* The two modes come from different places. "Linked     */
+		/* biological processes" is a statement the DATABASE     */
+		/* makes about two pathways - a KEGG map link, a         */
+		/* Reactome hierarchy or embedded sub-pathway - so it is */
+		/* read from the installed file. "Shared biological      */
+		/* features" is a statement about THIS JOB's data, and   */
+		/* is derived from the matched features here: the file's */
+		/* 's' edges list the pairs that share a GENE, so two    */
+		/* pathways joined only by their metabolites could never */
+		/* be connected however much they shared. Equivalent for */
+		/* gene-based jobs - a shipped pair with no shared       */
+		/* MATCHED feature scores zero and was already dropped.  */
 		/********************************************************/
-		nElems = data.edges.length;
-		for (var i = nElems; i--;) {
-			elem = data.edges[i];
+		if (visualOptions.edgesClass === 's') {
+			var matchedFeatures = {}, drawnIDs = [];
+			for (var i = 0; i < nodesAux.length; i++) {
+				var drawnID = nodesAux[i].id;
+				drawnIDs.push(drawnID);
+				matchedFeatures[drawnID] = {
+					genes: indexedPathways[drawnID].getMatchedGenes(),
+					compounds: indexedPathways[drawnID].getMatchedCompounds()
+				};
+			}
+			var sharedEdges = paNetworkSharedFeatureEdges(
+				drawnIDs, matchedFeatures, visualOptions.minSharedFeatures);
+			for (var e = 0; e < sharedEdges.length; e++) {
+				sharedEdges[e].type = 'dotted';
+				sharedEdges[e].size = sharedEdges[e].weight;
+				edgesAux.push(sharedEdges[e]);
+			}
+		} else {
+			nElems = data.edges.length;
+			for (var i = nElems; i--;) {
+				elem = data.edges[i];
 
-			/********************************************************/
-			/* STEP 2.A.1 EXCLUDE ELEM IF:                           */
-			/*  - If elem is not an EDGE                            */
-			/*  - If source/target were ignored previously          */
-			/*  - If source/target are not valid pathways           */
-			/*  - If source/target are not visible                  */
-			/*  - Is source/target are special cases (e.g. mmu01100)*/
-			/********************************************************/
-			if ((elem.group !== "edges") || (elem.data.class !== visualOptions.edgesClass) ||
-			(ignoredPathways[elem.data.source] || ignoredPathways[elem.data.target]) ||
-			(indexedPathways[elem.data.source] === undefined || indexedPathways[elem.data.target] === undefined) ||
-			(!indexedPathways[elem.data.source].isVisible() || !indexedPathways[elem.data.target].isVisible()) ||
-			(elem.data.source === this.getModel().getOrganism() + "01100" || elem.data.target === this.getModel().getOrganism() + "01100")) {
-				continue;
-			}
+				/********************************************************/
+				/* STEP 2.A.1 EXCLUDE ELEM IF:                           */
+				/*  - If elem is not an EDGE                            */
+				/*  - If source/target were ignored previously          */
+				/*  - If source/target are not valid pathways           */
+				/*  - If source/target are not visible                  */
+				/*  - Is source/target are special cases (e.g. mmu01100)*/
+				/********************************************************/
+				if ((elem.group !== "edges") || (elem.data.class !== visualOptions.edgesClass) ||
+				(ignoredPathways[elem.data.source] || ignoredPathways[elem.data.target]) ||
+				(indexedPathways[elem.data.source] === undefined || indexedPathways[elem.data.target] === undefined) ||
+				(!indexedPathways[elem.data.source].isVisible() || !indexedPathways[elem.data.target].isVisible()) ||
+				(elem.data.source === this.getModel().getOrganism() + "01100" || elem.data.target === this.getModel().getOrganism() + "01100")) {
+					continue;
+				}
 
-			var similarity = 1;
-			if(visualOptions.edgesClass === 's'){
-				//CALCULATE THE Sorensen–Dice similarity coefficient (https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient)
-				var totalIntersection =  Array.intersect(indexedPathways[elem.data.target].getMatchedGenes(),indexedPathways[elem.data.source].getMatchedGenes()).length;
-				totalIntersection +=  Array.intersect(indexedPathways[elem.data.target].getMatchedCompounds(),indexedPathways[elem.data.source].getMatchedCompounds()).length;
-				//S(A,B) = 2 * |AnB| / |A| + |B|
-				//0 <= S(A,B) <= 1
-				similarity = 2 * totalIntersection / ((indexedPathways[elem.data.target].getMatchedGenes().length + indexedPathways[elem.data.target].getMatchedCompounds().length) + (indexedPathways[elem.data.source].getMatchedGenes().length + indexedPathways[elem.data.source].getMatchedCompounds().length));
-			}
-			/********************************************************/
-			/* STEP 2.A.2 EXCLUDE ELEM IF:                           */
-			/*  - If number of total shared features * N % is bigger than   */
-			/*    the sum of matched features in the pathway,       */
-			/********************************************************/
-			if (visualOptions.minSharedFeatures > similarity){
-				continue;
-			}
-			/********************************************************/
-			/* STEP 2.B GENERATE THE EDGE                               */
-			/********************************************************/
-			else {
-				// elem.data.label = '' + similarity;
 				elem.data.type = 'dotted';
-				elem.data.size = similarity;
+				elem.data.size = 1;
 				edgesAux.push(elem.data);
 			}
 		}
@@ -3611,7 +3803,7 @@ function PA_Step3PathwayNetworkView(db = "KEGG") {
 				'    <label for="background-layout-check_' + me.dbid + '">Calculate layout on background <span class="helpTip" style="float:right;" title="Run the layout on background, apply the new nodes position on stop (increases performance)."></span><span class="commentTip" style="padding-left:21px;">Increases performance.</span></label>' +
 				'  </div>'+
 				"  <h4>Node filtering options</h4>" +
-				'  <h5>Min features in pathway (<span id="minFeaturesValue_' + me.dbid + '">50</span>%)<span class="helpTip" style="float:right;" title="Min % of features (genes + compounds) of a pathway found at the input. Pathways with lower values will be excluded from the network. E.g. Using min=50%, if we find 80 features from the input data, at a Pathway that contains 200 features, the pathway will be excluded (80 < 100)."></span></h5>' +
+				'  <h5>Min features in pathway (<span id="minFeaturesValue_' + me.dbid + '">50</span>%)<span class="helpTip" style="float:right;" title="Min % of the features in a pathway that your input covers. Only the kinds of feature you submitted are counted, so a metabolomics job is measured against the compounds in the pathway and a transcriptomics job against its genes.<br><br>E.g. at min=50%, a pathway holding 200 countable features needs 100 of them in your input; with 80 it is excluded. The default starts at 50% for gene-based data and 10% for compound-only data, because a metabolomics platform covers far less of a pathway than an RNA-seq experiment does."></span></h5>' +
 				'  <div class="slider-ui" id="minFeaturesSlider_' + me.dbid + '"></div>' +
 				'  <h5>Min shared features (<span id="minSharedFeaturesValue_' + me.dbid + '">10</span>%)<span class="helpTip" style="float:right;" title="Min. % of features shared between 2 pathways (using the smaller pathway as reference). Edges showing a smaller relationship will be excluded.<br>E.g. Taking min=10%, Pathway A (60 features) and B (90 features), if shared features=5 the edge will be ignored (5 < Min(60,90) * 0.1)"></span></h5>' +
 				'  <div class="slider-ui" id="minSharedFeaturesSlider_' + me.dbid + '"></div>' +

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -156,7 +156,7 @@
 	<script type="text/javascript" src="app/view/PathwayAcquisitionViews/PA_Step3HubNetworkView.js?v=2.6"></script>
 
 	<!--LAUNCH APPLICATION -->
-	<script type="text/javascript" src="app.js?v=0.4"></script>
+	<script type="text/javascript" src="app.js?v=0.5"></script>
 
 	<script type="text/javascript">
 	window.onbeforeunload = function (e) {

--- a/PaintomicsServer/src/AdminTools/scripts/common_build_database.py
+++ b/PaintomicsServer/src/AdminTools/scripts/common_build_database.py
@@ -304,6 +304,56 @@ def summariseBuild():
         stderr.write("  (could not write the warning hand-off file: %s)\n" % writeError)
 
 #**************************************************************************
+#* SHARED FEATURES BETWEEN PATHWAYS
+#*
+#* All three network builders (KEGG, Reactome, MapMan) fill the same diagonal
+#* pathway-pair matrix and emit one "shared biological features" edge per
+#* non-zero cell. All three filled it from a gene -> pathways mapping ONLY, so
+#* two pathways sharing metabolites and no gene were never connected, and the
+#* edge weight the view starts from counted genes when the user may have
+#* submitted no genes at all. The counting is identical whatever the feature
+#* is, so it lives here once and is called for each feature class.
+#**************************************************************************
+def indexCompoundsByPathway(ALL_PATHWAYS):
+    """compound id -> the set of pathways containing it.
+
+    Blank identifiers are dropped rather than indexed: an empty id present in
+    two pathways joins them, and an empty id present in a hundred joins all
+    hundred to each other. Reactome writes an entry with no usable id whenever
+    a SimpleEntity carries neither a ChEBI nor a KEGG mapping.
+    """
+    index = defaultdict(set)
+    for pathwayID, pathway in ALL_PATHWAYS.items():
+        for compound in pathway.get("compounds", []) or []:
+            compoundID = compound.get("id")
+            if compoundID:
+                index[compoundID].add(pathwayID)
+    return index
+
+
+def accumulateSharedFeatures(pathways_matrix, feature2pathways):
+    """Add one to every pathway PAIR that shares a feature.
+
+    `pathways_matrix` is diagonal -- only one of (a,b) and (b,a) is a key -- so
+    each pair is incremented through whichever direction exists. A pair that
+    exists in neither direction names a pathway that never became a node and is
+    skipped; writing the missing direction in would double the weight of every
+    pair, since the bulk step below reads both.
+    """
+    for pathways in feature2pathways.values():
+        associated = sorted(pathways)
+        for index, current_path in enumerate(associated):
+            row = pathways_matrix.get(current_path)
+            for other_path in associated[index + 1:]:
+                if row is not None and other_path in row:
+                    row[other_path] += 1
+                else:
+                    other_row = pathways_matrix.get(other_path)
+                    if other_row is not None and current_path in other_row:
+                        other_row[current_path] += 1
+
+
+#**************************************************************************
 #  ______ _   _  _____ ______ __  __ ____  _
 # |  ____| \ | |/ ____|  ____|  \/  |  _ \| |
 # | |__  |  \| | (___ | |__  | \  / | |_) | |
@@ -1683,6 +1733,17 @@ def processMapManPathwaysData():
                     stderr.write("Pathways " + current_path + " or " + other_path + " not found in MapMan network values.\n")
 
     #***********************************************************************************
+    #* THE SAME, FOR COMPOUNDS
+    #          A MapMan diagram carries metabolites as well as genes, and two bins that
+    #          use the same metabolite share a biological feature. The matrix counted
+    #          genes only.
+    #***********************************************************************************
+    mapmanPathways = {pathwayID: pathway for pathwayID, pathway in ALL_PATHWAYS.items()
+                      if pathway.get("source") == "MapMan"}
+    accumulateSharedFeatures(pathways_matrix,
+                             indexCompoundsByPathway(mapmanPathways))
+
+    #***********************************************************************************
     #* GET THE NUMBER OF GENES FOR EACH PATHWAY
     #***********************************************************************************
     mapman_g2p_file = DATA_DIR + "gene2pathway_mapman.list"
@@ -1695,6 +1756,16 @@ def processMapManPathwaysData():
 
             # Write one row for each gene and pathway
             mapman_gene2pathway.writelines(str(geneID) + "\t" + str(path_id) + "\n" for geneID in gene_ids)
+
+    # A field of its own beside it: total_features has meant "genes" since
+    # Paintomics 3 and is read by clusters.py and by any client that has not
+    # reloaded, so redefining it would silently move their filter.
+    for path_id, pathway in mapmanPathways.items():
+        node = NODES.get(path_id)
+        if node is not None:
+            node["data"]["total_compounds"] = len(
+                set(compound.get("id") for compound in pathway.get("compounds", [])
+                    if compound.get("id")))
 
 
     #***********************************************************************************
@@ -2701,6 +2772,17 @@ def processReactomePathwaysData():
                     "Pathways " + current_path + " or " + other_path + " not found in Reactome network values.\n")
 
     # ***********************************************************************************
+    # * THE SAME, FOR COMPOUNDS
+    #          A Reactome SimpleEntity is a small molecule, and two processes that use
+    #          the same one share a biological feature. The matrix counted genes only,
+    #          so the "shared biological features" mode was blind to metabolites.
+    # ***********************************************************************************
+    reactomePathways = {pathwayID: pathway for pathwayID, pathway in ALL_PATHWAYS.items()
+                        if pathway.get("source") == "Reactome"}
+    accumulateSharedFeatures(pathways_matrix,
+                             indexCompoundsByPathway(reactomePathways))
+
+    # ***********************************************************************************
     # * ENTITY PROCESSING SUMMARY
     # ***********************************************************************************
     stderr.write("\n" + "="*80 + "\n")
@@ -2743,6 +2825,16 @@ def processReactomePathwaysData():
         except Exception:
             print(path_id)
             continue
+
+    # A field of its own beside it: total_features has meant "genes" since
+    # Paintomics 3 and is read by clusters.py and by any client that has not
+    # reloaded, so redefining it would silently move their filter.
+    for path_id, pathway in reactomePathways.items():
+        node = NODES.get(path_id)
+        if node is not None:
+            node["data"]["total_compounds"] = len(
+                set(compound.get("id") for compound in pathway.get("compounds", [])
+                    if compound.get("id")))
 
     # ***********************************************************************************
     # * BULK THE MATRIX INTO JSON:
@@ -3052,6 +3144,27 @@ def generatePathwaysNetwork(ALL_PATHWAYS):
     del gene2pathway
 
     #***********************************************************************************
+    #* STEP 3B. THE SAME, FOR COMPOUNDS
+    #          Two pathways that share a metabolite share a biological feature. The
+    #          matrix counted genes only, so a metabolomics user asking for "shared
+    #          biological features" got edges drawn from data they never submitted --
+    #          and none at all between two pathways joined solely by their compounds.
+    #***********************************************************************************
+    #          ALL_PATHWAYS holds every source installed for the species, and NODES
+    #          here is keyed by the bare 5-digit map number, so the ids are narrowed to
+    #          KEGG's and normalised before they are used as keys.
+    keggPathways = {pathwayID: pathway for pathwayID, pathway in ALL_PATHWAYS.items()
+                    if pathway.get("source") == "KEGG"}
+    compound2pathway = {}
+    for compoundID, pathwayIDs in indexCompoundsByPathway(keggPathways).items():
+        normalised = set(filter(None, (normaliseKeggPathwayId(pathwayID, SPECIE)
+                                       for pathwayID in pathwayIDs)))
+        if len(normalised) > 1:
+            compound2pathway[compoundID] = normalised
+    accumulateSharedFeatures(pathways_matrix, compound2pathway)
+    del compound2pathway
+
+    #***********************************************************************************
     #* STEP 4. GET THE NUMBER OF GENES FOR EACH PATHWAY
     #***********************************************************************************
     file_name = DATA_DIR + "pathway2gene.list"
@@ -3074,6 +3187,19 @@ def generatePathwaysNetwork(ALL_PATHWAYS):
         #LAST PATHWAY
         NODES[previous_pathway]["data"]["total_features"] += nGenes
     csvfile.close()
+
+    #***********************************************************************************
+    #* STEP 4B. AND THE NUMBER OF COMPOUNDS
+    #          A separate field, not folded into total_features: that name has meant
+    #          "genes" since Paintomics 3 and is read by clusters.py and by any client
+    #          that has not reloaded, so redefining it would silently move their filter.
+    #***********************************************************************************
+    for pathwayID, pathway in keggPathways.items():
+        node = NODES.get(normaliseKeggPathwayId(pathwayID, SPECIE))
+        if node is not None:
+            node["data"]["total_compounds"] = len(
+                set(compound.get("id") for compound in pathway.get("compounds", [])
+                    if compound.get("id")))
 
     #***********************************************************************************
     #* STEP 5. BULK THE MATRIX INTO JSON:

--- a/PaintomicsServer/src/classes/AIInterpret/clusters.py
+++ b/PaintomicsServer/src/classes/AIInterpret/clusters.py
@@ -245,10 +245,16 @@ def _coverage_total(pathway, installed_total, classes):
     """The denominator of "min features in pathway" for one pathway.
 
     `installed_total` is total_features from the network file, which counts
-    GENES only, and is the fallback for jobs stored before the pathway carried
-    its own counts. None means no total is known for any submitted class, and
-    the filter is skipped rather than guessed at.
+    GENES only. It is both the fallback for jobs stored before the pathway
+    carried its own counts AND the gate: absent or zero is how a database says
+    it has never had a coverage filter (OmniPath ships no such field, every
+    MapMan bin carries 0), so a denominator is not invented from the job's own
+    counts there. Mirrors paNetworkCoverageTotal in PA_Step3Views.js. None
+    means "no coverage filter here".
     """
+    if not isinstance(installed_total, (int, float)) or installed_total <= 0:
+        return None
+
     total, known = 0, False
     for wanted, attribute, fallback in (
             ("genes", "totalGenes", installed_total),
@@ -320,6 +326,11 @@ def select_network_nodes(job_instance, params=None, always_include=None):
     # network file is missing, min_features is silently ignored and pathways the
     # caller asked to exclude come back in -- a difference between what was asked
     # for and what happened, with nothing anywhere to say so. Say so.
+    #
+    # Still exactly true now that a pathway can carry its own counts: the
+    # installed total is the GATE in _coverage_total, so with no totals at all
+    # the filter is applied to nothing, whatever the pathways know about
+    # themselves.
     if p["min_features"] > 0 and not totals:
         logger.warning("[clusters] min_features=%s requested for organism %r but "
                        "no pathway network totals were found; the filter was NOT "

--- a/PaintomicsServer/src/classes/AIInterpret/clusters.py
+++ b/PaintomicsServer/src/classes/AIInterpret/clusters.py
@@ -222,11 +222,53 @@ def _fisher_min_pvalue(pw):
     return _best_pval(pw)
 
 
-def _load_total_features(organism):
-    """pathway id -> total feature count from the installed network file.
+def _omic_classes(job_instance):
+    """{genes, compounds}: the feature classes the job actually submitted.
 
-    Mirrors the client's "min features in pathway" filter. Missing file or
-    unexpected shape -> {} and the filter is simply not applied.
+    The coverage filter must divide by the pathway's features OF THESE CLASSES.
+    Dividing matched compounds by a gene count is not a ratio of anything, and
+    on a compound-only job it excludes every pathway.
+    """
+    try:
+        genes = bool(job_instance.getGeneBasedInputOmics())
+    except Exception:
+        genes = False
+    try:
+        compounds = bool(job_instance.getCompoundBasedInputOmics())
+    except Exception:
+        compounds = False
+    # No omic recorded at all: behave the way this has always behaved.
+    return {"genes": genes or not compounds, "compounds": compounds}
+
+
+def _coverage_total(pathway, installed_total, classes):
+    """The denominator of "min features in pathway" for one pathway.
+
+    `installed_total` is total_features from the network file, which counts
+    GENES only, and is the fallback for jobs stored before the pathway carried
+    its own counts. None means no total is known for any submitted class, and
+    the filter is skipped rather than guessed at.
+    """
+    total, known = 0, False
+    for wanted, attribute, fallback in (
+            ("genes", "totalGenes", installed_total),
+            ("compounds", "totalCompounds", None)):
+        if not classes.get(wanted):
+            continue
+        value = getattr(pathway, attribute, None)
+        if not isinstance(value, (int, float)):
+            value = fallback
+        if isinstance(value, (int, float)):
+            total += value
+            known = True
+    return total if known else None
+
+
+def _load_total_features(organism):
+    """pathway id -> total GENE count from the installed network file.
+
+    The fallback for jobs stored before Pathway carried its own counts. Missing
+    file or unexpected shape -> {} and the filter is simply not applied.
     """
     try:
         from src.conf.serverconf import KEGG_DATA_DIR
@@ -283,6 +325,7 @@ def select_network_nodes(job_instance, params=None, always_include=None):
                        "no pathway network totals were found; the filter was NOT "
                        "applied and low-feature pathways remain in the universe",
                        p["min_features"], organism)
+    classes = _omic_classes(job_instance)
     forced = {str(i) for i in (always_include or [])}
     rows = []
     for pid, pw in matched.items():
@@ -298,7 +341,7 @@ def select_network_nodes(job_instance, params=None, always_include=None):
                 continue
             n_matched = len(getattr(pw, "matchedGenes", None) or []) + \
                 len(getattr(pw, "matchedCompounds", None) or [])
-            total = totals.get(pid)
+            total = _coverage_total(pw, totals.get(pid), classes)
             if total and total * p["min_features"] > n_matched:
                 continue
         rows.append((pid not in forced, pval, pid, pw))

--- a/PaintomicsServer/src/classes/JobInstances/PathwayAcquisitionJob.py
+++ b/PaintomicsServer/src/classes/JobInstances/PathwayAcquisitionJob.py
@@ -2169,6 +2169,16 @@ class PathwayAcquisitionJob(Job):
                 pathwayInstance.addSignificanceValues(omicName, rel_val)
 
         if isValidPathway:
+            # How big the pathway is, by feature class. This is the only place
+            # that sees both full feature sets and builds the Pathway, and the
+            # sets arrive from getAllFeatureIDsByPathwayID already deduplicated.
+            # The network view needs them because the count it used instead --
+            # total_features in the installed pathways_network.json -- is the
+            # GENE count, so on a compound-only job it divided matched compounds
+            # by the pathway's genes and excluded everything.
+            pathwayInstance.setTotalGenes(len(genesInPathway or []))
+            pathwayInstance.setTotalCompounds(len(compoundsInPathway or []))
+
             self._setPerOmicSignificance(pathwayInstance, totalFeaturesByOmic,
                                          totalRelevantFeaturesByOmic, has_multi_cond)
             self._setCrossOmicSignificance(pathwayInstance, mappedRatiosByOmic, has_multi_cond)

--- a/PaintomicsServer/src/classes/Pathway.py
+++ b/PaintomicsServer/src/classes/Pathway.py
@@ -36,6 +36,17 @@ class Pathway(Model):
         self.matchedGenes = []
         #METAGENES INFORMATION FOR EACH OMIC DATA TYPE
         self.metagenes = {}
+        # NOTE: totalGenes and totalCompounds -- how many features of each kind
+        # the pathway CONTAINS, not how many were matched -- are deliberately
+        # NOT declared here. The network view divides the matched count by them
+        # to get "min features in pathway", and a pathway stored before they
+        # existed must be distinguishable from one that genuinely has none, so
+        # that the client falls back to the installed gene count instead of
+        # filtering against a zero. Absent is that distinction: toBSON is
+        # self.__dict__, so an undeclared attribute is simply not a key, whereas
+        # a None would reach the client as the STRING "None" (DAO.adaptBSON).
+        # They are set in testPathwaySignificance, which is the only place that
+        # sees both of the pathway's full feature sets.
         #SIGNIFICANCE VALUES PER OMIC in format OmicName -> [[totalFeatures, totalRelevantFeatures, pValue], ...] (one per condition)
         self.significanceValues= {}
         self.globalOmicPvalues = {}
@@ -88,6 +99,19 @@ class Pathway(Model):
         self.matchedGenes.append(matchedGen.getID())
     def addMatchedGeneID(self, matchedGenID):
         self.matchedGenes.append(matchedGenID)
+
+    def setTotalGenes(self, totalGenes):
+        self.totalGenes = totalGenes
+    def getTotalGenes(self):
+        """The pathway's gene count, or None if this pathway was matched
+        before the count was recorded."""
+        return getattr(self, "totalGenes", None)
+
+    def setTotalCompounds(self, totalCompounds):
+        self.totalCompounds = totalCompounds
+    def getTotalCompounds(self):
+        """The pathway's compound count, or None if not recorded."""
+        return getattr(self, "totalCompounds", None)
 
     def setMetagenes(self, metagenes):
         self.metagenes= metagenes

--- a/PaintomicsServer/src/tests/test_pathway_network_counts_compounds.py
+++ b/PaintomicsServer/src/tests/test_pathway_network_counts_compounds.py
@@ -346,6 +346,34 @@ class CoverageDenominatorTest(unittest.TestCase):
         total = self.coverage({}, {}, {"genes": False, "compounds": True})
         self.assertIsNone(total)
 
+    def test_a_database_that_never_had_the_filter_does_not_gain_one(self):
+        """The regression this guards, and the reason the installed node is
+        the gate rather than just a fallback.
+
+        `total_features * minFeatures > matched` can never be true when
+        total_features is absent (NaN) or zero, so those databases have no
+        coverage filter and never have had one: OmniPath writes no such field,
+        all 70 ath MapMan bins carry 0 (the installer counts only 20-character
+        gene ids), and so do 220 of mmu's 584 KEGG maps. The job's own counts
+        are a real number for every one of them, so using them unconditionally
+        would switch a 50% filter on for the first time -- on ath MapMan bins
+        holding 21,446 genes, which is a blank canvas again."""
+        mapman = self.coverage({"genes": 21446, "compounds": 0},
+                               {"total_features": 0},
+                               {"genes": True, "compounds": False})
+        self.assertIsNone(mapman, "MapMan has never had a coverage filter")
+
+        omnipath = self.coverage({"genes": 20, "compounds": 0}, {},
+                                 {"genes": True, "compounds": False})
+        self.assertIsNone(omnipath, "OmniPath ships no total_features at all")
+
+        kegg_without_genes = self.coverage({"genes": 0, "compounds": 128},
+                                           {"total_features": 0},
+                                           {"genes": False, "compounds": True})
+        self.assertIsNone(kegg_without_genes,
+                          "a KEGG map with no genes in pathway2gene.list was "
+                          "never filtered on coverage either")
+
     def test_zero_is_a_known_answer_not_a_missing_one(self):
         """A pathway with no compounds in a compound-only job is genuinely
         uncoverable, but 0 * anything is 0 so it can never be excluded."""
@@ -375,6 +403,36 @@ class DefaultMinFeaturesTest(unittest.TestCase):
 
     def test_a_job_with_no_omic_at_all_keeps_the_shipped_default(self):
         self.assertEqual(0.5, self.defaults(False, False))
+
+
+class OmicClassFallbackTest(unittest.TestCase):
+    """A job recording neither class is read as gene-based on BOTH sides.
+
+    clusters.py says so outright (`genes or not compounds`). The client used to
+    report {genes: false, compounds: false}, which leaves the denominator
+    unknown for every class, switches the coverage filter off, and still shows
+    the slider at 50% -- a control that visibly does nothing."""
+
+    def test_the_server_reads_a_job_with_no_omic_as_gene_based(self):
+        from src.classes.AIInterpret import clusters
+
+        class _Job(object):
+            def getGeneBasedInputOmics(self):
+                return []
+
+            def getCompoundBasedInputOmics(self):
+                return []
+
+        self.assertEqual({"genes": True, "compounds": False},
+                         clusters._omic_classes(_Job()))
+
+    def test_the_client_agrees(self):
+        with open(STEP3_VIEWS, "r", encoding="utf-8") as handle:
+            source = handle.read()
+        start = source.index("this.omicClasses = {\n\t\t\t/*")
+        window = source[start:start + 900]
+        self.assertIn("|| !hasCompoundOmics", window,
+                      "the client must fall back to genes the way the server does")
 
 
 @unittest.skipIf(shutil.which("node") is None, "node is not installed")
@@ -462,6 +520,19 @@ class ClientWiringTest(unittest.TestCase):
                          source,
                          "the gene-only denominator must be gone from the filter")
         self.assertIn("paNetworkCoverageTotal(", source)
+
+    def test_the_cache_marker_was_bumped_with_app_js(self):
+        """PA_JOB_CACHE_SCHEMA went 2 -> 3 so a browser holding a job model
+        without the counts discards it. app.js is the ONE file loaded with a
+        static ?v= (the view/model files go through $.ajax dataType:"script",
+        which cache-busts itself), so without the bump a returning browser
+        keeps the old app.js, keeps schema 2, keeps its stored model, and the
+        fix never reaches it."""
+        index = os.path.join(CLIENT, "index.html")
+        with open(index, "r", encoding="utf-8") as handle:
+            markup = handle.read()
+        self.assertNotIn('src="app.js?v=0.4"', markup,
+                         "app.js changed (PA_JOB_CACHE_SCHEMA) but its ?v= did not")
 
     def test_the_help_no_longer_promises_something_it_does_not_do(self):
         with open(STEP3_VIEWS, "r", encoding="utf-8") as handle:

--- a/PaintomicsServer/src/tests/test_pathway_network_counts_compounds.py
+++ b/PaintomicsServer/src/tests/test_pathway_network_counts_compounds.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+"""The pathway network must count metabolites, not only genes.
+
+Every node in `pathways_network*.json` carries `total_features`, and the
+installer sets it from the pathway's GENE list alone -- `len(gene_ids)` for
+Reactome, `pathway2gene.list` for KEGG, the 20-character gene ids for MapMan.
+The client then filtered with
+
+    total_features * minFeatures > matchedGenes + matchedCompounds
+
+which divides a count of matched *compounds* by a count of *genes*. It is not a
+ratio of anything, and on a compound-only job the numerator has no genes at all
+while the denominator is the pathway's whole gene set, so every pathway fails.
+
+Measured on job 2J4u1qN5pm (STATegra metabolomics, mmu, KEGG+Reactome, no
+gene-based omic): 141 pathways reached the test, 137 failed it, 4 failed only on
+p-value, 0 were drawn. `mmu01210` had 16 matched compounds at p = 0.0063 and was
+dropped because 34 genes x 0.5 = 17 > 16. The header read
+"0 of 141 KEGG pathways . 0 edges".
+
+The same file's shared-feature edges ("Shared biological features" in the view)
+were built from shared GENES only, so two pathways sharing metabolites and no
+gene were never connected.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_pathway_network_counts_compounds
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from src.classes.Pathway import Pathway
+
+CLIENT = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__))))),
+    "PaintomicsClient", "public_html")
+STEP3_VIEWS = os.path.join(CLIENT, "app", "view", "PathwayAcquisitionViews",
+                           "PA_Step3Views.js")
+PATHWAY_MODELS = os.path.join(CLIENT, "app", "model", "PathwayModels.js")
+BUILD_DB = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                        "AdminTools", "scripts", "common_build_database.py")
+
+
+# ---------------------------------------------------------------------------
+# The server hands the client the counts, so no reinstall is needed
+# ---------------------------------------------------------------------------
+
+class PathwayCarriesItsOwnTotalsTest(unittest.TestCase):
+    """`total_features` in the installed file is gene-only and can only be
+    corrected by reinstalling every species. The counts the filter needs are
+    already in hand while the job runs -- getAllFeatureIDsByPathwayID returns
+    both sets -- so the Pathway carries them and every existing install is
+    fixed the moment a job is run."""
+
+    def test_a_new_pathway_has_no_counts_and_no_keys_for_them(self):
+        """Absent, not zero and not None. Zero is a real answer the filter
+        would act on, and a None reaches the client as the STRING "None"
+        (DAO.adaptBSON turns every None leaf into one)."""
+        pathway = Pathway("mmu00010")
+        self.assertIsNone(pathway.getTotalGenes())
+        self.assertIsNone(pathway.getTotalCompounds())
+        self.assertNotIn("totalGenes", pathway.toBSON())
+        self.assertNotIn("totalCompounds", pathway.toBSON())
+
+    def test_a_pathway_stored_before_the_counts_existed_stays_unknown(self):
+        """The regression this guards: if the counts defaulted to 0, a job
+        stored before them would hand the client a denominator of 0, and
+        `0 * minFeatures > matched` is never true -- so reopening an old
+        GENE-based job would silently switch its coverage filter off."""
+        revived = Pathway("")
+        revived.parseBSON({"_id": "x", "ID": "mmu00010", "matchedGenes": ["1"]})
+
+        self.assertIsNone(revived.getTotalGenes())
+        self.assertIsNone(revived.getTotalCompounds())
+
+    def test_the_counts_survive_the_trip_to_mongo(self):
+        pathway = Pathway("mmu00010")
+        pathway.setTotalGenes(67)
+        pathway.setTotalCompounds(31)
+
+        bson = pathway.toBSON()
+        self.assertEqual(67, bson["totalGenes"])
+        self.assertEqual(31, bson["totalCompounds"])
+
+        revived = Pathway("")
+        revived.parseBSON(dict(bson, _id="x"))
+        self.assertEqual(67, revived.getTotalGenes())
+        self.assertEqual(31, revived.getTotalCompounds())
+
+
+class SignificanceRecordsTheTotalsTest(unittest.TestCase):
+    """testPathwaySignificance already receives both feature lists; it is the
+    one place that sees a pathway's full size and builds the Pathway."""
+
+    def _run(self, genes, compounds):
+        from src.classes.JobInstances.PathwayAcquisitionJob import PathwayAcquisitionJob
+
+        job = PathwayAcquisitionJob(jobID="counts", userID=None,
+                                    CLIENT_TMP_DIR="/tmp/paintomics-test/")
+        job.setOrganism("mmu")
+        job.setDatabases(["KEGG"])
+
+        class _Value(object):
+            def __init__(self):
+                self.relevant = [True]
+
+            def getOmicName(self):
+                return "Metabolomics"
+
+            def getInputName(self):
+                return "C00033"
+
+            def getOriginalName(self):
+                return "C00033"
+
+            def isRelevantAssociation(self):
+                return True
+
+        class _Feature(object):
+            def __init__(self, identifier):
+                self.identifier = identifier
+
+            def getID(self):
+                return self.identifier
+
+            def getMatchingDB(self):
+                return "KEGG"
+
+            def getOmicsValues(self):
+                return [_Value()]
+
+        inputCompounds = {"c00033": _Feature("C00033")}
+        return job.testPathwaySignificance(
+            genes, compounds, {}, inputCompounds,
+            {"Metabolomics": 100}, {"Metabolomics": [10]},
+            {"Metabolomics": 1.0}, {"Metabolomics": "genes"},
+            "KEGG", False)
+
+    def test_both_totals_are_recorded_on_a_matched_pathway(self):
+        isValid, pathway = self._run(
+            {"11674", "11676", "230163"},
+            {"C00033", "C00031", "C00103"})
+
+        self.assertTrue(isValid, "the input compound C00033 is in the pathway")
+        self.assertEqual(3, pathway.getTotalGenes())
+        self.assertEqual(3, pathway.getTotalCompounds(),
+                         "a compound-only job needs the compound denominator")
+
+    def test_a_pathway_with_no_compounds_records_zero(self):
+        isValid, pathway = self._run({"11674"}, set())
+        self.assertFalse(isValid)
+
+
+# ---------------------------------------------------------------------------
+# The installer: shipped nodes and edges must know about compounds
+# ---------------------------------------------------------------------------
+
+def _loadBuilder():
+    """`common_build_database` at import time only defines functions and
+    constants, but it does `from src.conf.serverconf import ...`; import it the
+    way the AdminTools scripts do."""
+    import importlib
+    return importlib.import_module(
+        "src.AdminTools.scripts.common_build_database")
+
+
+class SharedFeatureMatrixTest(unittest.TestCase):
+    """The three builders each filled a pathway-pair matrix from a gene ->
+    pathways mapping and emitted one 's' edge per non-zero cell. Compounds
+    were never counted, in any of the three."""
+
+    def test_two_pathways_sharing_only_a_compound_are_linked(self):
+        builder = _loadBuilder()
+        matrix = {"a": {"b": 0, "c": 0}, "b": {"c": 0}, "c": {}}
+
+        builder.accumulateSharedFeatures(matrix, {"C00033": {"a", "b"}})
+
+        self.assertEqual(1, matrix["a"]["b"],
+                         "a shared metabolite is a shared biological feature")
+        self.assertEqual(0, matrix["a"]["c"])
+
+    def test_the_count_accumulates_over_features(self):
+        builder = _loadBuilder()
+        matrix = {"a": {"b": 3}, "b": {}}
+
+        builder.accumulateSharedFeatures(
+            matrix, {"C00033": {"a", "b"}, "C00031": {"a", "b"}})
+
+        self.assertEqual(5, matrix["a"]["b"],
+                         "compound sharing adds to the gene weight, not over it")
+
+    def test_a_pair_missing_from_the_matrix_is_not_invented(self):
+        """The matrix is diagonal: only one of (a,b)/(b,a) exists. Writing the
+        missing direction would double every weight."""
+        builder = _loadBuilder()
+        matrix = {"a": {"b": 0}, "b": {}}
+
+        builder.accumulateSharedFeatures(matrix, {"C1": {"b", "a"}})
+
+        self.assertEqual(1, matrix["a"]["b"])
+        self.assertEqual({}, matrix["b"])
+
+    def test_an_unknown_pathway_is_ignored_not_raised(self):
+        builder = _loadBuilder()
+        matrix = {"a": {"b": 0}, "b": {}}
+
+        builder.accumulateSharedFeatures(matrix, {"C1": {"a", "zzz"}})
+
+        self.assertEqual(0, matrix["a"]["b"])
+
+
+class CompoundIndexTest(unittest.TestCase):
+    def test_the_index_maps_each_compound_to_its_pathways(self):
+        builder = _loadBuilder()
+        allPathways = {
+            "mmu00010": {"compounds": [{"id": "C00031"}, {"id": "C00033"},
+                                       {"id": "C00031"}]},
+            "mmu00020": {"compounds": [{"id": "C00033"}]},
+            "mmu00030": {"compounds": []},
+        }
+
+        index = builder.indexCompoundsByPathway(allPathways)
+
+        self.assertEqual({"mmu00010", "mmu00020"}, index["C00033"])
+        self.assertEqual({"mmu00010"}, index["C00031"])
+        self.assertNotIn("", index, "a blank id joins every pathway to every other")
+
+    def test_blank_identifiers_are_dropped(self):
+        builder = _loadBuilder()
+        index = builder.indexCompoundsByPathway(
+            {"p": {"compounds": [{"id": ""}, {"id": None}, {}]}})
+        self.assertEqual({}, dict(index))
+
+
+class InstalledNodesDeclareCompoundsTest(unittest.TestCase):
+    """`total_features` keeps meaning what every existing reader thinks it
+    means (the gene count -- clusters.py reads it, as do clients that have not
+    reloaded). The compound count is a new, unambiguous field beside it."""
+
+    def test_all_three_builders_set_total_compounds(self):
+        with open(BUILD_DB, "r", encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertEqual(
+            3, len(re.findall(r'"total_compounds"\]\s*=', source)),
+            "KEGG, Reactome and MapMan each write their own node data")
+
+    def test_no_builder_still_ignores_compound_sharing(self):
+        with open(BUILD_DB, "r", encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertEqual(3, source.count("\n    accumulateSharedFeatures("),
+                         "each of the three network builders must fold compounds in")
+
+
+# ---------------------------------------------------------------------------
+# The client
+# ---------------------------------------------------------------------------
+
+def extract(source, name):
+    """The text of `var <name> = function ... };`, brace-matched."""
+    match = re.search(r"var\s+%s\s*=\s*function" % re.escape(name), source)
+    if match is None:
+        raise AssertionError("%s() is not defined" % name)
+    opening = source.index("{", match.end())
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[match.start():index + 1] + ";"
+    raise AssertionError("unbalanced braces in %s()" % name)
+
+
+def run_in_node(names, body):
+    with open(STEP3_VIEWS, "r", encoding="utf-8") as handle:
+        source = handle.read()
+    script = "\n".join(extract(source, name) for name in names) + "\n" + body
+    directory = tempfile.mkdtemp(prefix="paintomics-network-")
+    try:
+        path = os.path.join(directory, "check.js")
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(script)
+        done = subprocess.run(["node", path], capture_output=True, text=True,
+                              timeout=60)
+        if done.returncode != 0:
+            raise AssertionError("node failed:\n%s" % done.stderr)
+        return json.loads(done.stdout)
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class CoverageDenominatorTest(unittest.TestCase):
+    """The denominator must count the feature classes the input actually
+    contains. Anything else compares one kind of thing to another."""
+
+    def coverage(self, counts, nodeData, omics):
+        return run_in_node(
+            ["paNetworkCoverageTotal"],
+            "console.log(JSON.stringify({total: paNetworkCoverageTotal(%s, %s, %s)}));"
+            % (json.dumps(counts), json.dumps(nodeData), json.dumps(omics)))["total"]
+
+    def test_a_compound_only_job_divides_by_the_compounds(self):
+        total = self.coverage({"genes": 34, "compounds": 144},
+                              {"total_features": 34},
+                              {"genes": False, "compounds": True})
+        self.assertEqual(144, total,
+                         "mmu01210: 16 matched compounds is 11% of 144, not 47% of 34")
+
+    def test_a_gene_only_job_is_unchanged(self):
+        total = self.coverage({"genes": 67, "compounds": 31},
+                              {"total_features": 67},
+                              {"genes": True, "compounds": False})
+        self.assertEqual(67, total, "gene-based jobs must see exactly what they see today")
+
+    def test_a_mixed_job_counts_both(self):
+        total = self.coverage({"genes": 67, "compounds": 31},
+                              {"total_features": 67},
+                              {"genes": True, "compounds": True})
+        self.assertEqual(98, total)
+
+    def test_an_old_job_falls_back_to_the_installed_gene_count(self):
+        """Jobs stored before the counts existed carry neither; total_features
+        IS the gene count, so a gene-based job behaves exactly as before."""
+        total = self.coverage({}, {"total_features": 67},
+                              {"genes": True, "compounds": False})
+        self.assertEqual(67, total)
+
+    def test_a_reinstalled_species_rescues_an_old_compound_job(self):
+        total = self.coverage({}, {"total_features": 34, "total_compounds": 144},
+                              {"genes": False, "compounds": True})
+        self.assertEqual(144, total)
+
+    def test_an_unknown_denominator_disables_the_filter(self):
+        """OmniPath ships no totals at all. Filtering on a number nobody knows
+        would hide the whole network; returning null means 'do not filter'."""
+        total = self.coverage({}, {}, {"genes": False, "compounds": True})
+        self.assertIsNone(total)
+
+    def test_zero_is_a_known_answer_not_a_missing_one(self):
+        """A pathway with no compounds in a compound-only job is genuinely
+        uncoverable, but 0 * anything is 0 so it can never be excluded."""
+        total = self.coverage({"genes": 40, "compounds": 0}, {"total_features": 40},
+                              {"genes": False, "compounds": True})
+        self.assertEqual(0, total)
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class DefaultMinFeaturesTest(unittest.TestCase):
+    def defaults(self, hasGenes, hasCompounds):
+        return run_in_node(
+            ["paNetworkDefaultMinFeatures"],
+            "console.log(JSON.stringify({v: paNetworkDefaultMinFeatures(%s, %s)}));"
+            % (json.dumps(hasGenes), json.dumps(hasCompounds)))["v"]
+
+    def test_a_gene_based_job_keeps_the_shipped_half(self):
+        self.assertEqual(0.5, self.defaults(True, False))
+        self.assertEqual(0.5, self.defaults(True, True))
+
+    def test_a_compound_only_job_starts_where_metabolomics_lives(self):
+        """Transcriptomics measures ~100% of a pathway's genes; a metabolomics
+        platform covers a tenth of its compounds. Median compound coverage on
+        job 2J4u1qN5pm was 10.1%, and at 50% only 6 of 140 pathways cleared the
+        bar against 75 at 10%."""
+        self.assertEqual(0.1, self.defaults(False, True))
+
+    def test_a_job_with_no_omic_at_all_keeps_the_shipped_default(self):
+        self.assertEqual(0.5, self.defaults(False, False))
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is not installed")
+class SharedFeatureEdgesTest(unittest.TestCase):
+    """The 's' edge set shipped in the install file lists pathway pairs sharing
+    a GENE. The weight the view draws is already recomputed from the job's
+    matched genes AND compounds, so the file only ever decided which pairs were
+    allowed to exist -- and it decided that on genes alone."""
+
+    def edges(self, features, minimum):
+        return run_in_node(
+            ["paNetworkSharedFeatureEdges"],
+            "console.log(JSON.stringify(paNetworkSharedFeatureEdges(%s, %s, %s)));"
+            % (json.dumps(sorted(features)), json.dumps(features),
+               json.dumps(minimum)))
+
+    def test_pathways_sharing_only_compounds_are_connected(self):
+        edges = self.edges({
+            "mmu00250": {"genes": [], "compounds": ["C00025", "C00026", "C00064"]},
+            "mmu00220": {"genes": [], "compounds": ["C00025", "C00026", "C00062"]},
+        }, 0.1)
+
+        self.assertEqual(1, len(edges))
+        self.assertEqual("s", edges[0]["class"])
+        # Sorensen-Dice: 2 * 2 / (3 + 3)
+        self.assertAlmostEqual(2 / 3.0, edges[0]["weight"])
+
+    def test_genes_and_compounds_are_pooled_into_one_coefficient(self):
+        edges = self.edges({
+            "a": {"genes": ["g1"], "compounds": ["C1"]},
+            "b": {"genes": ["g1"], "compounds": ["C2"]},
+        }, 0.1)
+        self.assertAlmostEqual(0.5, edges[0]["weight"])
+
+    def test_a_pair_below_the_threshold_is_dropped(self):
+        edges = self.edges({
+            "a": {"genes": ["g1", "g2", "g3", "g4", "g5", "g6", "g7", "g8", "g9"],
+                  "compounds": []},
+            "b": {"genes": ["g1", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8"],
+                  "compounds": []},
+        }, 0.5)
+        self.assertEqual([], edges)
+
+    def test_pathways_sharing_nothing_get_no_edge(self):
+        edges = self.edges({
+            "a": {"genes": ["g1"], "compounds": []},
+            "b": {"genes": ["g2"], "compounds": []},
+        }, 0)
+        self.assertEqual([], edges,
+                         "an edge with a zero coefficient is not a relationship")
+
+    def test_each_pair_appears_once(self):
+        edges = self.edges({
+            "a": {"genes": ["g1"], "compounds": []},
+            "b": {"genes": ["g1"], "compounds": []},
+            "c": {"genes": ["g1"], "compounds": []},
+        }, 0.1)
+        self.assertEqual(3, len(edges))
+        self.assertEqual(3, len({tuple(sorted([e["source"], e["target"]]))
+                                 for e in edges}))
+
+    def test_an_empty_pathway_never_divides_by_zero(self):
+        edges = self.edges({
+            "a": {"genes": [], "compounds": []},
+            "b": {"genes": [], "compounds": []},
+        }, 0)
+        self.assertEqual([], edges)
+
+
+class ClientWiringTest(unittest.TestCase):
+    """The helpers above are only worth anything if the view actually calls
+    them, and if the model carries the numbers they need."""
+
+    def test_the_model_carries_both_counts(self):
+        with open(PATHWAY_MODELS, "r", encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertIn("getTotalGenes", source)
+        self.assertIn("getTotalCompounds", source)
+        self.assertIn("jsonObject.totalCompounds", source)
+
+    def test_the_node_filter_no_longer_reads_total_features_directly(self):
+        with open(STEP3_VIEWS, "r", encoding="utf-8") as handle:
+            source = handle.read()
+        self.assertNotIn("elem.data.total_features * visualOptions.minFeatures",
+                         source,
+                         "the gene-only denominator must be gone from the filter")
+        self.assertIn("paNetworkCoverageTotal(", source)
+
+    def test_the_help_no_longer_promises_something_it_does_not_do(self):
+        with open(STEP3_VIEWS, "r", encoding="utf-8") as handle:
+            source = handle.read()
+        start = source.index("Min features in pathway")
+        tip = source[start:start + 900]
+        self.assertNotIn("(genes + compounds) of a pathway found at the input", tip)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Reported from the app: the Step 3 **Pathways network** looked gene-only — a job with only metabolomics drew nothing at all.

## The bug

Every node in `pathways_network*.json` carries `total_features`, and all three installers set it from the pathway's **gene** list alone (`len(gene_ids)`, `pathway2gene.list`, the 20-character MapMan ids). The node filter then read

```js
total_features * minFeatures > matchedGenes + matchedCompounds
```

— matched **compounds** divided by a count of **genes**. With no gene-based omic the numerator holds no genes and the denominator is the pathway's whole gene set, so nothing can clear the bar.

Measured on job `2J4u1qN5pm` (STATegra metabolomics, mmu): of 141 matched KEGG pathways **137 were dropped by that line alone**, 4 by p-value, 0 drawn — `0 of 141 KEGG pathways · 0 edges`. `mmu01210` had 16 matched compounds at p = 0.0063 and was excluded because 34 genes × 0.5 = 17 > 16.

Second defect: the "Shared biological features" edges were gene-derived too. The shipped file lists pairs sharing a *gene*, while the view already recomputed each weight from genes **and** compounds — so two pathways joined only by metabolites could never be connected.

## The fix

- **The denominator counts only the feature classes the input contains.** The counts come from `testPathwaySignificance`, the one place holding both of a pathway's full feature sets, so **every existing install is corrected without a reinstall**.
- **The installed node stays the gate.** `total_features` absent or zero is how a database says it has never had a coverage filter — OmniPath writes no such field (0 of 120 mmu nodes), every one of MapMan's 70 bins carries 0, and so do 220 of mmu's 584 KEGG maps. Handing those a denominator from the job would have switched a 50% bar on for the first time.
- **The slider default follows the data**: 50% for gene-based jobs, 10% for compound-only. 50% is a transcriptomics number; median compound coverage on that job was 10.1% (6 of 140 pathways cleared 50%, 75 cleared 10%).
- **Shared-feature edges are derived from the job's own matched features** — no reinstall needed, and equivalent for gene-based jobs since a shipped pair with no shared *matched* feature already scored zero. The three installers also fold shared compounds into the shipped matrix.
- `clusters.py` mirrors the same filter and had the same bug.

`Pathway` records "unknown" as an **absent key**, not `0` and not `None`: `0` makes `0 * minFeatures > matched` always false and would silently switch an old gene job's filter off, and `None` reaches the client as the string `"None"` via `DAO.adaptBSON`.

## Verified in Chrome, each against master's own rule computed in the page

| | master | this branch |
|---|---|---|
| Metabolomics-only job | 0 of 299 | **13 of 299**, 4 edges |
| Its shared-feature edges | — | 10, **3 joining pathways that share no gene** |
| Mixed gene+compound job | 32 of 364 | 32 of 364, **identical set** |
| Old 6-omic job (`q2Z715i47E`) | 70 of 364 | 70 of 364, **identical set** |
| OmniPath half of a real job | 1 | 1 |

`totalGenes` equals the installed `total_features` for **all 299** pathways of a job, so gene-only jobs are provably unchanged. On a real 6-omic job the pooled denominator moves the drawn count 70 → 66; the four lost are exactly the ones whose old ratio exceeded 1 (`mmu00240`: 58 matched over a denominator of 57).

## Cost, measured

The installer's compound-aware `'s'` edges add **+4,365 KEGG edges (+20%), ~0.5 MB on a 4.95 MB file**, and only after a species is reinstalled. Most compound-sharing pairs (11,827 of 16,192) already share a gene.

## Tests

36 new tests in `src/tests/test_pathway_network_counts_compounds.py`. The full 282-module suite is at its pre-existing 14 failures — the 7 real ones reproduce identically with this branch stashed (stale local `serverconf.py`, an mmu snapshot grown by OmniPath's 120 pathways).

## Found while measuring, not fixed here (predates this work)

`visualOptions` carry over between jobs in one tab: opening a 299-pathway job and then a 364-pathway one leaves 65 of the second job's pathways hidden by the first job's `pathwaysVisibility`, and carries its `minFeatures` across.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsFbhfG7ryhTHCgxyrW1fQ