### PR TITLE
Make the reviewer say why it failed

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -62,6 +62,31 @@
 # the plugin, not the secret. (The token is good for 365 days from 2026-09-01;
 # when it lapses, that is what a sudden failure here will be.)
 
+# WHEN IT FAILS, THE LOG SAYS NOTHING. Runs 42 (three attempts, #139) and 44
+# (#138) on 2026-09-08 all ended
+#
+#   "is_error": true, "num_turns": 1, "duration_ms": 508, "total_cost_usd": 0,
+#   "modelUsage": {}
+#
+# one API call, rejected before any model ran, and not a word about why. The
+# action prints only the init line and that stripped result unless
+# show_full_output is on (sanitizeSdkOutput in base-action drops everything
+# else; "rerun in debug mode" in its own hint does NOT lift this), and
+# show_full_output dumps every tool result into a public log. Run 44 settled
+# what run 42 could not: the same workflow had reviewed the same pull request
+# 50 minutes earlier, so the rejection was the account's, not the diff's. It
+# was the WEEKLY LIMIT: the account that minted CLAUDE_CODE_OAUTH_TOKEN
+# reported "You've hit your weekly limit - resets Sep 10 at 7pm
+# (Europe/Madrid)" at 18:57 UTC that day, and a token spends its account's
+# quota, so a subscription that is out for the week takes every review with
+# it until the reset. That is exactly the class of failure the log needs to
+# name, and it will recur. The "Why the review failed" step below reads the
+# transcript the action keeps in RUNNER_TEMP and prints the rejection: an API
+# refusal arrives as the last assistant message ("API Error: 429 ...",
+# "Claude AI usage limit reached|<epoch>", "Invalid authentication ...").
+# It prints that message and the result's own error fields, nothing more --
+# tool results are `user` messages and are never read.
+
 name: Code Review
 
 on:
@@ -90,6 +115,7 @@ jobs:
         with:
           fetch-depth: 1
       - uses: anthropics/claude-code-action@v1
+        id: review
         # The orchestrator MUST run its subagents in the foreground. Run
         # 33546158945 -- tools right, no turn cap -- still ended "success" in
         # 19 s, 5 turns, zero comments, and its model usage listed haiku and
@@ -165,3 +191,30 @@ jobs:
           # the budget is actually about.
           claude_args: >-
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Task,TodoWrite,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git rev-parse:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Read,Grep,Glob"
+
+      # See the header: the action's own log never carries the reason.
+      # `execution_file` is set on the failure path too (base-action calls
+      # setExecutionFileOutputIfPresent before setFailed); the format()
+      # fallback is the path it always uses, for the case where the composite
+      # did not surface the output. An empty file means Claude never started:
+      # the token, the plugin install or the checkout failed, and that is in
+      # the action log above.
+      - name: Why the review failed
+        if: failure()
+        env:
+          EXECUTION_FILE: ${{ steps.review.outputs.execution_file || format('{0}/claude-execution-output.json', runner.temp) }}
+        run: |
+          if [ ! -s "$EXECUTION_FILE" ]; then
+            echo "no transcript at $EXECUTION_FILE: Claude never started; the reason is in the action step above"
+            exit 0
+          fi
+          jq -r '
+            (map(select(.type == "result")) | last // {}) as $r
+            | (map(select(.type == "assistant")) | last // {}) as $a
+            | def text: if type == "array" then map(.text // "") | join(" ") else tostring end;
+              "result: subtype=\($r.subtype // "none") is_error=\($r.is_error // "none") num_turns=\($r.num_turns // "none")",
+              "result text: \(($r.result // "") | tostring | .[0:2000])",
+              "result errors: \(($r.errors // []) | map(tostring) | join(" | "))",
+              "last assistant error: \($a.error // "none")",
+              "last assistant text: \(($a.message.content // "") | text | .[0:2000])"
+          ' "$EXECUTION_FILE"


### PR DESCRIPTION
## Problem

Every Claude review since 18:47 UTC today fails in under a second with

```
"is_error": true, "num_turns": 1, "duration_ms": 508, "total_cost_usd": 0, "modelUsage": {}
```

Run 42 on #139 failed that way three times; run 44 on #138 failed the same way on a pull request the same workflow had reviewed cleanly 50 minutes earlier, so the rejection is the account's, not the diff's. The log carries no reason: the action prints only the init line and a stripped result unless `show_full_output` is on, its debug mode does not change that, and `show_full_output` would put every tool result in a public log.

## Change

A failure-only step reads the transcript the action keeps in `RUNNER_TEMP` and prints the last assistant message plus the result's error fields, which is where an API refusal lands (`API Error: 429 ...`, `Claude AI usage limit reached|<epoch>`, `Invalid authentication ...`). Tool results are `user` messages and are never read. Dry-run against a synthetic 429 transcript:

```
result: subtype=success is_error=true num_turns=1
result text: API Error: 429 ...
last assistant error: rate_limit
last assistant text: API Error: 429 {"type":"error","error":{"type":"rate_limit_error","message":"Claude AI usage limit reached|1757380800"}}
```

## Not verifiable here

The reviewer skips any run whose workflow file differs from master, so the green "Claude review" on this pull request is the skip, not a review. The first failing review after this merges is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxqpnD65ZwMiRfn5N6xcvV
