### PR TITLE
Index pathway sources per organism; refuse requests for installed organisms

### DIFF
--- a/PaintomicsClient/public_html/app/controller/DataManagementController.js
+++ b/PaintomicsClient/public_html/app/controller/DataManagementController.js
@@ -279,6 +279,67 @@ this.submitForm = function (URL, form) {
  * now where it is needed: inside the Comments box, as its placeholder.
  */
 this.requestNewSpecieHandler = function(){
+	/* What is installed here: the same species.json the step 1 Organism combo
+	   is drawn from, so an organism this dialog refuses is one the visitor can
+	   pick on the form behind it. On 2026-09-03 a visitor requested Homo
+	   sapiens on paintomics.uv.es, where hsa has been installed for years --
+	   the dialog offered every organism in KEGG and let them ask for what they
+	   already had. Fetched per opening (a few KB, cached by the browser);
+	   never rejects, so an unreachable list degrades to the old dialog rather
+	   than to no dialog. The servlet checks again: this file is cached
+	   JavaScript and the POST can be made without it. */
+	var installed = {byCode: {}, byName: {}};
+	var installedReady = $.Deferred();
+	function normaliseName(name) {
+		return String(name == null ? "" : name).replace(/\s+/g, " ").replace(/^ | $/g, "").toLowerCase();
+	}
+	/* The installed organism a name/code pair denotes, or null. By code when a
+	   row was picked; by name when the visitor typed, and by name-as-code for
+	   a visitor who typed "hsa" into a field that shows names. */
+	function installedOrganismFor(name, code) {
+		var codeKey = String(code == null ? "" : code).toLowerCase(), nameKey = normaliseName(name);
+		if (codeKey && installed.byCode.hasOwnProperty(codeKey)) return installed.byCode[codeKey];
+		if (nameKey && installed.byName.hasOwnProperty(nameKey)) return installed.byName[nameKey];
+		if (nameKey && installed.byCode.hasOwnProperty(nameKey)) return installed.byCode[nameKey];
+		return null;
+	}
+	$.getJSON(SERVER_URL_GET_AVAILABLE_SPECIES)
+		.done(function(response) {
+			Ext.Array.each((response && response.species) || [], function(organism) {
+				if (organism == null || organism.value == null) return;
+				installed.byCode[String(organism.value).toLowerCase()] = organism;
+				installed.byName[normaliseName(organism.name)] = organism;
+			});
+		})
+		.always(function() { installedReady.resolve(installed); });
+
+	var requestStore = Ext.create('Ext.data.ArrayStore', {
+		fields: ['name', 'value'],
+		autoLoad: true,
+		proxy: {
+			type: 'ajax',
+			//TODO: MOVE THIS FILE TO KEGG_DATA FOLDER AND UPDATE
+			url: "resources/data/all_species.json",
+			reader: {
+				type: 'json',
+				root: 'species',
+				successProperty: 'success'
+			}
+		}
+	});
+	/* Installed organisms are not offered: the list is what can be requested.
+	   A filter rather than a second file, so the check lives in one place and
+	   the ~9,000-row list is downloaded once. Kept in the store's own filter
+	   set beside the combo's query filter (OrganismSearch.js), and re-run when
+	   the installed list lands, whichever of the two downloads finishes first. */
+	requestStore.addFilter(new Ext.util.Filter({
+		id: "installed-organisms",
+		filterFn: function(record) {
+			return installedOrganismFor(record.get('name'), record.get('value')) === null;
+		}
+	}), false);
+	installedReady.done(function() { requestStore.filter(); });
+
 	var messageDialog = Ext.create('Ext.window.Window', {
 		title: "Request an organism",
 		/* No height: the window shrink-wraps its two fields. It was 400px for
@@ -300,7 +361,8 @@ this.requestNewSpecieHandler = function(){
 				xtype: "box", cls: "po-dialog-intro",
 				html: '<p>Any organism in KEGG can be installed &mdash; ' +
 					'<a href="https://www.genome.jp/kegg/catalog/org_list.html"' +
-					' target="_blank" rel="noopener">see the full list</a>.</p>'
+					' target="_blank" rel="noopener">see the full list</a>. ' +
+					'Organisms already installed here are not listed: pick those in the Organism field of the form.</p>'
 			},
 			{
 				xtype: 'organismcombo', fieldLabel: 'Organism', name: 'specie',
@@ -310,20 +372,19 @@ this.requestNewSpecieHandler = function(){
 				displayField: 'name',
 				valueField: 'name',
 				editable: true,
-				store: Ext.create('Ext.data.ArrayStore', {
-					fields: ['name', 'value'],
-					autoLoad: true,
-					proxy: {
-						type: 'ajax',
-						//TODO: MOVE THIS FILE TO KEGG_DATA FOLDER AND UPDATE
-						url: "resources/data/all_species.json",
-						reader: {
-							type: 'json',
-							root: 'species',
-							successProperty: 'success'
-						}
-					}
-				})
+				store: requestStore,
+				listeners: {
+					/* The hint answers the value as typed; retyping clears it. */
+					change: function() { messageDialog.queryById('installedHint').hide(); }
+				}
+			},
+			{
+				/* Shown, in place of sending, when the chosen organism is one the
+				   form already offers. The dialog stays open with the choice in
+				   it, so the visitor can read the hint and pick something else. */
+				xtype: "box", itemId: "installedHint", cls: "po-dialog-hint",
+				hidden: true, html: "",
+				style: "color:#b5541c; margin:-8px 0 12px 0; font-size:13px;"
 			},
 			{
 				xtype: 'textareafield', name: 'comments', itemId: 'commentsTextArea',
@@ -342,10 +403,25 @@ this.requestNewSpecieHandler = function(){
 				text: 'Send request',
 				cls: 'po-dialog-primary',
 				handler : function() {
+					var combo = messageDialog.queryById('speciesCombobox');
+					var specie = combo.getValue();
+					/* valueField is the name, so the code comes from the row --
+					   when there is one: the field is free text for organisms
+					   KEGG lists under a name the file does not. */
+					var record = combo.findRecordByValue(specie);
+					var specieCode = record ? record.get('value') : "";
+					var already = installedOrganismFor(specie, specieCode);
+					if (already !== null) {
+						var hint = messageDialog.queryById('installedHint');
+						hint.update('<i class="fa fa-info-circle"></i> ' + Ext.String.htmlEncode(already.name) +
+							' is already installed &mdash; choose it in the Organism field of the form. No request is needed.');
+						hint.show();
+						return;
+					}
 					var type = "specie_request";
-					var message= "<p><b>Specie:</b> " + messageDialog.queryById('speciesCombobox').getValue()+ "</p><p><b>Comments:</b>" +  messageDialog.queryById('commentsTextArea').getValue() + "</p>";
+					var message= "<p><b>Specie:</b> " + specie + "</p><p><b>Comments:</b>" +  messageDialog.queryById('commentsTextArea').getValue() + "</p>";
 					messageDialog.close();
-					sendReportMessage(type, message);
+					sendReportMessage(type, message, undefined, undefined, {specie: specie, specieCode: specieCode});
 				}
 			},
 			{text: 'Cancel', handler : function() {messageDialog.close();}}

--- a/PaintomicsClient/public_html/app/view/common/Util.js
+++ b/PaintomicsClient/public_html/app/view/common/Util.js
@@ -979,13 +979,31 @@ function extJSErrorHandler(form, responseObj) {
 }
 
 
-function sendReportMessage(type, message, fromEmail, fromName) {
+/**
+ * POST a report, organism request or contact message to the developers.
+ *
+ * `extra` is merged into the form as further fields -- the organism request
+ * sends the organism as `specie` and `specieCode` beside the HTML message it
+ * always sent, so the servlet can refuse one that is already installed
+ * without parsing HTML. That refusal comes back as success=false with
+ * installed=true, and is shown as a warning: showErrorMessage's dialog offers
+ * a "report this error" button, which turned a refusal into an invitation to
+ * file an error report about it.
+ */
+function sendReportMessage(type, message, fromEmail, fromName, extra) {
     showInfoMessage("Sending message to developers...", {logMessage: "Sending new report...", showSpin: true});
     $.ajax({
         type: "POST", headers: {"Content-Encoding": "gzip"},
         url: SERVER_URL_DM_SEND_REPORT,
-        data: {type: type, message: message, fromEmail: fromEmail, fromName: fromName},
+        data: $.extend({type: type, message: message, fromEmail: fromEmail, fromName: fromName}, extra || {}),
         success: function (response) {
+            if (response.success === false && response.installed === true) {
+                showWarningMessage(response.organism + " is already installed", {
+                    message: response.errorMessage, showButton: true,
+                    logMessage: "Organism request refused: " + response.organism + " is installed"
+                });
+                return;
+            }
             if (response.success === false) {
                 showErrorMessage(response.errorMessage);
                 return;

--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -127,7 +127,7 @@
 	<!--SCRIPTS FOR SERVER CONNECTION CONFIGURATION-->
 	<script type="text/javascript" src="resources/ServerConfiguration.js?v=1.5"></script>
 	<!--CUSTOM SENCHA EXTENSIONS-->
-	<script type="text/javascript" src="app/view/common/Util.js?v=2.8"></script>
+	<script type="text/javascript" src="app/view/common/Util.js?v=2.9"></script>
 	<script type="text/javascript" src="app/view/common/ExtJS_extensions.js?v=0.7"></script>
 	<script type="text/javascript" src="app/view/common/OrganismSearch.js?v=1.0"></script>
 	<script type="text/javascript" src="app/view/common/upload/Panel.js?v=0.3"></script>

--- a/PaintomicsServer/src/AdminTools/customSpeciesInstaller.py
+++ b/PaintomicsServer/src/AdminTools/customSpeciesInstaller.py
@@ -478,9 +478,13 @@ def write_mongo(code, dbname_docs, xref_docs, kegg_docs, mongo_host, mongo_port)
     db["versions"].drop()
     db["versions"].insert_many([{"name": "KEGG", "date": stamp},
                                 {"name": "MAPPING", "date": stamp}])
-    # Same two indexes the standard build creates (common_build_database.py:3254)
+    # Same indexes the standard build creates (common_build_database.createDatabase):
+    # the two xref lookups, and the pathway `source` index that keeps
+    # /organism_databases from scanning every pathway document
+    # (DatabaseAvailability.PATHWAY_SOURCE_INDEX).
     db.xref.create_index([("dbname_id", ASCENDING), ("_id", ASCENDING)])
     db.xref.create_index([("display_id", ASCENDING)])
+    db.kegg.create_index([("source", ASCENDING)])
     client.close()
 
 

--- a/PaintomicsServer/src/AdminTools/omnipathInstaller.py
+++ b/PaintomicsServer/src/AdminTools/omnipathInstaller.py
@@ -780,6 +780,10 @@ def _write(code, documents, networks, mongo_host, mongo_port):
 
     removed = database[PATHWAY_COLLECTION].delete_many({"source": SOURCE_NAME})
     database[PATHWAY_COLLECTION].insert_many(documents)
+    # The KEGG build creates this index; an organism restored from a dump or
+    # built before it existed may not have it, and this is the write that
+    # adds a second `source` value for DatabaseAvailability to find.
+    database[PATHWAY_COLLECTION].create_index("source")
     logger.info("%s: replaced %d OmniPath pathways with %d",
                 code, removed.deleted_count, len(documents))
 

--- a/PaintomicsServer/src/AdminTools/scripts/clean_databases.py
+++ b/PaintomicsServer/src/AdminTools/scripts/clean_databases.py
@@ -430,6 +430,15 @@ def rebuildIndexes(connection):
             log("Failed to create index " + str(keys) + " on " + collectionName + ": " + str(err))
     log("jobID indexes created.")
 
+    # The per-organism pathway `source` index, for the same reason the jobID
+    # indexes are here: a deployment restored from a dump, or an organism
+    # installed by a build that predates the index, must not wait for a
+    # rebuild. Idempotent; see DatabaseAvailability.PATHWAY_SOURCE_INDEX.
+    from src.common import DatabaseAvailability
+    log("Creating pathway source indexes...")
+    indexed = DatabaseAvailability.ensurePathwaySourceIndexes(connection)
+    log("Pathway source index ensured for " + str(len(indexed)) + " organisms.")
+
 def log(msg):
     print(msg)
     frame,filename,line_number,function_name,lines,index=inspect.getouterframes(inspect.currentframe())[1]

--- a/PaintomicsServer/src/AdminTools/scripts/common_build_database.py
+++ b/PaintomicsServer/src/AdminTools/scripts/common_build_database.py
@@ -3491,6 +3491,12 @@ def createDatabase():
 
         db.xref.create_index([("dbname_id", ASCENDING),("_id", ASCENDING)])
         db.xref.create_index([("display_id", ASCENDING)])
+        # DatabaseAvailability reads distinct("source") from every organism
+        # on every /organism_databases cache miss; without this index that
+        # is a scan of every pathway document (DatabaseAvailability.
+        # PATHWAY_SOURCE_INDEX has the numbers). mongoimport recreated the
+        # collection just above, so the index has to be recreated here.
+        db.kegg.create_index([("source", ASCENDING)])
 
     except CalledProcessError as ex:
         raise ex

--- a/PaintomicsServer/src/common/DatabaseAvailability.py
+++ b/PaintomicsServer/src/common/DatabaseAvailability.py
@@ -73,6 +73,23 @@ _DB_SUFFIX = "-paintomics"
 #: Not an organism: the shared database that holds cross-organism data.
 _NON_ORGANISM_DATABASES = frozenset(["global" + _DB_SUFFIX])
 
+#: The collection every pathway database writes its pathways into, whatever
+#: the source -- the name predates there being anything but KEGG.
+PATHWAY_COLLECTION = "kegg"
+
+#: The field `_loadedSources` runs distinct() over, and the index that read
+#: needs. Unindexed, distinct is a scan of every pathway document: 17 KB each
+#: on average, 28 MB for hsa, times every installed organism on every cache
+#: miss. On paintomics.uv.es (133 organisms, an 8 GB host in swap) the sweep
+#: behind /organism_databases measured 4.9 s idle and 90 to 957 s under I/O
+#: pressure, nginx cut it off at 60 s, and the visitor saw "Unable to parse
+#: the error message". Indexed, the same distinct is an index-only
+#: DISTINCT_SCAN that touches no document. The installers create it; the
+#: server's startup pass and the nightly cron backfill it for organisms
+#: installed before it existed (ensurePathwaySourceIndexes). The docstring's
+#: "half a millisecond" was measured with 888 documents in cache.
+PATHWAY_SOURCE_INDEX = "source"
+
 #: Installing an organism means running DBManager and, in practice, restarting;
 #: this exists so that a server which is *not* restarted still notices within a
 #: few minutes rather than never. The read it saves is cheap -- what it really
@@ -146,6 +163,57 @@ def _loadedSources(organism, client=None):
             "(%s: %s); falling back to the identifier mappings in "
             "organismDB.py", organism, type(ex).__name__, ex)
         return None
+    finally:
+        if ownClient is not None:
+            ownClient.close()
+
+
+def _organismCodes(databaseNames):
+    """The organism codes among MongoDB's database names, in a stable order."""
+    return sorted(name[:-len(_DB_SUFFIX)] for name in databaseNames
+                  if name.endswith(_DB_SUFFIX) and name not in _NON_ORGANISM_DATABASES)
+
+
+def ensurePathwaySourceIndexes(client=None):
+    """Create the `source` index on every installed organism's pathways.
+
+    Idempotent and near-free once the index exists, so it is safe to call from
+    the server's startup pass and from the nightly cron as well as after an
+    install. One organism that cannot be indexed is logged and skipped rather
+    than costing the others their index; an unreachable MongoDB indexes
+    nothing and does not raise, because neither caller may die of it.
+
+    @param {MongoClient} client, an open connection to reuse; one is opened and
+           closed here when omitted.
+    @returns {List} of the organism codes whose collection now has the index
+    """
+    ownClient = None
+    try:
+        if client is None:
+            from pymongo import MongoClient
+            from src.conf.serverconf import MONGODB_HOST, MONGODB_PORT
+            ownClient = MongoClient(MONGODB_HOST, MONGODB_PORT,
+                                    serverSelectionTimeoutMS=3000)
+            client = ownClient
+        try:
+            names = client.list_database_names()
+        except Exception as ex:
+            logging.warning(
+                "Could not list the installed organisms to index their pathway "
+                "sources (%s: %s)", type(ex).__name__, ex)
+            return []
+
+        indexed = []
+        for organism in _organismCodes(names):
+            try:
+                client[organism + _DB_SUFFIX][PATHWAY_COLLECTION].create_index(
+                    PATHWAY_SOURCE_INDEX)
+                indexed.append(organism)
+            except Exception as ex:
+                logging.warning(
+                    "Could not index pathway sources for organism %s (%s: %s)",
+                    organism, type(ex).__name__, ex)
+        return indexed
     finally:
         if ownClient is not None:
             ownClient.close()
@@ -233,10 +301,7 @@ def getInstalledDatabasesByOrganism(refresh=False):
 
     try:
         availability = {}
-        for name in names:
-            if not name.endswith(_DB_SUFFIX) or name in _NON_ORGANISM_DATABASES:
-                continue
-            organism = name[:-len(_DB_SUFFIX)]
+        for organism in _organismCodes(names):
             availability[organism] = getInstalledDatabases(
                 organism, client=client, refresh=refresh)
         return availability

--- a/PaintomicsServer/src/paintomicsserver.py
+++ b/PaintomicsServer/src/paintomicsserver.py
@@ -1059,6 +1059,7 @@ class Application(object):
         # closed. Daemon so it can never keep a shutting-down process alive.
         def createIndexes():
             from src.AdminTools.scripts.clean_databases import JOBID_INDEXES
+            from src.common import DatabaseAvailability
             from src.common.DBmanager import getSharedClient
             from src.conf.serverconf import MONGODB_DATABASE
             try:
@@ -1070,6 +1071,14 @@ class Application(object):
                 # An unreachable database must not stop the server from
                 # serving; it did not before this call existed.
                 logging.warning("Could not ensure jobID indexes at startup: " + str(ex))
+
+            # Same thread, same reasoning: the organisms installed before the
+            # pathway `source` index existed get it here, once, so that
+            # /organism_databases stops scanning their pathway documents.
+            # Never raises; it logs the organism it could not index and goes
+            # on to the next.
+            indexed = DatabaseAvailability.ensurePathwaySourceIndexes(getSharedClient())
+            logging.info("Pathway source index ensured for %d organisms.", len(indexed))
 
         import threading
         threading.Thread(target=createIndexes, name="ensureIndexes", daemon=True).start()

--- a/PaintomicsServer/src/servlets/AdminServlet.py
+++ b/PaintomicsServer/src/servlets/AdminServlet.py
@@ -29,7 +29,6 @@ import psutil
 import subprocess
 from datetime import datetime
 import html
-import re
 
 from src.common.UserSessionManager import UserSessionManager
 from src.common.ServerErrorManager import handleException
@@ -766,7 +765,32 @@ def adminServletDeleteReport(request, response, reportID):
 #: How the request dialog has always written the organism into its HTML
 #: message: <p><b>Specie:</b> Homo sapiens (human)</p>. Read when a client
 #: cached from before the `specie`/`specieCode` fields sends only that.
-_SPECIE_IN_MESSAGE = re.compile(r"<b>\s*Specie:\s*</b>\s*(.*?)\s*</p>", re.I | re.S)
+_SPECIE_LABEL = "specie:"
+
+
+def _specieFromMessage(message):
+    """The organism an old client's HTML message names, or None.
+
+    Three plain searches, each linear and each run once. The message is
+    untrusted text of up to MAX_FORM_MEMORY_SIZE, posted without a session,
+    so the regex this replaces (``<b>\\s*Specie:\\s*</b>\\s*(.*?)\\s*</p>``)
+    was an outage waiting for one request: its three quantifiers overlap on
+    whitespace, so a label followed by a run of spaces and no ``</p>`` cost
+    cubic time. Dropping the inner ``\\s*`` still leaves a quadratic scan
+    when the label is repeated, which is why this is not a regex at all.
+    """
+    text = str(message or "")
+    lower = text.lower()
+    label = lower.find(_SPECIE_LABEL)
+    if label < 0:
+        return None
+    boldEnd = lower.find("</b>", label)
+    if boldEnd < 0 or lower[label + len(_SPECIE_LABEL):boldEnd].strip():
+        return None
+    paragraphEnd = lower.find("</p>", boldEnd)
+    if paragraphEnd < 0:
+        return None
+    return text[boldEnd + len("</b>"):paragraphEnd].strip()
 
 
 def _normaliseOrganismName(name):
@@ -804,9 +828,9 @@ def _installedOrganism(specieName, specieCode, message):
     """
     name = specieName
     if not name and message:
-        found = _SPECIE_IN_MESSAGE.search(message)
+        found = _specieFromMessage(message)
         if found:
-            name = html.unescape(found.group(1))
+            name = html.unescape(found)
     code = str(specieCode or "").strip().lower()
     name = _normaliseOrganismName(name)
     if not code and not name:

--- a/PaintomicsServer/src/servlets/AdminServlet.py
+++ b/PaintomicsServer/src/servlets/AdminServlet.py
@@ -28,6 +28,8 @@ import csv
 import psutil
 import subprocess
 from datetime import datetime
+import html
+import re
 
 from src.common.UserSessionManager import UserSessionManager
 from src.common.ServerErrorManager import handleException
@@ -761,6 +763,65 @@ def adminServletDeleteReport(request, response, reportID):
         return response
 
 
+#: How the request dialog has always written the organism into its HTML
+#: message: <p><b>Specie:</b> Homo sapiens (human)</p>. Read when a client
+#: cached from before the `specie`/`specieCode` fields sends only that.
+_SPECIE_IN_MESSAGE = re.compile(r"<b>\s*Specie:\s*</b>\s*(.*?)\s*</p>", re.I | re.S)
+
+
+def _normaliseOrganismName(name):
+    return " ".join(str(name or "").split()).lower()
+
+
+def installedOrganisms():
+    """The organisms the step 1 combo offers: KEGG_DATA_DIR/current/species.json.
+
+    That file is what DBManager wrote when it last installed something, and it
+    is what the combo is loaded from -- so an organism in it is one the
+    visitor can pick right now, which is the sense of "installed" a request
+    dialog has to refuse. Unreadable means an empty list, never an error: a
+    request that gets through is a nuisance, a request that cannot be made is
+    a lost organism.
+    """
+    try:
+        with open(os_path.join(KEGG_DATA_DIR, "current", "species.json")) as handle:
+            species = json.load(handle).get("species") or []
+        return [organism for organism in species
+                if isinstance(organism, dict) and organism.get("value")]
+    except Exception as ex:
+        logging.warning("Could not read the installed organisms from species.json "
+                        "(%s: %s); organism requests are not screened", type(ex).__name__, ex)
+        return []
+
+
+def _installedOrganism(specieName, specieCode, message):
+    """The installed organism a request names, or None when it names none.
+
+    Matched by code first (what the dialog sends when a row was picked), then
+    by display name, whitespace and case aside (what the dialog sends when
+    the visitor typed), then by the name against the code, for a visitor who
+    typed "hsa" into a field that shows names.
+    """
+    name = specieName
+    if not name and message:
+        found = _SPECIE_IN_MESSAGE.search(message)
+        if found:
+            name = html.unescape(found.group(1))
+    code = str(specieCode or "").strip().lower()
+    name = _normaliseOrganismName(name)
+    if not code and not name:
+        return None
+
+    for organism in installedOrganisms():
+        organismCode = str(organism.get("value")).strip().lower()
+        organismName = _normaliseOrganismName(organism.get("name"))
+        if code and code == organismCode:
+            return organism
+        if name and name in (organismName, organismCode):
+            return organism
+    return None
+
+
 def adminServletSendReport(request, response, ROOT_DIRECTORY):
     """
     This function...
@@ -794,6 +855,19 @@ def adminServletSendReport(request, response, ROOT_DIRECTORY):
 
         request_type = formFields.get("type")
         _message = formFields.get("message")
+
+        if request_type == "specie_request":
+            installed = _installedOrganism(formFields.get("specie"),
+                                           formFields.get("specieCode"), _message)
+            if installed is not None:
+                logging.info("Organism request for %s (%s) refused: already installed",
+                             installed["name"], installed["value"])
+                response.setContent({
+                    "success": False, "installed": True,
+                    "organism": installed["name"], "code": installed["value"],
+                    "errorMessage": installed["name"] + " is already installed. "
+                    "Choose it in the Organism field of the form; no request is needed."})
+                return response
 
         subject = "Other request"
         title = "<h1>Other request</h1>"

--- a/PaintomicsServer/src/tests/test_database_availability.py
+++ b/PaintomicsServer/src/tests/test_database_availability.py
@@ -45,8 +45,10 @@ from src.common import DatabaseAvailability
 
 
 class FakeCollection(object):
-    def __init__(self, sources):
+    def __init__(self, sources, indexLog=None, name=None):
         self._sources = sources
+        self._indexLog = indexLog
+        self._name = name
 
     def distinct(self, field):
         assert field == "source"
@@ -54,10 +56,21 @@ class FakeCollection(object):
             raise RuntimeError("connection refused")
         return list(self._sources)
 
+    def create_index(self, keys):
+        if self._sources is None:
+            raise RuntimeError("connection refused")
+        if self._indexLog is not None:
+            self._indexLog.append((self._name, keys))
+        return "source_1"
+
 
 class FakeDatabase(object):
-    def __init__(self, sources):
-        self.kegg = FakeCollection(sources)
+    def __init__(self, sources, indexLog=None, name=None):
+        self.kegg = FakeCollection(sources, indexLog=indexLog, name=name)
+
+    def __getitem__(self, collection):
+        """pymongo reaches a collection both ways; so does the code under test."""
+        return getattr(self, collection)
 
 
 class FakeClient(object):
@@ -70,9 +83,13 @@ class FakeClient(object):
     def __init__(self, sourcesByDatabase):
         self._sources = sourcesByDatabase
         self.closed = False
+        #: Every create_index call, as (database name, keys). What
+        #: ensurePathwaySourceIndexes is judged on.
+        self.indexes = []
 
     def __getitem__(self, name):
-        return FakeDatabase(self._sources.get(name, []))
+        return FakeDatabase(self._sources.get(name, []),
+                            indexLog=self.indexes, name=name)
 
     def list_database_names(self):
         return list(self._sources)
@@ -306,6 +323,91 @@ class OrganismMapTest(unittest.TestCase):
         finally:
             client.close()
 
+
+class PathwaySourceIndexTest(unittest.TestCase):
+    """distinct("source") must not read every pathway document.
+
+    Without an index on `source` the read is a collection scan of documents
+    that average 17 KB -- 28 MB for hsa -- repeated for every installed
+    organism on every cache miss. /organism_databases, which sweeps all 133
+    organisms on paintomics.uv.es, measured 4.9 s idle and 90 to 957 s under
+    I/O pressure (2026-09-02/03), nginx cut those off at 60 s, and visitors
+    reported the resulting 504 as "Unable to parse the error message". With
+    the index the same distinct is an index-only DISTINCT_SCAN.
+    """
+
+    def setUp(self):
+        DatabaseAvailability.clearCache()
+
+    def test_every_organism_collection_gets_the_source_index(self):
+        client = FakeClient({
+            "mmu-paintomics": ["KEGG", "Reactome"],
+            "ath-paintomics": ["KEGG", "MapMan"],
+            "global-paintomics": [],
+            "admin": [],
+            "PaintomicsDB": [],
+        })
+        indexed = DatabaseAvailability.ensurePathwaySourceIndexes(client)
+
+        self.assertEqual(["ath", "mmu"], indexed)
+        self.assertEqual(
+            sorted([("ath-paintomics", DatabaseAvailability.PATHWAY_SOURCE_INDEX),
+                    ("mmu-paintomics", DatabaseAvailability.PATHWAY_SOURCE_INDEX)]),
+            sorted(client.indexes),
+            "the shared database and the job database are not organisms")
+        self.assertFalse(client.closed, "a caller's connection is not closed for it")
+
+    def test_one_failing_organism_does_not_cost_the_others_their_index(self):
+        client = FakeClient({
+            "mmu-paintomics": ["KEGG"],
+            "bad-paintomics": None,          # create_index raises
+            "ath-paintomics": ["KEGG"],
+        })
+        self.assertEqual(["ath", "mmu"],
+                         DatabaseAvailability.ensurePathwaySourceIndexes(client))
+
+    def test_an_unreachable_mongodb_indexes_nothing_and_does_not_raise(self):
+        class Unreachable(FakeClient):
+            def list_database_names(self):
+                raise RuntimeError("connection refused")
+
+        self.assertEqual([], DatabaseAvailability.ensurePathwaySourceIndexes(
+            Unreachable({})))
+
+    def test_the_live_distinct_is_an_index_scan(self):
+        """Against a real MongoDB when one is running; skipped when not.
+
+        The fakes prove which collections are indexed; this proves the index
+        is the one the query planner picks for the read `_loadedSources`
+        actually issues, on the real collection name and field.
+        """
+        import json
+        try:
+            from pymongo import MongoClient
+            from src.conf.serverconf import MONGODB_HOST, MONGODB_PORT
+            client = MongoClient(MONGODB_HOST, MONGODB_PORT,
+                                 serverSelectionTimeoutMS=1500)
+            client.list_database_names()
+        except Exception as ex:
+            raise unittest.SkipTest("no MongoDB to check against (%s)" % (ex,))
+
+        try:
+            indexed = DatabaseAvailability.ensurePathwaySourceIndexes(client)
+            populated = [organism for organism in indexed
+                         if client[organism + "-paintomics"].kegg.estimated_document_count()]
+            if not populated:
+                raise unittest.SkipTest("no organism with pathways is installed here")
+            for organism in populated:
+                database = client[organism + "-paintomics"]
+                plan = database.command(
+                    "explain", {"distinct": "kegg",
+                                "key": DatabaseAvailability.PATHWAY_SOURCE_INDEX},
+                    verbosity="queryPlanner")
+                self.assertIn("DISTINCT_SCAN", json.dumps(plan, default=str),
+                              "%s: distinct(\"source\") still scans the collection"
+                              % organism)
+        finally:
+            client.close()
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_organism_request_rejects_installed.py
+++ b/PaintomicsServer/src/tests/test_organism_request_rejects_installed.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""An organism that is already installed cannot be requested.
+
+What happened
+-------------
+2026-09-03 08:36, paintomics.uv.es: an anonymous visitor submitted the
+"Request an organism" dialog for Homo sapiens (human). hsa has been installed
+on that server for years and sits in the Organism combo on the same page. The
+request was stored, mailed to the developers, and answered nobody's question:
+the visitor had missed the combo, and the dialog let them ask for what they
+already had.
+
+The rule
+--------
+"Installed" means listed in KEGG_DATA_DIR/current/species.json -- exactly the
+list the step 1 Organism combo is drawn from, so an organism this rejects is
+one the visitor can pick right now. The dialog checks first, so the usual
+outcome is a hint next to the field and no round trip; the servlet checks
+again, because the dialog is a cached JavaScript file and the request is a
+POST anyone can make. The servlet answers success=false with installed=true
+and the organism's display name, stores nothing and mails nobody.
+
+A client older than this change sends no `specie`/`specieCode` fields, only
+the HTML message it always sent, so the servlet also reads the organism out of
+that message. An unreadable species.json blocks nothing: a request that gets
+through is a nuisance, a request that cannot be made is a lost organism.
+
+Run:  PYTHONPATH=PaintomicsServer python3 PaintomicsServer/src/tests/test_organism_request_rejects_installed.py
+"""
+import importlib.util
+import io
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(HERE, "..", "..", ".."))
+sys.path.insert(0, os.path.abspath(os.path.join(HERE, "..", "..")))
+
+
+def _ensureServerConfig():
+    """serverconf.py is gitignored; bind the tracked template when it is absent."""
+    try:
+        import src.conf.serverconf                       # noqa: F401 -- availability probe
+        return
+    except ImportError:
+        pass
+    template = os.path.join(HERE, "..", "resources", "example_serverconf.py")
+    spec = importlib.util.spec_from_file_location("src.conf.serverconf", template)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["src.conf.serverconf"] = module
+    spec.loader.exec_module(module)
+
+
+_ensureServerConfig()
+
+import src.servlets.AdminServlet as AdminServlet   # noqa: E402
+
+INSTALLED = [{"name": "Homo sapiens (human)", "value": "hsa"},
+             {"name": "Mus musculus (house mouse)", "value": "mmu"}]
+
+
+class _Cookies(object):
+    def get(self, _name):
+        return None
+
+
+class _Request(object):
+    def __init__(self, form):
+        self.cookies = _Cookies()
+        self.form = form
+
+
+class _Response(object):
+    def __init__(self):
+        self.content = None
+
+    def setContent(self, content):
+        self.content = content
+
+    def setStatus(self, status):
+        pass
+
+
+class OrganismRequestTest(unittest.TestCase):
+    def setUp(self):
+        self.keggDataDir = tempfile.mkdtemp(prefix="paintomics-species-")
+        os.makedirs(os.path.join(self.keggDataDir, "current"))
+        with io.open(os.path.join(self.keggDataDir, "current", "species.json"),
+                     "w", encoding="utf-8") as handle:
+            json.dump({"success": True, "species": INSTALLED}, handle)
+
+        self.calls = []
+        calls = self.calls
+
+        class _StubDAO(object):
+            def insert(self, instance):
+                calls.append(("insert", instance.report_type, instance.message))
+                return "stub-report-id"
+
+            def markDelivered(self, reportID, delivered, deliveryError=""):
+                calls.append(("markDelivered", reportID, delivered))
+                return True
+
+        def _stubSendEmail(*args, **kwargs):
+            calls.append(("sendEmail",))
+
+        self._saved = (AdminServlet.ReportDAO, AdminServlet.sendEmail,
+                       AdminServlet.KEGG_DATA_DIR)
+        AdminServlet.ReportDAO = _StubDAO
+        AdminServlet.sendEmail = _stubSendEmail
+        AdminServlet.KEGG_DATA_DIR = self.keggDataDir + "/"
+
+    def tearDown(self):
+        (AdminServlet.ReportDAO, AdminServlet.sendEmail,
+         AdminServlet.KEGG_DATA_DIR) = self._saved
+        shutil.rmtree(self.keggDataDir, ignore_errors=True)
+
+    def _request(self, **fields):
+        form = {"type": "specie_request",
+                "fromEmail": "requester@example.org",
+                "fromName": "A Researcher",
+                "message": "<p><b>Specie:</b> %s</p><p><b>Comments:</b></p>"
+                           % fields.get("specie", "")}
+        form.update(fields)
+        response = _Response()
+        AdminServlet.adminServletSendReport(_Request(form), response, self.keggDataDir)
+        return response.content
+
+    def _stored(self):
+        return [call for call in self.calls if call[0] == "insert"]
+
+    def _mailed(self):
+        return [call for call in self.calls if call[0] == "sendEmail"]
+
+    # -- rejected ------------------------------------------------------------
+
+    def test_an_installed_code_is_rejected_stored_nowhere_and_mailed_to_nobody(self):
+        content = self._request(specie="Homo sapiens (human)", specieCode="hsa")
+
+        self.assertIs(False, content["success"])
+        self.assertIs(True, content["installed"])
+        self.assertEqual("Homo sapiens (human)", content["organism"])
+        self.assertEqual("hsa", content["code"])
+        self.assertIn("already installed", content["errorMessage"])
+        self.assertEqual([], self._stored())
+        self.assertEqual([], self._mailed())
+
+    def test_an_installed_name_is_rejected_whatever_its_case_or_spacing(self):
+        """The combo lets the visitor type; the typed name still counts."""
+        content = self._request(specie="  homo SAPIENS (Human) ", specieCode="")
+        self.assertIs(False, content["success"])
+        self.assertEqual("Homo sapiens (human)", content["organism"])
+
+    def test_a_code_typed_as_the_name_is_rejected(self):
+        content = self._request(specie="hsa", specieCode="")
+        self.assertIs(False, content["success"])
+        self.assertEqual("hsa", content["code"])
+
+    def test_a_client_that_predates_the_fields_is_read_from_its_message(self):
+        """Cached JavaScript sends only the HTML it always sent."""
+        form = {"type": "specie_request", "fromEmail": "r@example.org",
+                "fromName": "R",
+                "message": "<p><b>Specie:</b> Mus musculus (house mouse)</p>"
+                           "<p><b>Comments:</b>Entrez IDs please</p>"}
+        response = _Response()
+        AdminServlet.adminServletSendReport(_Request(form), response, self.keggDataDir)
+
+        self.assertIs(False, response.content["success"])
+        self.assertEqual("mmu", response.content["code"])
+        self.assertEqual([], self._stored())
+
+    # -- allowed -------------------------------------------------------------
+
+    def test_an_organism_that_is_not_installed_goes_through(self):
+        content = self._request(specie="Fusarium oxysporum", specieCode="fox")
+
+        self.assertIs(True, content["success"])
+        self.assertEqual(1, len(self._stored()))
+        self.assertEqual(1, len(self._mailed()))
+
+    def test_an_unreadable_species_list_blocks_nothing(self):
+        shutil.rmtree(self.keggDataDir)
+        content = self._request(specie="Homo sapiens (human)", specieCode="hsa")
+
+        self.assertIs(True, content["success"])
+        self.assertEqual(1, len(self._stored()))
+
+    def test_other_report_types_are_not_screened(self):
+        """An error report that mentions hsa is still an error report."""
+        form = {"type": "error", "fromEmail": "r@example.org", "fromName": "R",
+                "message": "hsa job crashed", "specie": "Homo sapiens (human)",
+                "specieCode": "hsa"}
+        response = _Response()
+        AdminServlet.adminServletSendReport(_Request(form), response, self.keggDataDir)
+
+        self.assertIs(True, response.content["success"])
+        self.assertEqual(1, len(self._stored()))
+
+
+CLIENT = os.path.join(REPO, "PaintomicsClient", "public_html")
+
+
+def _read(*parts):
+    with io.open(os.path.join(CLIENT, *parts), encoding="utf-8") as handle:
+        return handle.read()
+
+
+class DialogWiringTest(unittest.TestCase):
+    """The dialog checks before it sends, and tells the servlet what it chose.
+
+    Source assertions, as in test_database_checkboxes_follow_the_server: the
+    client has no test harness. Verified in Chrome -- picking Homo sapiens
+    shows the hint and sends nothing; Fusarium oxysporum sends.
+    """
+
+    def setUp(self):
+        source = _read("app", "controller", "DataManagementController.js")
+        match = re.search(r"this\.requestNewSpecieHandler = function\(\)\{.*?\n\};",
+                          source, re.S)
+        self.assertTrue(match, "requestNewSpecieHandler is gone")
+        self.dialog = match.group(0)
+
+    def test_the_dialog_reads_the_installed_list_the_form_uses(self):
+        self.assertIn("SERVER_URL_GET_AVAILABLE_SPECIES", self.dialog)
+
+    def test_installed_organisms_are_kept_out_of_the_request_list(self):
+        self.assertRegex(self.dialog, r"addFilter\(")
+
+    def test_the_request_names_the_organism_as_fields_not_only_as_html(self):
+        self.assertRegex(self.dialog, r"specie:\s*\w+")
+        self.assertRegex(self.dialog, r"specieCode:\s*\w+")
+
+    def test_an_installed_choice_is_stopped_before_the_round_trip(self):
+        self.assertIn("already installed", self.dialog)
+        self.assertNotIn("sendReportMessage(type, message);", self.dialog,
+                         "the request is sent without the organism fields")
+
+    def test_the_sender_shows_the_servlet_refusal_as_a_hint_not_a_crash(self):
+        """success=false used to mean showErrorMessage, whose dialog carries a
+        'report this error' button -- a refusal that invited an error report."""
+        util = _read("app", "view", "common", "Util.js")
+        match = re.search(r"function sendReportMessage\(.*?\n\}", util, re.S)
+        self.assertTrue(match)
+        self.assertIn("response.installed", match.group(0))
+        self.assertRegex(match.group(0), r"extra")
+
+    def test_the_edited_scripts_are_cache_busted(self):
+        index = _read("index.html")
+        self.assertRegex(index, r'Util\.js\?v=(2\.9|[3-9]\.\d+)')
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_organism_request_rejects_installed.py
+++ b/PaintomicsServer/src/tests/test_organism_request_rejects_installed.py
@@ -33,6 +33,7 @@ import json
 import os
 import re
 import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -174,6 +175,32 @@ class OrganismRequestTest(unittest.TestCase):
         self.assertEqual("mmu", response.content["code"])
         self.assertEqual([], self._stored())
 
+    def test_an_old_client_message_is_read_in_bounded_time(self):
+        """The message is untrusted text of up to MAX_FORM_MEMORY_SIZE, posted
+        without a session. Reading the organism out of it was a regex with
+        three quantifiers overlapping on whitespace: a label followed by a run
+        of spaces and no </p> cost cubic time, so one request pinned a worker
+        for hours. Dropping the inner \\s* leaves a quadratic scan when the
+        label repeats. Run in a subprocess so a regression fails on a timeout
+        instead of hanging the suite."""
+        probe = (
+            "import sys\n"
+            "sys.path.insert(0, %r)\n"
+            "import test_organism_request_rejects_installed as suite\n"
+            "servlet = suite.AdminServlet\n"
+            "assert servlet._installedOrganism(None, None, '<p><b>Specie:</b>' + ' ' * 20000) is None\n"
+            "assert servlet._installedOrganism(None, None, '<b>Specie:</b>' * 200000) is None\n"
+            "print('bounded')\n"
+        ) % HERE
+        try:
+            result = subprocess.run([sys.executable, "-c", probe], capture_output=True,
+                                    text=True, timeout=20)
+        except subprocess.TimeoutExpired:
+            self.fail("reading the organism out of a 20 kB whitespace run and a "
+                      "2.8 MB run of repeated labels did not finish in 20 s")
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("bounded", result.stdout)
+
     # -- allowed -------------------------------------------------------------
 
     def test_an_organism_that_is_not_installed_goes_through(self):
@@ -208,6 +235,25 @@ CLIENT = os.path.join(REPO, "PaintomicsClient", "public_html")
 def _read(*parts):
     with io.open(os.path.join(CLIENT, *parts), encoding="utf-8") as handle:
         return handle.read()
+
+
+class OldClientMessageTest(unittest.TestCase):
+    """_specieFromMessage reads <p><b>Specie:</b> name</p> and nothing else."""
+
+    def test_reads_the_name_between_the_label_and_the_end_of_its_paragraph(self):
+        self.assertEqual("Homo sapiens (human)", AdminServlet._specieFromMessage(
+            "<p><b>Specie:</b> Homo sapiens (human)</p><p><b>Comments:</b>hi</p>"))
+
+    def test_the_label_is_read_whatever_its_case_or_spacing(self):
+        self.assertEqual("Mus musculus", AdminServlet._specieFromMessage(
+            "<p><b> SPECIE: </b>\n Mus musculus \n</p>"))
+
+    def test_a_message_that_does_not_carry_the_label_names_nothing(self):
+        for message in (None, "", "<p>hello</p>",
+                        "<b>Specie:</b> hsa",             # no paragraph end
+                        "<b>Specie: hsa</b> x</p>",       # text inside the label
+                        "Specie: hsa</p>"):               # no bold end
+            self.assertIsNone(AdminServlet._specieFromMessage(message), repr(message))
 
 
 class DialogWiringTest(unittest.TestCase):

--- a/PaintomicsServer/src/tests/test_pathway_source_index_is_installed.py
+++ b/PaintomicsServer/src/tests/test_pathway_source_index_is_installed.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Every path that writes pathway documents must leave a `source` index behind.
+
+Why
+---
+`DatabaseAvailability._loadedSources` answers "which pathway databases does
+this organism have" with distinct("source") on the organism's `kegg`
+collection. Without an index that is a scan of every pathway document -- 17 KB
+each on average, 28 MB for hsa -- once per organism per cache miss, and
+/organism_databases sweeps every organism. On paintomics.uv.es (133 organisms,
+8 GB, swapping) the sweep took 4.9 s idle and 90 to 957 s under I/O pressure;
+nginx gave up at 60 s and the visitor saw "Unable to parse the error message".
+
+The index is cheap and turns the read into an index-only DISTINCT_SCAN, but
+it only helps if it exists on every organism, including the ones installed
+next year. So it is created in four places and this file pins all four:
+
+  * the two installers that build an organism from KEGG
+    (common_build_database.createDatabase, customSpeciesInstaller)
+  * the installer that adds a source to an existing organism (omnipathInstaller)
+  * the running server's startup pass and the nightly cron, for organisms
+    installed before the index existed (paintomicsserver.ensureIndexes,
+    clean_databases.rebuildIndexes) -- both through
+    DatabaseAvailability.ensurePathwaySourceIndexes, so there is one sweep
+    and one definition of the key.
+
+Why source assertions
+---------------------
+The installers download from KEGG and shell out to mongoimport; the server's
+startup pass is a daemon thread. None of them can run in a unit test. The
+behaviour was verified against a live MongoDB (test_database_availability
+checks the query plan); these keep the wiring that produced it from being
+unpicked file by file.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_pathway_source_index_is_installed
+"""
+import io
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+SRC = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _read(*parts):
+    with io.open(os.path.join(SRC, *parts), encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _function(source, name):
+    """The body of `def name(` up to the next top-level def/class."""
+    match = re.search(r"^def %s\(.*?(?=^def |^class |\Z)" % re.escape(name),
+                      source, re.S | re.M)
+    assert match, "no function %s" % name
+    return match.group(0)
+
+
+# `create_index("source")` or `create_index([("source", ASCENDING)])`: both
+# build the same index, source_1, and both are what the planner needs.
+SOURCE_INDEX = re.compile(
+    r'create_index\(\s*(?:"source"|\[\s*\(\s*"source"\s*,\s*ASCENDING\s*\)\s*\])\s*\)')
+
+
+class InstallersCreateTheIndexTest(unittest.TestCase):
+    def test_the_kegg_build_indexes_source_beside_the_xref_indexes(self):
+        body = _function(_read("AdminTools", "scripts", "common_build_database.py"),
+                         "createDatabase")
+        self.assertRegex(body, r"db\.kegg\." + SOURCE_INDEX.pattern)
+
+    def test_the_custom_species_installer_indexes_source(self):
+        source = _read("AdminTools", "customSpeciesInstaller.py")
+        self.assertRegex(source, r"db\.kegg\." + SOURCE_INDEX.pattern)
+
+    def test_the_omnipath_installer_indexes_source_after_writing(self):
+        body = _function(_read("AdminTools", "omnipathInstaller.py"), "_write")
+        self.assertRegex(body, r"\[PATHWAY_COLLECTION\]\." + SOURCE_INDEX.pattern)
+
+
+class TheServerBackfillsTheIndexTest(unittest.TestCase):
+    """Organisms installed before the index existed get it without a rebuild."""
+
+    def test_startup_ensures_the_index_on_every_organism(self):
+        source = _read("paintomicsserver.py")
+        match = re.search(r"def ensureIndexes\(self\):.*?(?=\n    def )", source, re.S)
+        self.assertTrue(match, "paintomicsserver.ensureIndexes is gone")
+        self.assertIn("ensurePathwaySourceIndexes", match.group(0))
+
+    def test_the_nightly_cron_ensures_it_too(self):
+        body = _function(_read("AdminTools", "scripts", "clean_databases.py"),
+                         "rebuildIndexes")
+        self.assertIn("ensurePathwaySourceIndexes", body)
+
+    def test_the_key_is_defined_once(self):
+        """Installers and the sweep must agree on the field, or the planner
+        has an index it cannot use."""
+        from src.common import DatabaseAvailability
+        self.assertEqual("source", DatabaseAvailability.PATHWAY_SOURCE_INDEX)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
+++ b/PaintomicsServer/src/tests/test_versioned_assets_are_bumped.py
@@ -117,8 +117,12 @@ PUBLISHED = {
     # user's doing -- extJSErrorHandler's CLIENT_INVALID, which is only reached
     # after checkForm()/isValid() already approved the form, so it means ExtJS
     # refused something the app had just passed. That is #109's shape.
+    # v=2.9 lets sendReportMessage carry extra form fields (the organism
+    # request sends specie/specieCode beside its HTML) and shows the
+    # servlet's "already installed" refusal as a warning, not the error
+    # dialog with its report button. That is #130's shape.
     "app/view/common/Util.js": (
-        "2.8", "5e32bd98a485def921b7c64292bc735e43c08381871632e18e3d2202d27bd1f5"),
+        "2.9", "69c3bdaa628db402fd8e707c9a1d679b331df548301bf26316c8bebdfcddafaf"),
     "app/view/common/OrganismSearch.js": (
         "1.0", "7903626835e7703bdb6a1e31b78e3ca00539eee23b8fa67a37524cd9cc4d2e7f"),
     "app/view/common/ExtJS_extensions.js": (


### PR DESCRIPTION
## Why

`/organism_databases` runs `distinct("source")` on every organism's `kegg` collection. The field had no index, so each cache miss scanned every pathway document (17 KB avg, 28 MB for hsa) across all 133 organisms. On paintomics.uv.es: 4.9 s idle, 90–957 s under I/O pressure, cut off by nginx at 60 s → visitors reported the 504 as *"Unable to parse the error message"* (5 distinct IPs on 2–3 Sep 2026).

Separately, the **Request an organism** dialog offered every organism in KEGG, including installed ones — on 3 Sep a visitor requested *Homo sapiens* on a server that has had `hsa` for years.

## What

- **`source` index on every organism's pathway collection.** Created by `common_build_database.createDatabase`, `customSpeciesInstaller` and `omnipathInstaller._write`; backfilled by `DatabaseAvailability.ensurePathwaySourceIndexes` from the server's startup index pass and the nightly cron. `distinct` becomes an index-only `DISTINCT_SCAN`.
- **Installed organisms cannot be requested.** The dialog loads `species.json` (what the step-1 combo shows), filters those organisms out of the request list, and shows an inline hint if one is typed. The servlet checks again — via new `specie`/`specieCode` fields, or by reading the organism from the HTML message for cached older clients — and answers `success:false, installed:true` without storing or mailing. `sendReportMessage` shows that as a warning rather than the error dialog with its "report this error" button.

## Measured

| Sweep over 133 organisms (prod) | before | after |
|---|---|---|
| idle | 4.9 s | 0.11 s |
| docs examined per organism | all | 0 |

The index was already created by hand on production (idempotent); this PR makes it permanent for new installs and restarts.

## Tests

- `test_database_availability`: +4 (fake client asserts every organism DB is indexed and failures are isolated; live test asserts `DISTINCT_SCAN` on a real MongoDB).
- `test_pathway_source_index_is_installed` (new): pins the installers, startup pass and cron.
- `test_organism_request_rejects_installed` (new): servlet guard for code / name / old-client shapes, allowed path, unreadable species.json, other report types; dialog and `Util.js` wiring.
- Full offline suite: 285 suites pass, 0 introduced. ruff + eslint clean.

Verified in Chrome on a dev server: `mmu`/`ath` absent from the list, typing the mouse shows the hint with no request, a blue-whale request is sent with the new fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018mZF1iCz3wJJpS66rrw6nz
