### PR TITLE
Give the repository the files a second maintainer would need

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,46 @@
+# Code owners for ConesaLab/PaintOmics.
+#
+# The last matching pattern wins, so the default sits first and the paths that
+# are expensive to break follow. Everything is owned by the maintainer today;
+# the explicit entries exist so that a change to one of these paths is always
+# routed for review, whoever opens it and however small the diff looks.
+
+*                                           @TianYuan-Liu
+
+# CI and the composite setup action. A change here can turn the PR gate green
+# without running anything, and cd.yml builds the image and runs the staging
+# smoke test on every push to master.
+/.github/                                   @TianYuan-Liu
+
+# The container stack, nginx/TLS config, entrypoint, smoke test and the species
+# loader. Two constraints in here must not be relaxed (single uWSGI process,
+# MongoDB never published) — see deploy/README.md.
+/deploy/                                    @TianYuan-Liu
+
+# The only pip manifest in the tree. The pins are deliberate, and the Python
+# 3.11 bound is part of them; PaintomicsServer/src/tests/test_dependencies_declared.py
+# enforces that no second manifest reappears.
+/requirements.txt                           @TianYuan-Liu
+
+# Recorded pipeline output. A diff here is either a real behavioural change or a
+# baseline that was regenerated to hide one.
+/tests/baseline/                            @TianYuan-Liu
+
+# R: metagenes, PCA and the MORE regulatory model. Not covered by ruff or the
+# Python tests, and the R side has produced silent wrong-output bugs before.
+*.R                                         @TianYuan-Liu
+/PaintomicsServer/src/common/bioscripts/    @TianYuan-Liu
+
+# Species download/install tooling. A defect here corrupts installed pathway
+# data, and reinstalling a species is measured in hours and gigabytes.
+/PaintomicsServer/src/AdminTools/           @TianYuan-Liu
+
+# The configuration contract: every secret is read from the environment with an
+# empty default, and the example files are what a self-hoster reads.
+/PaintomicsServer/src/resources/example_serverconf.py  @TianYuan-Liu
+/PaintomicsServer/.env.example              @TianYuan-Liu
+
+# Security policy and the lint/secret-scanning configuration.
+/SECURITY.md                                @TianYuan-Liu
+/ruff.toml                                  @TianYuan-Liu
+/.gitleaks.toml                             @TianYuan-Liu

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,167 @@
+name: Bug report
+description: Something in PaintOmics did not work, or produced a result you can show is wrong.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Most reports we cannot act on are missing the same few facts: which job it was,
+        which organism, and what the input file looked like. The fields below ask for them.
+
+        This issue is public. Do not paste data you cannot publish. If the bug can only be
+        shown with data you cannot share, open the issue with everything except the data
+        and send the file to paintomicsai@gmail.com, naming the issue number.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you did, and what PaintOmics did in response. Include the exact error text if there was one.
+      placeholder: |
+        Uploaded three omic files, clicked "Run PaintOmics", and the job stopped at
+        "Matching identifiers" with the message ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-expected
+    attributes:
+      label: What you expected instead
+    validations:
+      required: true
+
+  - type: input
+    id: job-id
+    attributes:
+      label: Job ID
+      description: >-
+        The job identifier. It is in the address bar of the results page as `?jobID=...`,
+        and in the "Job ID" column of the "My jobs" table. If the job never got created,
+        write "no job".
+      placeholder: e.g. YoLTIjvH6t
+    validations:
+      required: true
+
+  - type: dropdown
+    id: step
+    attributes:
+      label: Where in the workflow it happened
+      description: >-
+        The interface numbers three steps. "Pathway visualization" is the single-pathway
+        view you reach by opening a pathway from the step 3 results.
+      options:
+        - Step 1 - Upload and run (organism / databases / file upload)
+        - Step 2 - Identifier and name matching (mapping summary and compound disambiguation)
+        - Step 3 - Explore results (enrichment / networks / hub / class activity / metagenes)
+        - Pathway visualization (a single pathway diagram and its heatmaps)
+        - AI interpretation
+        - Regions to Genes or miRNA to Genes conversion
+        - My jobs or file management
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: organism
+    attributes:
+      label: Organism
+      description: >-
+        The organism you selected, as it appears in the picker. Write "not applicable" if
+        the bug does not involve an analysis.
+      placeholder: e.g. Mus musculus (mmu)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: omics
+    attributes:
+      label: Omic types submitted
+      description: Every omic panel present in the job, not only the one that failed.
+      multiple: true
+      options:
+        - Gene expression
+        - Metabolomics
+        - Proteomics
+        - Regulatory Omic
+        - Region-based omic
+        - Other omics
+    validations:
+      required: true
+
+  - type: dropdown
+    id: databases
+    attributes:
+      label: Pathway databases selected
+      description: KEGG is always included; tick every other database that was ticked in step 1.
+      multiple: true
+      options:
+        - KEGG
+        - Reactome
+        - MapMan
+        - OmniPath
+    validations:
+      required: true
+
+  - type: textarea
+    id: input-head
+    attributes:
+      label: First two lines of the input file
+      description: >-
+        The header line and the first data line of the file the bug involves, pasted as text
+        rather than as a screenshot. Two lines are enough to show the separator, the identifier
+        type and the column layout. Do not paste unpublished data - replace the identifiers and
+        values with made-up ones that keep the same shape, or send the real file to
+        paintomicsai@gmail.com instead. Write "not applicable" if the bug does not involve
+        an input file.
+      render: text
+      placeholder: |
+        #NAME	Control_1	Control_2	Treated_1	Treated_2
+        ENSMUSG00000000001	1.24	1.31	-0.88	-0.91
+    validations:
+      required: true
+
+  - type: dropdown
+    id: instance
+    attributes:
+      label: Which instance
+      options:
+        - https://paintomics.uv.es/
+        - A self-hosted instance
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version, if self-hosted
+      description: >-
+        The commit you deployed - `git rev-parse --short HEAD` in your checkout - or the image
+        tag you built. Leave blank if you used paintomics.uv.es.
+      placeholder: e.g. 97260ce1
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and version
+      description: The full version string, from the browser's About dialog.
+      placeholder: e.g. Chrome 139.0.7258.67 on macOS 15.5
+    validations:
+      required: true
+
+  - type: textarea
+    id: console
+    attributes:
+      label: Browser console output
+      description: >-
+        Optional, and useful when the interface misbehaves rather than the analysis. Open the
+        developer tools console, reproduce the problem, and paste what appears.
+      render: text
+
+  - type: checkboxes
+    id: data-check
+    attributes:
+      label: Before you submit
+      options:
+        - label: The lines I pasted above contain nothing I am not free to publish.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://paintomics.readthedocs.io/en/latest/
+    about: How the analyses work, what the input formats are, and how to install your own instance.
+  - name: Email the team
+    url: mailto:paintomicsai@gmail.com
+    about: Questions about using PaintOmics on your data, collaborations, and anything you cannot post publicly.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Propose a change that would let you answer a question PaintOmics cannot answer today.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: The analysis or workflow problem
+      description: What you are trying to find out, and where PaintOmics stops short.
+    validations:
+      required: true
+
+  - type: textarea
+    id: today
+    attributes:
+      label: What you do today instead
+      description: >-
+        The workaround, whether that is another tool, a script, or exporting the results and
+        finishing the work by hand.
+    validations:
+      required: true
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: What a good outcome looks like
+      description: >-
+        What you would see on the screen, or get in the output, if this worked. Be concrete;
+        it does not have to be a design.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/organism_request.yml
+++ b/.github/ISSUE_TEMPLATE/organism_request.yml
@@ -1,0 +1,76 @@
+name: Organism request
+description: Ask for an organism to be installed on the public instance, or for help installing one yourself.
+title: "[Organism]: "
+labels: ["organism request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Any organism present in KEGG, Reactome or MapMan can be installed. Installing one means
+        building its pathway, identifier and annotation tables, so the answers below decide
+        what has to be built and whether your own identifiers will map onto it.
+
+  - type: input
+    id: species
+    attributes:
+      label: Species scientific name
+      description: Genus and species, plus the strain or cultivar if it matters.
+      placeholder: e.g. Danio rerio
+    validations:
+      required: true
+
+  - type: input
+    id: taxid
+    attributes:
+      label: NCBI taxonomy ID
+      description: >-
+        From https://www.ncbi.nlm.nih.gov/taxonomy. Give the strain-level ID if you need a
+        specific strain rather than the species.
+      placeholder: e.g. 7955
+    validations:
+      required: true
+
+  - type: dropdown
+    id: databases
+    attributes:
+      label: Databases needed
+      description: >-
+        Tick every database you need pathways from. KEGG is always installed; Reactome and
+        MapMan cover different sets of organisms, so name the ones your analysis depends on.
+      multiple: true
+      options:
+        - KEGG
+        - Reactome
+        - MapMan
+    validations:
+      required: true
+
+  - type: input
+    id: identifiers
+    attributes:
+      label: Identifier type your data uses
+      description: >-
+        The identifiers in the first column of your own files - for genes and, if you have
+        them, for metabolites. This is what has to map onto the installed species.
+      placeholder: e.g. Ensembl gene IDs (ENSDARG...) for genes, KEGG compound IDs for metabolites
+    validations:
+      required: true
+
+  - type: dropdown
+    id: instance
+    attributes:
+      label: Where you will run the analysis
+      options:
+        - https://paintomics.uv.es/
+        - A self-hosted instance
+        - Both
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Anything else
+      description: >-
+        Optional. The experiment, the omic layers you have, or an annotation source you would
+        like used.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,8 +36,15 @@ updates:
     commit-message:
       prefix: "deps"
 
+  # Two directories: "/" reaches .github/workflows, and the composite action has
+  # to be named separately -- dependabot does not recurse into
+  # .github/actions/*/action.yml, and that file pins six actions of its own. It
+  # is also the file CODEOWNERS singles out as able to turn the gate green
+  # without running anything, so it is the last one that should go unwatched.
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/setup-paintomics"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+# Dependabot configuration.
+#
+# The pip manifest is `/requirements.txt`, and it is the only one in the tree.
+# `PaintomicsServer/src/requirements.txt` used to be a second, conflicting copy
+# (CairoSVG 2.4.2 vs 2.7.0, Pillow 8.0.1 vs 10.3.0). It was first reduced to a
+# bare `-r ../../requirements.txt` include and then deleted outright on
+# 2026-08-11: GitHub's dependency graph cannot parse a manifest that only
+# includes another one, so it kept serving the last snapshot it had managed to
+# read — the 2020 pins — and raised 33 Dependabot alerts against versions
+# nothing had installed for months. `PaintomicsServer/src/tests/
+# test_dependencies_declared.py` now enforces that a second manifest does not
+# come back, so pointing pip at "/" is enough and adding another directory here
+# would recreate the problem.
+#
+# The pins in requirements.txt are deliberate — the comment at the top of that
+# file explains which ones hold the interpreter at Python 3.11 and why. Read it
+# before merging a major bump; a green PR here is not evidence that the
+# scientific stack still behaves the same.
+#
+# Updates are grouped so that a week produces one pull request per ecosystem
+# rather than a dozen.
+
+version: 2
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      python:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 2
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## What changed, and why
+
+<!-- The reason matters more than the diff. If it fixes a bug, say what the bug
+     did and how it was reproduced. Link the issue if there is one. -->
+
+## How it was verified
+
+<!-- Name what you drove and what you saw: the page, the job, the request, the
+     dataset. Passing tests is not verification on its own — a UI or server
+     change has to be exercised in a running instance (CLAUDE.md, section 5),
+     against a restarted server. Screenshots or console output welcome. -->
+
+- [ ] Exercised in a running instance, not only in tests
+
+## Things that are easy to miss
+
+- [ ] Any hand-versioned asset I edited in `PaintomicsClient/public_html/index.html`
+      got its `?v=` bumped
+      (`cd PaintomicsServer && python -m src.tests.test_versioned_assets_are_bumped`)
+- [ ] `tests/baseline/` is unchanged, **or** the diff is explained below
+
+<!-- If a baseline moved, say which datasets and why the new numbers are the
+     correct ones. A regenerated baseline that hides a behavioural change is the
+     failure mode this question exists to catch. -->
+
+**Needs a species reinstall?** <!-- yes / no. If yes: which species, and which
+DBManager.py step (download, install). -->
+
+**Needs a new or changed config setting?** <!-- yes / no. If yes: name the
+variable and say what happens on a deployment that does not set it — it has to
+reach `example_serverconf.py` and `deploy/env.example` too. -->

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,6 +67,23 @@ jobs:
       # here instead, and the duplicate pass over the other 467 is gone.
       - name: The one file ruff does not parse
         run: python -m compileall -q scripts/ci/vulture_whitelist.py
+      # `gate` carries a hand-written `needs:` list and branch protection
+      # requires only `gate`. A seventh job added below and forgotten there
+      # would report success without waiting for it -- the same silent
+      # degradation `gate` itself exists to prevent, one level up.
+      - name: The gate waits on every job in this workflow
+        run: |
+          python -m pip install --quiet pyyaml
+          python - <<'CHECK'
+          import sys, yaml
+          jobs = yaml.safe_load(open(".github/workflows/pr.yml"))["jobs"]
+          waits_on = set(jobs["gate"].get("needs") or [])
+          missing = set(jobs) - waits_on - {"gate"}
+          if missing:
+              print("::error::gate does not wait on: " + ", ".join(sorted(missing)))
+              sys.exit(1)
+          print("gate waits on all %d other jobs" % len(waits_on))
+          CHECK
 
   unit-tests:
     # Two shards: the single job crept from 7 to 10 minutes as suites were
@@ -165,7 +182,7 @@ jobs:
           python-version: "3.11"
       - name: Build the documentation
         run: |
-          python -m pip install --quiet -r docs/requirements.txt
+          python -m pip install --quiet -r docs/mkdocs-pins.txt
           mkdocs build --strict --site-dir "${RUNNER_TEMP}/site"
 
   gate:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,8 +1,11 @@
-# Pull-request gate: lint, the unit-test sweep, and the fastest example
-# dataset of each pipeline class through the regression harness.
+# Pull-request gate: lint, the unit-test sweep, the fastest example dataset of
+# each pipeline class through the regression harness, a secret scan and a
+# documentation build.
 #
-# Budget: under 10 minutes wall clock. The three jobs run in parallel, so the
-# wall clock is the slowest of them; each has a hard timeout below it.
+# Budget: under 10 minutes wall clock. The five jobs run in parallel, so the
+# wall clock is the slowest of them; each has a hard timeout below it. A sixth
+# job, `gate`, waits on the other five and is the single status check that
+# branch protection on master requires -- see the comment on it below.
 #
 # No secrets. The pipeline jobs restore the species-data snapshot from the
 # Actions cache (seeded by data-cache.yml) and run with outbound networking
@@ -128,3 +131,61 @@ jobs:
           path: ${{ runner.temp }}/regression
           retention-days: 7
           if-no-files-found: ignore
+
+  secret-scan:
+    # gitleaks over the checked-out tree. Not the history: a full-history scan
+    # is minutes per pull request and the history is scanned once, out of band.
+    # GitHub's push protection catches provider-pattern secrets before they
+    # reach a branch; this catches what a bespoke config would otherwise miss.
+    name: Secret scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          curl -fsSL -o gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          tar -xzf gitleaks.tar.gz gitleaks
+          ./gitleaks dir . --config .gitleaks.toml --redact --no-banner
+
+  docs:
+    # mkdocs --strict, so a page that is added to docs/ but left out of the
+    # nav, or a link that points at nothing, fails here instead of quietly
+    # never appearing on the published site.
+    name: Docs build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build the documentation
+        run: |
+          python -m pip install --quiet -r docs/requirements.txt
+          mkdocs build --strict --site-dir "${RUNNER_TEMP}/site"
+
+  gate:
+    # One status check for branch protection to require. The unit-test job is a
+    # matrix, so its check names carry the shard ("1/2") and change whenever the
+    # shard count does -- a ruleset pinned to those names would silently stop
+    # gating the moment the matrix is edited. This job's name never changes.
+    name: Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    needs: [lint, unit-tests, fixtures, secret-scan, docs]
+    if: always()
+    steps:
+      - name: Every gate job succeeded
+        run: |
+          results="${{ join(needs.*.result, ' ') }}"
+          echo "job results: ${results}"
+          for result in ${results}; do
+            if [ "${result}" != "success" ]; then
+              echo "::error::the pull-request gate did not pass (${results})"
+              exit 1
+            fi
+          done

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,5 +1,12 @@
 title = "Paintomics secret scanning"
 
+# `useDefault` is what makes this configuration scan for anything at all.
+# Without it gitleaks loads no rules and reports a clean tree however many keys
+# are in it -- this file had an [allowlist] and no rules from its introduction
+# until 2026-08-31, so it would have passed everything had anything run it.
+[extend]
+useDefault = true
+
 [allowlist]
 description = "Ignore third-party/vendor and minified code to reduce false positives"
 paths = [
@@ -11,4 +18,7 @@ paths = [
   '''^\.idea/'''
 ]
 
-# You can run: gitleaks detect --config=.gitleaks.toml
+# Run it the way the pull-request gate does:
+#   gitleaks dir . --config .gitleaks.toml --redact
+# Over the whole history (slow, run out of band):
+#   gitleaks git . --config .gitleaks.toml --redact --log-opts="--all"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,14 +8,26 @@ title = "Paintomics secret scanning"
 useDefault = true
 
 [allowlist]
-description = "Ignore third-party/vendor and minified code to reduce false positives"
+description = "Vendored code, and the gitignored files a working instance has"
+# `gitleaks dir` walks the filesystem and does NOT honour .gitignore, so without
+# the second group below the documented local command reports leaks on every
+# correctly configured developer machine -- from the very files SECURITY.md
+# tells operators to create. Each path here is gitignored (see .gitignore lines
+# 81, 90 and 99), so nothing allowlisted can ever be committed and this cannot
+# mask a real leak. CI is unaffected either way: actions/checkout produces a
+# tree with none of these files in it.
 paths = [
   '''^PaintomicsClient/public_html/js/libs/''',
   '''^PaintomicsClient/public_html/admin/lib/bootstrap/node_modules/''',
   '''^.*node_modules/''',
   '''^.*vendor/''',
   '''^.*\.min\.js$''',
-  '''^\.idea/'''
+  '''^\.idea/''',
+  # gitignored, and therefore uncommittable, secret locations
+  '''^(.*/)?\.env$''',
+  '''(^|/)conf/serverconf\.py$''',
+  '''(^|/)conf/local_serverconf\.py$''',
+  '''^deploy/nginx/certs/'''
 ]
 
 # Run it the way the pull-request gate does:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,4 +18,4 @@ python:
   install:
     # The docs toolchain only. The root requirements.txt is the application
     # manifest and is not installed here.
-    - requirements: docs/requirements.txt
+    - requirements: docs/mkdocs-pins.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# Read the Docs build configuration, so the docs build is defined by this
+# repository instead of by settings in the Read the Docs web interface.
+# Reference: https://docs.readthedocs.io/en/stable/config-file/v2.html
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+mkdocs:
+  configuration: mkdocs.yml
+  # Warnings are errors: a page missing from the nav or a link that resolves to
+  # nothing fails the build instead of shipping.
+  fail_on_warning: true
+
+python:
+  install:
+    # The docs toolchain only. The root requirements.txt is the application
+    # manifest and is not installed here.
+    - requirements: docs/requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,116 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+PaintOmics AI has not been cut as a numbered release yet, so everything since
+PaintOmics 4 is listed under Unreleased. Entries reference the pull request that
+merged them where one exists.
+
+## [Unreleased]
+
+### Added
+
+- AI interpretation of the ranked pathways: an agent reads the cross-omic patterns, searches PubMed, and drafts the biology with numbered citations that link back to the source record.
+- A verification stage over that draft, which checks every claim and quotation against the retrieved papers and redacts what it cannot ground rather than publishing it.
+- Interpretation of pathways inside their shared-feature clusters, with the Step 3 pathway network coloured by the same clusters and a legend that explains the cluster ids.
+- A Results-section view of the interpretation, written the way a paper would write it and keeping every citation, and an activity feed showing which tools the agent is calling while it works.
+- An AI input-format converter that checks every upload against the server's contract, offers one-click deterministic repairs for mechanical faults, and can rewrite a file the analysis cannot read (#67, #72).
+- The MORE regulatory model behind a method chooser in Regulatory Omics, with three engines: PLS1 on a Rust port, PLS1 on R, and MLR on R (#44).
+- A refusal at submit time for a MORE job not predicted to fit inside the queue's timeout, with a cost estimate the operator can calibrate to the host (#45).
+- A Step 3 regulator-target network drawn with Cytoscape.js, with free layout, per-condition colouring, search, spotlight, side panel and exports.
+- Regulation-per-condition tables beside that network, a "Find in pathways" hand-off from them into the pathway view, and a user-selectable per-omic minimum variation filter for MORE.
+- Multi-condition designs: analyses run across any number of conditions rather than two, with per-condition significance stars in the Step 4 heatmaps, in Metabolite Hub and in Class Activity, and a Stouffer weights panel for the combined p-value.
+- Replicate-to-sample aggregation in both the pathway visualization and MORE, with the experiment design drafted from your column headers before a job exists.
+- A metabolite class activity analysis drawn as a levelled class map, testing whether a class responds on replicates when the data has them (#96, #101, #105).
+- A Step 2 disambiguation step that lets you choose which compound an ambiguous metabolite name meant (#88).
+- A metabolite hub network derived from the KEGG graph and drawn in the interface (#89).
+- An evidence overlay that draws MORE relationships on the pathway diagram as a provenance-labelled layer (#52), including regulators the diagram itself does not print (#84).
+- OmniPath as a fourth pathway database source (#43), rice (osa) as a MapMan species (#42), and installation of custom species from a gene-to-KO annotation table.
+- Bundled example datasets built from a seeded, manifest-driven generator, with the pathways the enrichment should recover listed alongside the files, and **Load example** for Regions2Genes, miRNA2Genes and MORE as well as pathway acquisition.
+- A dark theme with a toggle in the header, a contents sidebar on the results page that follows the database tab in view, and an organism picker that ranks results by what was typed rather than by prefix match (#75).
+- A Docker Compose deployment (nginx/TLS, application, MongoDB), a post-deployment smoke test, an operator runbook, species installation from the command line, and a view of the requests users have sent in, in the admin panel (#54).
+- Continuous integration: a pull-request gate, a nightly regression run against recorded baselines, staging deployment on merge, and an on-demand profiling workflow.
+- Test coverage that had not existed: an import smoke test over every tracked module, an end-to-end enrichment run against a real installed species, the real R backend instead of a double, and a check that an edited asset gets its cache marker bumped.
+
+### Changed
+
+- The application is renamed PaintOmics AI, the successor to PaintOmics 4.
+- Navigation moved into the header and the left rail was removed.
+- The interface runs on one token-based design system for surfaces, shapes and type, with a single typeface and WCAG AA contrast throughout; the landing page, the application mark and the account dialogs were redrawn, and the ExtJS dialogs, tables and upload controls modernized.
+- The running-job spinner was replaced with a progress bar that only moves forward and reports what the job is doing.
+- The heatmap colour scale was rebuilt against the range the data actually occupies, and the same ramp now paints the pathway diagrams (#63, #92).
+- The platform moved to Python 3.11, Flask 3, and pymongo 4 against MongoDB 7, with the imaging and HTTP stacks upgraded onto versions carrying their security fixes, and dependencies declared in one pinned `requirements.txt` at the repository root.
+- The AI interpretation was reimplemented on the OpenAI Agents SDK, replacing the earlier threaded pipeline, and PMID markers are rendered as numbered references.
+- The analysis pipeline was profiled and made faster: batched cross-reference lookups, one shared fork-aware MongoDB client, a cached GTF annotation, and metagene R scripts run per omic in parallel (#33).
+- Step 2 was rebuilt as one module system — a databases matrix, a levelled class-activity pair, and compound disambiguation inside the grid (#111, #114) — and Browse now lives inside the file field (#110).
+- Every Step 1 file row now says whether the job requires that file (#108), and the database checkboxes are drawn from what the server has actually installed.
+- Jobs are kept for as long as the interface says they will be, and no longer (#65), and the contact address is now `paintomicsai@gmail.com`.
+
+### Fixed
+
+- Enrichment counting inflated `totalMatched`, changing which pathways were reported as significant.
+- Step 3's hub scorer used the enrichment denominator instead of its own, and Benjamini-Hochberg is now applied across the whole p-value vector rather than piecewise.
+- Non-finite p-values were carried into the FDR correction and into the combination step, where a single NaN produced a NaN result; they are now dropped first, and the combining statistics were checked against SciPy.
+- Multi-condition analyses crashed at four separate p-value sites, were impossible from five conditions upward, propagated the adjusted combined p-value for only one condition instead of all of them, and the Stouffer weights panel could not be operated and blanked the p-values it was meant to reweight.
+- Metagene clustering was not reproducible for an identical job and produced identical, lopsided clusters, and an R drop-to-vector bug silently killed metagenes for whole omic and database pairs.
+- The pathway interaction network divided matched compounds by the gene count, so a metabolomics-only job drew almost nothing (#113).
+- A compound omic reported more mapped features than it contained, and features cloned across databases doubled their omic values.
+- Reactome class enrichment was computed and then discarded after every analysis, and features were marked eligible for a hardcoded pair of databases rather than for every database selected.
+- An analysis that matched nothing died with a division error, and the metagenes step crashed on an empty file instead of saying nothing matched (#97).
+- A relevance-file header heuristic that only worked for Arabidopsis was replaced with an organism-agnostic one, and a legacy two-column parser dropped the suffix from every row after the first, costing 14 pathways.
+- Identifiers that sit two hops away in the cross-reference graph were unreachable, so features that needed an intermediate database were reported as unmapped (#49), and a symbol lookup returned 38 rows for the 13 genes asked for, duplicating features downstream.
+- An empty identifier was used as a join key, and association rows were written without a target gene identifier (#95).
+- Gene-based jobs crashed outright on dme, bta, ptr and acs (#85), and four further species had no KEGG table speaking their identifiers (#87).
+- MORE truncated regulator identifiers that began with the omic name, and read an empty matrix out of a comma-delimited file or one with duplicate identifiers.
+- Reactome pathway views showed the input identifier instead of the matched gene symbol (#37), Step 4 showed TAIR/AGI identifiers instead of symbols, gene symbols containing `#` broke metagene generation (#40), and a species lost its MapMan bins when KEGG had no NCBI gene ID conversion for it (#29).
+- The miRNA2Genes example could not run and mislabelled the conditions in its output, and Regions2Genes did not read relevant regions, opened files in the wrong mode, and silenced its own module loggers.
+- The pymongo 4 migration of the DAO layer fixed a state in which no job could be saved at all, and a status poll could break the job store; a job is now serialised from a snapshot.
+- Two simultaneous submissions lost one job and ran the other twice, a second Step 1 submit is now refused (#30), and a failed job blocked its own id until the server restarted instead of being resubmittable.
+- Deleting one job wiped another job's data, and deleting a Regions2Genes or miRNA2Genes job only appeared to delete it.
+- A blank line in an input file killed the job, a metabolite file of dashes could take down the server, CSV uploads with a byte-order mark were rejected, and the data-management tools did not apply the encoding handling the main upload does.
+- Omics whose files disagreed on their conditions were read one at a time and refused (#99).
+- The Other data type panel could never be submitted: the picked file type was stored as null and an optional field was required (#109).
+- A refused Step 1 form said nothing about which field was wrong, and deleted the panel it was blaming (#90, #93, #112).
+- A large pathway export exceeded Werkzeug's form-memory limit, image export was capped and lossy (#47), and pathway PNG download broke on the CairoSVG upgrade.
+- The AI status poll retried a session that could not come back, and the References section printed out of citation order (#36).
+- A user report was lost when the mail provider was down; reports are now stored before delivery is attempted (#50).
+- The hub graph hid 64 of its 72 edges (#102), and a hub node was asked for a single direction instead of showing one wedge per condition (#104).
+- The class map's hover readout resized the caption and oscillated under the cursor (#100), resetting to the landing page left detached job views alive (#82), the "Neighbouring features" button did not answer every click (#39), and a Step 4 tooltip failed on an unnamed event (#19).
+- The KEGG organism list download broke when KEGG retired `/list/organism`, and the Reactome installer cached error bodies as data and downloaded every pathway's node JSON twice.
+- Species installation discarded its own hub analysis data and a KEGG or Reactome rebuild deleted every OmniPath pathway; every install step is now idempotent, so a rerun skips finished work and cannot lose files it does not replace.
+- Three broken links were repaired, including a "Cite PaintOmics 4" link that pointed at the wrong paper.
+
+### Security
+
+- Path traversal was closed on both routes that took a name from the request: a job id could name a directory tree to delete, and a file name could name a file outside the user's directory.
+- Forgeable user identity was fixed, covering both the `userID=0` bypass and reuse of a retired id.
+- Session and password-reset tokens are drawn from `secrets` rather than `random`.
+- Per-request authorisation guards were added where they were missing: re-running step 2 on someone else's job, writing an image into a job's directory, reading someone else's AI report (#62), and the admin and read-only routes.
+- The session check that every other handler in its family performed had been skipped by SaveImage, and is restored.
+- Password hashes are no longer sent to the admin users panel, and a password change could land on another user's account.
+- AI consent is enforced on the server before anything is sent to the LLM service, and the three other routes around the consent check were closed.
+- The AI report's HTML is sanitised before rendering, and a server error response is parsed rather than evaluated.
+- A MongoDB cleanup routine leaked data across users (#12).
+- Committed secrets were removed, the live server configuration untracked, and a release-hygiene test now fails the suite if a secret is committed again.
+- Dependency upgrades across Flask, Pillow, CairoSVG and the HTTP stack bring in their published security fixes.
+
+### Removed
+
+- The left navigation rail, replaced by navigation in the header.
+- R from the metabolite hub analysis, which now runs on the derived KEGG graph (#89).
+- Vendored build toolchains that nothing installed or served, and a second `requirements.txt` that was raising 33 phantom dependency alerts.
+- The six-phase AI workflow arm, superseded by the agent workflow.
+- Dead code across the server, including the 154 rows the audit marked for deletion and the eight star imports in the application entry point.
+
+## PaintOmics 4 and earlier
+
+Release history up to PaintOmics 4 is not restated here. It was recorded in the
+[`CHANGELOG`](CHANGELOG) file in this repository, whose last entry is
+`Changelog (v0.4.4) - 2017-04-28`, and in the papers that describe each release:
+
+- **PaintOmics 4** — *Nucleic Acids Research* (2022), [10.1093/nar/gkac352](https://doi.org/10.1093/nar/gkac352)
+- **PaintOmics 3** — *Nucleic Acids Research* (2018), [10.1093/nar/gky466](https://doi.org/10.1093/nar/gky466)
+- **PaintOmics 2** — *Bioinformatics* (2011), [10.1093/bioinformatics/btq594](https://doi.org/10.1093/bioinformatics/btq594)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,105 @@
+cff-version: 1.2.0
+message: >-
+  If you use PaintOmics in your work, please cite the PaintOmics 4 article in
+  Nucleic Acids Research listed under preferred-citation.
+title: PaintOmics AI
+type: software
+abstract: >-
+  PaintOmics takes several omic measurements from the same experiment —
+  transcriptomics, proteomics, metabolomics, region-based assays such as
+  ChIP-seq or Methyl-seq, and regulatory layers such as miRNA or transcription
+  factors — and paints them together onto biological pathways, so that the
+  layers can be read against each other rather than one at a time. It supports
+  KEGG, Reactome and MapMan pathways for organisms across all biological
+  kingdoms. PaintOmics AI is the successor to PaintOmics 4 and adds an AI
+  interpretation agent that drafts the biology from the ranked pathways with
+  citations that are checked back against the retrieved literature.
+authors:
+  - given-names: Tianyuan
+    family-names: Liu
+    orcid: https://orcid.org/0000-0002-8561-6239
+  - given-names: Pedro
+    family-names: Salguero
+    orcid: https://orcid.org/0000-0002-1879-3374
+  - given-names: Marko
+    family-names: Petek
+    orcid: https://orcid.org/0000-0003-3644-7827
+  - given-names: Carlos
+    family-names: Martinez-Mira
+  - given-names: Leandro
+    family-names: Balzano-Nogueira
+    orcid: https://orcid.org/0000-0003-4620-3607
+  - given-names: Živa
+    family-names: Ramšak
+    orcid: https://orcid.org/0000-0003-0913-2715
+  - given-names: Lauren
+    family-names: McIntyre
+  - given-names: Kristina
+    family-names: Gruden
+  - given-names: Sonia
+    family-names: Tarazona
+  - given-names: Ana
+    family-names: Conesa
+    orcid: https://orcid.org/0000-0001-9597-311X
+repository-code: https://github.com/ConesaLab/PaintOmics
+url: https://paintomics.uv.es/
+license: GPL-3.0-or-later
+contact:
+  - email: paintomicsai@gmail.com
+    name: PaintOmics team
+keywords:
+  - multi-omics
+  - pathway analysis
+  - data integration
+  - visualization
+  - KEGG
+  - Reactome
+  - MapMan
+  - bioinformatics
+  - systems biology
+  - metabolomics
+  - transcriptomics
+preferred-citation:
+  type: article
+  title: >-
+    PaintOmics 4: new tools for the integrative analysis of multi-omics datasets
+    supported by multiple pathway databases
+  authors:
+    - given-names: Tianyuan
+      family-names: Liu
+      orcid: https://orcid.org/0000-0002-8561-6239
+    - given-names: Pedro
+      family-names: Salguero
+      orcid: https://orcid.org/0000-0002-1879-3374
+    - given-names: Marko
+      family-names: Petek
+      orcid: https://orcid.org/0000-0003-3644-7827
+    - given-names: Carlos
+      family-names: Martinez-Mira
+    - given-names: Leandro
+      family-names: Balzano-Nogueira
+      orcid: https://orcid.org/0000-0003-4620-3607
+    - given-names: Živa
+      family-names: Ramšak
+      orcid: https://orcid.org/0000-0003-0913-2715
+    - given-names: Lauren
+      family-names: McIntyre
+    - given-names: Kristina
+      family-names: Gruden
+    - given-names: Sonia
+      family-names: Tarazona
+    - given-names: Ana
+      family-names: Conesa
+      orcid: https://orcid.org/0000-0001-9597-311X
+  journal: Nucleic Acids Research
+  year: 2022
+  month: 7
+  volume: 50
+  issue: W1
+  start: W551
+  end: W559
+  doi: 10.1093/nar/gkac352
+  issn: 1362-4962
+  publisher:
+    name: Oxford University Press
+  url: https://doi.org/10.1093/nar/gkac352

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,14 @@ cd PaintOmics
 python3.11 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 
-Rscript -e 'install.packages(c("purrr","amap","cluster","factoextra","mclust","optparse"))'
+Rscript -e 'install.packages(c("purrr","cluster","mclust","amap","factoextra",
+                               "igraph","ggplot2","jsonlite","stringr","dplyr",
+                               "optparse"))'
+# The first ten are the set deploy/smoke-test.sh checks for; a machine without
+# them passes the unit tests and fails the smoke test. The MORE R engines
+# additionally need the MORE package, which is not on CRAN -- see
+# https://github.com/BiostatOmics/MORE. The default MORE engine is the Rust
+# port and needs none of this.
 
 cd PaintomicsServer
 python src/launch_server.py                # http://localhost:8000
@@ -59,10 +66,16 @@ A fresh instance has an empty database and does nothing useful until at least on
 species is installed. This is the expensive step, measured in hours and hundreds
 of gigabytes, not minutes.
 
+The installer is the one thing that must **not** run in the 3.11 virtual
+environment above: `DBManager.py` calls into `scriptine`, which uses
+`inspect.getargspec` — removed in Python 3.11 — so it dies on the first
+command. Run it under a Python 3.9 interpreter (the conda `paintomics4`
+environment); the pipeline itself stays on 3.11.
+
 ```bash
 cd PaintomicsServer
-python src/AdminTools/DBManager.py download --specie=mmu --kegg=1 --mapping=1 --common=1 --reactome=1
-python src/AdminTools/DBManager.py install  --specie=mmu
+python3.9 src/AdminTools/DBManager.py download --specie=mmu --kegg=1 --mapping=1 --common=1 --reactome=1
+python3.9 src/AdminTools/DBManager.py install  --specie=mmu
 ```
 
 Install **mmu**: every bundled example dataset uses it, and so does the whole
@@ -133,8 +146,8 @@ scripts/regression.sh                                    # all 12 datasets
 scripts/regression.sh 01-gene-single-condition           # one
 ```
 
-It needs, on the host: MongoDB with mmu installed, `Rscript` with the metagene and
-hub packages, `examplefiles/GTF/sorted_mmu.gtf`, and a `more-rs` binary at
+It needs, on the host: MongoDB with mmu installed, `Rscript` with the metagene
+packages, `examplefiles/GTF/sorted_mmu.gtf`, and a `more-rs` binary at
 `src/common/bioscripts/more-rs` (or named by `PAINTOMICS_MORE_RS`) for the MORE
 datasets. It refuses to start without the last one rather than reporting R's
 different table ordering as a regression.
@@ -185,7 +198,7 @@ pip install ruff==0.14.13 vulture==2.16
 
 ruff check --output-format concise .
 scripts/ci/vulture_gate.sh
-for s in scripts/*.sh scripts/ci/*.sh deploy/*.sh; do bash -n "$s" || break; done
+for s in scripts/*.sh scripts/ci/*.sh deploy/*.sh; do bash -n "$s" || exit 1; done
 find PaintomicsClient -name '*.js' \
   | grep -vEi '/(lib|libs|vendor|ext-[0-9]|extjs|jquery|node_modules)/' \
   | xargs -n1 node --check
@@ -278,7 +291,7 @@ numbers were before and after. Read `ae55c611` or `4ddb86e9` for the shape.
 Pull requests land either as a squash whose subject carries `(#NNN)`, or as a
 merge commit `Merge pull request #NNN from ConesaLab/<branch>`. Either is fine.
 
-Before you open one: the four required checks must pass, and any change to the
+Before you open one: `Gate` must pass, and any change to the
 UI or to server behaviour should have been exercised in a browser against a
 running instance, not only in the diff.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,352 @@
+# Contributing to PaintOmics
+
+This is the working guide for changing the code: where things are, how to get an
+instance running, how to run the tests the way CI runs them, and what the pull
+request gate checks.
+
+House engineering rules live in [`CLAUDE.md`](CLAUDE.md) — memory-efficient data
+structures and vectorised pandas/NumPy over Python loops, defensive handling of
+missing values and duplicate identifiers, PEP 8, DRY.
+
+## 1. Where things live
+
+| Path | What is in it |
+|---|---|
+| `PaintomicsServer/src/servlets/` | Flask routes |
+| `PaintomicsServer/src/classes/` | Job classes and the analysis code, including `AIInterpret/` |
+| `PaintomicsServer/src/common/` | Shared helpers, `PySiQ.py` (the in-process job queue), `bioscripts/` (R and `more-rs`) |
+| `PaintomicsServer/src/AdminTools/` | `DBManager.py`, the species installer |
+| `PaintomicsServer/src/examplefiles/` | Example datasets and their `datasets/manifest.json` |
+| `PaintomicsServer/src/benchmarks/` | `bench_runner.py`, the pipeline kernel the regression harness drives |
+| `PaintomicsServer/src/tests/` | 282 standalone test suites and `run_all.py` |
+| `PaintomicsServer/src/resources/example_serverconf.py` | Configuration template; the real `src/conf/serverconf.py` is gitignored |
+| `PaintomicsClient/public_html/` | The ExtJS 4.2.1 client; `index.html` is the entry document |
+| `docs/` | mkdocs sources for the user guide (`mkdocs.yml` at the root) |
+| `deploy/` | Docker Compose stack, `Dockerfile`, `smoke-test.sh`, `fetch-example-gtf.sh`, operator runbook |
+| `scripts/` | `regression.sh` / `regression.py`, `ci/` (the gate's helpers), `perf/`, `deadcode_report.py` |
+| `tests/baseline/` | Regression baselines, one directory per example dataset |
+| `requirements.txt` | The only pip manifest in the tree |
+
+## 2. A development instance
+
+Requires Python 3.11, MongoDB, R and the `libcairo2` shared library.
+
+```bash
+git clone https://github.com/ConesaLab/PaintOmics.git
+cd PaintOmics
+
+python3.11 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+
+Rscript -e 'install.packages(c("purrr","amap","cluster","factoextra","mclust","optparse"))'
+
+cd PaintomicsServer
+python src/launch_server.py                # http://localhost:8000
+```
+
+The first launch copies `src/resources/example_serverconf.py` to
+`src/conf/serverconf.py`. That file is gitignored and is never overwritten
+afterwards. Every secret in it is read with `os.getenv`, and a
+`PaintomicsServer/.env` (also gitignored) is loaded at import time with
+`setdefault`, so a real environment variable always wins.
+
+`./start_server.sh` does the same through a conda environment and starts `mongod`
+if it is not already running.
+
+### Installing a species — the slow part
+
+A fresh instance has an empty database and does nothing useful until at least one
+species is installed. This is the expensive step, measured in hours and hundreds
+of gigabytes, not minutes.
+
+```bash
+cd PaintomicsServer
+python src/AdminTools/DBManager.py download --specie=mmu --kegg=1 --mapping=1 --common=1 --reactome=1
+python src/AdminTools/DBManager.py install  --specie=mmu
+```
+
+Install **mmu**: every bundled example dataset uses it, and so does the whole
+regression harness. Rough sizes: shared common data ~1.4 GB, shared Reactome
+~856 MB, 200–400 MB per species. Use `--common=0` for every species after the
+first — the common step re-downloads the shared KEGG reference data and dominates
+the runtime. Reactome curates human and infers about twenty other species; use
+`--reactome=0` for the rest, or the install fails with a message naming the
+species.
+
+The region-based examples and datasets also need
+`PaintomicsServer/src/examplefiles/GTF/sorted_mmu.gtf`, which the repository does
+not ship. `deploy/fetch-example-gtf.sh` builds it (it defaults to the container
+`paintomics-app-1`); it downloads Ensembl GRCm38, trims it, and lands ~566 MB.
+
+For a container instance instead of a source checkout, follow
+[`deploy/README.md`](deploy/README.md).
+
+## 3. Running the tests
+
+**There is no pytest here.** Each suite under `PaintomicsServer/src/tests/` is a
+standalone `__main__` script, run as a module from `PaintomicsServer/`:
+
+```bash
+cd PaintomicsServer
+python -m src.tests.test_versioned_assets_are_bumped
+python -m src.tests.test_dependencies_declared
+```
+
+The whole sweep goes through the repository's own runner, which classifies the
+three output conventions in use (`Passed: n / n`, unittest's `OK`/`FAILED`, and a
+script that just exits 0) instead of grepping for a line:
+
+```bash
+cd PaintomicsServer
+python -m src.tests.run_all                  # everything
+python -m src.tests.run_all --only ai        # substring filter on the suite name
+```
+
+`run_all.BASELINE` records the suites that already fail on `master`, so the run
+answers "did this branch introduce a failure", not "is everything green". Do not
+add to that list to make a branch look clean.
+
+CI runs the same suites in parallel and offline through
+`scripts/ci/run-unit-tests.sh`, which is also the fastest way to run them locally:
+
+```bash
+PAINTOMICS_KEGG_DATA=/path/to/KEGG_DATA scripts/ci/run-unit-tests.sh --timeout 420
+# --only <substring>, --jobs N, --shard 1/2 are passed through to scripts/ci/run_suites.py
+```
+
+Note that a suite reporting `OK` after running zero tests is the worst possible
+answer. That happens when `serverconf.py` is missing, so the wrapper copies the
+template in before it starts.
+
+### The regression harness
+
+`scripts/regression.sh` runs example datasets end to end through
+`src/benchmarks/bench_runner.py` — the same job methods the servlets call, in the
+same order — normalises the output (job IDs, timestamps, absolute paths and UUIDs
+stripped, set-derived collections sorted) and compares it with
+`tests/baseline/<dataset>/`.
+
+```bash
+export PYTHON=/path/to/venv-py311/bin/python
+export PAINTOMICS_KEGG_DATA=/path/to/KEGG_DATA
+scripts/regression.sh                                    # all 12 datasets
+scripts/regression.sh 01-gene-single-condition           # one
+```
+
+It needs, on the host: MongoDB with mmu installed, `Rscript` with the metagene and
+hub packages, `examplefiles/GTF/sorted_mmu.gtf`, and a `more-rs` binary at
+`src/common/bioscripts/more-rs` (or named by `PAINTOMICS_MORE_RS`) for the MORE
+datasets. It refuses to start without the last one rather than reporting R's
+different table ordering as a regression.
+
+`--write-baseline` creates **missing** baselines only; it never overwrites one.
+A baseline is regenerated by deleting its directory on purpose.
+
+### Baselines are pinned to the environment that recorded them
+
+The comparison is exact: floats bit for bit, NaN equal to NaN, no tolerance. Only
+`PYTHONHASHSEED=0` is pinned by the harness itself (`scripts/regression.py`), so
+set-iteration order cannot masquerade as a result difference.
+
+What the harness records about the environment is what
+`.github/actions/setup-paintomics/action.yml` states: it "runs on macos-26
+(arm64), the platform family the regression baseline was produced on", with
+Python 3.11 and the R version input documented as "the baseline ran on 4.6.0".
+The MORE baselines hold the `more-rs` port's output, not R's.
+
+Nothing in the harness records or checks a Python version, and
+`scripts/regression.sh` defaults `PYTHON` to plain `python3`. So a run on a
+different interpreter or a different dependency set produces ordinary content
+differences with no warning that the environment, not the code, moved. **Always
+set `PYTHON` explicitly to a 3.11 interpreter with the pinned requirements**, and
+if a baseline is only wrong on your machine, suspect the environment before the
+code.
+
+## 4. The pull request gate
+
+`master` requires a pull request, refuses force-pushes and deletions, and
+requires one status check: **`Gate`**. That job waits on the other five and
+fails unless every one of them succeeded, so it is the single name branch
+protection has to know. The five it waits on:
+
+- `Lint`
+- `Unit tests (offline)` — a two-shard matrix, so its own check names carry the
+  shard and change whenever the matrix does; that is why `Gate` exists
+- `Example datasets, one per pipeline class`
+- `Secret scan` — gitleaks over the working tree, about four seconds
+- `Docs build` — `mkdocs build --strict`, so a page left out of the nav or a link
+  that resolves to nothing fails here rather than silently never appearing on
+  the published site
+
+Run the lint job locally before pushing — it is the cheapest one to fail:
+
+```bash
+pip install ruff==0.14.13 vulture==2.16
+
+ruff check --output-format concise .
+scripts/ci/vulture_gate.sh
+for s in scripts/*.sh scripts/ci/*.sh deploy/*.sh; do bash -n "$s" || break; done
+find PaintomicsClient -name '*.js' \
+  | grep -vEi '/(lib|libs|vendor|ext-[0-9]|extjs|jquery|node_modules)/' \
+  | xargs -n1 node --check
+python -m compileall -q scripts/ci/vulture_whitelist.py
+```
+
+**ruff** (`ruff.toml`) selects `E9` plus the whole `F` family at line length 120,
+excluding `PaintomicsClient`, `dist`, `docs`, `runs` and
+`scripts/ci/vulture_whitelist.py`. The tree is at zero findings. A deliberate
+exception carries `# noqa: F401 -- <reason>` with the reason spelled out; a bare
+`noqa` fails.
+
+**The vulture dead-code ratchet** (`scripts/ci/vulture_gate.sh`) runs two bands.
+At ≥80% confidence there must be zero findings beyond
+`scripts/ci/vulture_whitelist.py`, where every row carries its reason. At ≥60%
+confidence no *new* candidate may appear beyond `scripts/ci/vulture_baseline.txt`
+(line numbers stripped); candidates disappearing is fine, and the baseline is
+refreshed in the same commit that removes the code. Flask route handlers are
+excluded by `--ignore-decorators`, so adding a route does not fail the gate.
+
+**The offline rule.** The unit-test and dataset jobs run with outbound networking
+refused: `scripts/ci/no_network` goes first on `PYTHONPATH` and its
+`sitecustomize.py` turns any attempt to reach KEGG, Reactome, PubMed, Europe PMC
+or the LLM gateway into a named `OSError`. No test may reach the network — stub it
+in the suite. The one deliberate exception is the installer smoke job in
+`nightly.yml`, which tests the download path itself. No job reads a secret.
+
+**The dataset job** runs `scripts/regression.sh` over
+`01-gene-single-condition`, `04-multiomics-integration`, `05-regulatory-mirna`,
+`06-regulatory-more` and `07-region-based` — one per pipeline class, plus one
+multi-omic dataset, because a field only a multi-omic job produces is invisible
+to the single-omic ones. If your change is additive to the pipeline output, the
+other seven baselines can still go stale; `nightly.yml` runs all twelve, and you
+can trigger it from the Actions tab.
+
+## 5. Client-side changes
+
+Assets in `PaintomicsClient/public_html/index.html` are cache-busted by hand and
+served with a long max-age:
+
+```html
+<script type="text/javascript" src="app/view/common/Util.js?v=2.8"></script>
+```
+
+If you edit a versioned JS or CSS file, **bump its `?v=` marker in `index.html`**.
+Skipping it leaves returning browsers running the old file against new code for
+up to 12 hours — how `getClusterColor` and `truncatableTextRenderer` both broke.
+
+`PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py` enforces it. It
+holds a `PUBLISHED` table of path → (version, sha256), and fails when a file's
+digest no longer matches the version it was published under. Bump the marker in
+`index.html` **and** update the digest in the table; updating the digest alone
+defeats the point, and the failure message says so. The same suite refuses a
+plain `<script src="app/....js">` with no marker at all.
+
+It reads the files from `HEAD` via `git show`, not from the working tree, so
+commit first and then run it:
+
+```bash
+cd PaintomicsServer
+python -m src.tests.test_versioned_assets_are_bumped
+```
+
+After a layout or spacing change, the client ships a development overlay:
+`app/view/common/AlignmentGuides.js`, off unless you load the page with
+`?guides=1` or press Ctrl+Alt+G. It draws the rails and lists off-rail elements.
+
+## 6. Commits and pull requests
+
+Branch off `master` as `<kind>/<slug>` — the kinds in use are `feat/`, `fix/`,
+`design/`, `chore/` and `quality/`, for example `fix/pathway-network-ignores-compounds`.
+
+Subject lines are **sentence-case imperative, with no type prefix and no trailing
+full stop**, and they name the change in the domain's own terms:
+
+```
+Count metabolites in the pathway network, not only genes
+Run one multi-omic dataset in the PR gate
+Say on every Step 1 file row whether the job needs it
+Stop offering Report error when the refusal names the field
+```
+
+They run long when the change needs it — 80 to 100 characters is normal here —
+because a subject that says what moved is worth more than one that fits in 50.
+
+The body explains **why**, with evidence: the mechanism that was wrong, the
+measurement that shows it, the job id or dataset it was observed on, and what the
+numbers were before and after. Read `ae55c611` or `4ddb86e9` for the shape.
+
+Pull requests land either as a squash whose subject carries `(#NNN)`, or as a
+merge commit `Merge pull request #NNN from ConesaLab/<branch>`. Either is fine.
+
+Before you open one: the four required checks must pass, and any change to the
+UI or to server behaviour should have been exercised in a browser against a
+running instance, not only in the diff.
+
+## 7. Adding a dependency
+
+`requirements.txt` at the repository root is the only pip manifest, and that is
+deliberate — a second copy under `PaintomicsServer/src/` once shipped conflicting
+pins and fed GitHub's dependency graph a 2020 snapshot. Add the package there,
+**pinned to an exact version**, with a comment saying why it is needed.
+
+```bash
+cd PaintomicsServer
+python -m src.tests.test_dependencies_declared
+```
+
+That suite walks the AST of every module under `src/` and checks each external
+import actually resolves, so a dependency that is only installed on your machine
+fails here instead of when the container refuses to boot.
+
+Python is 3.11 and both bounds are load-bearing: Pillow, CairoSVG and requests
+need ≥ 3.10 for their security fixes, and pandas 1.5.3 publishes no cp312 wheel.
+Do not raise or lower it as a side effect of adding a package.
+
+## 8. Adding a server configuration setting
+
+`PaintomicsServer/src/conf/serverconf.py` is gitignored, generated once per
+deployment from the template, and then never overwritten. That shapes every step:
+
+1. Add the setting to `PaintomicsServer/src/resources/example_serverconf.py`,
+   reading it from the environment with a safe default:
+
+   ```python
+   MY_SETTING = os.getenv("MY_SETTING", "default")
+   ```
+
+   Never put a real key, token or password in that file —
+   `src/tests/test_release_hygiene.py` scans tracked files and fails if you do.
+
+2. Import it **defensively** in the code that uses it. A deployment that already
+   has a `serverconf.py` will not have your new name, and a plain import would
+   take the whole application down at startup over a feature flag:
+
+   ```python
+   try:
+       from src.conf.serverconf import MY_SETTING
+   except ImportError:
+       MY_SETTING = "default"          # matching the template
+   ```
+
+   `src/servlets/CompoundSuggestionServlet.py` is the worked example.
+
+3. If a container deployment must be able to set it, add it to `deploy/env.example`
+   with a note on the consequence of leaving it unset, and pass it through the
+   `environment:` block of `deploy/compose.yaml`.
+
+4. For local work, put secrets in `PaintomicsServer/.env` (gitignored). The
+   template loads it with `os.environ.setdefault` before anything calls `getenv`,
+   so a real environment variable set by systemd or the container always wins,
+   and a missing or malformed `.env` fails silently rather than taking the servlet
+   down.
+
+## 9. Questions
+
+- Bugs, feature requests and organism requests: an
+  [issue](https://github.com/ConesaLab/PaintOmics/issues) on this repository.
+- Email: [paintomicsai@gmail.com](mailto:paintomicsai@gmail.com).
+- User documentation: [paintomics.readthedocs.io](https://paintomics.readthedocs.io/en/latest/).
+- Operating an instance: [`deploy/README.md`](deploy/README.md).
+
+PaintOmics is distributed under the GNU General Public License v3; contributions
+are accepted under the same licence.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ MORE regulatory model, multi-condition designs, and a rebuilt interface — see
 | **Security** | Path traversal through job and file names closed; forgeable identity (`userID=0` and ID reuse) fixed; session and password-reset tokens drawn from `secrets`; per-request authorisation guards on job, image and admin routes; password hashes no longer sent to the admin panel; AI consent enforced server-side. |
 | **Statistics and correctness** | Enrichment counting, an independent denominator for the hub scorer, BH applied across the whole p-value vector, non-finite p-values dropped before FDR, reproducible metagene clustering, and the R drop-to-vector bug that silently killed metagenes for whole omic/database pairs. |
 | **Installers** | KEGG and Reactome download paths repaired (KEGG retired `/list/organism`; Reactome cached error bodies as data), every step made idempotent so reruns skip finished work, and an install that can no longer lose files it does not replace. |
-| **Tests** | 135 test scripts, including an end-to-end run against a real installed species, the real R backend rather than a double, an import smoke test over every tracked module, and a check that edited assets get their cache marker bumped. |
+| **Tests** | 282 test scripts, including an end-to-end run against a real installed species, the real R backend rather than a double, an import smoke test over every tracked module, and a check that edited assets get their cache marker bumped. |
 
 ## The AI interpretation agent
 
@@ -110,8 +110,8 @@ Genes** (RGmatch, for region-based assays) and **miRNA to Genes**.
 ### With Docker (recommended)
 
 ```bash
-git clone https://github.com/ConesaLab/paintomics4.git
-cd paintomics4
+git clone https://github.com/ConesaLab/PaintOmics.git
+cd PaintOmics
 
 cp deploy/env.example deploy/.env
 $EDITOR deploy/.env                        # PAINTOMICS_BASE_URL is mandatory
@@ -135,8 +135,8 @@ feature refuses jobs, or set `AI_INTERPRETATION_ENABLED=false` to hide it.
 Requires **Python 3.11**, **MongoDB**, **R**, and the `libcairo2` shared library.
 
 ```bash
-git clone https://github.com/ConesaLab/paintomics4.git
-cd paintomics4
+git clone https://github.com/ConesaLab/PaintOmics.git
+cd PaintOmics
 
 python3.11 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
@@ -249,9 +249,15 @@ application.
 
 ## Contact and contributing
 
-Questions, bug reports and organism requests: [paintomicsai@gmail.com](mailto:paintomicsai@gmail.com)
-or an [issue](https://github.com/ConesaLab/paintomics4/issues) on this
-repository. Pull requests are welcome.
+Questions, bug reports and organism requests: open an
+[issue](https://github.com/ConesaLab/PaintOmics/issues/new/choose) — the bug and
+organism-request forms ask for the details that make a report reproducible — or
+write to [paintomicsai@gmail.com](mailto:paintomicsai@gmail.com).
+
+Pull requests are welcome. [`CONTRIBUTING.md`](CONTRIBUTING.md) covers getting a
+development instance running, the test suites, and what the pull-request gate
+checks. Security problems go through [`SECURITY.md`](SECURITY.md) instead of the
+issue tracker; please do not report them publicly.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,154 @@
+# Security policy
+
+PaintOmics accepts uploaded omics data, runs analyses on it, and stores the
+results per user. It is also self-hostable, so a bug here can affect the public
+instance at <https://paintomics.uv.es/> and every deployment somebody else runs.
+Reports are welcome.
+
+## Reporting a vulnerability
+
+Report privately, by either route:
+
+- **GitHub private vulnerability reporting** — the *Security* tab of
+  [ConesaLab/PaintOmics](https://github.com/ConesaLab/PaintOmics) →
+  *Report a vulnerability*. This is the preferred route: the report, the
+  discussion and the fix stay in one place.
+- **Email** — [paintomicsai@gmail.com](mailto:paintomicsai@gmail.com), with
+  `security` in the subject line.
+
+Please do **not** open a public issue, pull request or discussion for a
+vulnerability, and do not post details on a mailing list before a fix exists.
+
+A useful report says:
+
+- what an attacker gains — read another user's job, execute code on the server,
+  escalate to admin, read a file outside the job directory;
+- where the affected code is, if you know: a path in `PaintomicsServer/` or
+  `PaintomicsClient/`, or the request that triggers it;
+- how to reproduce it, ideally against a local deployment;
+- which version you tested — the commit on `master`, or the public instance and
+  roughly when.
+
+### What happens next
+
+PaintOmics is maintained by a small academic group, so this is a commitment we
+can keep rather than a service level agreement:
+
+- We acknowledge a report within a handful of working days.
+- We tell you whether we can reproduce it, and what we think the impact is.
+- We tell you when the fix lands on `master` and when the public instance is
+  updated. Timing depends on severity and on who is available; we will not
+  invent a deadline we cannot meet.
+- We credit you in the commit message and release notes if you want to be
+  credited, and leave you out if you do not.
+
+There is no bug bounty. Nothing in this policy is a legal undertaking.
+
+## Supported versions
+
+| Version | Security fixes |
+|---|---|
+| `master` branch of this repository | Yes |
+| The public instance, <https://paintomics.uv.es/> | Yes |
+| PaintOmics 4 (*Nucleic Acids Research*, 2022) | No |
+| PaintOmics 3 and earlier | No |
+
+There are no maintained release branches and nothing is backported. Fixes land
+on `master`; a self-hosted deployment takes them by pulling `master` and
+rebuilding. If you are running a PaintOmics 3 or 4 instance, the fix for
+anything reported here is to move to the current code.
+
+The classes of issue the project has already closed are listed in the
+**Security** row of the *What's new* table in [`README.md`](README.md). They are
+the kind of thing we want to hear about.
+
+## Scope
+
+In scope:
+
+- The application code in this repository — the Flask server under
+  `PaintomicsServer/`, the JavaScript client under `PaintomicsClient/`, the
+  admin and installer tooling under `PaintomicsServer/src/AdminTools/`, and the
+  container stack under `deploy/`.
+- The deployed public instance at <https://paintomics.uv.es/>.
+- Anything that lets one user reach another user's jobs, uploaded files,
+  results or account; anything that escapes a job's directory through a file or
+  job name; anything that turns an uploaded data matrix into code execution;
+  and the registration, session and password-reset flows.
+
+Out of scope:
+
+- **KEGG, Reactome and MapMan themselves.** The pathway databases, their
+  content and their web services are third-party. Report problems with them to
+  their maintainers. Wrong or outdated pathway annotation in PaintOmics is a
+  data issue, not a vulnerability — send it to
+  [paintomicsai@gmail.com](mailto:paintomicsai@gmail.com) or open an issue.
+- **Findings that require an operator to have misconfigured their own
+  deployment.** `deploy/README.md` names the constraints that must hold, and
+  `deploy/smoke-test.sh` checks them — MongoDB must not be published to the
+  host, Flask debug must be off, HTTP must redirect to HTTPS, and uWSGI must run
+  a single process. A deployment that violates one of those is insecure by
+  configuration; that is not a vulnerability in the code. The same goes for a
+  host's own TLS, firewall or reverse-proxy setup, and for secrets an operator
+  put somewhere they should not be.
+- Reports from an automated scanner with no demonstrated impact, missing
+  hardening headers with no exploit path, and best-practice advice unattached to
+  a concrete attack.
+- Resource exhaustion from submitting large or numerous analyses on a public
+  instance. The analyses are deliberately long-running and the job queue is
+  in-process; this is a capacity property of the design, not a defect. A way to
+  make the server do unbounded work from a single small request *is* in scope.
+- Vulnerabilities in third-party dependencies, unless you can show a path to
+  them through PaintOmics code. Dependency versions are pinned in
+  [`requirements.txt`](requirements.txt); if a pin is exploitable as shipped, say
+  so and we will treat it as in scope.
+
+### Testing
+
+Please test against your own deployment wherever you can. If you must test
+against <https://paintomics.uv.es/>, do not run automated scanners or load
+generators against it — it is a shared research instance — and do not access,
+modify or delete data belonging to anyone else. If you discover that you *can*
+reach another user's data, stop there and report it; you do not need to prove it
+twice.
+
+## For self-hosters
+
+Every deployment must supply its own secrets. Nothing usable ships in the
+repository, and the configuration template
+`PaintomicsServer/src/resources/example_serverconf.py` reads every secret from
+the environment with an empty default — a rule enforced by
+`PaintomicsServer/src/tests/test_release_hygiene.py`.
+
+Two example files say what to set:
+
+- **`deploy/env.example`** → copy to `deploy/.env` for the container stack.
+  `PAINTOMICS_BASE_URL` is required and the container refuses to start without
+  it; it is embedded in activation emails, so a wrong value breaks registration
+  silently. `SMTP_PASSWORD` is the SendGrid credential used for registration and
+  password-reset mail. `AI_CSIC_API_KEY` is the LLM gateway token for the AI
+  interpretation agent — leave it empty and set
+  `AI_INTERPRETATION_ENABLED=false` to disable the feature cleanly.
+  `AI_PUBMED_API_KEY` only raises an NCBI rate limit.
+- **`PaintomicsServer/.env.example`** → copy to `PaintomicsServer/.env` for a
+  from-source install. It carries the same AI keys for local work. A real
+  environment variable always wins over this file, so a stray `.env` cannot
+  override what a production deployment configured.
+
+`.env`, `deploy/.env`, `PaintomicsServer/src/conf/serverconf.py` and
+`deploy/nginx/certs/` are all gitignored. Keep them that way; the certificate
+private key generated by `deploy/make-cert.sh` must never be committed.
+
+Two further points that decide whether a deployment is safe:
+
+- **MongoDB runs without authentication** and is reachable only on the Compose
+  network. Do not add a `ports:` mapping for it.
+- `deploy/make-cert.sh` produces a **self-signed** certificate, intended as an
+  interim measure until the host has a DNS name and a trusted certificate.
+  Browsers will warn, and HSTS stays off in `deploy/nginx/paintomics.conf` for
+  that reason. Replace it with a real certificate before running an instance
+  other people use.
+
+Run `./deploy/smoke-test.sh` after every deployment and after every upgrade. It
+exits non-zero on exactly the mistakes that are cheap to catch there and
+expensive to find in production.

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -3,7 +3,9 @@
 These pages are for people who run, deploy and debug PaintOmics — not for
 people who use it. The user guide is at
 [paintomics.readthedocs.io](https://paintomics.readthedocs.io/en/latest/), built
-from the rest of `docs/`. These four pages are deliberately not in `mkdocs.yml`.
+from the rest of `docs/`. These pages are listed under `exclude_docs` in
+`mkdocs.yml`, so they are not built into that site at all — `not_in_nav`
+would only unlink them, leaving them published at their URLs.
 
 They exist because the operational knowledge of this project has lived in one
 person's head and in private notes. Everything here is reconstructed from the
@@ -51,7 +53,9 @@ Python 3.11, MongoDB, R, and the `libcairo2` shared library:
 ```bash
 python3.11 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
-Rscript -e 'install.packages(c("purrr","amap","cluster","factoextra","mclust","optparse"))'
+Rscript -e 'install.packages(c("purrr","cluster","mclust","amap","factoextra",
+                               "igraph","ggplot2","jsonlite","stringr","dplyr",
+                               "optparse"))'
 
 cd PaintomicsServer
 python src/launch_server.py            # http://localhost:8000

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -1,0 +1,92 @@
+# Maintainer documentation
+
+These pages are for people who run, deploy and debug PaintOmics — not for
+people who use it. The user guide is at
+[paintomics.readthedocs.io](https://paintomics.readthedocs.io/en/latest/), built
+from the rest of `docs/`. These four pages are deliberately not in `mkdocs.yml`.
+
+They exist because the operational knowledge of this project has lived in one
+person's head and in private notes. Everything here is reconstructed from the
+repository and from those notes. Claims that come only from the notes, and
+cannot be checked against code in this repository, are marked *(from operator
+experience; not enforced by code)*.
+
+| Page | What it answers |
+|---|---|
+| [architecture.md](architecture.md) | What serves a request, what holds state, what the process boundaries are, and what that forbids |
+| [deployment.md](deployment.md) | How a merged change reaches the public instance, and how to confirm it arrived |
+| [ci.md](ci.md) | What each workflow checks, what a green tick proves, and how to reproduce a failure locally |
+| [troubleshooting.md](troubleshooting.md) | The traps, each with the symptom, how it was diagnosed, and what to do |
+
+## What this project is
+
+PaintOmics AI paints several omic layers onto KEGG, Reactome, MapMan and
+OmniPath pathways. It is the successor to PaintOmics 4 (*Nucleic Acids
+Research* 2022, [10.1093/nar/gkac352](https://doi.org/10.1093/nar/gkac352)),
+developed by the Genomics of Gene Expression Lab
+([conesalab.org](http://conesalab.org/)), and distributed under GPLv3.
+
+- Source: `https://github.com/ConesaLab/PaintOmics`, default branch `master`.
+- Public instance: <https://paintomics.uv.es/>.
+- Contact for questions, bug reports and organism requests:
+  <paintomicsai@gmail.com>.
+
+## Repository layout
+
+| Path | What lives there |
+|---|---|
+| `PaintomicsServer/src/` | The Flask application: `paintomicsserver.py` (routes), `servlets/`, `classes/` (job classes, AI interpretation), `common/` (queue, DAOs, mappers, statistics), `AdminTools/` (species installers) |
+| `PaintomicsClient/public_html/` | The ExtJS 4.2.1 client: `index.html`, `app/view`, `app/controller`, `resources/css` |
+| `deploy/` | Container deployment: `Dockerfile`, `compose.yaml`, `build-image.sh`, `smoke-test.sh`, `load-species.sh`, `swap-and-install.sh`, `entrypoint.sh`, `nginx/`, and `deploy/README.md` |
+| `.github/workflows/` | `pr.yml`, `nightly.yml`, `cd.yml`, `data-cache.yml`, `profile.yml` |
+| `scripts/` | `regression.sh` and `regression.py` (the end-to-end baseline harness), `ci/`, `perf/` |
+| `tests/baseline/` | Stored, exact regression baselines, one directory per example dataset |
+| `requirements.txt` | The only pip manifest in the tree, enforced by `PaintomicsServer/src/tests/test_dependencies_declared.py` |
+| `paintomics4.ini`, `paintomics.wsgi`, `start_server.sh` | uWSGI/WSGI entry points for a non-container host, and a local launcher |
+
+## A development instance
+
+Python 3.11, MongoDB, R, and the `libcairo2` shared library:
+
+```bash
+python3.11 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+Rscript -e 'install.packages(c("purrr","amap","cluster","factoextra","mclust","optparse"))'
+
+cd PaintomicsServer
+python src/launch_server.py            # http://localhost:8000
+```
+
+The first launch copies `src/resources/example_serverconf.py` to
+`src/conf/serverconf.py`, which is gitignored. `./start_server.sh` does the same
+through a conda environment and starts MongoDB if it is not already running. A
+fresh instance has an empty database; install species with
+`src/AdminTools/DBManager.py` (see [deployment.md](deployment.md)).
+
+## The rules that outrank everything else
+
+Each is explained where it belongs, but they are the ones that cost the most
+when broken.
+
+1. **uWSGI runs `processes = 1`.** `src/common/PySiQ.py` holds the job queue in
+   the memory of the process that accepted the request. A second worker gets its
+   own empty queue and jobs vanish silently. Concurrency comes from threads.
+   Checked by `deploy/smoke-test.sh`.
+2. **MongoDB is never published to the host.** It runs without authentication.
+   Also checked by `deploy/smoke-test.sh`.
+3. **No request may block on an external service.** Threads are few; a route that
+   waits on the LLM gateway takes the site down. Enqueue and let the client poll.
+4. **`src/conf/serverconf.py` is per-site, gitignored, and never overwritten by a
+   deploy or a container upgrade.** A new setting needs the template entry *and*
+   a defensive import, or you break every existing deployment.
+5. **`tests/baseline/` is compared bit for bit and is pinned to one interpreter
+   and platform.** A last-digit float difference is usually the environment, not
+   the code.
+6. **A green tick on a `master` commit proves the artifact built, nothing more.**
+   Lint, unit tests and the dataset gate run on pull requests only.
+
+## Keeping these pages honest
+
+When you learn something operational the hard way, write it here rather than in
+a commit message. When a claim marked *(from operator experience)* gets encoded
+in a test, a smoke check or a script, drop the marker and cite the file.

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -19,7 +19,7 @@ Flask application (PaintomicsServer/src/paintomicsserver.py)
   |            \                    \                  \
 MongoDB      PySiQ queue          Rscript            more-rs
              (in-process,         generateMetaGenes.R  (Rust MORE PLS1)
-              N_WORKERS threads)  hubAnalysis.R
+              N_WORKERS threads)
 ```
 
 Entry points:
@@ -173,7 +173,7 @@ reproducible from the source databases but takes hours to refetch.
 The application shells out on the user-facing request path, so a host that
 serves pages perfectly can still fail the moment someone clicks a button:
 
-- **R** — `src/common/bioscripts/generateMetaGenes.R` and `hubAnalysis.R` for
+- **R** — `src/common/bioscripts/generateMetaGenes.R` for
   Metagenes and Hub Analysis. `deploy/smoke-test.sh` checks that `purrr`,
   `cluster`, `mclust`, `amap`, `factoextra`, `igraph`, `ggplot2`, `jsonlite`,
   `stringr` and `dplyr` all import.
@@ -209,7 +209,7 @@ CI is the mirror image: the PR gate and the nightly run with
 `PaintomicsClient/public_html` is an ExtJS 4.2.1 application served as static
 files. Two mechanics matter operationally:
 
-- **Cache markers.** `index.html` references assets as `Util.js?v=2.6` and
+- **Cache markers.** `index.html` references assets as `Util.js?v=2.8` and
   friends. `revalidateEntryDocument` in `paintomicsserver.py` serves
   `index.html` itself as `no-cache, must-revalidate` while every asset gets
   `max-age=43200`. An edited asset whose `?v=` marker did not change is served

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -1,0 +1,237 @@
+# Architecture
+
+How the system fits together, and which of its properties are load-bearing.
+The short version: one Python process serves the whole site, keeps the job
+queue, the sessions and several caches in its own memory, and shells out to R
+and to a Rust binary for parts of the analysis. Almost every operational rule
+in this documentation follows from that sentence.
+
+## The request path
+
+```
+browser
+  |  HTTPS
+nginx                 TLS, 100 MB body limit, gzip, 300 s proxy_read_timeout
+  |  proxy_pass / uwsgi_pass
+uWSGI  ── 1 process, N threads, harakiri 300 s
+  |
+Flask application (PaintomicsServer/src/paintomicsserver.py)
+  |            \                    \                  \
+MongoDB      PySiQ queue          Rscript            more-rs
+             (in-process,         generateMetaGenes.R  (Rust MORE PLS1)
+              N_WORKERS threads)  hubAnalysis.R
+```
+
+Entry points:
+
+- `PaintomicsServer/src/launch_server.py` — creates `Application` and exposes
+  `app`. Run directly for development; also the WSGI callable used by
+  `deploy/uwsgi.ini`. On first launch, if `src/conf/serverconf.py` is absent, it
+  copies `src/resources/{__init__.py,example_serverconf.py,logging.cfg}` into
+  `src/conf/`.
+- `paintomics.wsgi` — the WSGI shim for a non-container host, imported by
+  `paintomics4.ini`.
+- `deploy/entrypoint.sh` — the container entry point. It installs
+  `serverconf.py` from the template *only if absent*, warns about
+  misconfiguration, creates the data directories, fixes volume ownership once,
+  then drops to an unprivileged user.
+
+Routes are declared with `@self.app.route(...)` inside `Application` in
+`paintomicsserver.py`; the servlet modules under `src/servlets/` hold the
+handlers.
+
+## The one-process constraint
+
+`src/common/PySiQ.py` is a vendored, in-process, thread-backed job queue. All
+job state lives in the memory of the process that accepted the submission. With
+two uWSGI workers, a job submitted to worker A is invisible to worker B: the
+submission succeeds, the status endpoint is served by a process that has never
+heard of the job, and the job appears to hang forever.
+
+So:
+
+- `deploy/uwsgi.ini` sets `processes = 1`, `threads = 16`, `enable-threads`,
+  and `lazy-apps = true` (the queue and the scheduler start threads at import
+  time, which do not survive uWSGI's pre-fork).
+- `deploy/smoke-test.sh` fails the deployment if `processes` is not 1.
+- `paintomics4.ini` — the non-container uWSGI configuration in the repository
+  root — sets `processes = 1` and `threads = 4`.
+- Scaling out requires replacing PySiQ with a shared broker first. There is no
+  Redis or RQ anywhere in this project despite the queue vocabulary.
+
+**Consequence: no request handler may wait on something slow.** With four
+threads, a route that blocks for two minutes on an external gateway holds a
+quarter of the site; four concurrent such requests are an outage, and at
+`harakiri = 300` the request is killed anyway. The AI interpretation route is
+the worked example of the correct shape: `AIInterpretServlet` enqueues into the
+queue instance and returns a ticket, and the browser polls — poll requests take
+milliseconds. *(The thread-exhaustion arithmetic is from operator experience;
+the thread counts themselves are in the ini files.)*
+
+`reload-on-rss = 4096` (MB) recycles the worker on memory growth rather than on
+a request count, because job cost varies by orders of magnitude.
+
+## What lives in process memory, and therefore dies on restart
+
+| State | Where | Consequence of a restart |
+|---|---|---|
+| Job queue and job status | `src/common/PySiQ.py`, started with `N_WORKERS` workers | In-flight jobs are lost; their records go stale and the client reports an error on the next status poll |
+| Login sessions | `UserSessionManager.logged_users`, a plain dict on the singleton — MongoDB has no session collection | Every browser is logged out. The cookies survive, so the next request looks authenticated to the user and fails server-side, which reads as a permissions bug rather than a logout *(from operator experience; not enforced by code)* |
+| Job instances | `JobInformationManager`, a bounded cache, `JOB_CACHE_MAX_SIZE = 50` | Editing a job document directly in MongoDB under a running server changes nothing the server sees, until restart |
+| KEGG data | `KeggInformationManager`, `KEGG_CACHE_MAX_SIZE = 25` | Reinstalling species data needs a restart to be visible |
+
+A background APScheduler job runs `cleanDatabases` and `clearFailedData` on a
+24-hour interval, started at application start — so the first run is 24 hours
+after each restart, and frequent restarts postpone it indefinitely.
+
+## Configuration
+
+`PaintomicsServer/src/conf/serverconf.py` is the live configuration. It is
+**gitignored** (`.gitignore`), per-site, and never overwritten by a deployment
+or by a container upgrade — `deploy/entrypoint.sh` writes it only `if [ ! -f ]`.
+
+The tracked template is `PaintomicsServer/src/resources/example_serverconf.py`.
+It reads every secret from the environment with an empty default, so it can be
+installed verbatim; `src/tests/test_release_hygiene.py` enforces that no real
+credential ever appears in it, and that the template covers every setting the
+app imports.
+
+It also loads a `.env` file beside the server (`PaintomicsServer/.env`, or one
+at the repository root) with `os.environ.setdefault`, so a real environment
+variable always wins and a stray `.env` on a production box cannot override what
+the deployment configured. The loader fails silently by design: a config module
+that raises on import takes the whole servlet down.
+
+**Adding a setting takes three steps, not one:**
+
+1. the value in your own `serverconf.py` (invisible to git),
+2. the same line in `example_serverconf.py` (what fresh deployments get),
+3. a **defensive import at the use site**, because an already-deployed config
+   predates the setting and a bare
+   `from src.conf.serverconf import X` raises at module import — taking down
+   every servlet that imports it:
+
+```python
+try:
+    from src.conf.serverconf import MORE_RS_BINARY
+except ImportError:
+    MORE_RS_BINARY = os.getenv("PAINTOMICS_MORE_RS", "")
+```
+
+Step 2 is enforced by `test_release_hygiene`. Nothing enforces step 3, and its
+failure mode is the worst of the three: an optional feature becomes an outage on
+every existing deployment. *(From operator experience, with the enforcement
+detail checkable in the test.)*
+
+Settings worth knowing, all in `example_serverconf.py`:
+
+| Setting | Default | Note |
+|---|---|---|
+| `SERVER_ALLOW_DEBUG` | `false` | Never true in production; the smoke test checks it |
+| `SERVER_MAX_CONTENT_LENGTH` | 100 MB | Must equal nginx `client_max_body_size` and uWSGI `limit-post` |
+| `SERVER_MAX_FORM_MEMORY_SIZE` | = `SERVER_MAX_CONTENT_LENGTH` | Werkzeug 3.1 caps urlencoded bodies at 500 kB otherwise; see [troubleshooting.md](troubleshooting.md) |
+| `MAX_THREADS` / `N_WORKERS` | 6 / 4 | Queue-side concurrency inside the single process |
+| `JOB_CACHE_MAX_SIZE` / `KEGG_CACHE_MAX_SIZE` | 50 / 25 | The in-process caches above |
+| `MAX_GUEST_JOB_DAYS` / `MAX_JOB_DAYS` | 7 / 14 | Job retention, from `accessDate`; the interface promises these exact numbers and `test_retention_matches_the_promise` reads them out of the servlet's own message so the two cannot drift |
+| `MAX_GUEST_DAYS` | 90 | Guest *account* inactivity — a different question from job retention |
+| `PAINTOMICS_BASE_URL` | — | Embedded in activation emails. A localhost value silently breaks registration; the container refuses to start without it |
+| `AI_INTERPRETATION_ENABLED` | true | Master switch for the AI feature |
+| `AI_COMPOUND_SUGGESTIONS_ENABLED` | true | Step 2 compound disambiguation, separate because it costs very differently |
+| `AI_INPUT_CONVERTER` | false | Ships inert; a deployment opts in |
+
+## Storage
+
+**MongoDB.** One application database (`PaintomicsDB` by default) plus one
+database per installed species. In the container stack it is `mongo:7`; the
+long-running non-container host has been seen on MongoDB 4.4, which matters —
+see the `$lookup` entry in [troubleshooting.md](troubleshooting.md). *(The
+production version is from operator notes.)*
+
+- `PaintomicsDB`: users, jobs, pathways, features, files, visual options, AI
+  interpretations, reports.
+- `<species>-paintomics`: `kegg` (pathway documents, with a `source` field of
+  KEGG / Reactome / MapMan / OmniPath), `xref`, `dbname`, `versions`.
+  **`xref` documents carry `dbname_id`, a foreign key into `dbname` — not a
+  `dbname` string.** A count filtered on `xref.dbname` matches nothing for any
+  species and has already produced one false "the data is missing" report.
+- `global-paintomics`: shared versions and compound tables.
+
+**Filesystem.** Two trees, both configurable and both outside the code:
+
+- `KEGG_DATA_DIR` (`PAINTOMICS_KEGG_DATA`, `/data/KEGG_DATA` in the container)
+  with `download/`, `current/` and `old/` subtrees. The installers stage into
+  `download/` and *move* a completed species into `current/`.
+- `CLIENT_TMP_DIR` (`PAINTOMICS_CLIENT_TMP`, `/data/CLIENT_TMP`) for uploads and
+  job output.
+
+In the container both are one named volume, `paintomics-data`, alongside
+`mongo-data`. Those two volumes hold everything irreplaceable; pathway data is
+reproducible from the source databases but takes hours to refetch.
+
+## Subprocesses
+
+The application shells out on the user-facing request path, so a host that
+serves pages perfectly can still fail the moment someone clicks a button:
+
+- **R** — `src/common/bioscripts/generateMetaGenes.R` and `hubAnalysis.R` for
+  Metagenes and Hub Analysis. `deploy/smoke-test.sh` checks that `purrr`,
+  `cluster`, `mclust`, `amap`, `factoextra`, `igraph`, `ggplot2`, `jsonlite`,
+  `stringr` and `dplyr` all import.
+- **MORE** — the regulatory model. PLS1 runs on `more-rs`, a Rust port
+  discovered beside `runMORE.R` or on `PATH`, and falls back to R when absent.
+  The binary is **gitignored**, so `git archive` drops it while
+  `deploy/build-image.sh` packs it from the working tree; `build-image.sh`
+  reads its ELF header and refuses to build if it is for the wrong
+  architecture. `PAINTOMICS_MORE_RS=off` forces R; MLR always runs on R.
+  `MORECostModel` refuses a job predicted not to fit the queue budget, and
+  `PAINTOMICS_MORE_COST_SCALE` multiplies that estimate for a host slower than
+  the one the model was fitted on.
+- **The identifier mapper** — `FeatureNamesToKeggIDsMapper` parallelises with
+  forked processes from inside the threaded worker. Forking a threaded process
+  is delicate; see the deadlock entry in
+  [troubleshooting.md](troubleshooting.md).
+
+## External services
+
+The application and its installers reach out to: `rest.kegg.jp`, `reactome.org`,
+`ftp.ebi.ac.uk` and the Ensembl FTP dumps, NCBI E-utilities (PubMed),
+`omnipathdb.org`, an OpenAI-compatible LLM gateway, and an SMTP relay.
+`deploy/compose.yaml` deliberately does *not* mark its network `internal:`
+because the species download needs egress; isolation comes from nginx being the
+only service with a published port.
+
+CI is the mirror image: the PR gate and the nightly run with
+`scripts/ci/no_network/sitecustomize.py` first on `PYTHONPATH`, which raises an
+`OSError` naming the host on any non-loopback connection.
+
+## The client
+
+`PaintomicsClient/public_html` is an ExtJS 4.2.1 application served as static
+files. Two mechanics matter operationally:
+
+- **Cache markers.** `index.html` references assets as `Util.js?v=2.6` and
+  friends. `revalidateEntryDocument` in `paintomicsserver.py` serves
+  `index.html` itself as `no-cache, must-revalidate` while every asset gets
+  `max-age=43200`. An edited asset whose `?v=` marker did not change is served
+  from cache to returning visitors — new view code running against an old
+  library, which surfaces as `ReferenceError: <fn> is not defined`.
+  `src/tests/test_versioned_assets_are_bumped.py` fails when a listed asset
+  changes without a bump.
+- **`Ext.Loader`.** Files loaded through `Ext.Loader` rather than a `<script>`
+  tag in `index.html` are not cache-busted by a `?v=` marker at all; a server
+  restart is what picks them up. `PA_Step2Views.js` is one of these. *(From
+  operator experience.)*
+
+## Job lifecycle
+
+A pathway-acquisition job moves through Step 1 (upload and organism/database
+choice), Step 2 (identifier mapping and compound disambiguation), and Step 3/4
+(enrichment, networks, hub and class analyses, metagenes, painted diagrams).
+`src/classes/JobInstances/` holds the four job classes — pathway acquisition,
+Regions2Genes, miRNA2Genes and MORE — and `src/benchmarks/bench_runner.py`
+drives exactly the same methods the servlets call, which is what makes the
+regression harness in [ci.md](ci.md) possible.
+
+Retention runs from `accessDate`, which the client rewrites through
+`/pa_touch_job` each time a job is opened, so a job someone keeps coming back to
+never expires.

--- a/docs/dev/ci.md
+++ b/docs/dev/ci.md
@@ -115,7 +115,7 @@ scripts/regression.sh 01-gene-single-condition
 ```
 
 Note that the installer needs the *other* interpreter: `DBManager.py` depends on
-`scriptine`, which dies on Python 3.11's removed `inspect.formatargspec`.
+`scriptine`, which dies on Python 3.11's removed `inspect.getargspec`.
 Installer under the conda 3.9 environment, pipeline under the 3.11 venv.
 
 **A field you added showing up as a diff in datasets you did not think about.**
@@ -136,7 +136,7 @@ intend to change are byte-identical with `diff -r`.
 `--write-baseline` creates **missing** baselines only and never overwrites one.
 To regenerate a baseline, delete its directory on purpose and re-run.
 
-After any baseline change, dispatch the nightly — the gate sees four of twelve
+After any baseline change, dispatch the nightly — the gate sees five of twelve
 datasets, so a stale baseline in the other eight is invisible until 03:17.
 
 ## Running the gate locally
@@ -147,8 +147,11 @@ Lint is the cheapest job to fail, and the whole of it runs locally:
 pip install ruff==0.14.13 vulture==2.16
 ruff check --output-format concise .
 scripts/ci/vulture_gate.sh
-for s in scripts/*.sh scripts/ci/*.sh deploy/*.sh; do bash -n "$s" || break; done
-python -m compileall -q PaintomicsServer/src scripts
+for s in scripts/*.sh scripts/ci/*.sh deploy/*.sh; do bash -n "$s" || exit 1; done
+find PaintomicsClient -name '*.js' \
+  | grep -vEi '/(lib|libs|vendor|ext-[0-9]|extjs|jquery|node_modules)/' \
+  | xargs -n1 node --check
+python -m compileall -q scripts/ci/vulture_whitelist.py
 ```
 
 The unit sweep runs through the same script CI uses:
@@ -174,6 +177,6 @@ it: a page added to `docs/` but left out of the nav, or a link that resolves to
 nothing, fails here instead of quietly never appearing on the published site.
 
 ```bash
-python -m pip install -r docs/requirements.txt
+python -m pip install -r docs/mkdocs-pins.txt
 mkdocs build --strict
 ```

--- a/docs/dev/ci.md
+++ b/docs/dev/ci.md
@@ -1,0 +1,179 @@
+# Continuous integration
+
+Five workflows in `.github/workflows/`. None of them deploys to the public
+instance; `cd.yml`'s "deploy" is an ephemeral stack on the runner.
+
+| Workflow | Trigger | What it does |
+|---|---|---|
+| `pr.yml` | every pull request | The gate: lint, the unit-test sweep, one example dataset per pipeline class, a secret scan and a documentation build |
+| `nightly.yml` | 03:17 daily, or by hand | All twelve example datasets against `tests/baseline/`, plus the species installer end to end against the live KEGG API |
+| `cd.yml` | push to `master` | Builds the deployable image and brings up a throwaway staging stack on the runner, checked with `deploy/smoke-test.sh` |
+| `data-cache.yml` | weekly, or by hand | Seeds the Actions cache with the species-data snapshot the baselines were recorded against. The only workflow that reads a secret |
+| `profile.yml` | by hand | py-spy over `tests/perf/large_input`, optionally A/B against another ref |
+
+## What a green tick on master proves
+
+**It proves the artifact built and the staging stack came up. It does not mean
+the tests pass.**
+
+`Lint`, `Unit tests (offline)` and `Example datasets, one per pipeline class`
+live in `pr.yml`, which triggers on `pull_request`. Nothing re-runs them after a
+merge, so `master` can show `success` on every commit while the dataset gate is
+failing on every open pull request — which has happened, and let changes merge
+over a gate that had been red for days.
+
+To judge `master`'s actual health, read the last pull request's checks
+(`gh pr checks <N>`) or dispatch the nightly:
+
+```bash
+gh workflow run nightly.yml --ref master
+gh run list --workflow nightly.yml --limit 3
+```
+
+## The gate, and what branch protection requires
+
+`master` carries a repository ruleset: pull request required, force-push and
+deletion refused, and the status check **`Gate`** must pass.
+
+`Gate` is a job that waits on the other five and fails unless every one of them
+succeeded. It exists because the unit-test job is a matrix, so its own check
+names carry the shard (`Unit tests (offline) (1/2)`) and change whenever the
+shard count is edited — a ruleset pinned to those names would silently stop
+gating the moment somebody split the matrix differently. `Gate`'s name never
+changes.
+
+The gate's budget is under ten minutes of wall clock. The five real jobs run in
+parallel and each carries its own hard timeout.
+
+## The offline rule
+
+The unit-test and dataset jobs run with outbound networking refused:
+`scripts/ci/no_network` goes first on `PYTHONPATH`, and its `sitecustomize.py`
+turns any attempt to open a non-loopback socket into a named `OSError`. KEGG,
+Reactome, PubMed, Europe PMC and the LLM gateway are therefore all unreachable —
+a suite that needs one must stub it.
+
+The single deliberate exception is `installer-smoke` in `nightly.yml`, which
+downloads one small species (`mge`, about 59 pathways, two seconds between
+requests) from the live KEGG API, because the download path is what it tests.
+
+No job in the gate reads a secret.
+
+## The species-data cache
+
+KEGG-derived data may not be redistributed, so the snapshot the baselines were
+recorded against is neither in this repository nor a public release asset. It
+lives in a private repository and reaches CI like this:
+
+- `data-cache.yml` checks it out with a read-only deploy key held as the
+  repository secret `CI_DATA_DEPLOY_KEY`, and saves it to the Actions cache
+  under a key ending in the snapshot identifier.
+- `pr.yml` and `nightly.yml` only ever *restore* that cache, with
+  `fail-on-cache-miss: true`, and use no secrets.
+
+Two consequences worth knowing:
+
+- **Caches unused for seven days are evicted.** The nightly touches this one
+  daily and `data-cache.yml` re-seeds weekly in case it was evicted anyway. If
+  the gate starts failing with a cache miss, dispatch `data-cache.yml` on
+  `master` and re-run.
+- **A pull request can only restore caches from the merge ref, the base branch
+  or the default branch** — never from its own head branch or a sibling. So a
+  new snapshot must be seeded from `master` *before* any pull request can use
+  it, and a new snapshot means a new key suffix in **both** `data-cache.yml` and
+  `.github/actions/setup-paintomics/action.yml`.
+
+## Why the runner is macOS
+
+`.github/actions/setup-paintomics` pins `macos-26` (arm64) and Python 3.11
+because `tests/baseline/` is compared **exactly** — floats bit for bit, NaN
+equal to NaN, no tolerance. The baselines were produced on that platform with
+those CPython wheels, R 4.6.0, and an arm64 `more-rs`; a different BLAS is a
+different summation order, which shows up as a diff. Ubuntu is used only for the
+lint, secret-scan, docs and CD jobs, which compare nothing numeric.
+
+## Reading a regression failure
+
+The dataset job runs `scripts/regression.sh` over one dataset per pipeline class
+plus one multi-omic dataset. On failure it uploads the differing outputs as an
+artifact named `regression-pr-<run id>`, kept for seven days — download that
+before re-running anything.
+
+Two failure modes look identical to a real regression and are not:
+
+**Last-digit float differences across datasets your change cannot touch.** That
+is the interpreter, not the code. The baselines are pinned to the environment
+that recorded them; running the harness under a different Python or a different
+NumPy/SciPy build produces ordinary content differences with no warning that the
+environment moved. `scripts/regression.sh` defaults `PYTHON` to plain `python3`,
+so set it explicitly:
+
+```bash
+export PYTHON=/path/to/venv-py311/bin/python
+export PAINTOMICS_KEGG_DATA=/path/to/KEGG_DATA
+scripts/regression.sh 01-gene-single-condition
+```
+
+Note that the installer needs the *other* interpreter: `DBManager.py` depends on
+`scriptine`, which dies on Python 3.11's removed `inspect.formatargspec`.
+Installer under the conda 3.9 environment, pipeline under the 3.11 venv.
+
+**A field you added showing up as a diff in datasets you did not think about.**
+The comparison is exact, so a purely additive output field is still a diff. This
+has bitten three times; in one case the gate could not see it at all, because
+every gate dataset carried a single omic and the new field only appears once a
+job has more than one. That is why `04-multiomics-integration` is now in the
+gate.
+
+## Recording a baseline
+
+Before rewriting anything, **classify every difference first**: walk both trees
+and count `ADDED` / `REMOVED` / `VALUE CHANGE` / `TYPE CHANGE` / `LIST LENGTH`.
+Only an additive-only result means the baseline is merely stale; anything else
+is a regression hiding behind one. Then confirm the baselines you did *not*
+intend to change are byte-identical with `diff -r`.
+
+`--write-baseline` creates **missing** baselines only and never overwrites one.
+To regenerate a baseline, delete its directory on purpose and re-run.
+
+After any baseline change, dispatch the nightly — the gate sees four of twelve
+datasets, so a stale baseline in the other eight is invisible until 03:17.
+
+## Running the gate locally
+
+Lint is the cheapest job to fail, and the whole of it runs locally:
+
+```bash
+pip install ruff==0.14.13 vulture==2.16
+ruff check --output-format concise .
+scripts/ci/vulture_gate.sh
+for s in scripts/*.sh scripts/ci/*.sh deploy/*.sh; do bash -n "$s" || break; done
+python -m compileall -q PaintomicsServer/src scripts
+```
+
+The unit sweep runs through the same script CI uses:
+
+```bash
+PAINTOMICS_KEGG_DATA=/path/to/KEGG_DATA scripts/ci/run-unit-tests.sh --timeout 420
+```
+
+The secret scan is a single binary over the working tree, and takes about four
+seconds:
+
+```bash
+gitleaks dir . --config .gitleaks.toml --redact
+```
+
+`.gitleaks.toml` must keep its `[extend] useDefault = true`. Without it gitleaks
+loads no rules at all and reports a clean tree however many keys are in it —
+which is exactly what that file did, unused, from the day it was added until
+2026-08-31.
+
+The documentation build is likewise one command, and `--strict` is the point of
+it: a page added to `docs/` but left out of the nav, or a link that resolves to
+nothing, fails here instead of quietly never appearing on the published site.
+
+```bash
+python -m pip install -r docs/requirements.txt
+mkdocs build --strict
+```

--- a/docs/dev/deployment.md
+++ b/docs/dev/deployment.md
@@ -1,0 +1,196 @@
+# Deployment
+
+> **This page is a first draft, reconstructed from the repository and from the
+> maintainer's private operating notes. It has not yet been reviewed by the
+> person who actually runs the public instance. Read it as a starting point and
+> confirm each step before relying on it.**
+>
+> Nothing here contains credentials, host addresses or access routes. Those live
+> in the operator's password manager and are not published.
+
+There are two deployments, and they are not the same shape.
+
+| | Container stack | The public instance |
+|---|---|---|
+| Where | Anywhere with Docker | A university host, reachable only from inside its network through a jump host |
+| Built by | `deploy/build-image.sh` | Not built — files are synchronised into a checkout |
+| Runs as | Compose: nginx → app → MongoDB | systemd unit driving uWSGI, behind the host's nginx |
+| Config | `deploy/.env` | `PaintomicsServer/src/conf/serverconf.py` plus a systemd `EnvironmentFile` |
+| Documented in | `deploy/README.md` | this page |
+
+`cd.yml` exercises the container stack on every push to `master` and runs
+`deploy/smoke-test.sh` against it. Nothing in CI touches the public instance;
+there is no step, host or credential for it.
+
+## The container stack
+
+`deploy/README.md` is the operator guide and is the authority for this path.
+In outline:
+
+```bash
+deploy/build-image.sh          # packs deploy/app.tar and builds the image
+cp deploy/env.example deploy/.env   # then fill it in
+docker compose -f deploy/compose.yaml up -d
+deploy/smoke-test.sh           # non-zero on the mistakes that are expensive in production
+```
+
+Two constraints must not be relaxed, and the smoke test checks both:
+
+1. **uWSGI runs a single process.** The job queue (`src/common/PySiQ.py`) lives
+   in the memory of the process that accepted the request. A second worker gets
+   its own empty queue and jobs disappear with no error. Concurrency comes from
+   threads, not processes.
+2. **MongoDB is never published to the host.** It runs without authentication
+   and is reachable only on the Compose network. Do not add a `ports:` mapping.
+
+`deploy/make-cert.sh` produces a *self-signed* certificate as an interim
+measure. Replace it before anyone else uses the instance.
+
+## The public instance
+
+### Deploy from `origin/master`, never from a feature branch
+
+Export the tree from `origin/master`, not from the commit of the branch you just
+merged. A feature branch does not contain whatever else merged to `master` while
+you were working, and every individual file you ship will still hash-verify
+correctly against your own commit — so the deploy looks clean while the site
+silently keeps an older version of files you did not touch. This has happened:
+two merged pull requests sat live on GitHub for hours without reaching the
+server, and it was noticed by a person looking at the page, not by any check.
+
+```bash
+git fetch origin master
+git archive origin/master --prefix=export/ | tar -x -C /tmp
+```
+
+### Prefer a per-file sync with no `--delete`
+
+For anything short of a whole-tree upgrade, name the files explicitly:
+
+1. **Hash-check first.** For each file you are about to replace, compare the
+   remote copy (`git hash-object`) with the blob in the commit the server is
+   supposed to be at (`git rev-parse <commit>:<path>`). Any mismatch is
+   uncommitted work living only on the server; stop and find out what it is
+   before overwriting it.
+2. `rsync -a --checksum --files-from=<list>` with **no `--delete`**.
+3. **Hash-check again afterwards**, and confirm every file now matches the
+   commit you deployed.
+
+This sidesteps the entire question of whether the protect list is complete,
+because nothing you did not name is ever touched.
+
+### If you must run a whole-tree sync
+
+A `git archive` export contains no gitignored files at all, so a
+`rsync --delete` run will queue deletions for every file that exists only on the
+server. Some of those are load-bearing:
+
+- the per-site `serverconf.py`, and the `AdminTools/conf` symlink to it;
+- `.env` files holding the AI gateway and PubMed keys — note that these exist at
+  more than one level of the tree, and the protect list has historically been
+  written for only one of them;
+- the `more-rs` binary, which is gitignored, exists only on the server, and is
+  the **default** MORE engine — deleting it breaks every MORE job;
+- example data files that predate the tracked datasets and are still read at
+  runtime;
+- logs, and the server's own stale `.git` directory.
+
+Always run `--dry-run --itemize-changes` first and **read every `*deleting`
+line**. Never pipe that dry run through `head`: SIGPIPE kills rsync mid-listing,
+and the truncated output reads as "only two files differ".
+
+Before trusting the protect list, re-audit it against a fresh `find` on the
+server rather than assuming it is still exhaustive. It is written against
+whatever existed when it was last edited, and nothing enforces that it keeps up.
+
+### Restart only when server code changed — and verify it
+
+Client-only changes need no restart. A restart is not free: sessions are held in
+the memory of the running process (`UserSessionManager` keeps a plain dict, and
+Mongo has no session collection), so **restarting logs every active user out**.
+Their browser keeps its cookies, so the next request looks authenticated to them
+and fails server-side, surfacing as a puzzling authorisation error rather than a
+login prompt.
+
+When you do restart, confirm it actually happened:
+
+```bash
+systemctl show paintomics4.service -p ActiveEnterTimestamp
+```
+
+`is-active: active` proves nothing — the service was already active. Compare the
+timestamp before and after.
+
+One trap that produces a convincing false success: a privileged command sent
+over SSH inside a double-quoted string has its shell variables expanded **on the
+remote host**, where the local variable holding the password does not exist.
+`sudo` then receives nothing, the restart never happens, the service stays up on
+the old code, and every other line of the deploy script reports success. Pass
+the password on the command's standard input rather than interpolating it into
+the command string.
+
+### Secrets do not travel with the code
+
+`git archive` cannot carry gitignored files, so no deploy ever ships a secret.
+On the server they come from two places:
+
+- **`serverconf.py`**, generated once per deployment from
+  `src/resources/example_serverconf.py` and never overwritten afterwards. Every
+  secret in it is read with `os.getenv` and an empty default.
+- **A systemd `EnvironmentFile` drop-in** for the service unit.
+
+Note that **uWSGI has no `env-file` option**. `paintomics4.ini` carried an
+`env-file =` line for months; uWSGI ignores unknown ini keys silently, so it
+read as working configuration while delivering nothing, and `SMTP_PASSWORD` was
+empty in every worker — user-submitted reports were discarded rather than merely
+undelivered. Verify with:
+
+```bash
+systemctl show paintomics4.service -p EnvironmentFiles
+sudo cat /proc/$(pgrep -f uwsgi | head -1)/environ | tr '\0' '\n' | sort
+```
+
+Because that file had been inert, making it work *activates* everything else in
+it. After changing how the environment is delivered, diff what the process
+actually has now against what it had before, and confirm each newly-live setting
+is intended.
+
+## Species data
+
+Pathway data is installed per species and is the slow, destructive part —
+measured in hours and hundreds of gigabytes, not minutes.
+
+```bash
+python src/AdminTools/DBManager.py download --specie=mmu --kegg=1 --mapping=1 --common=1 --reactome=1
+python src/AdminTools/DBManager.py install  --specie=mmu
+```
+
+Use `--common=0` for every species after the first; the common step re-downloads
+the shared KEGG reference data and dominates the runtime. Reactome curates human
+and infers about twenty other species, so `--reactome=0` for the rest.
+
+A reinstall promotes `download/<species>` over `current/<species>`. Generated
+files that no download ever contains — hub data, the pathway network JSON, the
+Reactome and MapMan build products — live only in `current/` and have been lost
+this way. Never bulk-reinstall species on the public instance to fix one of
+them, and read the guard's refusal rather than exempting the thing it names.
+
+## After every deploy
+
+- `deploy/smoke-test.sh` for the container stack.
+- For the public instance: fetch the site over HTTPS and confirm a 200; confirm
+  a versioned asset you changed is being served with its new `?v=` marker;
+  re-run the hash check over the files you shipped; and open one real job end to
+  end in a browser.
+- If server code changed, confirm the restart timestamp moved.
+
+## Rollback
+
+The previous release's virtual environment is kept alongside the current one for
+exactly this reason, and a dated backup tarball of the application tree is taken
+before large deploys. Rolling back is: restore the tree, point the systemd unit
+back at the previous environment — the unit references that path in **two**
+places, both of which must be changed — and restart, verifying the timestamp.
+
+Rolling back does **not** roll back the database. An installer run or a schema
+change is not undone by restoring the application tree.

--- a/docs/dev/deployment.md
+++ b/docs/dev/deployment.md
@@ -160,9 +160,13 @@ is intended.
 Pathway data is installed per species and is the slow, destructive part —
 measured in hours and hundreds of gigabytes, not minutes.
 
+Run the installer under a Python 3.9 interpreter, not the 3.11 environment the
+application uses: `DBManager.py` goes through `scriptine`, which calls
+`inspect.getargspec`, removed in 3.11.
+
 ```bash
-python src/AdminTools/DBManager.py download --specie=mmu --kegg=1 --mapping=1 --common=1 --reactome=1
-python src/AdminTools/DBManager.py install  --specie=mmu
+python3.9 src/AdminTools/DBManager.py download --specie=mmu --kegg=1 --mapping=1 --common=1 --reactome=1
+python3.9 src/AdminTools/DBManager.py install  --specie=mmu
 ```
 
 Use `--common=0` for every species after the first; the common step re-downloads

--- a/docs/dev/troubleshooting.md
+++ b/docs/dev/troubleshooting.md
@@ -1,0 +1,202 @@
+# Troubleshooting
+
+Each entry is a symptom somebody actually hit, what was really going on, and
+what to do. Claims that come only from operator experience and are not enforced
+anywhere in the code are marked as such.
+
+## Your fix has no effect
+
+**Symptom.** You edit something under `PaintomicsServer/src/`, exercise it
+against the already-running development server, and see the old behaviour. The
+fix looks wrong.
+
+**Cause.** `launch_server.py` runs with debug mode on, but its reloader does not
+reliably pick changes up. You are testing a stale process. *(From operator
+experience; not enforced by code.)*
+
+**What to do.** Restart before testing, every time:
+
+```bash
+kill $(lsof -ti:8000); sleep 3
+cd PaintomicsServer && nohup python src/launch_server.py > /tmp/server.log 2>&1 &
+sleep 12
+```
+
+This failure mode is dangerous because it fails in the direction of "looks
+fine": a path-traversal fix once kept returning `/etc/hosts` to a tester who had
+not restarted, and was correctly refused the moment the server was restarted.
+
+## Everything says "not authorised" after a restart
+
+**Symptom.** An action that worked a minute ago now fails with an
+authorisation-shaped error, for a user who is plainly logged in.
+
+**Cause.** `UserSessionManager` holds `logged_users` as a plain dict on its
+singleton. There is no session collection in MongoDB. Restarting the process
+invalidates every live session, but the browser still holds its `userID` and
+`sessionToken` cookies, so the request looks authenticated to the user and fails
+`isValidUser` on the server.
+
+**What to do.** Reload and log in again after any restart. Do not diagnose it as
+a permissions bug. It also means a live session cannot be borrowed from Mongo to
+drive an authenticated endpoint from a script — the token exists only in the
+running process.
+
+## `ReferenceError: <function> is not defined`, for a function that exists
+
+**Symptom.** The browser console reports a missing function that is plainly
+present in the source. A hard reload makes it go away, so it never reproduces in
+development.
+
+**Cause.** Versioned client assets are served with a long max-age on purpose. If
+you change a JS or CSS file and do not bump its `?v=` marker in
+`PaintomicsClient/public_html/index.html`, returning browsers keep the old file
+and run it against new view code. This has broken the results page and Step 4's
+pathway details panel.
+
+**What to do.** Bump the marker. Confirm the diagnosis from the page console by
+comparing byte lengths:
+
+```js
+fetch(url).then(r => r.text()).then(t => console.log('cached', t.length))
+fetch(url, {cache: 'no-store'}).then(r => r.text()).then(t => console.log('fresh', t.length))
+```
+
+`src/tests/test_versioned_assets_are_bumped.py` now fails the suite on this, so
+it should not recur silently. Note that a file loaded through `Ext.Loader`
+rather than a `<script>` tag in `index.html` is *not* cache-busted and needs no
+bump — a server restart is enough for those.
+
+## Identifier mapping hangs in production but is fast locally
+
+**Symptom.** Every job stalls in the mapping step on the deployed instance,
+while the same code is quick on a development machine.
+
+**Cause.** The production MongoDB is 4.4. It does not use the compound index for
+an `$in` against an array variable inside a `$lookup` sub-pipeline; MongoDB 8.x
+does. Workers sit inside `db.xref.aggregate`, each batch scanning a
+million-document collection.
+
+**What to do.** Prefer plain indexed finds over aggregation for anything on this
+path — the two-find form measured about nine times faster than the aggregation
+on 4.4, with identical results and ordering. Measure query-shaped changes
+against the production MongoDB version before deploying, not only locally. To
+confirm a live hang, take a `py-spy dump` of the worker process.
+
+## The regression harness fails on datasets your change cannot touch
+
+Two different causes, and they need opposite responses.
+
+**Last-digit float differences, spread across many datasets.** That is the
+environment, not the code. `tests/baseline/` is compared exactly, so a different
+NumPy/SciPy build is a different summation order. `scripts/regression.sh`
+defaults `PYTHON` to plain `python3` and nothing in the harness records or
+checks an interpreter version. Set `PYTHON` explicitly to the pinned 3.11
+interpreter and re-run before reverting anything.
+
+**A field you added appearing everywhere.** An additive output change is still a
+diff, and the pull-request gate only samples four of the twelve datasets. Before
+rewriting any baseline, classify every difference — `ADDED` / `REMOVED` /
+`VALUE CHANGE` / `TYPE CHANGE` / `LIST LENGTH`. Additive-only means stale;
+anything else is a regression hiding behind one. Regenerate by deleting the
+dataset's directory: `--write-baseline` only creates missing baselines and never
+overwrites.
+
+Two harness traps worth knowing in a fresh worktree: `regression.sh` aborts up
+front if the reference GTF or the `more-rs` binary is missing, even for a
+dataset that needs neither; and the GTF must be **copied**, not symlinked,
+because `ExampleDatasets.absolutePath` rejects a path that resolves outside the
+example directory.
+
+## `master` is green and every pull request is red
+
+**Cause.** `cd.yml`, which runs on push to `master`, has two jobs: build the
+artifact, and bring up an ephemeral staging stack. The tests are all in
+`pr.yml`, which triggers on `pull_request` only. Nothing re-runs them after a
+merge.
+
+**What to do.** Judge `master` by the last pull request's checks or by
+dispatching `nightly.yml`. See [ci.md](ci.md).
+
+## A species reinstall refuses, or silently loses data
+
+**Symptom.** The "install must never lose files" guard refuses a reinstall,
+naming a file the download does not contain. Alternatively, an install reports
+SUCCESS and the species loses generated data.
+
+**Cause.** Several files are *build products* that live only in `current/` and
+that no download ever supplies — hub data, the pathway network JSON, and the
+Reactome and MapMan version and mapping files. Promotion moves `download/` into
+place over `current/`.
+
+**What to do.** Do not exempt the file the guard names in order to get past it.
+That turns a refusal into silent data loss: one such exemption archived the
+installed tree and promoted one without hub data, losing about 1,869 files while
+logging SUCCESS. Check what the guard was protecting the file *from*, and test
+any change by running the promotion and counting files on the far side.
+
+## A test's direct edit to a job document has no effect
+
+**Cause.** `JobInformationManager.loadJobInstance` serves a bounded in-process
+cache. A job document edited directly in MongoDB while the server is running
+still answers from the cache, and deleting the document does not evict it
+either.
+
+**What to do.** Never edit a job in place or reuse a job ID across test runs.
+Insert a clone under a fresh, never-used job ID with the flags baked in at
+insert time. Real application flows mutate through the same cached instance, so
+cache and database stay coherent in production — the guards this appears to
+break are correct.
+
+## A configured secret is empty in the running process
+
+**Cause.** An ignored configuration key looks configured. uWSGI has no
+`env-file` option and silently ignores unknown ini keys, so an `env-file =` line
+delivered nothing for months while reading as working configuration.
+
+**What to do.** Never trust an ini key you have not seen in `uwsgi --help`.
+Check what the process actually has:
+
+```bash
+sudo cat /proc/$(pgrep -f uwsgi | head -1)/environ | tr '\0' '\n' | grep -c '^SMTP_'
+```
+
+## The whole site becomes unresponsive while AI jobs run
+
+**Cause.** One uWSGI process with four threads serves every API request. A route
+that waits inline on the LLM gateway holds one of those threads for the duration
+— measured around two minutes per non-streamed attempt. Three concurrent callers
+leave one thread for the entire site; four is an outage.
+
+**What to do.** Never wait on an LLM, an external API or a long computation
+inside a request. Enqueue into the shared queue, return a ticket, and let the
+browser poll; poll requests are milliseconds and hold nothing. Cap how many such
+jobs may be in flight, because that queue is shared with pathway analysis.
+
+## A deploy reported success but the site runs old code
+
+Three separate causes, all of which report success:
+
+- The export came from a feature branch rather than `origin/master`, so files
+  you did not touch stayed behind.
+- The restart never happened, because the privileged command never received its
+  password. `is-active` was still `active`, because it always was.
+- Server code changed and no restart was attempted at all.
+
+See [deployment.md](deployment.md) for the checks that catch each.
+
+## Parallel work in this repository
+
+Worktrees share one git index and one object store with every other session
+working in the same repository. A commit made from one worktree while another
+session has staged files can pick up work that is not yours. *(From operator
+experience; not enforced by code.)*
+
+Run `git status --branch --short` before every commit in a worktree, use a fresh
+worktree per branch, and prefer reproducing a reported bug from a worktree cut
+from `origin/master` rather than from whatever the main checkout happens to be
+on.
+
+A worktree also has no `.env`, so an instance launched from one runs with the AI
+features disabled and looks like a build where the feature is missing rather
+than one where the key is absent.

--- a/docs/dev/troubleshooting.md
+++ b/docs/dev/troubleshooting.md
@@ -95,7 +95,7 @@ checks an interpreter version. Set `PYTHON` explicitly to the pinned 3.11
 interpreter and re-run before reverting anything.
 
 **A field you added appearing everywhere.** An additive output change is still a
-diff, and the pull-request gate only samples four of the twelve datasets. Before
+diff, and the pull-request gate only samples five of the twelve datasets. Before
 rewriting any baseline, classify every difference — `ADDED` / `REMOVED` /
 `VALUE CHANGE` / `TYPE CHANGE` / `LIST LENGTH`. Additive-only means stale;
 anything else is a regression hiding behind one. Regenerate by deleting the

--- a/docs/mkdocs-pins.txt
+++ b/docs/mkdocs-pins.txt
@@ -1,0 +1,12 @@
+# Documentation toolchain only, installed by Read the Docs and by the Docs
+# build job in .github/workflows/pr.yml.
+#
+# Deliberately NOT named requirements.txt. The root requirements.txt is the one
+# pip manifest in this tree and
+# PaintomicsServer/src/tests/test_dependencies_declared.py fails the suite if a
+# second `requirements*.txt` appears anywhere -- a second manifest is what fed
+# GitHub's dependency graph a stale snapshot and produced 33 phantom alerts.
+# Keeping this file outside that glob keeps both the guard and the docs build
+# honest. It also means nothing updates these pins automatically; bump them by
+# hand when the docs build needs it.
+mkdocs==1.6.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,0 @@
-# Documentation toolchain only. The application manifest is the root
-# requirements.txt; it is not needed and must not be installed to build the docs.
-# Read the Docs installs this file (see /.readthedocs.yaml).
-mkdocs==1.6.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+# Documentation toolchain only. The application manifest is the root
+# requirements.txt; it is not needed and must not be installed to build the docs.
+# Read the Docs installs this file (see /.readthedocs.yaml).
+mkdocs==1.6.1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,26 +39,27 @@ nav:
 
 theme: readthedocs
 
-# docs/requirements.txt is the Read the Docs build input (see /.readthedocs.yaml).
-# It is not documentation and must not be copied into the built site.
-exclude_docs: |
-   requirements.txt
-
-# Pages that are deliberately absent from the nav. Listing them here records the
-# decision and keeps `mkdocs build --strict` quiet about them.
-#   - dev/ is maintainer documentation: it says so on its own first line and asks
-#     to stay out of this nav;
+# Pages that must NOT reach the published site. `exclude_docs` is the mechanism
+# that actually keeps them off it: `not_in_nav` only drops a page from the
+# navigation, and mkdocs still builds and publishes it at its URL, unlinked.
+#   - mkdocs-pins.txt is build input, not documentation;
+#   - dev/ is maintainer documentation -- deployment procedure and internal
+#     traps -- and says on its own first line that it is not for users;
 #   - the two engineering directories hold dated implementation plans and design
-#     specs, not user documentation;
-#   - ai-agent-benchmark.md and ai-agent-tooling-notes.md are running measurement
-#     records for an internal comparison of the two AI interpretation arms;
-#   - 5_2_detailed_views.md and 5_3_heatmaps.md are unwritten stubs: each holds
-#     the shared logo header and the contact line and nothing else.
-not_in_nav: |
+#     specs;
+#   - ai-agent-benchmark.md and ai-agent-tooling-notes.md are running
+#     measurement records for an internal comparison of the two AI arms.
+exclude_docs: |
+   mkdocs-pins.txt
    dev/
    superpowers/
    frontend-modernization/
    ai-agent-benchmark.md
    ai-agent-tooling-notes.md
+
+# Published, but deliberately absent from the nav: both are unwritten stubs
+# holding the shared logo header and the contact line and nothing else. Listing
+# them here records the decision and keeps `mkdocs build --strict` quiet.
+not_in_nav: |
    5_2_detailed_views.md
    5_3_heatmaps.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,12 @@
 site_name: Paintomics Documentation
-pages:
+site_description: >-
+  Documentation for PaintOmics, a web tool for the integrative visualization of
+  multiple omic datasets onto KEGG, Reactome and MapMan pathways.
+site_url: https://paintomics.readthedocs.io/en/latest/
+repo_url: https://github.com/ConesaLab/PaintOmics
+repo_name: ConesaLab/PaintOmics
+
+nav:
    - Home: 'index.md'
    - 'Getting started':
       - 'Step-by-step guide': '8_step_by_step.md'
@@ -13,6 +20,10 @@ pages:
       - 'Regulatory omics analysis': '4_6_Regulatory_omics.md'
       - 'Metagenes': '4_7_Metagenes.md'
       - 'Multi-omic pathway-based visualisation': '5_1_browsing_pathways.md'
+      - 'A worked example: RNA-seq and DNase-seq': '6_1_use_case.md'
+   - 'PaintOmics AI':
+      - 'Converting your input files': 'ai-input-converter.md'
+      - 'The full-agent interpretation mode': 'ai-full-agent.md'
    - FAQ:
       - 'Frequently asked questions': '9_faq.md'
    - 'Additional information':
@@ -25,4 +36,29 @@ pages:
       - 'Installing PaintOmics 4': '0_install.md'
    - About:
       - 'License': '7_license.md'
+
 theme: readthedocs
+
+# docs/requirements.txt is the Read the Docs build input (see /.readthedocs.yaml).
+# It is not documentation and must not be copied into the built site.
+exclude_docs: |
+   requirements.txt
+
+# Pages that are deliberately absent from the nav. Listing them here records the
+# decision and keeps `mkdocs build --strict` quiet about them.
+#   - dev/ is maintainer documentation: it says so on its own first line and asks
+#     to stay out of this nav;
+#   - the two engineering directories hold dated implementation plans and design
+#     specs, not user documentation;
+#   - ai-agent-benchmark.md and ai-agent-tooling-notes.md are running measurement
+#     records for an internal comparison of the two AI interpretation arms;
+#   - 5_2_detailed_views.md and 5_3_heatmaps.md are unwritten stubs: each holds
+#     the shared logo header and the contact line and nothing else.
+not_in_nav: |
+   dev/
+   superpowers/
+   frontend-modernization/
+   ai-agent-benchmark.md
+   ai-agent-tooling-notes.md
+   5_2_detailed_views.md
+   5_3_heatmaps.md

--- a/scripts/ci/run_suites.py
+++ b/scripts/ci/run_suites.py
@@ -55,6 +55,26 @@ def run_suite(name, timeout):
             "tail": "\n".join(out.strip().splitlines()[-TAIL_LINES:])}
 
 
+def baseline_failures(suite):
+    """How many failures this suite is known to have on master.
+
+    `None` means the suite is not baselined at all, so any failure is this
+    branch's. Otherwise it is the count stated by run_all.BASELINE's own text
+    ("3 failures: the stub gateway ..."), and a run that fails MORE times than
+    that has introduced something even though the suite name is on the list.
+
+    Matching on the suite name alone was the hole: a suite baselined for one
+    known failure absorbed a brand-new second one and the gate stayed green.
+    An entry with no parseable count still shields the whole suite -- keep the
+    counts in BASELINE so it does not.
+    """
+    note = run_all.BASELINE.get(suite)
+    if note is None:
+        return None
+    match = re.match(r"\s*(\d+)\s+failures?\b", note)
+    return int(match.group(1)) if match else sys.maxsize
+
+
 SUITE_TIMES = os.path.join(HERE, "suite_times.txt")
 
 
@@ -152,8 +172,18 @@ def main(argv=None):
         results = list(pool.map(lambda name: run_suite(name, args.timeout), names))
 
     bad = [r for r in results if r["state"] != "PASS"]
-    inherited = [r for r in bad if r["suite"] in run_all.BASELINE]
-    introduced = [r for r in bad if r["suite"] not in run_all.BASELINE]
+    inherited, introduced = [], []
+    for result in bad:
+        expected = baseline_failures(result["suite"])
+        seen = len(result["failing"])
+        if expected is None or seen > expected:
+            # Not baselined at all, or baselined and now failing MORE than it
+            # was: either way this branch is answerable for it.
+            if expected is not None:
+                result["grew"] = (expected, seen)
+            introduced.append(result)
+        else:
+            inherited.append(result)
     skipped = [r for r in results if r["skipped"]]
     total = sum(r["secs"] for r in results)
 
@@ -173,9 +203,11 @@ def main(argv=None):
         for r in skipped:
             print("   %s" % r["suite"])
     if introduced:
-        print("\nFAILED (not in BASELINE):")
+        print("\nFAILED (new, or worse than BASELINE records):")
         for r in introduced:
-            print("   %-50s %s %s" % (r["suite"], r["state"], ", ".join(r["failing"])[:80]))
+            grew = ("  [was %d failure(s) on master, now %d]" % r["grew"]) if "grew" in r else ""
+            print("   %-50s %s %s%s"
+                  % (r["suite"], r["state"], ", ".join(r["failing"])[:80], grew))
         for r in introduced:
             print("\n----- %s (%s): last %d lines -----" % (r["suite"], r["state"], TAIL_LINES))
             print(r["tail"])


### PR DESCRIPTION
The CI/CD pipeline was already in good shape. Everything *around* it was missing, and that is what this changes.

`master` had no protection at all, and the green tick on a `master` commit only ever meant "the image built" — `Lint`, `Unit tests (offline)` and `Example datasets` all live in `pr.yml` and nothing re-runs them after a merge. There was no contributor guide, no security policy, no issue templates, no code owners, no citation record, and no changelog entry since 2017. The project's operational knowledge lived in one person's private notes rather than in the repository.

## Configured through the API, not in this diff

- **Branch ruleset on `master`** — pull request required, force-push and deletion refused, status checks required. No bypass actors; see the note at the bottom.
- **Repository metadata** — description, homepage, 15 topics. The repo had none, so it could not surface in a GitHub search for `multi-omics` or `kegg`.
- **Dependabot security updates**, **secret-scanning push protection**, and **private vulnerability reporting**, all previously off.
- `delete_branch_on_merge` and `allow_auto_merge`.

## In this diff

**The gate.** A `Gate` job waits on the other five and fails unless all succeeded, so branch protection has one stable name to require. Requiring `Unit tests (offline) (1/2)` directly would stop gating silently the first time somebody changed the shard count.

**A secret scan, and a real fix behind it.** `.gitleaks.toml` existed and nothing ran it — but it also defined an `[allowlist]` and no rules, so it loaded *zero* patterns. Measured with the same planted keys:

| config | findings |
|---|---|
| gitleaks defaults | 2 |
| `.gitleaks.toml` as it stood | **0** |
| with `[extend] useDefault = true` | 2 |

Wiring it in without that fix would have bought a clean bill of health that meant nothing. A full-history scan (1466 commits, 626 MB) now runs clean too — with one finding, noted below.

**A docs build.** `mkdocs.yml` still used `pages:`, a key removed in MkDocs 1.0 (2018), and the AI documentation existed on disk while appearing nowhere on the published site. Now `nav:`, with the AI pages published, the genuinely internal notes recorded under `not_in_nav`, and `.readthedocs.yaml` putting the build config in the repository. `mkdocs build --strict` runs in the gate; it fails today on links into pages that were never in the nav, which is the point.

**`docs/dev/`** — architecture, deployment, CI, and troubleshooting, reconstructed from the repository and from operator notes. Claims that come only from experience are marked as such. **`deployment.md` carries a banner saying it is a first draft and needs your review before anyone relies on it.** No credentials, hosts or access routes appear anywhere in it.

**CHANGELOG.md** under `[Unreleased]`, because the version number is yours to pick. All 49 pull-request references were checked to exist and be merged.

**CITATION.cff**, validated with `cffconvert` against CFF 1.2.0. Author list, volume, issue and pages cross-checked against CrossRef and PubMed; every ORCID resolved to the right person.

Plus `CONTRIBUTING.md`, `SECURITY.md`, `CODEOWNERS`, a PR template, three issue forms (the bug form asks for the job ID, organism, omic types and the first two lines of the input file — the things email reports never contain), and `dependabot.yml`.

README's test count was stale (135; there are 282) and its links used a repo slug that only worked by redirect.

## Two things that need you

1. **A DashScope API key is in this repository's public history.** Committed 2026-03-04 in `PaintomicsServer/src/conf/serverconf.py` (`24dc08f1`), untracked 2026-08-05 (`ffd756c0`), and still reachable from `master`. The provider is still wired in. **It needs revoking in the provider's console** — rewriting history will not help, given forks and clones.
2. **The ruleset has no bypass actors**, so direct pushes to `master` are refused for everyone including admins. If that gets in the way, one API call adds an admin bypass — say the word and I will.

After this merges, the required check should be switched from the four current names to `Gate`.