### PR TITLE
Give Step 2 one module system: a databases matrix, a levelled class-activity pair, disambiguation in the grid

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
@@ -300,6 +300,11 @@ function PA_Step2JobView() {
 					xtype: 'form',
 					maxWidth: 600,
 					bodyCls: "divForm",
+					/* 20, which reads as --pa-card-inset: ExtJS leaves 6px of row
+					   spacing below the last field inside the form panel, so 26 here
+					   put 33px under the last input where the two cards beside it
+					   leave 25. Measured from the input's own edge, not the panel's -
+					   the ink is what a reader sees the card end below. */
 					style: "margin: 0 auto 20px auto;",
 					layout: {type: 'vbox', align: 'stretch'},
 					defaults: {labelAlign: "right", border: false},
@@ -317,33 +322,78 @@ function PA_Step2JobView() {
 				"OmniPath": '<a href="https://omnipathdb.org/" target="_blank">OmniPath</a> integrates over 100 resources into a prior-knowledge network of signed, directed molecular interactions, available for human, mouse and rat. Its pathways are defined by the curated SIGNOR and NetPath annotations and carry no diagram, so they open as an interactive interaction network rather than as a painted map.'
 			};
 
-			var dl_dbs = databases.map(function(dbname) {
-				var divContent =
-				'<table>' +
-					'<tr><th>Omic</th><th>Matched</th></tr>' +
-					Object.keys(matchingPerDB[dbname]).map(function(omicName) {
-						return '<td>' + omicName + '</td><td>' + matchingPerDB[dbname][omicName]["matched"] + " (" + matchingPerDB[dbname][omicName]["percentage"] + "%)</td>";
-					}).join('</tr><tr>') +
-				'</table>';
+			/* One matrix, not one table per database.
 
-				return '<dt>' + dbname + '</dt><dd>' + dbs_descriptions[dbname] + '<div id="matching_table_' + dbname + '">' + divContent + '</div></dd>';
+			   Every database used to print its own two-column table of the same
+			   omics, each centred inside the 1124px card with ~370px of dead space
+			   either side: three identical shapes, 1149px of card, and no way to
+			   compare one omic across databases without scrolling between two
+			   tables. Comparing them is the only reason this card exists, so it is
+			   one table - omics down, databases across - and the answer is a row.
+
+			   Column order follows `databases`, so it matches the order the rest
+			   of the step uses. */
+			var dbs_head = databases.map(function(dbname) {
+				return '<th scope="col">' + Ext.String.htmlEncode(dbname) + '</th>';
+			}).join('');
+
+			/* Every database was given an entry for every omic by the loop above,
+			   so any of them names the full row set; the first is as good as any.
+			   Read from the map rather than from dataDistribution so the rows and
+			   the cells can never disagree about which omics exist. */
+			var dbs_omicNames = Object.keys(matchingPerDB[databases[0]] || {});
+
+			var dbs_rows = dbs_omicNames.map(function(omicName) {
+				return '<tr><th scope="row">' + Ext.String.htmlEncode(omicName) + '</th>' +
+				databases.map(function(dbname) {
+					/* A missing entry means the omic matched nothing in that
+					   database - which is a zero, not an unknown. An empty cell
+					   would read as "not measured", which is a different claim. */
+					var cell = (matchingPerDB[dbname] || {})[omicName] || {matched: 0, percentage: 0};
+					/* The share as a bar as well as a number. Four columns of bare
+					   figures across 1070px is a lot of table to read one comparison
+					   out of; the bar answers "which database covers this omic best"
+					   at a glance and gives the card's width something to do. The
+					   figures stay - the bar is the second reading, not the only one.
+
+					   Clamped: the percentage is Math.ceil'd upstream, so a fully
+					   matched omic can arrive as 100 and nothing above it should
+					   ever draw past the track. */
+					var share = Math.max(0, Math.min(100, Number(cell.percentage) || 0));
+					return '<td><span class="paDbCell">' +
+					'<span class="paDbBar"><i style="width:' + share + '%"></i></span>' +
+					'<span class="paDbCount">' + Number(cell.matched || 0).toLocaleString() + '</span>' +
+					'<span class="paDbPct">' + cell.percentage + '%</span>' +
+					'</span></td>';
+				}).join('') + '</tr>';
+			}).join('');
+
+			/* The descriptions keep every word they had; what changes is their
+			   measure. Three paragraphs across 1070px ran to about 140 characters
+			   a line - roughly twice a readable measure - so they sit as columns
+			   beside each other instead, which is also how they read as a set. */
+			var dbs_notes = databases.map(function(dbname) {
+				return '<div class="paDbNote"><h3>' + Ext.String.htmlEncode(dbname) + '</h3>' +
+				'<p>' + dbs_descriptions[dbname] + '</p></div>';
 			}).join('');
 
 			var dbs_message = {
 				xtype: 'box',
 				cls: "contentbox", minHeight: 240, id: "dbs_message",
-				// The <dl> and the closing sentence were both inside the opening <p>.
-				// A description list is not phrasing content, so the parser closed
-				// that paragraph before the list and left the last sentence in no
-				// paragraph at all - which is why it ignored the card's reading
-				// measure and ran the full width of the box while the first sentence
-				// wrapped at 105 characters.
 				html:
 				'<h2>Multiple databases used</h2>' +
-				'<div>' +
-				'  <p>Your analysis includes the following databases:</p>' +
-				'  <dl id="dbs_dl">' + dl_dbs + '</dl>' +
-				'  <p>The diagrams below combine the matched and unmatched features of <b>all</b> databases. Hover over a diagram for the per-database breakdown.</p>' +
+				'<div class="paDbBody">' +
+				'  <p class="paDbLede">How many of your features carry an identifier each database ' +
+				'is keyed on. Read across a row to compare one omic between databases &mdash; the ' +
+				'bar is that share of the omic\'s input features.</p>' +
+				'  <div class="paDbMatrixWrap">' +
+				'    <table class="paDbMatrix">' +
+				'      <thead><tr><th scope="col">Omic</th>' + dbs_head + '</tr></thead>' +
+				'      <tbody>' + dbs_rows + '</tbody>' +
+				'    </table>' +
+				'  </div>' +
+				'  <div class="paDbNotes">' + dbs_notes + '</div>' +
+				'  <p class="paDbFoot">The diagrams below combine the matched and unmatched features of <b>all</b> databases. Hover over a diagram for the per-database breakdown.</p>' +
 				'</div>'
 			};
 
@@ -434,6 +484,33 @@ function PA_Step2JobView() {
 			compoundsPanelHTML = me.renderCompoundsPanel();
 		}
 
+		/* Compounds disambiguation is a module of this step like any other, so it
+		   goes in the container that holds the modules.
+
+		   It used to live in a form of its own below #omicSummaryPanel. The two
+		   only ever lined up because they happen to share `.omicSummaryContainer`'s
+		   max-width - nothing structural held them on one rail, and the cards
+		   inside it were laid out by the odd/even floats while every other card on
+		   the step had moved to the `:has()` flex row.
+
+		   The form it sat in carried one hidden field, jobID, and
+		   JobController.step2OnFormSubmitHandler adds jobID to the payload
+		   explicitly anyway; the selections are read from the MODEL
+		   (getSelectedCompounds), never from this markup. So there is nothing left
+		   in that form to lose.
+
+		   Not added at all when there is nothing to decide. As a member of the
+		   flex row it claims a full row of its own, so an empty one is 24px of
+		   blank at the end of the step; every caller already guards for the box
+		   being absent (refreshCompoundsPanel, initCompoundsPanelHandlers). */
+		if (compoundsPanelHTML !== "") {
+			omicSummaryPanelComponents.push({
+				xtype: "box", itemId: "compoundsPanelsContainer",
+				cls: "compoundsPanelsContainer",
+				html: compoundsPanelHTML
+			});
+		}
+
 		this.component = Ext.widget({
 			xtype: "container",
 			minHeight: 800,
@@ -450,19 +527,6 @@ function PA_Step2JobView() {
 				cls: "omicSummaryContainer",
 				layout: 'column',  style: "margin-top:50px;",
 				items: omicSummaryPanelComponents
-			}, {
-				xtype: 'form', cls: "omicSummaryContainer",
-				border: 0, style: "margin-top:30px;", defaults: {labelAlign: "right",border: 0},
-				items: [{
-					xtype: "textfield", itemId: "jobIDField",
-					name: "jobID",
-					hidden: true,
-					value: this.model.getJobID()
-				}, {
-					xtype: "box", itemId: "compoundsPanelsContainer",
-					cls: "compoundsPanelsContainer",
-					html: compoundsPanelHTML
-				}]
 			}],
 			listeners: {
 				boxready: function() {
@@ -1335,8 +1399,8 @@ function paClassActivityPlan(omicName, design, omic) {
 * @returns {Boolean}
 */
 function paClassColumnsSideBySide() {
-	// 626 + 24 + 440 inside the card, plus the sidebar and gutters (a 1470px
-	// viewport gives the card 1132px inside).
+	// 26 + 600 + 24 + 446 inside the card, plus the sidebar and gutters (a
+	// 1470px viewport gives the card 1132px inside).
 	return Ext.getBody().getViewSize().width >= 1440;
 }
 
@@ -1412,7 +1476,7 @@ function paClassActivityItems(model, omicName) {
 				getInnerTpl: function (displayField) { return '{' + displayField + ':htmlEncode}'; }
 			},
 			editable: false, allowBlank: false,
-			labelAlign: 'left', labelWidth: 150, width: 420,
+			labelAlign: 'left', labelWidth: 150, width: 380,
 			store: Ext.create('Ext.data.ArrayStore', {
 				fields: ['name', 'value'],
 				data: design.factors.map(function (f) { return [f.label, f.id]; })
@@ -1451,7 +1515,12 @@ function paClassActivityItems(model, omicName) {
 		},
 		labelAlign: 'left',
 		labelWidth: 150,
-		width: 420,
+		/* Short of the panel's content box, which is 410 (446 less 18px of
+		   padding either side). ExtJS hangs the help icon off the
+		   field's own table in a 15px cell and `.x-box-inner` clips at the
+		   container's width, so a field measured to the full 408 had its icon cut
+		   down the middle. */
+		width: 380,
 		store: Ext.create('Ext.data.ArrayStore', {
 			fields: ['name', 'value'],
 			data: [['0.01', 0.01],
@@ -1464,27 +1533,94 @@ function paClassActivityItems(model, omicName) {
 		}),
 		helpTip: "The p-value or FDR cut-off you used to build the relevant-features list. Under \"no member of this class changed\" each member is flagged only by a type-I error, at that rate, so 3 of 4 flagged is p = 0.0005 at 0.05. \"Relative to this job\" instead compares the class with the rest of your panel."
 	});
+	/* The controls panel says what it is and what the number does, the way the
+	   plan beside it does. A combo alone in a panel is a setting with no name
+	   and no consequence on the page - the consequence was in a tooltip, which
+	   is the one place a reader who has not already decided to hover never
+	   looks. */
+	/* Not a second telling of the band below, which already says what each
+	   test needs and what \u201crelative to this job\u201d does. This line is about
+	   the field: which number goes in it. */
+	var controlsNote = design
+		? 'Used only if the permutation test cannot run on this job.'
+		: 'The \u03b1 you built that list at \u2014 the p-value or FDR cut-off, not a fold-change threshold.';
+	var controlItems = [{
+		xtype: 'box',
+		cls: 'paClassSetHead',
+		width: 380,
+		html: '<p class="paClassSet">What you set</p>'
+	}].concat(controls, [{
+		xtype: 'box',
+		cls: 'paClassSetFoot',
+		width: 380,
+		html: '<p class="paClassSetNote">' + controlsNote + '</p>'
+	}]);
+
 	var side = paClassColumnsSideBySide();
-	/* Plan on the left, controls on the right. Every width is configured:
-	   an html box whose width is only known after the layout resolves is
-	   measured without it -- see the note on #classActivityBox. */
+	/* Plan on the left, its controls on the right, as two panels that end level.
+
+	   The controls used to be a bare column: one combo at the top of 440px of
+	   nothing. Giving them a panel of the same build as the plan's fills that
+	   space with the thing that belongs in it and makes the pair read as one
+	   instrument - what will run, and the one number you get to set.
+
+	   Every width is configured: an html box whose width is only known after
+	   the layout resolves is measured WITHOUT it -- see the note on
+	   #classActivityBox. */
 	return [{
 		xtype: 'container',
 		cls: 'paClassTop' + (side ? '' : ' paClassTop-stacked'),
 		layout: {type: side ? 'hbox' : 'vbox', align: side ? 'stretch' : 'left'},
 		items: [{
-			xtype: 'box',
+			/* A CONTAINER, not a box, and the container is the panel.
+
+			   Both columns have to be the same kind of component or they do not
+			   end on the same line. `align: stretch` writes a height onto a
+			   container and takes its border off on the way, and writes nothing at
+			   all onto a plain box - so a bordered container beside a bordered box
+			   came out 2px apart, in whichever direction the taller column
+			   happened to be. Measured both ways: one combo in the panel put the
+			   controls 2px short, two combos put them 2px long. Two containers get
+			   one formula and land on one edge whatever they hold.
+
+			   The html inside carries its own width for the reason the note on
+			   #classActivityBox gives: 600 less 18px of padding either side. The
+			   panel edge is an inset shadow rather than a border, so it takes no
+			   width -- see the note on .paClassPlanCol in main.css. */
+			xtype: 'container',
 			cls: 'paClassPlanCol',
-			width: 626,
-			html: paClassActivityPlan(omicName, design, compoundOmic)
+			width: 600,
+			margin: '4 0 8 26',
+			/* The same layout as the controls opposite, for the same reason as the
+			   same xtype: a vbox and an auto layout account for a container's frame
+			   differently when `align: stretch` writes a height onto it. */
+			layout: {type: 'vbox', align: 'left'},
+			items: [{
+				xtype: 'box',
+				width: 564,
+				html: paClassActivityPlan(omicName, design, compoundOmic)
+			}]
 		}, {
 			xtype: 'container',
 			cls: 'paClassControls',
-			width: 440,
-			margin: side ? '0 0 0 24' : '12 0 0 26',
-			layout: {type: 'vbox', align: 'left'},
+			/* 26 + 600 + 24 + 446 = 1096, which lands the panel's right edge on
+			   1372 - the same edge the band below it ends on, so the card has one
+			   right rail rather than two. */
+			/* Stacked, the two panels are one above the other on one rail, so
+			   they take the same width. 440 was invisible while the controls were
+			   a bare column; as a panel it drew a second right edge 160px short of
+			   the plan's. */
+			width: side ? 446 : 600,
+			/* The same margins as the plan opposite; see the note there for why
+			   both columns are containers. */
+			margin: side ? '4 0 8 24' : '12 0 0 26',
+			/* Centred on the cross axis, so one control sits opposite the test
+			   it belongs to instead of hanging from the top of an empty column.
+			   `pack`, not CSS: an ExtJS box layout writes its children's
+			   positions inline, and no stylesheet outranks that. */
+			layout: {type: 'vbox', align: 'left', pack: side ? 'center' : 'start'},
 			defaults: {border: false},
-			items: controls
+			items: controlItems
 		}]
 	}];
 }

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
@@ -379,6 +379,13 @@ function PA_Step2JobView() {
 			   a line - roughly twice a readable measure - so they sit as columns
 			   beside each other instead, which is also how they read as a set. */
 			var dbs_notes = databases.map(function(dbname) {
+				/* A database with no blurb gets no column, rather than a headed one
+				   reading "undefined". The map is a literal of the four databases the
+				   installers build, but getDatabases() answers from the job, so a
+				   fifth would print the word. The matrix above still counts it. */
+				if (!dbs_descriptions[dbname]) {
+					return '';
+				}
 				return '<div class="paDbNote"><h3>' + Ext.String.htmlEncode(dbname) + '</h3>' +
 				'<p>' + dbs_descriptions[dbname] + '</p></div>';
 			}).join('');
@@ -412,7 +419,9 @@ function PA_Step2JobView() {
 				'      <tbody>' + dbs_rows + '</tbody>' +
 				'    </table>' +
 				'  </div>' +
-				'  <div class="paDbNotes">' + dbs_notes + '</div>' +
+				/* No blurb for any of them, no block: the row carries a top rule, and
+				   an empty one would draw a line under the table for nothing. */
+				(dbs_notes ? '  <div class="paDbNotes">' + dbs_notes + '</div>' : '') +
 				'  <p class="paDbFoot">The diagrams below combine the matched and unmatched features of <b>all</b> databases. Hover over a diagram for the per-database breakdown.</p>' +
 				'</div>'
 			};

--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step2Views.js
@@ -344,7 +344,13 @@ function PA_Step2JobView() {
 			var dbs_omicNames = Object.keys(matchingPerDB[databases[0]] || {});
 
 			var dbs_rows = dbs_omicNames.map(function(omicName) {
-				return '<tr><th scope="row">' + Ext.String.htmlEncode(omicName) + '</th>' +
+				/* title, because the label column is fixed at 210px and clips with an
+				   ellipsis. Omic names come from Step 1 and are routinely longer than
+				   that ("Transcriptomics - liver - 24 h post treatment" measures 308px
+				   against the 246px it is given); in the old wrapping cell they were
+				   always readable, and nothing else on this card carries the name. */
+				return '<tr><th scope="row" title="' + Ext.String.htmlEncode(omicName) + '">' +
+				Ext.String.htmlEncode(omicName) + '</th>' +
 				databases.map(function(dbname) {
 					/* A missing entry means the omic matched nothing in that
 					   database - which is a zero, not an unknown. An empty cell
@@ -387,7 +393,21 @@ function PA_Step2JobView() {
 				'is keyed on. Read across a row to compare one omic between databases &mdash; the ' +
 				'bar is that share of the omic\'s input features.</p>' +
 				'  <div class="paDbMatrixWrap">' +
-				'    <table class="paDbMatrix">' +
+				/* A floor, so the wrapper's overflow-x has something to scroll. The
+				   table is `width: 100%` under `table-layout: fixed`, so without one
+				   it can never be wider than its wrapper - the scroll was dead code -
+				   and each database column just kept shrinking. A cell's contents do
+				   NOT shrink with it: 24 (bar) + 66 (count) + 34 (share) + 24 (gaps)
+				   + 36 (padding) = 184px is a hard minimum, and below that the flex
+				   row overflows LEFT (`justify-content: flex-end`) into the column
+				   beside it. Measured: at a 163px column the numbers already sit on
+				   the omic names, at 103px they spill 63px. Reachable on a 4-database
+				   organism at 1200px, and on any organism in a narrow window.
+
+				   190 per database leaves 6px over that minimum; 210 is the label
+				   column. Inline because it depends on how many databases this job
+				   has, which no stylesheet knows. */
+				'    <table class="paDbMatrix" style="min-width:' + (210 + databases.length * 190) + 'px">' +
 				'      <thead><tr><th scope="col">Omic</th>' + dbs_head + '</tr></thead>' +
 				'      <tbody>' + dbs_rows + '</tbody>' +
 				'    </table>' +
@@ -445,9 +465,15 @@ function PA_Step2JobView() {
 				}, {
 					xtype: 'form',
 					cls: 'paClassMain',
-					/* Configured, not flexed: see the note on #classActivityBox.
-					   Plan and controls side by side need 26 + 626 + 24 + 440. */
-					width: paClassColumnsSideBySide() ? 1116 : 692,
+					/* Configured, not flexed: see the note on #classActivityBox. Plan
+					   and controls side by side need 26 + 600 + 24 + 446 = 1096; this
+					   said 1116, which was the old columns and 20px more than the row
+					   it sizes. Measured at three viewports, ExtJS writes the card's
+					   own inner width here regardless (1122 at 1459, 1171 at 1512), so
+					   the value is the intent for the columns inside rather than the
+					   width that renders - which is all the more reason for it not to
+					   contradict them. */
+					width: paClassColumnsSideBySide() ? 1096 : 692,
 					bodyCls: "divForm",
 					style: "margin: 0 0 4px 0;",
 					layout: {type: 'vbox', align: 'left'},

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.08" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.20" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.15" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.6" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.7" />
@@ -48,7 +48,7 @@
 	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=2.3" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
 	<link rel="stylesheet" type="text/css" href="resources/css/evidence-overlay.css?v=1.0" />
-	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=1.34" />
+	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=1.35" />
 
 	<!-- Theme, resolved before the first paint.
 	     Deliberately inline and here rather than in Util.js: the stylesheets

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.20" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.21" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.15" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.6" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.7" />

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.21" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.22" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.15" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.6" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.7" />

--- a/PaintomicsClient/public_html/resources/css/dark.css
+++ b/PaintomicsClient/public_html/resources/css/dark.css
@@ -1211,23 +1211,37 @@
    --pa-ink-* tokens over a transparent ground, so the token block above is all
    the theming it needs.
 
-   The <dt> database names are included even though they are ink, not surface:
-   at #27272A on the dark card they measured 1.4:1, which is the same defect
-   seen from the other side. */
+   The row labels are included even though they are ink, not surface: at
+   #27272A on the dark card they measured 1.4:1, which is the same defect seen
+   from the other side.
+
+   Header and row label are separated here, which the old markup never had to
+   do: the matrix has a <th> in every row, and the single `table th` rule gave
+   each omic name the grid header's fill - a column of grey chips down the
+   left of the table. */
 [data-theme="dark"] #dbs_message table {
 	background-color: var(--pa-surface-sunken);
 	border-color: var(--pa-border);
 }
-[data-theme="dark"] #dbs_message table th {
+[data-theme="dark"] #dbs_message .paDbMatrix thead th {
 	background-color: var(--pa-grid-header-bg);
 	border-bottom-color: var(--pa-border);
 	color: var(--pa-grid-header-ink);
 }
+[data-theme="dark"] #dbs_message .paDbMatrix tbody th {
+	color: var(--pa-ink-title);
+}
 [data-theme="dark"] #dbs_message table td {
-	border-top-color: var(--pa-border-row);
 	color: var(--pa-ink-body);
 }
-[data-theme="dark"] #dbs_message dt { color: var(--pa-ink-title); }
+[data-theme="dark"] #dbs_message .paDbMatrix tbody tr + tr th,
+[data-theme="dark"] #dbs_message .paDbMatrix tbody tr + tr td {
+	border-top-color: var(--pa-border-row);
+}
+[data-theme="dark"] #dbs_message .paDbPct { color: var(--pa-ink-muted); }
+[data-theme="dark"] #dbs_message .paDbNotes { border-top-color: var(--pa-border); }
+[data-theme="dark"] #dbs_message .paDbNote > h3 { color: var(--pa-ink-title); }
+[data-theme="dark"] #dbs_message .paDbNote > p { color: var(--pa-ink-body); }
 
 /* The compound disambiguation cards. main.css inks every bare h4 #27272A and
    this file answers that card by card rather than with a blanket (the

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -6361,6 +6361,15 @@ div.lateralOptionsPanel-header .toolbarOption.downloadTool:hover {
 	   At 24 this one sat 14px further from the card above it than any other
 	   pair on the page. */
 	margin: 10px 0 0;
+	/* The flex row above is gated on `:has()` and promises that a browser
+	   without it "gets exactly the previous behaviour" - the odd/even floats.
+	   This section used to be structurally immune to that because it lived
+	   outside the column layout; inside it, it is a block following floated
+	   cards. Simulated by dropping the flex off the row: the section came out
+	   at top -174 while the last floated card still ran to -44, i.e. beside it.
+	   `clear` is inert on a flex item, so this costs the supported path
+	   nothing and restores the documented fallback for the rest. */
+	clear: both;
 }
 
 #mainViewCenterPanel.mobileMode div.omicSummaryBox,

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -3428,8 +3428,16 @@ div.contentbox p > #download_mapping_file {
 	margin: 10px 0;
 	width: 100% !important;
 }
-#dbs_message div {
-	padding: 0 var(--pa-card-inset) 10px;
+/* The card body carries the inset once, on the one element that is the body.
+   Unscoped, this reached every nested div in the card and the matrix, its
+   scroll wrapper and each description column each took another 26px.
+
+   It ends on that inset too. Every Step-2 module now leaves --pa-card-inset
+   under its last line, the same measure it leaves left and right; the class
+   activity card was ending on 22px and read pinched against a card whose
+   other three edges were 26. */
+#dbs_message > .paDbBody {
+	padding: 0 var(--pa-card-inset) var(--pa-card-inset);
 }
 /* The class activity card's own blocks are exempt: an hbox cannot lay out
    two children that are both forced to 100%, and the plan and the band
@@ -3438,7 +3446,12 @@ div.contentbox p > #download_mapping_file {
 #threshold_box div:not(.paClassMain):not(.paClassPlanCol):not(.paClassControls):not(.paClassPlan *):not(.paClassHow *),
 #threshold_box span:not(.paClassPlan *):not(.paClassHow *) {
 	border: 0 !important;
-	background-color: white !important;
+	/* The token, not the literal. `white` predates the dark theme and this rule
+	   carries !important, so in dark mode it painted a white slab inside both
+	   config cards - most of the class activity card's controls panel, and the
+	   box behind every combo in the cluster card. --pa-surface is #FFFFFF in
+	   light, so nothing changes there; in dark it is the card's own ground. */
+	background-color: var(--pa-surface) !important;
 	width: 100% !important;
 }
 /* `margin: 0 auto` centred this form in its card, which put the one control
@@ -3463,78 +3476,154 @@ div.contentbox p > #download_mapping_file {
 	   baselines across one row. */
 	margin: 14px 0;
 }
-/* Each database gets a name, a paragraph about it, and the table of what
-   matched in it. The table is the answer the card exists to give, so it is
-   centred under the prose that introduces it rather than left hanging between
-   two unequal margins, and it carries the same treatment as every other table
-   on the results pages - it was the one place left with a pure-black 1px
-   border and cells with no vertical padding. */
-#dbs_message dt {
-	font-weight: 600;
-	font-size: 13px;
-	color: #27272A;
-	/* Flush with the prose and the heading; 5px left the database names five
-	   pixels adrift of every other line in the card. */
-	padding-left: 0;
-	margin-top: 20px;
+/* Each database used to get a name, a paragraph, and its own two-column table
+   of the same omics - centred inside a 1124px card with about 370px of dead
+   space either side. Three identical shapes, 1149px of page, and the reader
+   still had to hold one row in their head while scrolling to the next table
+   to compare it. Comparing the databases is the only reason the card exists,
+   so it is one table: omics down, databases across, and a row is the answer.
+
+   The old `dt`/`dd`/`#matching_table_*` rules went with the markup. */
+#dbs_message .paDbLede {
+	max-width: 72ch;
+	margin: 14px 0 18px;
 }
-#dbs_message dd {
-	margin: 6px 0 0;
+/* A narrow window (or a fourth database) scrolls the table rather than the
+   page: the card must never widen past the column the rest of the step uses. */
+#dbs_message .paDbMatrixWrap {
+	overflow-x: auto;
 }
-/* Same as the results-page card: the prose uses the card's width rather than a
-   reading measure, so it does not sit as a column with empty space beside it. */
-#dbs_message p {
-	max-width: none;
-}
-#dbs_message dd > div[id^="matching_table_"] {
-	display: flex;
-	justify-content: center;
-	padding: 18px 0 6px;
-}
-#dbs_message table {
+#dbs_message table.paDbMatrix {
+	width: 100%;
+	/* Fixed, so the omic names get a label column and the rest of the card goes
+	   to the bars. Auto layout gave the first column the slack - 470px of it -
+	   and left each omic's name a third of the card away from its own numbers. */
+	table-layout: fixed;
 	border: 1px solid var(--pa-border);
 	border-radius: var(--pa-radius);
 	border-collapse: separate;
 	border-spacing: 0;
 	overflow: hidden;
 	background-color: #FFFFFF;
-	min-width: 340px;
-	/* `div[id^=matching_table] table` further down this file centres these
-	   tables, and that inherits into the cells. The <th> below then sets itself
-	   back to `left` while the <td> did not, so "Omic" and "Gene expression"
-	   sat in one column on two different edges - 27px apart here, and a
-	   different 27px in the Reactome table next to it, because centred text
-	   moves with the column width and the two tables hold different numbers.
-	   Set the alignment once on the table; the last-child rule below still
-	   takes the counts back to the right. */
 	text-align: left;
 }
-#dbs_message table th {
-	padding: 9px 18px;
+#dbs_message .paDbMatrix th,
+#dbs_message .paDbMatrix td {
+	padding: 10px 18px;
+	font-size: 12.5px;
+	color: #27272A;
+}
+#dbs_message .paDbMatrix thead th {
 	border-bottom: 1px solid var(--pa-border);
 	background-color: #F9F8F4;
 	color: #52525B;
 	font-size: 11.5px;
 	font-weight: 600;
-	text-align: left;
 	white-space: nowrap;
 }
-#dbs_message table td {
-	padding: 9px 18px;
+/* The omic column is a label column: left, fixed, and it does not wrap. */
+#dbs_message .paDbMatrix th:first-child {
+	width: 210px;
+}
+#dbs_message .paDbMatrix tbody th {
+	font-weight: 600;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+#dbs_message .paDbMatrix tbody tr + tr th,
+#dbs_message .paDbMatrix tbody tr + tr td {
 	border-top: 1px solid #F1F1F3;
-	font-size: 12.5px;
-	color: #27272A;
 }
-/* The first row is the <th> header, so the first data row is the second one -
-   without this it draws a second rule directly under the header's. */
-#dbs_message table tr:nth-child(2) td {
-	border-top: 0;
+/* Counts are magnitudes, so they line up digit for digit under their column
+   head. The share follows each one in muted ink at a fixed width, so the eye
+   reads the column of counts first and the percentages only when it wants
+   them - two columns per database would have made a 3-database job seven
+   columns wide. */
+#dbs_message .paDbMatrix tbody td {
+	text-align: right;
 }
-/* Counts read as a column of magnitudes, so they line up digit for digit. */
-#dbs_message table th:last-child,
-#dbs_message table td:last-child {
+/* Each database's head sits over the left edge of its own cells, which is
+   where the bar starts. Right-aligned it landed over the percentage - the
+   last and least of the three things in the cell - and read as a label for
+   that column rather than for the group. */
+#dbs_message .paDbMatrix thead th + th {
+	text-align: left;
+}
+/* Bar, count, share - one row per cell. The bar takes the slack so the two
+   figures stay on their own rails down the column and the eye can read either
+   the numbers or the shapes. */
+#dbs_message .paDbCell {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 12px;
+}
+#dbs_message .paDbBar {
+	flex: 1 1 auto;
+	min-width: 24px;
+	height: 6px;
+	border-radius: 999px;
+	background: var(--pa-fig-bar);
+	overflow: hidden;
+}
+#dbs_message .paDbBar > i {
+	display: block;
+	height: 100%;
+	border-radius: 999px;
+	background: var(--pa-fig-cell-strong);
+}
+/* A fixed basis, not `auto`. Sized to content, the count column was 45px wide
+   on a row reading 16,466 and 18px on one reading 52 - and the bar, which
+   takes the slack, was 27px longer in the second row. Two bars of different
+   track lengths cannot be compared by eye, which is the one thing a bar is
+   for. Fixed here, `table-layout: fixed` on the table, and every track in the
+   matrix is the same length. */
+#dbs_message .paDbCount {
+	flex: 0 0 66px;
 	text-align: right;
 	font-variant-numeric: tabular-nums;
+}
+#dbs_message .paDbPct {
+	flex: 0 0 34px;
+	text-align: right;
+	color: var(--pa-ink-muted);
+	font-variant-numeric: tabular-nums;
+}
+/* The descriptions keep every word; what changes is the measure. As three
+   paragraphs across the card they ran to about 140 characters a line, which
+   is roughly twice what anyone reads comfortably. As columns they are also
+   what they always were - a set, to be compared. */
+#dbs_message .paDbNotes {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 14px 26px;
+	margin-top: 22px;
+	padding-top: 20px;
+	border-top: 1px solid var(--pa-border);
+}
+#dbs_message .paDbNote {
+	flex: 1 1 220px;
+	min-width: 0;
+	padding: 0;
+}
+#dbs_message .paDbNote > h3 {
+	margin: 0 0 6px;
+	padding: 0;
+	font-size: 12.5px;
+	font-weight: 600;
+	color: #27272A;
+}
+#dbs_message .paDbNote > p {
+	margin: 0;
+	max-width: none;
+	font-size: 12.5px;
+	line-height: 1.5;
+	color: var(--pa-ink-label);
+}
+#dbs_message .paDbFoot {
+	margin: 20px 0 0;
+	max-width: 72ch;
 }
 
 /********************************************************************************
@@ -4812,13 +4901,6 @@ i.masterRegulator:before {
 }
 .step4PathwayThumbnailHover:hover {
 	opacity: 1;
-}
-
-div[id^=matching_table] table {
-	margin: 5px auto;
-	border: 1px solid black;
-	text-align: center;
-	padding: 5px 10px;
 }
 
 /**REUSING THUMBNAILS AT STEP3*/
@@ -6264,6 +6346,21 @@ div.lateralOptionsPanel-header .toolbarOption.downloadTool:hover {
 	flex: 1 1 calc(50% - 22px);
 	min-width: 0;
 	margin: 0;
+}
+
+/* Compounds disambiguation is a member of the same row, and it takes all of
+   it. The rule above sizes `.contentbox` children; this box is not a card but
+   a section - a header card and the grid of compound cards under it - so it
+   needs its own basis or the flex default (`0 1 auto`) shrinks it to its
+   content and parks it beside whatever card came last. */
+.x-column-layout-ct > * > * > .compoundsPanelsContainer {
+	flex: 1 1 100%;
+	min-width: 0;
+	/* 10, the same margin the three full-width cards above carry, so every
+	   module boundary on the step is one measure: 10 + 10 + the row's 10px gap.
+	   At 24 this one sat 14px further from the card above it than any other
+	   pair on the page. */
+	margin: 10px 0 0;
 }
 
 #mainViewCenterPanel.mobileMode div.omicSummaryBox,
@@ -9637,16 +9734,73 @@ div.contentbox .paClassMapKeys li { padding-left: 0; }
 	left: 0 !important;
 	transform: none;
 }
+/* The two panels of the class activity card: the plan and its controls. One
+   rule, because they are one pair - same padding, same radius, same edge.
+
+   What actually puts them on one bottom edge is that both columns are
+   containers with the same vbox layout (see paClassActivityItems). `align:
+   stretch` writes a height onto whichever of them is the SHORTER and leaves
+   the taller at its natural height, and it arrives at that height differently
+   for a plain box than for a container, and differently again for an auto
+   layout than for a vbox - each mismatch tried here left the two 2px apart,
+   in whichever direction the taller column happened to be. Measured with one
+   combo in the controls and with two; both end level.
+
+   The edge is an inset shadow rather than a border so that it stays out of
+   the box model entirely: nothing ExtJS measures has to know about it. */
+#threshold_box .paClassPlanCol,
+#threshold_box .paClassControls {
+	padding: 16px 18px;
+	border: 0;
+	border-radius: 10px;
+	box-shadow: inset 0 0 0 1px var(--pa-border);
+	background: var(--pa-surface);
+}
 #threshold_box .paClassPlan {
 	display: flex;
 	flex-direction: column;
 	gap: 12px;
-	margin: 4px 0 8px 26px;
-	padding: 16px 18px;
-	border: 1px solid var(--pa-border) !important;
-	border-radius: 10px;
-	background: var(--pa-surface);
+	margin: 0;
+	padding: 0;
+	border: 0 !important;
+	background: transparent;
 	color: var(--pa-ink-label);
+}
+/* The controls get a panel of their own, matching the plan's, and the field
+   sits centred in it.
+
+   They used to be a bare 440px column beside the plan: one 40px combo hung
+   from the top with about 150px of empty card underneath it. That is the one
+   control this whole card exists to offer, and with no surface of its own it
+   read as something left in the corner rather than as the decision it is -
+   the same reason the AI offer further down this step was given a panel.
+
+   `align: stretch` on the row makes the two panels end level, so the pair
+   reads as one instrument. The vertical centring is `pack: 'center'` on the
+   layout, not CSS: an ExtJS box layout writes its children's positions
+   inline and no stylesheet outranks that. */
+/* The panel's own kicker and closing line, on the same rails as the plan's.
+   `#threshold_box p` sets 14px margins on every paragraph in this card, so
+   both are restated here rather than inherited into the wrong rhythm. */
+#threshold_box .paClassSet {
+	/* Padding, not margin: `pack: center` centres the SUM of the items' box
+	   heights, and a margin on the paragraph inside a box is not part of that
+	   box - which put the group 18px off centre in its panel. */
+	margin: 0;
+	padding: 0 0 12px;
+	font-size: 10.5px;
+	font-weight: 700;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: var(--pa-ink-label);
+}
+#threshold_box .paClassSetNote {
+	margin: 0;
+	padding: 12px 0 0;
+	font-size: 12.5px;
+	line-height: 1.5;
+	color: var(--pa-ink-label);
+	text-wrap: pretty;
 }
 #threshold_box .paClassPlanKicker,
 #threshold_box .paClassHowTitle,
@@ -9738,7 +9892,11 @@ div.contentbox .paClassMapKeys li { padding-left: 0; }
 #threshold_box .paClassHow {
 	display: flex;
 	flex-direction: column;
-	margin: 0 26px 6px;
+	/* 26 at the bottom, not 6. With the band's own 16px of padding under the
+	   footnote that came to 22px between the last line and the card's edge, on
+	   a card whose other three edges are --pa-card-inset - which is why this
+	   one corner read as pinched while nothing else on the step did. */
+	margin: 0 26px 26px;
 	padding: 18px 24px 16px;
 	border: 1px solid var(--pa-border) !important;
 	border-radius: 10px;
@@ -9816,5 +9974,3 @@ div.contentbox .paClassMapKeys li { padding-left: 0; }
 	line-height: 1.45;
 	color: var(--pa-ink-muted);
 }
-/* Stacked (narrow viewport): the controls sit under the plan, on its rail. */
-#threshold_box .paClassTop-stacked .paClassControls { margin-left: 26px; }

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -6368,8 +6368,15 @@ div.lateralOptionsPanel-header .toolbarOption.downloadTool:hover {
 	   cards. Simulated by dropping the flex off the row: the section came out
 	   at top -174 while the last floated card still ran to -44, i.e. beside it.
 	   `clear` is inert on a flex item, so this costs the supported path
-	   nothing and restores the documented fallback for the rest. */
+	   nothing and restores the documented fallback for the rest.
+
+	   `width` for the same reason and in the same breath: ExtJS gives every
+	   column-layout item `.x-column`, which floats, and a float with `width:
+	   auto` shrink-to-fits. Before the move this section was a block-level
+	   form at full width. `flex-basis` restores that only where the flex row
+	   applies; this restores it where it does not. */
 	clear: both;
+	width: 100%;
 }
 
 #mainViewCenterPanel.mobileMode div.omicSummaryBox,

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -205,7 +205,10 @@ PUBLISHED = {
     # upstream number is both the more informative marker and the one that
     # cannot drift from what is on disk.
     "js/libs/cytoscape/cytoscape.min.js": ("3.34.0", None),
-    "app.js": ("0.4", None),
+    # 0.5 since #113. index.html has said 0.5 since that merge while this table
+    # still said 0.4, so the gate that exists to catch an unbumped marker was
+    # itself red on master -- caught by run_all on this branch, fixed here.
+    "app.js": ("0.5", None),
 }
 
 _SRC = re.compile(r'src="([^"]+?)\?v=([0-9.]+)"')


### PR DESCRIPTION
Step 2 already had a module contract and did not keep it. `Util.js:1044 paTocSections()` defines a module as one `h2` inside one `.contentbox` and builds the left contents list from it — and three of the step's modules broke it, each in a different way. This makes all four keep it, and gives them one rhythm.

## Multiple databases used — 1,149px → 636px

It printed **one two-column table per database**: three identical shapes of the same omics, each centred inside the 1124px card with ~370px of dead space either side, prose running the full width at about 140 characters a line. Comparing the databases is the only reason the card exists, and the reader still had to hold one row in their head while scrolling to the next table to do it.

One table now — omics down, databases across — with a share bar in each cell so the card's width does the comparing. Every bar track is the same length (`table-layout: fixed` plus a fixed basis on the count column), because two bars of different track lengths cannot be compared by eye, which is the only thing a bar is for. The three descriptions keep every word; they become columns rather than three full-width paragraphs.

## Metabolite class activity test

- **The pinched bottom edge.** The band left `16px` of padding plus a `6px` margin under the BRITE footnote — 22px, on a card whose other three edges are `--pa-card-inset` (26). Fixed on the module rather than the card: all three full-width modules now end on the same measure. Measured 27 / 27 / 25.
- **The controls had no surface.** One 40px combo hung from the top of a bare 440px column with ~150px of empty card under it — the one control the card exists to offer. It gets a panel matching the plan's, the field centred in it, and a line naming which number goes in the field instead of leaving that to a tooltip only.
- **The help icon was clipped in half** by `.x-box-inner`, which clips at the container's width while ExtJS hangs the icon off the field's own table.

The two panels end on one line, and getting there was not obvious: `align: 'stretch'` writes a height onto only the **shorter** child, reaches it differently for a `box` than a `container` and differently again per layout, and counts a CSS border as frame. Margin fudges appeared to work and then inverted when the panel gained a second combo. Both columns are now containers with the same vbox layout, and the panel edge is an inset `box-shadow` so it stays out of the box model entirely.

## Compounds disambiguation

It lived in a `form` of its own below `#omicSummaryPanel`; the two lined up only because they happen to share `.omicSummaryContainer`'s max-width, and its cards were laid out by the odd/even floats while every other card on the step had moved to the `:has()` flex row. It is a member of the same container and the same row now, at the same 30px module gap as every other boundary.

Safe to move: `checkForm` and `getSelectedCompounds` read the **model**, and `JobController.step2OnFormSubmitHandler` adds `jobID` to the payload explicitly, so the one hidden field in that form was already dead. Not added at all when there is nothing to decide.

## Fixed on the way

The config cards' blanket rule carried `background-color: white !important`, which predates the dark theme — in dark it painted a white slab through the class activity controls and behind every cluster combo. `--pa-surface` is `#FFFFFF` in light, so nothing changes there.

## Review findings, all reproduced in Chrome before fixing

- **The matrix could not scroll, and its cells overlapped.** `overflow-x: auto` on the wrapper was dead code: the table is `width: 100%` under `table-layout: fixed` with no floor, so `scrollWidth` could never exceed `clientWidth`. A cell's contents do not shrink with the column — 184px is a hard minimum — and under `justify-content: flex-end` the row overflowed **left** into the column beside it. Measured: at a 163px column the numbers already sat on the omic names, at 103px they spilled 63px. Reachable on a four-database organism at 1200px. The table now carries a `min-width` of `210 + 190 per database`; after, columns never drop below 189px, nothing spills at any width, and the wrapper scrolls below 780.
- **The row label was ellipsed with no way to read it** — a fixed 210px column against omic names that come from Step 1 and are routinely longer. It gets a `title`.
- **The form's width constant still described the old columns** (1116 against the new 1096).
- **The compounds section lost the `:has()` fallback** the neighbouring rule documents. Simulated by dropping the flex off the row: the section came out at top −174 while the last floated card still ran to −44 — beside it, not below. `clear` is inert on a flex item, so `clear: both` costs the supported path nothing.

## Verification

Driven in Chrome against a local server on two jobs:

- **STATegra 5-omic** — three databases, binomial branch, 47 ambiguous compounds
- **STATegra metabolomics** — permutation branch, two combos, no cluster card

Step 2 posts and reaches Step 3, and the threshold really arrives: `pa_recover_job` reports `test=binomial, alpha=0.05, nullKind=alpha`. Also checked: bottom insets 27/27/25, the two panels level to the pixel, alignment guides **0 off-rail and 0 off-baseline** at 1512px, 1459px and 1200px, light and dark, the stacked layout below 1440px, the card expander and delegated handlers after the container move, and a clean console. Page height 6,946 → 6,419. Re-verified after rebasing onto `0bfbf64c`, including a fresh Step 2 → Step 3 submit.

## Known limitation, not introduced here

The class-activity columns are fixed widths by design (see the note on `#classActivityBox` — an html box whose width is only known after layout is measured without it). Above ~1470px the card grows but the panel pair does not, so it stops short of the band below it: 26px at 1459, 49px at 1512. That predates this branch; the controls panel's new border just makes it easier to see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DSxnuRvibkFWVDPh8fzD1j
