### PR TITLE
Keep the GTF window's sort when the filter clears, and say which emptiness

### DIFF
--- a/PaintomicsClient/public_html/app/view/DataManagementViews/DM_MyDataView.js
+++ b/PaintomicsClient/public_html/app/view/DataManagementViews/DM_MyDataView.js
@@ -907,6 +907,7 @@ function DM_GTFFileListView() {
 		if (filterField && filterField.getValue()) {
 			this.filterData(filterField.getValue());
 		} else {
+			this.setEmptyText(false);
 			this.updateSummary();
 		}
 		this.getComponent().setLoading(false);
@@ -917,11 +918,35 @@ function DM_GTFFileListView() {
 	   one" by eye means reading every row. Ext 4.2 semantics: filterBy()
 	   filters from the store's snapshot and so replaces the previous
 	   predicate, and clearFilter() restores it. */
+	/* Which emptiness the grid is reporting. An empty grid means one of two
+	   unrelated things -- this server hosts no reference GTF, or your filter
+	   matched none of the ones it hosts -- and the static text asserted the
+	   first while the second was true. Set before the store change, because
+	   filterBy()/clearFilter() are what trigger the refresh that paints it. */
+	this.setEmptyText = function(filtered) {
+		var view = this.getComponent().queryById("GTFFilesGrid").getView();
+		var message = filtered
+			? "No inbuilt GTF file matches this filter."
+			: "No inbuilt GTF files are installed on this server.";
+		view.emptyText = '<div style="padding: 10px;"><i>' + message + '</i></div>';
+	};
+
 	this.filterData = function(term) {
 		var store = this.getComponent().queryById("GTFFilesGrid").getStore();
 		var needle = $.trim(term || "").toLowerCase();
+		this.setEmptyText(needle !== "");
 		if (needle === "") {
 			store.clearFilter();
+			/* Re-sort after unfiltering. Ext 4.2's filterBy() takes a snapshot
+			   of me.data on first use and clearFilter() restores it verbatim,
+			   but doSort() only ever sorts me.data -- so a sort applied while
+			   the filter was active was thrown away the moment it was cleared,
+			   and the grid silently reverted to the order it had when the user
+			   first typed. sort() with no arguments re-applies the sorters the
+			   store already holds. */
+			if (store.sorters && store.sorters.getCount()) {
+				store.sort();
+			}
 		} else {
 			store.filterBy(function(record) {
 				return ["fileName", "specie", "version", "source", "description"].some(function(field) {
@@ -982,6 +1007,10 @@ function DM_GTFFileListView() {
 				}),
 				viewConfig: {
 					deferEmptyText: false,
+					/* Replaced by setEmptyText() before every store change: the
+					   two emptinesses are not the same statement, and saying
+					   the server has no reference files while it holds 24 of
+					   them is worse than saying nothing. */
 					emptyText: '<div style="padding: 10px;"><i>No inbuilt GTF files are installed on this server.</i></div>'
 				},
 				tbar: [{


### PR DESCRIPTION
Follow-up to #142, fixing the two defects its review flagged. Both were mine, both are real.

## 1. Sorting was lost when the filter cleared

Ext 4.2's `filterBy()` snapshots `me.data` on first use (`me.snapshot = me.snapshot || me.data.clone()`) and `clearFilter()` restores that snapshot verbatim — but `doSort()` only ever sorts `me.data`, never the snapshot.

So: type a filter term → click a column header to sort → clear the filter → **the sort is gone**, and the grid silently reverts to the order it had when the user first typed. `sort()` with no arguments re-applies the sorters the store already holds, so it is restored after `clearFilter()`.

## 2. The empty grid asserted something false

`viewConfig.emptyText` was one static string — *"No inbuilt GTF files are installed on this server."* — and it renders for **both** of the two unrelated ways this grid can now be empty. Since #142 made the grid filterable, narrowing 24 hosted references down to zero matches told the user the server had no reference files at all.

The message is now picked before each store change (`filterBy()`/`clearFilter()` are what trigger the refresh that paints it):

| state | text |
|---|---|
| filter matched nothing | No inbuilt GTF file matches this filter. |
| server genuinely has none | No inbuilt GTF files are installed on this server. |

## Testing

- `node --check` — passes.
- `npx eslint@10.9.1 .` — exit 0, no output.
- Both paths reasoned against the Ext 4.2 sources (`Ext.data.Store.filterBy`/`clearFilter`/`doSort`, `Ext.view.Table.emptyText`), which is where the snapshot/sort asymmetry comes from.

Presentation-only, same as #142: no server, API or job-submission change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)