### PR TITLE
Count an ERROR as a failure, and a suite that names none as broken

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,15 @@ python -m src.tests.run_all --only ai        # substring filter on the suite nam
 answers "did this branch introduce a failure", not "is everything green". Do not
 add to that list to make a branch look clean.
 
+Each entry states a **count**, and the count is `FAIL` plus `ERROR` — an
+exception is a test that broke before it reached an assertion, and unittest
+reports those on a separate line. A baselined suite is inherited only while it
+names no more failing tests than its entry records; naming *more* is this
+branch's, and naming *none* while still not passing means it crashed before
+running anything, which is also this branch's. `run_all --baseline` prints the
+counts for you; an entry without one is refused at startup, because a baseline
+entry with no number shields its suite from every failure it ever acquires.
+
 CI runs the same suites in parallel and offline through
 `scripts/ci/run-unit-tests.sh`, which is also the fastest way to run them locally:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,11 +122,15 @@ add to that list to make a branch look clean.
 Each entry states a **count**, and the count is `FAIL` plus `ERROR` — an
 exception is a test that broke before it reached an assertion, and unittest
 reports those on a separate line. A baselined suite is inherited only while it
-names no more failing tests than its entry records; naming *more* is this
-branch's, and naming *none* while still not passing means it crashed before
-running anything, which is also this branch's. `run_all --baseline` prints the
-counts for you; an entry without one is refused at startup, because a baseline
-entry with no number shields its suite from every failure it ever acquires.
+actually runs its tests *and* names no more failing ones than its entry
+records. Naming **more** is this branch's. So is running **none** of them,
+whether the suite died on import or lost a `setUpClass` — unittest reports that
+as one `ERROR: setUpClass` line and `Ran 0 tests`, which compared favourably
+against a baseline of four while the whole suite had stopped executing. So is
+timing out. `run_all --baseline` prints the counts for you; an entry without one
+is refused at startup, because a baseline entry with no number shields its suite
+from every failure it ever acquires. `test_gate_baseline_rules` holds these
+rules in place.
 
 CI runs the same suites in parallel and offline through
 `scripts/ci/run-unit-tests.sh`, which is also the fastest way to run them locally:

--- a/PaintomicsServer/src/tests/run_all.py
+++ b/PaintomicsServer/src/tests/run_all.py
@@ -45,15 +45,89 @@ _ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 # running them in a master worktree with this checkout's serverconf.py copied in.
 # A failure here is inherited, not caused. Trim this list when master goes green;
 # never add to it to make a branch look clean.
+# The count is FAIL plus ERROR, not the "failures=N" that unittest prints in its
+# last line: an exception is a test that broke before it reached an assertion,
+# and unittest reports those separately. test_more_servlet_step1 is why this is
+# spelled out -- it ran for months recorded as "17 failures" while producing 17
+# failures and one error (ERROR: test_queues_step2_with_the_job), so the
+# eighteenth broken test was outside the count by construction.
 BASELINE = {
-    "test_ai_agent_endtoend": "3 failures: the stub gateway cannot satisfy the "
+    "test_ai_agent_endtoend": "4 failures: the stub gateway cannot satisfy the "
                               "quote extractor, so reference [1] renders with no "
                               "Cited Text and every citation is then redacted",
-    "test_more_servlet_step1": "17 failures",
+    "test_more_servlet_step1": "18 failures: 17 assertions and one error, "
+                               "ERROR: test_queues_step2_with_the_job",
     "test_pathway_universe_database_filter": "1 failure",
     "test_relevance_file_shape_and_conditions": "2 failures",
     "test_dependencies_declared": "1 failure: an external import does not resolve",
 }
+
+# Both conventions the suites use to name a broken test: unittest's
+# "FAIL: test_x" / "ERROR: test_x", and the hand-rolled runners' "FAIL name:" /
+# "ERROR name:".
+FAILING_TEST = re.compile(r"^(?:FAIL|ERROR)[: ]+(\S+)", re.M)
+
+
+def baseline_failures(suite):
+    """How many failing tests this suite is known to have on master.
+
+    `None` means the suite is not baselined at all, so any failure belongs to
+    this branch. Otherwise it is the count BASELINE's own text states, and a run
+    that fails MORE times than that has introduced something even though the
+    suite name is on the list.
+
+    A note with no parseable count raises rather than shielding the suite. The
+    silent version of that used to be printable: `--baseline` emitted an entry
+    per failing suite with an empty note, and pasting it back would have made
+    every listed suite absorb an unlimited number of new failures forever.
+    """
+    note = BASELINE.get(suite)
+    if note is None:
+        return None
+    match = re.match(r"\s*(\d+)\s+failures?\b", note)
+    if not match:
+        raise ValueError(
+            "BASELINE[%r] does not begin with a count: %r. Write it as "
+            "'<n> failures: why', because a baseline entry without a number "
+            "shields the suite from every new failure it acquires." % (suite, note))
+    return int(match.group(1))
+
+
+def check_baseline():
+    """Every BASELINE note states a count -- checked before anything runs."""
+    for suite in BASELINE:
+        baseline_failures(suite)
+
+
+def split_by_baseline(bad):
+    """Partition failing suites into (inherited, introduced).
+
+    Matching on the suite NAME alone was the original hole: a suite baselined
+    for one known failure absorbed a brand-new second one and the gate stayed
+    green. Counting closed that. This closes the two ways a count can still be
+    fooled: a failure reported as ERROR was never counted at all, and a suite
+    that crashes before running anything names no test, so `0 <= expected` read
+    as "no worse than master" while the whole suite stopped being checked.
+
+    Annotates each result in place with `seen`, and with `collapsed` or `grew`
+    where they apply, so the caller can say which of the three it is.
+    """
+    inherited, introduced = [], []
+    for result in bad:
+        expected = baseline_failures(result["suite"])
+        seen = len(result["failing"])
+        result["seen"] = seen
+        if expected is None:
+            introduced.append(result)
+        elif seen == 0:
+            result["collapsed"] = expected
+            introduced.append(result)
+        elif seen > expected:
+            result["grew"] = (expected, seen)
+            introduced.append(result)
+        else:
+            inherited.append(result)
+    return inherited, introduced
 
 
 def classify(returncode, out):
@@ -90,7 +164,7 @@ def run_one(name, timeout):
         out, state, skipped = "", "TIMEOUT", False
     return {"suite": name, "state": state, "skipped": skipped,
             "secs": round(time.time() - started, 1),
-            "failing": re.findall(r"^FAIL[: ]+(\S+)", out, re.M)}
+            "failing": FAILING_TEST.findall(out)}
 
 
 def main(argv=None):
@@ -116,10 +190,10 @@ def main(argv=None):
                   % args.only, file=sys.stderr)
             return 2
 
+    check_baseline()
     results = [run_one(n, args.timeout) for n in names]
     bad = [r for r in results if r["state"] != "PASS"]
-    inherited = [r for r in bad if r["suite"] in BASELINE]
-    introduced = [r for r in bad if r["suite"] not in BASELINE]
+    inherited, introduced = split_by_baseline(bad)
     skipped = [r for r in results if r["skipped"]]
 
     print("%d suites | %d pass | %d inherited | %d INTRODUCED"
@@ -131,16 +205,28 @@ def main(argv=None):
     if inherited:
         print("\ninherited from master (not this branch):")
         for r in inherited:
-            print("   %-46s %s" % (r["suite"], BASELINE[r["suite"]][:60]))
+            print("   %-46s %2d/%-2d %s"
+                  % (r["suite"], r["seen"], baseline_failures(r["suite"]),
+                     BASELINE[r["suite"]][:60]))
     if introduced:
         print("\nINTRODUCED BY THIS BRANCH:")
         for r in introduced:
-            print("   %-46s %s" % (r["suite"], ", ".join(r["failing"])[:60]))
+            if "collapsed" in r:
+                note = ("  [baselined for %d failing test(s) and named none: "
+                        "the suite did not run]" % r["collapsed"])
+            elif "grew" in r:
+                note = "  [was %d on master, now %d]" % r["grew"]
+            else:
+                note = ""
+            print("   %-46s %s%s" % (r["suite"], ", ".join(r["failing"])[:60], note))
 
     if args.baseline:
+        # The count is the point. Printing an empty note used to produce a
+        # BASELINE that let every listed suite absorb any number of new
+        # failures, and baseline_failures() now refuses to load one.
         print("\nBASELINE = {")
         for r in bad:
-            print('    "%s": "",' % r["suite"])
+            print('    "%s": "%d failures: WHY",' % (r["suite"], len(r["failing"])))
         print("}")
 
     return 1 if introduced else 0

--- a/PaintomicsServer/src/tests/run_all.py
+++ b/PaintomicsServer/src/tests/run_all.py
@@ -63,9 +63,38 @@ BASELINE = {
 }
 
 # Both conventions the suites use to name a broken test: unittest's
-# "FAIL: test_x" / "ERROR: test_x", and the hand-rolled runners' "FAIL name:" /
-# "ERROR name:".
-FAILING_TEST = re.compile(r"^(?:FAIL|ERROR)[: ]+(\S+)", re.M)
+# "FAIL: test_x (mod.Class)" / "ERROR: test_x (mod.Class)", and the hand-rolled
+# runners' "FAIL  name". The separator must be a colon FOLLOWED by whitespace,
+# or two spaces -- not a bare colon. `logging.error()` writes "ERROR:root:..."
+# at the start of a line once basicConfig has run, and the server logs on every
+# report, mail and hub failure path, so the looser `[: ]+` counted log records
+# as failing tests: it inflated the number written into BASELINE, and a suite
+# whose logging then went quiet could acquire that many real failures unnoticed.
+FAILING_TEST = re.compile(r"^(?:FAIL|ERROR)(?::[ \t]+|[ \t]{2,})(\S+)", re.M)
+
+# How many tests a suite actually executed, in whichever convention it used --
+# unittest's "Ran 29 tests in 5.076s", the hand-rolled runners' "Passed: 3 / 4".
+# None means neither line appeared, which is what a suite that died on import
+# looks like.
+_RAN_UNITTEST = re.compile(r"^Ran (\d+) tests?\b", re.M)
+_RAN_HANDROLLED = re.compile(r"Passed:\s*\d+\s*/\s*(\d+)")
+
+
+def tests_run(out):
+    """The number of tests the run reported executing, or None if it never said."""
+    match = _RAN_UNITTEST.search(out) or _RAN_HANDROLLED.search(out)
+    return int(match.group(1)) if match else None
+
+
+# A class or module fixture that raises: unittest prints one `ERROR: setUpClass`
+# line and then silently does not run that class's tests, while the OTHER
+# classes in the file run normally -- so the suite still reports a healthy
+# "Ran 8 tests". The count rule is blind to it, because the dead fixture is
+# exactly one name: a suite baselined for one failure can trade its known
+# failure for an entire class that stopped executing and still compare equal.
+# Whatever else is true, a run in that state has not reproduced the baseline,
+# so it is never credited with it.
+BROKEN_FIXTURE = re.compile(r"^ERROR:[ \t]+((?:setUp|tearDown)(?:Class|Module))\b", re.M)
 
 
 def baseline_failures(suite):
@@ -104,22 +133,39 @@ def split_by_baseline(bad):
 
     Matching on the suite NAME alone was the original hole: a suite baselined
     for one known failure absorbed a brand-new second one and the gate stayed
-    green. Counting closed that. This closes the two ways a count can still be
+    green. Counting closed that. This closes the ways a count can still be
     fooled: a failure reported as ERROR was never counted at all, and a suite
-    that crashes before running anything names no test, so `0 <= expected` read
-    as "no worse than master" while the whole suite stopped being checked.
+    that never reaches its tests still compares favourably against its baseline.
 
-    Annotates each result in place with `seen`, and with `collapsed` or `grew`
-    where they apply, so the caller can say which of the three it is.
+    That last one is not only the import crash, which names nothing. unittest
+    reports a broken class fixture as a single `ERROR: setUpClass (...)` line
+    and then runs none of that class's tests -- one name against a baseline of
+    four, which read as "no worse than master" while a whole class had stopped
+    executing. If the file holds a second class the count does not even drop:
+    planting a `raise` in one setUpClass of test_pathway_universe_database_filter
+    still reported `Ran 8 tests`, one failing name, baseline 1, inherited, exit
+    0. So the COUNT is consulted only once the run is known to have executed its
+    tests with its fixtures intact; a broken fixture, a run of zero tests and a
+    suite that never finished are all this branch's, whatever the number says.
+
+    Annotates each result in place with `seen`, and with `fixture`, `collapsed`,
+    `timedout` or `grew` where they apply, so the caller can say which it is.
     """
     inherited, introduced = [], []
     for result in bad:
         expected = baseline_failures(result["suite"])
         seen = len(result["failing"])
+        ran = result.get("ran")
         result["seen"] = seen
         if expected is None:
             introduced.append(result)
-        elif seen == 0:
+        elif result.get("state") == "TIMEOUT":
+            result["timedout"] = expected
+            introduced.append(result)
+        elif result.get("fixtures"):
+            result["fixture"] = result["fixtures"]
+            introduced.append(result)
+        elif ran == 0 or (ran is None and seen == 0):
             result["collapsed"] = expected
             introduced.append(result)
         elif seen > expected:
@@ -164,6 +210,8 @@ def run_one(name, timeout):
         out, state, skipped = "", "TIMEOUT", False
     return {"suite": name, "state": state, "skipped": skipped,
             "secs": round(time.time() - started, 1),
+            "ran": tests_run(out),
+            "fixtures": BROKEN_FIXTURE.findall(out),
             "failing": FAILING_TEST.findall(out)}
 
 
@@ -211,9 +259,19 @@ def main(argv=None):
     if introduced:
         print("\nINTRODUCED BY THIS BRANCH:")
         for r in introduced:
-            if "collapsed" in r:
-                note = ("  [baselined for %d failing test(s) and named none: "
-                        "the suite did not run]" % r["collapsed"])
+            if "fixture" in r:
+                note = ("  [%s failed, so a class never ran: this run did not "
+                        "reproduce the baseline]"
+                        % ", ".join(sorted(set(r["fixture"]))))
+            elif "timedout" in r:
+                note = ("  [baselined for %d failing test(s) but did not "
+                        "finish: nothing can be credited to master]"
+                        % r["timedout"])
+            elif "collapsed" in r:
+                note = ("  [baselined for %d failing test(s) but this run %s: "
+                        "it did not get that far]"
+                        % (r["collapsed"], "ran 0 tests" if r.get("ran") == 0
+                           else "named no failing test"))
             elif "grew" in r:
                 note = "  [was %d on master, now %d]" % r["grew"]
             else:

--- a/PaintomicsServer/src/tests/test_gate_baseline_rules.py
+++ b/PaintomicsServer/src/tests/test_gate_baseline_rules.py
@@ -1,0 +1,219 @@
+"""The rules that decide whether a failing suite is master's fault or yours.
+
+`run_all.BASELINE` is the only thing standing between "this branch broke a
+test" and "this test was already broken", and every hole found in it so far has
+been a hole in the *classification*, not in the list: matching on the suite name
+alone absorbed a brand-new failure, and counting only `FAIL` lines missed every
+error. Each of those shipped green. The rules are cheap to state and cheap to
+check, so they are checked here rather than rediscovered the next time a gate
+goes green over a suite that stopped running.
+
+Offline, no fixtures, no server:
+
+    cd PaintomicsServer && python -m src.tests.test_gate_baseline_rules
+"""
+import unittest
+
+from src.tests import run_all
+
+
+# What unittest really prints when a class fixture raises: one ERROR line that
+# names setUpClass rather than a test, and a zero count. The suite executed
+# nothing, but it does name one thing -- which is how it passed for "no worse
+# than a baseline of 4".
+SETUPCLASS_DIED = """\
+E
+======================================================================
+ERROR: setUpClass (__main__.AiPipelineEndToEndTest)
+----------------------------------------------------------------------
+Traceback (most recent call last):
+  File "test_ai_agent_endtoend.py", line 227, in setUpClass
+    cls.gateway = _startGateway()
+FileNotFoundError: [Errno 2] No such file or directory: 'stub_gateway.py'
+
+----------------------------------------------------------------------
+Ran 0 tests in 0.002s
+
+FAILED (errors=1)
+"""
+
+FOUR_REAL_FAILURES = """\
+FAIL: test_reference_has_cited_text (__main__.AiPipelineEndToEndTest)
+FAIL: test_quote_survives_redaction (__main__.AiPipelineEndToEndTest)
+FAIL: test_citation_is_not_dropped (__main__.AiPipelineEndToEndTest)
+ERROR: test_report_reaches_the_user (__main__.AiPipelineEndToEndTest)
+----------------------------------------------------------------------
+Ran 31 tests in 12.418s
+
+FAILED (failures=3, errors=1)
+"""
+
+# The server logs through `logging` on its report, mail and hub failure paths,
+# and `basicConfig`'s default format puts the level at the start of the line.
+SUITE_THAT_LOGS = """\
+ERROR:root:Report could not be delivered, storing it instead
+ERROR:root:Report could not be delivered, storing it instead
+FAIL: test_mail_outage_is_reported (__main__.ReportTest)
+----------------------------------------------------------------------
+Ran 16 tests in 0.940s
+
+FAILED (failures=1)
+"""
+
+
+# The same accident in a file that holds more than one test class: the other
+# class runs to completion, so the count does not even drop. Measured by
+# planting a `raise` in one setUpClass of test_pathway_universe_database_filter,
+# whose baseline is 1: "Ran 8 tests", one failing name, inherited, exit 0.
+ONE_CLASS_OF_TWO_DIED = """\
+test_a_kept_pathway_survives (__main__.PathwayUniverseDatabaseFilterTest) ... ok
+setUpClass (__main__.RealOrganismPathwayCountsTest) ... ERROR
+
+======================================================================
+ERROR: setUpClass (__main__.RealOrganismPathwayCountsTest)
+----------------------------------------------------------------------
+Traceback (most recent call last):
+RuntimeError: the fixture this branch broke
+
+----------------------------------------------------------------------
+Ran 8 tests in 0.000s
+
+FAILED (errors=1)
+"""
+
+
+def _result(suite, out, state="FAIL"):
+    """A result dict shaped exactly as both runners build one."""
+    return {"suite": suite, "state": state,
+            "ran": run_all.tests_run(out),
+            "fixtures": run_all.BROKEN_FIXTURE.findall(out),
+            "failing": run_all.FAILING_TEST.findall(out)}
+
+
+class NamingFailingTests(unittest.TestCase):
+
+    def test_unittest_failures_and_errors_both_count(self):
+        self.assertEqual(len(run_all.FAILING_TEST.findall(FOUR_REAL_FAILURES)), 4)
+
+    def test_a_dead_fixture_is_found_by_name(self):
+        self.assertEqual(run_all.BROKEN_FIXTURE.findall(SETUPCLASS_DIED),
+                         ["setUpClass"])
+        self.assertEqual(run_all.BROKEN_FIXTURE.findall(FOUR_REAL_FAILURES), [])
+
+    def test_a_log_record_is_not_a_failing_test(self):
+        """`ERROR:root:...` is a log line; only `ERROR: name` is a test."""
+        self.assertEqual(run_all.FAILING_TEST.findall(SUITE_THAT_LOGS),
+                         ["test_mail_outage_is_reported"])
+
+    def test_the_hand_rolled_convention_still_counts(self):
+        out = "PASS  test_a\nFAIL  test_b: expected 3, got 4\n"
+        self.assertEqual(run_all.FAILING_TEST.findall(out), ["test_b:"])
+
+    def test_the_word_fail_mid_line_is_not_a_test(self):
+        self.assertEqual(run_all.FAILING_TEST.findall("  FAIL: not at line start\n"), [])
+
+
+class CountingTestsRun(unittest.TestCase):
+
+    def test_unittest(self):
+        self.assertEqual(run_all.tests_run(FOUR_REAL_FAILURES), 31)
+        self.assertEqual(run_all.tests_run(SETUPCLASS_DIED), 0)
+
+    def test_hand_rolled(self):
+        self.assertEqual(run_all.tests_run("PASS  a\n\nPassed: 3 / 4\n"), 4)
+
+    def test_a_suite_that_never_said(self):
+        self.assertIsNone(run_all.tests_run("Traceback (most recent call last):\n"))
+
+
+class SplittingByBaseline(unittest.TestCase):
+    """The whole point: which side of the line does a failing suite fall on."""
+
+    def setUp(self):
+        self._real = run_all.BASELINE
+        run_all.BASELINE = {"baselined": "4 failures: the stub gateway cannot "
+                                         "satisfy the quote extractor"}
+
+    def tearDown(self):
+        run_all.BASELINE = self._real
+
+    def split(self, result):
+        inherited, introduced = run_all.split_by_baseline([result])
+        return "introduced" if introduced else "inherited"
+
+    def test_no_worse_than_master_is_masters(self):
+        self.assertEqual(self.split(_result("baselined", FOUR_REAL_FAILURES)),
+                         "inherited")
+
+    def test_one_more_than_master_is_yours(self):
+        out = FOUR_REAL_FAILURES + "ERROR: test_five (__main__.T)\n"
+        result = _result("baselined", out)
+        self.assertEqual(self.split(result), "introduced")
+        self.assertEqual(result["grew"], (4, 5))
+
+    def test_a_dead_class_fixture_is_yours_even_though_it_names_one_thing(self):
+        """The regression this file exists for.
+
+        `ERROR: setUpClass` is one name against a baseline of four, so the
+        count rule alone called it inherited while the suite ran no tests.
+        """
+        result = _result("baselined", SETUPCLASS_DIED)
+        self.assertEqual(result["failing"], ["setUpClass"])
+        self.assertEqual(result["ran"], 0)
+        self.assertEqual(self.split(result), "introduced")
+        self.assertEqual(result["fixture"], ["setUpClass"])
+
+    def test_a_suite_that_ran_nothing_is_yours(self):
+        """No fixture error to point at -- it simply executed no test."""
+        result = _result("baselined", "Passed: 0 / 0\n")
+        self.assertEqual(result["ran"], 0)
+        self.assertEqual(self.split(result), "introduced")
+        self.assertEqual(result["collapsed"], 4)
+
+    def test_a_dead_fixture_is_yours_even_when_the_count_does_not_move(self):
+        """One class of two stops running; the other keeps the number honest.
+
+        This is the shape the `ran == 0` rule cannot see, and it is the shape
+        the real suites have: eight tests ran, one name is failing, the
+        baseline is one. Only "a fixture died" distinguishes it.
+        """
+        run_all.BASELINE = {"baselined": "1 failure"}
+        result = _result("baselined", ONE_CLASS_OF_TWO_DIED)
+        self.assertEqual(result["ran"], 8)
+        self.assertEqual(len(result["failing"]), 1)
+        self.assertEqual(result["fixtures"], ["setUpClass"])
+        self.assertEqual(self.split(result), "introduced")
+        self.assertEqual(result["fixture"], ["setUpClass"])
+
+    def test_a_suite_that_died_on_import_is_yours(self):
+        result = _result("baselined", "ModuleNotFoundError: no module named x\n")
+        self.assertIsNone(result["ran"])
+        self.assertEqual(self.split(result), "introduced")
+
+    def test_a_suite_that_did_not_finish_is_yours(self):
+        result = _result("baselined", FOUR_REAL_FAILURES, state="TIMEOUT")
+        self.assertEqual(self.split(result), "introduced")
+        self.assertEqual(result["timedout"], 4)
+
+    def test_a_suite_nobody_baselined_is_yours(self):
+        self.assertEqual(self.split(_result("not_baselined", FOUR_REAL_FAILURES)),
+                         "introduced")
+
+
+class BaselineNotes(unittest.TestCase):
+
+    def test_a_note_without_a_count_is_refused_before_anything_runs(self):
+        real = run_all.BASELINE
+        run_all.BASELINE = {"suite": "flaky on macOS"}
+        try:
+            with self.assertRaises(ValueError):
+                run_all.check_baseline()
+        finally:
+            run_all.BASELINE = real
+
+    def test_every_real_entry_states_its_count(self):
+        run_all.check_baseline()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_gate_baseline_rules.py
+++ b/PaintomicsServer/src/tests/test_gate_baseline_rules.py
@@ -90,7 +90,7 @@ def _result(suite, out, state="FAIL"):
             "failing": run_all.FAILING_TEST.findall(out)}
 
 
-class NamingFailingTests(unittest.TestCase):
+class FailingTestNamesTest(unittest.TestCase):
 
     def test_unittest_failures_and_errors_both_count(self):
         self.assertEqual(len(run_all.FAILING_TEST.findall(FOUR_REAL_FAILURES)), 4)
@@ -113,7 +113,7 @@ class NamingFailingTests(unittest.TestCase):
         self.assertEqual(run_all.FAILING_TEST.findall("  FAIL: not at line start\n"), [])
 
 
-class CountingTestsRun(unittest.TestCase):
+class TestsRunCountTest(unittest.TestCase):
 
     def test_unittest(self):
         self.assertEqual(run_all.tests_run(FOUR_REAL_FAILURES), 31)
@@ -126,7 +126,7 @@ class CountingTestsRun(unittest.TestCase):
         self.assertIsNone(run_all.tests_run("Traceback (most recent call last):\n"))
 
 
-class SplittingByBaseline(unittest.TestCase):
+class SplitByBaselineTest(unittest.TestCase):
     """The whole point: which side of the line does a failing suite fall on."""
 
     def setUp(self):
@@ -200,7 +200,7 @@ class SplittingByBaseline(unittest.TestCase):
                          "introduced")
 
 
-class BaselineNotes(unittest.TestCase):
+class BaselineNotesTest(unittest.TestCase):
 
     def test_a_note_without_a_count_is_refused_before_anything_runs(self):
         real = run_all.BASELINE

--- a/scripts/ci/run_suites.py
+++ b/scripts/ci/run_suites.py
@@ -15,9 +15,10 @@ Exit status 1 when a suite fails that run_all's BASELINE does not already
 account for -- exactly run_all's rule, and literally its code: the comparison
 lives in run_all.split_by_baseline so the two runners cannot disagree.
 A suite is answerable to this branch when it is not baselined at all, when it
-names MORE failing tests than BASELINE records, or when it is baselined and
-names NONE while still not passing (it crashed before running anything). Suites that skipped every test are listed
-(a skip is not a pass) but, as in run_all, do not fail the run.
+names MORE failing tests than BASELINE records, or when it is baselined but did
+not reproduce that baseline intact -- a class fixture died, no test ran, or it
+timed out. Suites that skipped every
+test are listed (a skip is not a pass) but, as in run_all, do not fail the run.
 """
 import argparse
 import glob
@@ -55,6 +56,8 @@ def run_suite(name, timeout):
         state, skipped = "TIMEOUT", False
     return {"suite": name, "state": state, "skipped": skipped,
             "secs": round(time.time() - started, 1),
+            "ran": run_all.tests_run(out),
+            "fixtures": run_all.BROKEN_FIXTURE.findall(out),
             "failing": run_all.FAILING_TEST.findall(out),
             "tail": "\n".join(out.strip().splitlines()[-TAIL_LINES:])}
 
@@ -185,9 +188,18 @@ def main(argv=None):
     if introduced:
         print("\nFAILED (new, or worse than BASELINE records):")
         for r in introduced:
-            if "collapsed" in r:
-                note = ("  [baselined for %d failing test(s) and named none: the "
-                        "suite did not run]" % r["collapsed"])
+            if "fixture" in r:
+                note = ("  [%s failed, so a class never ran: this run did not "
+                        "reproduce the baseline]"
+                        % ", ".join(sorted(set(r["fixture"]))))
+            elif "timedout" in r:
+                note = ("  [baselined for %d failing test(s) but did not finish: "
+                        "nothing can be credited to master]" % r["timedout"])
+            elif "collapsed" in r:
+                note = ("  [baselined for %d failing test(s) but this run %s: it "
+                        "did not get that far]"
+                        % (r["collapsed"], "ran 0 tests" if r.get("ran") == 0
+                           else "named no failing test"))
             elif "grew" in r:
                 note = "  [was %d failing test(s) on master, now %d]" % r["grew"]
             else:

--- a/scripts/ci/run_suites.py
+++ b/scripts/ci/run_suites.py
@@ -11,8 +11,12 @@ a slow one can be seen rather than guessed.
 
     python scripts/ci/run_suites.py --jobs 4 [--timeout 180] [--only SUBSTR]
 
-Exit status 1 when any suite fails that run_all's BASELINE does not already
-list -- exactly run_all's rule. Suites that skipped every test are listed
+Exit status 1 when a suite fails that run_all's BASELINE does not already
+account for -- exactly run_all's rule, and literally its code: the comparison
+lives in run_all.split_by_baseline so the two runners cannot disagree.
+A suite is answerable to this branch when it is not baselined at all, when it
+names MORE failing tests than BASELINE records, or when it is baselined and
+names NONE while still not passing (it crashed before running anything). Suites that skipped every test are listed
 (a skip is not a pass) but, as in run_all, do not fail the run.
 """
 import argparse
@@ -51,28 +55,8 @@ def run_suite(name, timeout):
         state, skipped = "TIMEOUT", False
     return {"suite": name, "state": state, "skipped": skipped,
             "secs": round(time.time() - started, 1),
-            "failing": re.findall(r"^FAIL[: ]+(\S+)", out, re.M),
+            "failing": run_all.FAILING_TEST.findall(out),
             "tail": "\n".join(out.strip().splitlines()[-TAIL_LINES:])}
-
-
-def baseline_failures(suite):
-    """How many failures this suite is known to have on master.
-
-    `None` means the suite is not baselined at all, so any failure is this
-    branch's. Otherwise it is the count stated by run_all.BASELINE's own text
-    ("3 failures: the stub gateway ..."), and a run that fails MORE times than
-    that has introduced something even though the suite name is on the list.
-
-    Matching on the suite name alone was the hole: a suite baselined for one
-    known failure absorbed a brand-new second one and the gate stayed green.
-    An entry with no parseable count still shields the whole suite -- keep the
-    counts in BASELINE so it does not.
-    """
-    note = run_all.BASELINE.get(suite)
-    if note is None:
-        return None
-    match = re.match(r"\s*(\d+)\s+failures?\b", note)
-    return int(match.group(1)) if match else sys.maxsize
 
 
 SUITE_TIMES = os.path.join(HERE, "suite_times.txt")
@@ -157,6 +141,8 @@ def main(argv=None):
                              "slow suites by accident")
     args = parser.parse_args(argv)
 
+    run_all.check_baseline()
+
     names = sorted(os.path.basename(path)[:-3]
                    for path in glob.glob(os.path.join(SERVER, "src/tests/test_*.py")))
     if args.only:
@@ -172,18 +158,10 @@ def main(argv=None):
         results = list(pool.map(lambda name: run_suite(name, args.timeout), names))
 
     bad = [r for r in results if r["state"] != "PASS"]
-    inherited, introduced = [], []
-    for result in bad:
-        expected = baseline_failures(result["suite"])
-        seen = len(result["failing"])
-        if expected is None or seen > expected:
-            # Not baselined at all, or baselined and now failing MORE than it
-            # was: either way this branch is answerable for it.
-            if expected is not None:
-                result["grew"] = (expected, seen)
-            introduced.append(result)
-        else:
-            inherited.append(result)
+    # One rule, defined next to BASELINE itself, so this wrapper and the runner
+    # CONTRIBUTING points contributors at cannot drift apart -- they did, and
+    # the documented one was the weaker of the two.
+    inherited, introduced = run_all.split_by_baseline(bad)
     skipped = [r for r in results if r["skipped"]]
     total = sum(r["secs"] for r in results)
 
@@ -197,7 +175,9 @@ def main(argv=None):
     if inherited:
         print("\ninherited from master (run_all.BASELINE):")
         for r in inherited:
-            print("   %-50s %s" % (r["suite"], run_all.BASELINE[r["suite"]][:70]))
+            print("   %-50s %2d/%-2d  %s"
+                  % (r["suite"], r["seen"], run_all.baseline_failures(r["suite"]),
+                     run_all.BASELINE[r["suite"]][:60]))
     if skipped:
         print("\nskipped everything -- a skip is not a pass:")
         for r in skipped:
@@ -205,9 +185,15 @@ def main(argv=None):
     if introduced:
         print("\nFAILED (new, or worse than BASELINE records):")
         for r in introduced:
-            grew = ("  [was %d failure(s) on master, now %d]" % r["grew"]) if "grew" in r else ""
+            if "collapsed" in r:
+                note = ("  [baselined for %d failing test(s) and named none: the "
+                        "suite did not run]" % r["collapsed"])
+            elif "grew" in r:
+                note = "  [was %d failing test(s) on master, now %d]" % r["grew"]
+            else:
+                note = ""
             print("   %-50s %s %s%s"
-                  % (r["suite"], r["state"], ", ".join(r["failing"])[:80], grew))
+                  % (r["suite"], r["state"], ", ".join(r["failing"])[:80], note))
         for r in introduced:
             print("\n----- %s (%s): last %d lines -----" % (r["suite"], r["state"], TAIL_LINES))
             print(r["tail"])


### PR DESCRIPTION
#116 made the gate compare failure *counts* instead of suite names, which closed the hole a brand-new failure had walked through. Two more were still open, and both matter for the five suites on `BASELINE`.

**An `ERROR` was never counted.** `^FAIL[: ]` does not match unittest's `ERROR: test_x`, which is what it prints when a test raises before reaching an assertion — reported on a separate line from failures. A baselined suite could acquire any number of them without the count moving.

That is not hypothetical. `test_more_servlet_step1` has said `"17 failures"` since it was written, and produces:

```
Ran 29 tests in 5.076s
FAILED (failures=17, errors=1)
ERROR: test_queues_step2_with_the_job (__main__.HappyPathTest)
```

The eighteenth broken test has been outside the count by construction.

**Zero is always ≤ the baseline.** A suite that dies on import names no test, so `seen(0) <= expected(17)` read as "no worse than master" and the gate called it *inherited* while 29 tests silently stopped being checked. A rename, a bad merge or a syntax error in any of the five would have merged green. A suite baselined for N failing tests must now produce them.

**An unparseable note absorbed everything** — it returned `sys.maxsize`. Reachable through the documented route: `run_all --baseline` printed one entry per failing suite with an **empty** note, so pasting its output back disarmed the guard for every suite it listed. Notes now must state a count, `--baseline` prints the observed one, and `check_baseline()` refuses the file at startup rather than at the moment it would have shielded something.

**The two runners had drifted.** `run_all` still partitioned on suite name alone, so the runner CONTRIBUTING points contributors at was strictly weaker than the one in CI. The comparison now lives in `run_all.split_by_baseline` and both call it.

### Verified against the real suites

| planted state | result | exit |
|---|---|---|
| clean tree | `18/18`, `2/2` — inherited | 0 |
| suite crashes on import | INTRODUCED — *baselined for 2 failing test(s) and named none: the suite did not run* | 1 |
| failing assertion added | INTRODUCED — *[was 2 failing test(s) on master, now 3]* | 1 |
| raising test added | INTRODUCED — *[was 2, now 3]* | 1 |
| **the same raising test, on master's rule** | **inherited** | **0** |
| `BASELINE` note with no count | `ValueError` before any suite runs | 1 |

### Baseline counts

Re-measured with `serverconf.py` copied from the template (without it three of the five crash on import and report nothing), not transcribed from unittest's summary line: `test_more_servlet_step1` → 18 (17 assertions + 1 error), `test_ai_agent_endtoend` → 4. The other three were already right.

---

## Second round: two more ways the count was fooled

Review of the above found the rule still had a hole on each side of the number.

**A log record is not a failing test.** `^(?:FAIL|ERROR)[: ]+` matches `ERROR:root:...`, which is what `logging.error()` writes once `basicConfig` has run — and the server logs on every report, mail and hub failure path. On the real shape, three names come back where one test failed:

```
['root:Report', 'root:Report', 'test_mail_outage_is_reported']
```

Every phantom inflates the number written into `BASELINE`, and the suite can then acquire that many real failures unnoticed the day its logging goes quiet. The separator now has to be a colon *followed by* whitespace, or two spaces — which is what unittest and the hand-rolled runners actually print.

**A count says nothing about whether the tests ran.** unittest reports a broken class fixture as one `ERROR: setUpClass (...)` line and then runs none of that class's tests. Against a baseline of four, one name read as "no worse than master". `seen == 0` does not catch that, and where the file holds a second test class the count does not even drop — planting a `raise` in one `setUpClass` of `test_pathway_universe_database_filter` (baseline 1):

```
Ran 8 tests in 0.000s
FAILED (errors=1)
→ 1 suites | 0 pass | 1 inherited | 0 INTRODUCED     exit 0
```

A whole class had stopped executing and the gate was green. So the count is now consulted only for a run that reproduced its baseline intact: a broken `setUp`/`tearDownClass` or `Module`, a run that executed no tests, and a suite that timed out are all this branch's, whatever the number says. After:

```
→ 1 suites | 0 pass | 0 INTRODUCED → 1 INTRODUCED     exit 1
   test_pathway_universe_database_filter  FAIL setUpClass
   [setUpClass failed, so a class never ran: this run did not reproduce the baseline]
```

None of the five baselined suites produces a fixture error today; all five were run to check before the rule went in.

**`test_gate_baseline_rules` now holds these rules down** — 18 offline tests, no fixtures, no server, over the real output shapes. Run against this branch *before* this round, the log-record case and both fixture cases fail.
