### PR TITLE
Publish the documentation, which nothing has done since July 2022

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://paintomics.readthedocs.io/en/latest/
+    url: https://conesalab.github.io/PaintOmics/
     about: How the analyses work, what the input formats are, and how to install your own instance.
   - name: Email the team
     url: mailto:paintomicsai@gmail.com

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,70 @@
+# Publish the user guide.
+#
+# `.readthedocs.yaml` describes a build that has not run since July 2022: the
+# repository has no webhook, and the Read the Docs project still points at
+# github.com/ConesaLab/paintomics4, the name this repository had before it was
+# renamed. So https://paintomics.readthedocs.io/ still serves "PaintOmics v4.0
+# documentation", and the pages for the two AI features return 404 -- while
+# pr.yml's `Docs build` job proved on every pull request that the site compiles.
+# Something built the docs; nothing published them.
+#
+# This publishes them from the repository itself, so the site cannot drift from
+# master again. The Read the Docs config is left in place: if that project is
+# ever reconnected it can serve the same tree, and the old URL is worth
+# redirecting here rather than leaving stale.
+name: Docs
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+# `contents: read` to check out, `pages: write` + `id-token: write` for the
+# deployment's OIDC token. Nothing here needs write access to the repository.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deployment at a time, and never cancel one half-done: an interrupted
+# deploy leaves the site serving whichever version got there first.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build the site
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+      - name: Build
+        run: |
+          python -m pip install --quiet -r docs/mkdocs-pins.txt
+          # --strict, as in the pull-request gate: a broken internal link or an
+          # unrecognised config key fails here rather than reaching the site.
+          mkdocs build --strict --site-dir _site
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: _site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -380,7 +380,8 @@ deployment from the template, and then never overwritten. That shapes every step
 - Bugs, feature requests and organism requests: an
   [issue](https://github.com/ConesaLab/PaintOmics/issues) on this repository.
 - Email: [paintomicsai@gmail.com](mailto:paintomicsai@gmail.com).
-- User documentation: [paintomics.readthedocs.io](https://paintomics.readthedocs.io/en/latest/).
+- User documentation: [conesalab.github.io/PaintOmics](https://conesalab.github.io/PaintOmics/), published by
+  `.github/workflows/docs.yml` on every push to `master` that touches `docs/`.
 - Operating an instance: [`deploy/README.md`](deploy/README.md).
 
 PaintOmics is distributed under the GNU General Public License v3; contributions

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://paintomics.uv.es/"><img alt="Live instance" src="https://img.shields.io/badge/try%20it-paintomics.uv.es-2E7D9A"></a>
-  <a href="https://paintomics.readthedocs.io/en/latest/"><img alt="Documentation" src="https://img.shields.io/badge/docs-readthedocs-8CA1AF"></a>
+  <a href="https://conesalab.github.io/PaintOmics/"><img alt="Documentation" src="https://img.shields.io/badge/docs-user%20guide-8CA1AF"></a>
   <a href="https://doi.org/10.1093/nar/gkac352"><img alt="DOI" src="https://img.shields.io/badge/DOI-10.1093%2Fnar%2Fgkac352-B31B1B"></a>
   <img alt="Python" src="https://img.shields.io/badge/python-3.11-3776AB">
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-GPLv3-blue"></a>
@@ -92,14 +92,14 @@ feature off entirely with `AI_INTERPRETATION_ENABLED=false`.
 
 | Analysis | What it answers |
 |---|---|
-| [Pathway enrichment](https://paintomics.readthedocs.io/en/latest/4_1_pathway_enrichment/) | Which pathways are significantly affected, per omic and combined |
-| [Pathway classification](https://paintomics.readthedocs.io/en/latest/4_2_kegg_categories/) | Where the affected pathways sit in the database hierarchy |
-| [Pathway interaction network](https://paintomics.readthedocs.io/en/latest/4_3_pathways_network/) | How the enriched pathways connect through shared features |
-| [Metabolite hub analysis](https://paintomics.readthedocs.io/en/latest/4_4_metabolite_hub_analysis/) | Which metabolites act as hubs for the observed changes |
-| [Metabolite class activity](https://paintomics.readthedocs.io/en/latest/4_5_metabolite_class_activity_analysis/) | Which chemical classes of metabolites move as a group |
-| [Regulatory omics](https://paintomics.readthedocs.io/en/latest/4_6_Regulatory_omics/) (incl. MORE) | Which trans-acting regulators (miRNA, TF, SF, RBP…) drive the changes |
-| [Metagenes](https://paintomics.readthedocs.io/en/latest/4_7_Metagenes/) | The dominant expression trends inside a pathway |
-| [Pathway visualisation](https://paintomics.readthedocs.io/en/latest/5_1_browsing_pathways/) | All omics painted on one diagram, with per-feature heatmaps |
+| [Pathway enrichment](https://conesalab.github.io/PaintOmics/4_1_pathway_enrichment/) | Which pathways are significantly affected, per omic and combined |
+| [Pathway classification](https://conesalab.github.io/PaintOmics/4_2_kegg_categories/) | Where the affected pathways sit in the database hierarchy |
+| [Pathway interaction network](https://conesalab.github.io/PaintOmics/4_3_pathways_network/) | How the enriched pathways connect through shared features |
+| [Metabolite hub analysis](https://conesalab.github.io/PaintOmics/4_4_metabolite_hub_analysis/) | Which metabolites act as hubs for the observed changes |
+| [Metabolite class activity](https://conesalab.github.io/PaintOmics/4_5_metabolite_class_activity_analysis/) | Which chemical classes of metabolites move as a group |
+| [Regulatory omics](https://conesalab.github.io/PaintOmics/4_6_Regulatory_omics/) (incl. MORE) | Which trans-acting regulators (miRNA, TF, SF, RBP…) drive the changes |
+| [Metagenes](https://conesalab.github.io/PaintOmics/4_7_Metagenes/) | The dominant expression trends inside a pathway |
+| [Pathway visualisation](https://conesalab.github.io/PaintOmics/5_1_browsing_pathways/) | All omics painted on one diagram, with per-feature heatmaps |
 | **AI interpretation** | What the ranked pathways mean biologically, with literature to back it |
 
 Two supporting tools convert data into a usable input format: **Regions to
@@ -186,10 +186,10 @@ python -m src.tests.test_bug_fixes           # multi-condition statistics
 
 ## Documentation
 
-Full user guide: **[paintomics.readthedocs.io](https://paintomics.readthedocs.io/en/latest/)**
-— including [accepted input formats](https://paintomics.readthedocs.io/en/latest/2_1_accepted_input/),
-a [step-by-step guide](https://paintomics.readthedocs.io/en/latest/8_step_by_step/)
-and the [FAQ](https://paintomics.readthedocs.io/en/latest/9_faq/).
+Full user guide: **[conesalab.github.io/PaintOmics](https://conesalab.github.io/PaintOmics/)**
+— including [accepted input formats](https://conesalab.github.io/PaintOmics/2_1_accepted_input/),
+a [step-by-step guide](https://conesalab.github.io/PaintOmics/8_step_by_step/)
+and the [FAQ](https://conesalab.github.io/PaintOmics/9_faq/).
 The sources live in [`docs/`](docs) and build with `mkdocs`.
 
 ## Video tutorials

--- a/docs/1_5_update_history.md
+++ b/docs/1_5_update_history.md
@@ -4,5 +4,5 @@
 
 # PaintOmics Update history:
 - New tutorial video (07/18/2022)
-- New user guide (https://paintomics.readthedocs.io/en/latest/) (07/01/2022)
+- New user guide (https://conesalab.github.io/PaintOmics/) (07/01/2022)
 - Release of PaintOmics (v1.0.0) (05/31/2022)

--- a/docs/8_step_by_step.md
+++ b/docs/8_step_by_step.md
@@ -10,7 +10,7 @@ The following document will guide you through the required steps to perform a ba
 2. Review initial matching results and configure metabolite assignment, if required.
 3. Visualization of final results.
 
-However, before starting to use the application you must choose between starting an anonymous session or continuing with an user account, which provides many benefits, <a target="_blank" href="http://paintomics.readthedocs.io/en/latest/2_2_cloud_drive/">read more about them</a>.
+However, before starting to use the application you must choose between starting an anonymous session or continuing with an user account, which provides many benefits, <a target="_blank" href="../2_2_cloud_drive/">read more about them</a>.
 
 
 # Step 1: upload data
@@ -22,16 +22,16 @@ The second section allows you to select analysis databases (**Figure 1.B**). For
 The third section contains two parts. In the right one (**Figure 1.D**) you can enter the input data for each omic to include in the analysis. For doing so the "Browse" button opens a menu with 3 options:
 
 1. **Upload file from my PC**: conventional approach to select the file from your computer.
-2. **Use a file from 'My data'**: only available for registered users. Read more at <a href="http://paintomics.readthedocs.io/en/latest/2_2_cloud_drive/" target="_blank">Cloud Drive</a> section.
+2. **Use a file from 'My data'**: only available for registered users. Read more at <a href="../2_2_cloud_drive/" target="_blank">Cloud Drive</a> section.
 3. **Clear selection**: reset the selected file, if any.
 
 By default "Gene expression" and "Metabolomics" omics are provided, but in the left side (**Figure 1.C**) you can add more by clicking the <img src="addicon.png" style="vertical-align: middle; height: 24px;margin:0;"/> icon; in a similar way, the <img src="removeicon.png"  style="vertical-align: middle; height: 24px;margin: 0;"/> icon allows to undo the action. You can add more than one omic of the same type, provided they have different names. Some options are simple shortcuts with predefined names (like "Proteomics") and will disappear from the list after adding them, unlike the generic ones (like Region based omic).
 
-An important setting is the type of enrichment to perform: based on genes or features. If no selection box is visible, like "Gene expression" or "Metabolomics" shortcuts, is because one default type is assumed by Paintomics. The selection might affect the contingency table used for Fisher test in the <a href="http://paintomics.readthedocs.io/en/latest/4_1_pathway_enrichment/" target="_blank">pathway enrichment</a>, for instance in proteomics data one protein identifier may match to more than one gene identifier; in feature enrichment type the protein would be counted once, whereas for the gene enrichment type the amount would be the number of genes matched by the protein.
+An important setting is the type of enrichment to perform: based on genes or features. If no selection box is visible, like "Gene expression" or "Metabolomics" shortcuts, is because one default type is assumed by Paintomics. The selection might affect the contingency table used for Fisher test in the <a href="../4_1_pathway_enrichment/" target="_blank">pathway enrichment</a>, for instance in proteomics data one protein identifier may match to more than one gene identifier; in feature enrichment type the protein would be counted once, whereas for the gene enrichment type the amount would be the number of genes matched by the protein.
 
 For more information about the configuration options of regulatory and region based omic, read the associated pages in the "Supporting tools" at the left menu of the main Paintomics webpage.
 
-You can read more about the accepted input data in the <a href="http://paintomics.readthedocs.io/en/latest/2_1_accepted_input/" target="_blank">dedicated page</a>. The example data is available from the server you are using, through the "Download example data" button in step 1 or the Downloads menu: it is built from that server's own catalogue, so it always matches what "Load example" offers, and it includes a `HOW-THIS-DATA-WAS-MADE.md` explaining which datasets are simulated and how.
+You can read more about the accepted input data in the <a href="../2_1_accepted_input/" target="_blank">dedicated page</a>. The example data is available from the server you are using, through the "Download example data" button in step 1 or the Downloads menu: it is built from that server's own catalogue, so it always matches what "Load example" offers, and it includes a `HOW-THIS-DATA-WAS-MADE.md` explaining which datasets are simulated and how.
 
 Once everything is ready, press the button "Run paintomics" in the upper left corner.
 
@@ -42,7 +42,7 @@ Once everything is ready, press the button "Run paintomics" in the upper left co
 
 # Step 2: matching summaries and metabolite assignment
 
-Paintomics processes your files and offers you different plots showing the results of matching the identifiers of your files to the KEGG/Reactome/MapMan ids (read more <a href="http://paintomics.readthedocs.io/en/latest/2_1_accepted_input/#identifier-and-name-conversion" target="_blank">here</a>). You can also view diverse information of your data by hovering the data distribution plot with the mouse cursor (**Figure 2**).
+Paintomics processes your files and offers you different plots showing the results of matching the identifiers of your files to the KEGG/Reactome/MapMan ids (read more <a href="../2_1_accepted_input/#identifier-and-name-conversion" target="_blank">here</a>). You can also view diverse information of your data by hovering the data distribution plot with the mouse cursor (**Figure 2**).
 
 <div class="imageContainer" style="box-shadow: 0px 0px 20px #D0D0D0; text-align:center; font-size:10px; color:#898989" >
     <img src="step2_up.png"/>
@@ -85,7 +85,7 @@ This panel shows you the summary of the pathway enrichment result from multiple 
 
 ### Pathways classification
 
-Each KEGG pathway is associated to a primary category and subcategory (see more <a href="http://paintomics.readthedocs.io/en/latest/4_2_kegg_categories/" target="_blank">here</a>). In this panel you can access that information by expanding the elements of the tree, with options to show or hide individual nodes or entire branches by clicking on the checkboxes or the links that appear when hovering over the options, then the "Apply" button.
+Each KEGG pathway is associated to a primary category and subcategory (see more <a href="../4_2_kegg_categories/" target="_blank">here</a>). In this panel you can access that information by expanding the elements of the tree, with options to show or hide individual nodes or entire branches by clicking on the checkboxes or the links that appear when hovering over the options, then the "Apply" button.
 
 
 <div class="imageContainer" style="box-shadow: 0px 0px 20px #D0D0D0; text-align:center; font-size:10px; color:#898989" >
@@ -95,7 +95,7 @@ Each KEGG pathway is associated to a primary category and subcategory (see more 
 
 ### Pathways network
 
-The pathway interaction network is built according to the process described in <a href="http://paintomics.readthedocs.io/en/latest/4_3_pathways_network/" target="_blank">this page</a>, in which a more detailed explanation is given.
+The pathway interaction network is built according to the process described in <a href="../4_3_pathways_network/" target="_blank">this page</a>, in which a more detailed explanation is given.
 
 <div class="imageContainer" style="box-shadow: 0px 0px 20px #D0D0D0; text-align:center; font-size:10px; color:#898989" >
     <img src="pathway_network.png"/>
@@ -104,7 +104,7 @@ The pathway interaction network is built according to the process described in <
 
 ### Pathway enrichment
 
-In the pathway enrichment table you can see every pathway that had at least one match with your data, as explained <a href="http://paintomics.readthedocs.io/en/latest/4_1_pathway_enrichment/" target="_blank">in this page</a>.
+In the pathway enrichment table you can see every pathway that had at least one match with your data, as explained <a href="../4_1_pathway_enrichment/" target="_blank">in this page</a>.
 
 The header of the table has some filtering options to quickly search through the table. Note that this "live search" is not permanent, will not be saved and will not affect the number of found & significant pathways, unlike filtering by category as explained in the classification panel section.
 

--- a/docs/9_faq.md
+++ b/docs/9_faq.md
@@ -4,7 +4,7 @@
 
 # I get an error every time I upload my data, what am I doing wrong?
 
-Be sure to check the message of the error, if any, as it may contain useful information like maximum number of lines exceeded, invalid numerical format... Also do not forget to read the appropiate documentation section (<a href="http://paintomics.readthedocs.io/en/latest/2_1_accepted_input/" target="_blank">accepted input data</a>) and download the example files to check them.
+Be sure to check the message of the error, if any, as it may contain useful information like maximum number of lines exceeded, invalid numerical format... Also do not forget to read the appropiate documentation section (<a href="../2_1_accepted_input/" target="_blank">accepted input data</a>) and download the example files to check them.
 
 # The page has been stuck for a very long time, waiting at the job to complete. Is it working?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Paintomics Documentation
 site_description: >-
   Documentation for PaintOmics, a web tool for the integrative visualization of
   multiple omic datasets onto KEGG, Reactome and MapMan pathways.
-site_url: https://paintomics.readthedocs.io/en/latest/
+site_url: https://conesalab.github.io/PaintOmics/
 repo_url: https://github.com/ConesaLab/PaintOmics
 repo_name: ConesaLab/PaintOmics
 


### PR DESCRIPTION
`.readthedocs.yaml` went in with #116 next to a build that has not run in four years.

| checked | result |
|---|---|
| `gh api repos/ConesaLab/PaintOmics/hooks` | `[]` — **no webhook**, so nothing triggers a build |
| RTD project API | `modified: 2022-05-11`, `repository.url: .../ConesaLab/paintomics4` — the name this repo had **before it was renamed** |
| last RTD build | 17362602, **2022-07-05**, commit `b347aea3` |
| `https://paintomics.readthedocs.io/en/latest/` | 200, and still says *"Welcome to PaintOmics v4.0 documentation"* |
| `.../ai-input-converter/`, `.../ai-full-agent/` | **404** |

So the README badge, `CONTRIBUTING.md` and the issue-template Documentation link all send people to a four-year-old site, and the two AI features the product is now named for are undocumented in public — while `pr.yml`'s `Docs build` job proved on every pull request that the site compiles. Something built the docs. Nothing published them.

### What this does

`.github/workflows/docs.yml` runs `mkdocs build --strict` — the same command as the gate — and deploys to GitHub Pages on every push to `master` that touches `docs/`, `mkdocs.yml` or the workflow itself. Pages is already enabled with `build_type: workflow`, so the site is **https://conesalab.github.io/PaintOmics/** and cannot drift from `master` again.

`site_url`, the README badge and its nine feature links, `CONTRIBUTING.md` and `.github/ISSUE_TEMPLATE/config.yml` follow it.

### The links inside the guide mattered more than the ones outside

Ten links in `docs/8_step_by_step.md` and `docs/9_faq.md` were absolute `readthedocs.io` URLs written as **raw HTML**, so publishing without touching them would have bounced a reader from the middle of a page straight back to the 2022 site — and `mkdocs --strict` cannot see them, because raw HTML is stashed before the link checker runs. They are relative now. The one exception is the dated *"New user guide"* entry in the update history, which points **at** the guide rather than between pages, so it stays absolute.

`.readthedocs.yaml` is deliberately left in place: if that project is ever reconnected it serves the same tree, and the old URL is worth redirecting here rather than leaving stale.

### Verified

- `mkdocs build --strict`: clean, 35 pages, both AI pages present, `docs/dev/` and `docs/superpowers/` correctly absent.
- Zero `readthedocs.io` strings anywhere in the built HTML; zero broken relative hrefs across the whole site (every `../…` resolved against the build output).
- Served the build and opened it in Chrome: the AI converter page renders with its nav, and all six converted links on `8_step_by_step` — anchor included — fetch **200**.