### PR TITLE
Read a MORE-less job's regulation table without crashing the evidence overlay

### DIFF
--- a/PaintomicsServer/src/classes/PathwayEvidence.py
+++ b/PaintomicsServer/src/classes/PathwayEvidence.py
@@ -472,9 +472,19 @@ class _RegulationTable(object):
     """
 
     def __init__(self, regulationData):
-        self.columns = list((regulationData or {}).get("columns") or [])
-        self.rows = list((regulationData or {}).get("rows") or [])
-        self.symbols = dict((regulationData or {}).get("symbols") or {})
+        # A job that never ran MORE stores this field as null. DAO.adaptBSON
+        # turns every None leaf into the string "None" on load, so what arrives
+        # here is "None" (truthy), not None -- and `("None" or {}).get(...)`
+        # called .get on a str, raising `'str' object has no attribute 'get'`.
+        # On paintomics.uv.es that surfaced as a 400 on /pa_pathway_evidence for
+        # the Step 4 diagram of every MORE-less job (the common case). Treat any
+        # non-dict as "no regulation" -- the same guard pa_recover_job already
+        # applies to these adaptBSON'd fields.
+        if not isinstance(regulationData, dict):
+            regulationData = {}
+        self.columns = list(regulationData.get("columns") or [])
+        self.rows = list(regulationData.get("rows") or [])
+        self.symbols = dict(regulationData.get("symbols") or {})
 
         index = {name: position for position, name in enumerate(self.columns)}
         self._target = index.get("targetF")

--- a/PaintomicsServer/src/tests/test_pathway_evidence_sources.py
+++ b/PaintomicsServer/src/tests/test_pathway_evidence_sources.py
@@ -338,5 +338,40 @@ class TranslatedSource(unittest.TestCase):
         self.assertFalse(source.knows("anything"))
 
 
+class RegulationTableToleratesLoadedNone(unittest.TestCase):
+    """The stored MORE table survives DAO.adaptBSON's None -> "None".
+
+    A job with no MORE analysis stores ``regulationPerConditionData`` as null.
+    DAO.adaptBSON turns every None leaf into the string ``"None"`` on load, so
+    the evidence overlay receives the string, not None -- and ``("None" or {})``
+    is truthy, so the old ``(regulationData or {}).get(...)`` called ``.get`` on
+    a str. On paintomics.uv.es that surfaced as a 400 with
+    ``'str' object has no attribute 'get'`` on /pa_pathway_evidence for every
+    Step 4 diagram of a job that never ran MORE (the common case), which is 43%
+    of all evidence requests in the production log.
+    """
+
+    def test_string_none_is_not_usable_and_does_not_raise(self):
+        table = PathwayEvidence._RegulationTable("None")
+        self.assertFalse(table.usable)
+        self.assertEqual(table.rows, [])
+        self.assertEqual(table.columns, [])
+        self.assertEqual(table.conditionNames, [])
+
+    def test_python_none_is_not_usable(self):
+        self.assertFalse(PathwayEvidence._RegulationTable(None).usable)
+
+    def test_any_other_non_dict_is_treated_as_empty(self):
+        for value in ("", "[]", [], 0, 3.5):
+            self.assertFalse(PathwayEvidence._RegulationTable(value).usable)
+
+    def test_a_real_dict_still_reads(self):
+        table = PathwayEvidence._RegulationTable(
+            {"columns": ["targetF", "regulator", "Group_C1"],
+             "rows": [["t1", "r1", "0.5"]]})
+        self.assertTrue(table.usable)
+        self.assertEqual(table.conditionNames, ["C1"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/ci/vulture_baseline.txt
+++ b/scripts/ci/vulture_baseline.txt
@@ -250,6 +250,7 @@ PaintomicsServer/src/tests/test_pathway_evidence_sources.py: unused class 'Evide
 PaintomicsServer/src/tests/test_pathway_evidence_sources.py: unused class 'KeggRelationGraph' (60% confidence)
 PaintomicsServer/src/tests/test_pathway_evidence_sources.py: unused class 'PrintedObstacles' (60% confidence)
 PaintomicsServer/src/tests/test_pathway_evidence_sources.py: unused class 'ReactomeRelationGraph' (60% confidence)
+PaintomicsServer/src/tests/test_pathway_evidence_sources.py: unused class 'RegulationTableToleratesLoadedNone' (60% confidence)
 PaintomicsServer/src/tests/test_pathway_evidence_sources.py: unused class 'TranslatedSource' (60% confidence)
 PaintomicsServer/src/tests/test_quote_source_covers_full_text.py: unused class 'QuoteSourceCoversFullText' (60% confidence)
 PaintomicsServer/src/tests/test_reactome_matches_get_symbol_names.py: unused class 'ReactomeMatchesGetSymbolNames' (60% confidence)


### PR DESCRIPTION
## What

`POST /pa_pathway_evidence` returns **400 `'str' object has no attribute 'get'`** for every Step 4 pathway diagram opened on a job that never ran MORE — the common case.

## Root cause

- A MORE-less job stores `regulationPerConditionData` as `null`.
- `DAO.adaptBSON` deliberately turns every `None` leaf into the **string `"None"`** on load (≈193k leaves across the DB depend on this).
- `_RegulationTable.__init__` did `(regulationData or {}).get("columns")`. With `regulationData == "None"`, the string is truthy, so `.get` was called on a `str` → `AttributeError`, surfaced as a 400 by the servlet.

## Evidence (paintomics.uv.es)

- **78 of 180** `/pa_pathway_evidence` requests in the current production log return 400 (43%), across jobs `d5io2UvF00`, `Fu2o2QAP67`, `jA6XZs27p0`, `FpG2HP3146`, `51hW65Br07`.
- Reproduced against the live server: a well-formed body on the cached job `d5io2UvF00` (saa, KEGG only) → 400, `exc_type AttributeError`. A DAO probe confirmed the loaded attribute is the string `"None"` for every stored job.

## Fix

Coerce any non-dict `regulationData` to `{}` in `_RegulationTable.__init__` — the same guard `pa_recover_job` already applies to these `adaptBSON`'d fields. The overlay now returns empty edges (200) for MORE-less jobs. The fix is in the consumer, not `adaptBSON`, because the `None → "None"` transform is load-bearing elsewhere.

## Tests

`test_pathway_evidence_sources.py`: new `RegulationTableToleratesLoadedNone` (4 cases) — the string `"None"`, Python `None`, other non-dicts, and a real dict. Fails before the change with the exact `AttributeError`; passes after. Full suite 25/25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJqtDXxL9ADY4KXRnCzJah