### PR TITLE
Import multipletests from where statsmodels still keeps it

### DIFF
--- a/PaintomicsServer/src/common/Statistics.py
+++ b/PaintomicsServer/src/common/Statistics.py
@@ -3,7 +3,12 @@ from math import log, isfinite
 import numpy as np
 from scipy import special as _special
 from scipy.stats import hypergeom
-from statsmodels.sandbox.stats.multicomp import multipletests
+# statsmodels.stats.multitest, not statsmodels.sandbox.stats.multicomp: the
+# sandbox module is a re-export that 0.15.0 removed, and the dependabot
+# pull request carrying that bump failed 36 suites on this one import
+# (#118). On the pinned 0.14.6 the two names are the SAME object, so this
+# is a no-op today and the bump becomes possible tomorrow.
+from statsmodels.stats.multitest import multipletests
 
 # Distinct out-of-domain argument tuples already reported by calculateFisher.
 # Bounded, because the alternative is one WARNING per pathway per omic: the

--- a/PaintomicsServer/src/tests/test_combined_pvalue_nan.py
+++ b/PaintomicsServer/src/tests/test_combined_pvalue_nan.py
@@ -221,7 +221,7 @@ class FDRCorrectionNaNTest(unittest.TestCase):
 
     def test_the_usable_subset_matches_statsmodels(self):
         """Checked against the library, not against this implementation."""
-        from statsmodels.sandbox.stats.multicomp import multipletests
+        from statsmodels.stats.multitest import multipletests
 
         expected = multipletests([0.01, 0.5], method="fdr_bh")[1].tolist()
         actual = self._adjust({"a": 0.01, "b": 0.5, "c": NAN})["FDR BH"]


### PR DESCRIPTION
With `.python-version` in place (#119), dependabot re-resolved #118 under 3.11 and the pull request **installed for the first time** — `numpy==2.4.6`, `scipy==1.17.1` instead of the 3.12-only versions it proposed before. So the suites ran, and 36 of them failed on one line:

```
ImportError: cannot import name 'multipletests' from
'statsmodels.sandbox.stats.multicomp'
```

`statsmodels.sandbox.stats.multicomp` is a re-export that 0.15.0 removed. `statsmodels.stats.multitest` is where the function has actually lived for years — and on the pinned 0.14.6 the two names are the **same object**:

```python
>>> from statsmodels.stats.multitest import multipletests as a
>>> from statsmodels.sandbox.stats.multicomp import multipletests as b
>>> a is b
True
```

So this changes nothing today and stops the bump failing tomorrow. Two call sites: `common/Statistics.py`, and a test that imports it directly.

Worth noting for the dependency config: `statsmodels` 0.14.6 → 0.15.0 is a semver-**minor**. It would have landed inside a "patch and minor only" pull request — a third demonstration, after `scipy` and the `openai`/`openai-agents` pin pair, that splitting the pip group on update-type would not have produced a mergeable half.

### Verified

- `test_combined_pvalue_nan`: **OK**.
- `run_suites.py --only pvalue` → 1 INTRODUCED and `--only enrichment` → 3 INTRODUCED + 1 skipped, which are **exactly** the counts `origin/master` gives on this machine with the same filters — both from the absent cairo library and Mongo, neither from this change.

This does not make #118 mergeable on its own: it still carries `pandas 1.5.3 → 3.0.5`, which `requirements.txt`'s header calls a behavioural change that is out of scope. It removes one blocker that had nothing to do with pandas.