### PR TITLE
Stop capping the reviewer's turns, since its turn count is its finding count

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -72,7 +72,7 @@ jobs:
   review:
     name: Claude review
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     permissions:
       contents: read
       pull-requests: write
@@ -106,9 +106,23 @@ jobs:
           # "Create a todo list before starting" (TodoWrite). Without Task the
           # command cannot execute step 1 and stops in 25 seconds.
           #
-          # Read/Grep/Glob are ours, for the code around a hunk. git rev-parse
-          # is for the full SHA the plugin requires in permalinks. Nothing here
-          # writes: the job holds `contents: read`.
+          # Read/Grep/Glob are ours, for the code around a hunk. The git
+          # reads are for the full SHA the plugin requires in permalinks and
+          # for the history a subagent reaches for. Nothing here writes: the
+          # job holds `contents: read`.
+          #
+          # NO --max-turns. 15 came from the upstream single-pass example and
+          # was carried over unexamined; 30 was a guess. Run 33545049328 with
+          # 30: error_max_turns at turn 31, $0.87, still zero comments -- the
+          # third silent failure in a row. The number was never derived from
+          # what the command does, and the command is a fan-out: a todo list,
+          # seven steps of subagent launches, one validation agent per candidate
+          # issue, then ONE TURN PER INLINE COMMENT POSTED. Its turn count
+          # therefore scales with how many problems it finds, so any fixed cap
+          # truncates exactly the reviews worth reading, and truncation is
+          # indistinguishable from a clean pass.
+          #
+          # timeout-minutes below is the real bound: wall clock, which is what
+          # the budget is actually about.
           claude_args: >-
-            --max-turns 30
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Task,TodoWrite,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git rev-parse:*),Read,Grep,Glob"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Task,TodoWrite,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git rev-parse:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Read,Grep,Glob"


### PR DESCRIPTION
**The turn cap was truncating the review, and truncation looks exactly like a clean pass.**

[Run 33545049328](https://github.com/ConesaLab/PaintOmics/actions/runs/33545049328), with `--max-turns 30`:

```json
"subtype": "error_max_turns",  "is_error": true,
"num_turns": 31,  "permission_denials_count": 4,  "total_cost_usd": 0.8658
```

`Task` works now — the fan-out is running. It just doesn't fit.

### Why no fixed number is right

`--max-turns 15` came from the upstream *single-pass* example, was carried over unexamined, and 30 was my guess on top of it. Neither was derived from what the command actually does. It is a fan-out:

- a todo list
- seven steps of subagent launches (haiku, haiku, sonnet, then 4 in parallel)
- one validation agent per candidate issue
- **one turn per inline comment posted**

The last item is the problem: **its turn count scales with how many problems it finds.** A cap therefore truncates precisely the reviews worth reading — a clean PR fits, a PR with fifteen real bugs does not. And `error_max_turns` arrives with zero comments posted, indistinguishable from a pass.

So the flag is removed. `timeout-minutes` (20 → 25) is the real bound: wall clock, which is what a CI budget is actually about.

### Also

Added `git log`, `git show`, `git diff` to the allowlist — read-only, and the residual 4 denials are most likely a subagent reaching for history.

### The four runs so far

| run | change | result | comments |
|---|---|---|---|
| [33542418503](https://github.com/ConesaLab/PaintOmics/actions/runs/33542418503) | one write tool, no reads | success, 24 denials | 0 |
| [33543891958](https://github.com/ConesaLab/PaintOmics/actions/runs/33543891958) | + reads | success, 1 denial, 25s | 0 |
| [33545049328](https://github.com/ConesaLab/PaintOmics/actions/runs/33545049328) | + `Task`, `TodoWrite` | **error_max_turns**, 31 turns | 0 |
| next | no turn cap | ? | ? |

Three of those four reported **success** to the checks UI while doing nothing useful. That is the single most important thing this file has taught, and it is why the header comment is as long as it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpPJv51oEh4YdoERSyPHJ5
