### PR TITLE
Let the reviewer read the code it is reviewing

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -88,4 +88,23 @@ jobs:
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
-          claude_args: '--max-turns 15 --allowedTools "mcp__github_inline_comment__create_inline_comment"'
+          # --allowedTools is an EXCLUSIVE allowlist, not an addition to a
+          # default set. Naming only the comment tool left the reviewer able to
+          # WRITE a comment and unable to READ anything to comment about: run
+          # 33542418503 was a success, 11 turns, $1.16, permission_denials_count
+          # 24, zero comments. Every upstream code-review recipe in
+          # anthropics/claude-code-action docs/solutions.md pairs the MCP tool
+          # with the `gh pr` reads, which is why they are here.
+          #
+          # `gh pr diff` rather than `git diff`: checkout above is fetch-depth 1,
+          # so there is no merge base in the clone to diff against, and the API
+          # does not need one. Read/Grep/Glob are for the surrounding code the
+          # diff does not show -- a hunk is rarely enough to tell a real defect
+          # from a plausible-looking one.
+          #
+          # Nothing here can write to the repository: the job holds
+          # `contents: read`, so the whole allowlist is reads plus two comment
+          # verbs.
+          claude_args: >-
+            --max-turns 15
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Read,Grep,Glob"


### PR DESCRIPTION
**The reviewer could not read anything.**

`--allowedTools` is an **exclusive** allowlist, not an addition to a default set. Naming only `mcp__github_inline_comment__create_inline_comment` left it able to *write* a comment and unable to *read* anything to comment about.

[Run 33542418503](https://github.com/ConesaLab/PaintOmics/actions/runs/33542418503) — the first run in which the action actually started, after #125 cleared the workflow-validation guard:

```json
"subtype": "success",  "is_error": false,
"num_turns": 11,  "total_cost_usd": 1.1559529,
"permission_denials_count": 24
```

Eleven turns and $1.16 spent being refused, a **success** verdict, and zero comments on a 21-file diff. The failure is silent in exactly the way the validation skip is silent: nothing distinguishes *reviewed and found nothing* from *could not open a single file*.

### The fix

Every code-review recipe in the action's own [docs/solutions.md](https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md) pairs the MCP tool with the `gh pr` reads. Those are added here, plus `Read`/`Grep`/`Glob` for the surrounding code — a hunk on its own is rarely enough to tell a real defect from a plausible-looking one.

`gh pr diff` rather than `git diff`: the checkout is `fetch-depth: 1`, so there is no merge base in the clone to diff against, and the API doesn't need one.

**Nothing added can write to the repository.** The job holds `contents: read`, so the allowlist is six reads and two comment verbs.

### Sequence

1. #125 put the file on master, which is what lets the action start at all.
2. This makes the action able to do its job once started.
3. #124 then gets the first real review — it carries the same file, so it stops being exempt once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpPJv51oEh4YdoERSyPHJ5
