### PR TITLE
Keep the reviewer's subagents in the foreground, or the session ends without them

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -83,6 +83,21 @@ jobs:
         with:
           fetch-depth: 1
       - uses: anthropics/claude-code-action@v1
+        # The orchestrator MUST run its subagents in the foreground. Run
+        # 33546158945 -- tools right, no turn cap -- still ended "success" in
+        # 19 s, 5 turns, zero comments, and its model usage listed haiku and
+        # sonnet but no opus: the two opus bug agents never ran. Reproduced on
+        # a laptop with the same allowlist: the orchestrator launches the four
+        # review agents with run_in_background: true and ends its turn with
+        # "I'll wait for their completion notifications". Interactively that
+        # notification is a new turn; in a non-interactive `-p` session a
+        # turn that ends in text is the end of the session, so the runner
+        # reports success and the reviewers die with it. Locally the same
+        # session just hangs. This variable removes run_in_background from the
+        # Agent tool altogether, which is the only setting that makes the
+        # choice unavailable rather than merely discouraged.
+        env:
+          CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"


### PR DESCRIPTION
One `env:` line on the action step: `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"`.

## What the last run actually did

Run 33546158945 had the tools right and no turn cap, and still reported `success` after 19 seconds, 5 turns and zero comments. Its `modelUsage` listed `claude-sonnet-5` and `claude-haiku-4-5` but no opus — so the two opus bug agents the plugin launches in step 4 never ran.

## Reproduced locally

The plugin's command body, run with `claude -p`, the same `--allowedTools`, and `--permission-mode default` (my machine is on `auto`, which approved everything and hid this): the orchestrator passes the preflight, finds `CLAUDE.md`, summarises the PR, then launches the four review agents with `run_in_background: true` and ends its turn with

> The four review agents are running in the background. I'll wait for their completion notifications before proceeding to validation.

In an interactive session that notification is a new turn. In a non-interactive `-p` session a turn that ends in text is the end of the session: the runner's SDK reports success and the background agents die with the process. Locally the same session hangs for 10+ minutes with no further events.

## Why an environment variable and not a prompt

`CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` removes `run_in_background` from the Agent tool's schema — checked by asking the CLI to list the tool's parameters with and without it:

```
unset:  description, isolation, mode, model, name, prompt, run_in_background, subagent_type
set:    description, isolation, mode, model, name, prompt, subagent_type, team_name
```

The orchestrator cannot choose what it cannot see. A system-prompt line asking it not to would only discourage it.

## What green means here

Same as before: nothing about this workflow is a gate, and the action skips itself on any PR that edits this file, so the "Claude review" check on this PR proves nothing. The proof is #124 reviewing after this lands and its branch carries the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpPJv51oEh4YdoERSyPHJ5
