### PR TITLE
Put the panel close controls on the same disc as the window ones

### DIFF
--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.25" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.26" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.17" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.7" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.7" />

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -6087,6 +6087,41 @@ div.lateralOptionsPanel-header .toolbarOption:hover {
 	background: rgba(0, 0, 0, 0.06);
 	color: #27272A;
 }
+/* The icon-only controls take the disc a window's close tool wears, so "close"
+   looks the same wherever it appears. They were a chip: `padding: 5px 8px`
+   around a 15px glyph, which is 31x25 -- a rounded rectangle wider than it is
+   tall, and an 8px radius on those proportions reads as neither a square nor a
+   circle. Next to the discs that landed on every window it looked like a
+   leftover, because it was one.
+
+   22px is the size the window tools reach (a 15px box plus a 3.5px shadow
+   spread on each side), and the fills are the same Apple system greys at the
+   same three states, so the two controls are the same object in two places
+   rather than two designs. Explicit width and height rather than padding: a
+   disc has to be square, and padding on a glyph that changes width between
+   times, compress and expand would not keep it that way.
+
+   .downloadTool is excluded: it carries a label, so it stays a labelled button
+   and a disc would not fit it. */
+div.lateralOptionsPanel-header .toolbarOption:not(.downloadTool) {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 22px;
+	height: 22px;
+	padding: 0;
+	font-size: 13px;
+	border-radius: 50%;
+	background-color: rgba(120, 120, 128, 0.16);
+	color: #5F5F66;
+}
+div.lateralOptionsPanel-header .toolbarOption:not(.downloadTool):hover {
+	background-color: rgba(120, 120, 128, 0.28);
+	color: #3F3F46;
+}
+div.lateralOptionsPanel-header .toolbarOption:not(.downloadTool):active {
+	background-color: rgba(120, 120, 128, 0.36);
+}
 /* The download control keeps a label, so it stays a button - just a quiet one. */
 div.lateralOptionsPanel-header .toolbarOption.downloadTool {
 	border-color: var(--pa-border);


### PR DESCRIPTION
Cherry-pick of `d0fa3467`, which has been running on paintomics.org since the 2026-09-08 deploy but only ever existed on the `deploy/drago-*` branches — it was never merged, so **master still draws the old control**. It surfaced again today as "the close button looks old" while comparing the two servers.

## What it fixes

`#132` gave every *window* close tool a disc — Apple system-fill grey, 22px, vector glyph. The lateral panel headers in Step 4 kept what they had: a 15px Font Awesome glyph inside `padding: 5px 8px`, i.e. 31×25. An 8px radius on those proportions is neither square nor circle, and it only paints a surface on hover — so the first time you notice it is when the pointer lands on it and a lopsided grey rectangle appears beside a row of discs.

The two controls do the same thing, so they are now the same object: 22px (the size a window tool reaches once its 3.5px shadow spread counts), same three system-fill greys at rest/hover/press. Width and height are explicit rather than padding-derived — a disc has to be square, and the three glyphs sharing the rule (`times`, `compress`, `expand`) are not the same width.

`.downloadTool` is excluded: it carries a label, so it stays a labelled button.

## Conflict resolution

Only `index.html`'s cache-buster block conflicted. `main.css` is the file this commit changes, so its version moves (`2.25` → `2.26`); `inputformat.css` and `inputconvert.css` are untouched here and keep master's newer `2.17` / `0.7` rather than the `2.15` / `0.6` the old branch carried.

## Testing

- `pytest src/tests/test_versioned_assets_are_bumped.py` — 6 passed (this is the test that enforces the bump above).
- `npx eslint@10.9.1 .` — clean.
- Original commit was verified by rendering the real `PA_Step4Views.js` markup against `main.css` in Chrome at 3x, before/after, at rest and hovered.

## Why it matters beyond appearance

paintomics.org currently runs CSS that exists on no merged branch. Until this lands, any deploy from master is a visible **regression** on that server — which is what blocked bringing both servers onto latest master today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)