### PR TITLE
Let the reviewer launch the agents it is built from

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -72,7 +72,7 @@ jobs:
   review:
     name: Claude review
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write
@@ -89,22 +89,26 @@ jobs:
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
           # --allowedTools is an EXCLUSIVE allowlist, not an addition to a
-          # default set. Naming only the comment tool left the reviewer able to
-          # WRITE a comment and unable to READ anything to comment about: run
-          # 33542418503 was a success, 11 turns, $1.16, permission_denials_count
-          # 24, zero comments. Every upstream code-review recipe in
-          # anthropics/claude-code-action docs/solutions.md pairs the MCP tool
-          # with the `gh pr` reads, which is why they are here.
+          # default set, and the list below is derived from what the plugin
+          # declares and does -- not guessed. Two rounds of guessing cost two
+          # runs and $1.30:
           #
-          # `gh pr diff` rather than `git diff`: checkout above is fetch-depth 1,
-          # so there is no merge base in the clone to diff against, and the API
-          # does not need one. Read/Grep/Glob are for the surrounding code the
-          # diff does not show -- a hunk is rarely enough to tell a real defect
-          # from a plausible-looking one.
+          #   33542418503  one write tool, no reads   11 turns  24 denials  $1.16
+          #   33543891958  reads, but no Task         6 turns   1 denial    $0.14
           #
-          # Nothing here can write to the repository: the job holds
-          # `contents: read`, so the whole allowlist is reads plus two comment
-          # verbs.
+          # Both reported SUCCESS with zero comments. `permission_denials_count`
+          # in the run log is the only thing that separates them from a clean
+          # review, so read it before believing a silent pass.
+          #
+          # plugins/code-review/commands/code-review.md in anthropics/claude-code
+          # is the source: its own frontmatter names the gh verbs, its steps say
+          # "Launch a haiku agent", "Launch 4 agents in parallel" (Task) and
+          # "Create a todo list before starting" (TodoWrite). Without Task the
+          # command cannot execute step 1 and stops in 25 seconds.
+          #
+          # Read/Grep/Glob are ours, for the code around a hunk. git rev-parse
+          # is for the full SHA the plugin requires in permalinks. Nothing here
+          # writes: the job holds `contents: read`.
           claude_args: >-
-            --max-turns 15
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Read,Grep,Glob"
+            --max-turns 30
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Task,TodoWrite,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git rev-parse:*),Read,Grep,Glob"


### PR DESCRIPTION
**The reviewer is a multi-agent command, and it was not allowed to launch agents.**

#126 gave it the reads. It got further — denials `24 → 1`, cost `$1.16 → $0.14` — and then exited in **25 seconds** with zero comments, on a 21-file diff.

[`plugins/code-review/commands/code-review.md`](https://github.com/anthropics/claude-code/blob/main/plugins/code-review/commands/code-review.md) explains why. The command is a fan-out, not a single pass:

> 1. Launch a **haiku agent** to check if any of the following are true…
> 3. Launch a **sonnet agent** to view the pull request…
> 4. Launch **4 agents in parallel** to independently review the changes…
> 5. …launch **parallel subagents** to validate the issue.

That needs `Task`, which was not on the allowlist. Step 1 is the very first thing it does, so it could not start — hence 25 seconds. The notes also say *"Create a todo list before starting"*, which needs `TodoWrite`.

### Derived, not guessed

Two rounds of guessing cost two runs and $1.30:

| run | allowlist | turns | denials | cost | comments |
|---|---|---|---|---|---|
| [33542418503](https://github.com/ConesaLab/PaintOmics/actions/runs/33542418503) | one write tool, no reads | 11 | 24 | $1.16 | 0 |
| [33543891958](https://github.com/ConesaLab/PaintOmics/actions/runs/33543891958) | reads, but no `Task` | 6 | 1 | $0.14 | 0 |

Both reported **success**. This list now comes from the plugin's own `allowed-tools` frontmatter plus the tools its steps demonstrably require.

### Also

- `--max-turns 15 → 30`: the command launches roughly ten subagents; each is a turn, and being truncated mid-review is another silent zero-comment pass.
- `timeout-minutes: 15 → 20`, so the job cap outlasts the fan-out rather than killing it.

### What this confirms about the "no issues" case

> If no issues are found and `--comment` argument is provided, post a comment with the following format: `## Code review` / `No issues found.`

So a working reviewer posts **something** either way. Zero comments is never the clean-pass signal — `permission_denials_count` in the run log is the thing to read.

Nothing added can write to the repository; the job holds `contents: read`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpPJv51oEh4YdoERSyPHJ5
