### PR TITLE
ci: let the reviewer run on Dependabot pull requests, and bump checkout

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -15,6 +15,13 @@
 # stays out of shell history). Until the secret exists every run of this
 # workflow fails at the action step. Setting it needs admin on the repository.
 #
+# The SAME secret must also exist in the Dependabot store, or the review cannot
+# run on a Dependabot pull request: GitHub serves those runs from a separate
+# store (the job log says `Secret source: Dependabot`) and
+# `secrets.CLAUDE_CODE_OAUTH_TOKEN` expands to "" there, so the action fails on
+# an empty token even with `allowed_bots` set. Same command plus `--app
+# dependabot`. Both copies expire together; see the 365-day note below.
+#
 # `pull-requests: write` rather than the `read` in the upstream example: the
 # only tool this run is allowed is create_inline_comment, and creating a review
 # comment on a pull request is a write to the pull-requests scope. With `read`
@@ -79,7 +86,7 @@ jobs:
       issues: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
       - uses: anthropics/claude-code-action@v1
@@ -100,6 +107,23 @@ jobs:
           CLAUDE_CODE_DISABLE_BACKGROUND_TASKS: "1"
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Dependabot opens its pull requests as `dependabot[bot]`, and the
+          # action refuses any actor of GitHub type Bot unless it is named
+          # here -- "Workflow initiated by non-human actor: dependabot (type:
+          # Bot)", a hard failure, which is why every Dependabot pull request
+          # has carried a red "Claude review" since this workflow was added.
+          # NOT '*': the repository is public and this job holds
+          # pull-requests: write plus a subscription token, so the set of
+          # actors that can spend it stays enumerated.
+          #
+          # A Dependabot run is served from the DEPENDABOT secret store, not
+          # the Actions one (the job log says `Secret source: Dependabot`), so
+          # this input alone is not enough -- CLAUDE_CODE_OAUTH_TOKEN has to
+          # exist in both, or it expands to "" here and the action fails on an
+          # empty token instead. Set the second copy with:
+          #   gh secret set CLAUDE_CODE_OAUTH_TOKEN --app dependabot \
+          #     --repo ConesaLab/PaintOmics
+          allowed_bots: "dependabot"
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"


### PR DESCRIPTION
Supersedes #134. Split out of #135 so that #135 can actually be reviewed — see below.

Two changes to one file, both prerequisites for the automated review ever having
run on a dependency bump.

**`allowed_bots`** defaults to empty, and the action refuses any actor of GitHub
type `Bot` that is not named in it — *"Workflow initiated by non-human actor:
dependabot (type: Bot)"*, a hard failure. The review has therefore been red on
**every** Dependabot PR since this workflow was added; #133 is simply the first
one anyone looked at. Set to `dependabot` rather than `*`: this repository is
public and this job holds `pull-requests: write` plus a subscription token, so
the set of actors that can spend it stays enumerated.

**That input alone was not enough.** GitHub serves a Dependabot run from a
*separate* secret store — the job log says `Secret source: Dependabot` — and
`secrets.CLAUDE_CODE_OAUTH_TOKEN` expands to `""` there. With `allowed_bots` set
but no second copy of the secret, the action would simply have gone on failing,
on an empty token, with nothing to show why. That copy now exists; the
prerequisite comment at the top of the file records that there are two, so
whoever rotates the token next doesn't strand one.

**`actions/checkout@v6 → v7`** is the entire content of #134. This was the last
`v6` in the tree — every other workflow moved when the rest did, and this file
was written afterwards.

## Why this is a separate PR

The action refuses to run whenever this file differs from the copy on the
default branch. That is the mechanism that stops a pull request from rewriting
the workflow to read the token, and it reports the refusal as a **green** check.

So a PR that edits this file can never be reviewed by it. Keeping these 26 lines
inside #135 bought a green tick over an unreviewed 337-line diff of numeric and
SDK changes. Landing them separately means #135's copy of this file matches
master, validation passes there, and the reviewer runs on the part that actually
warrants it.

⚠️ **This PR cannot be reviewed by the reviewer either** — same rule. It is two
edits, both described above, and the diff is short enough to read by eye. That
is the trade, and it is the better half of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvLVo5QSaidPjBnGRXKFxg