### PR TITLE
Stop the window close tool drawing a half-moon

### DIFF
--- a/PaintomicsClient/public_html/index.html
+++ b/PaintomicsClient/public_html/index.html
@@ -39,7 +39,7 @@
 	<link rel="stylesheet" type="text/css" href="js/libs/jquery-ui/jquery-ui.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/tooltipster-master/dist/css/tooltipster.bundle.min.css" />
 	<link rel="stylesheet" type="text/css" href="js/libs/odometer/odometer-theme-default.css" />
-	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.26" />
+	<link rel="stylesheet" type="text/css" href="resources/css/main.css?v=2.27" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputformat.css?v=2.17" />
 	<link rel="stylesheet" type="text/css" href="resources/css/inputconvert.css?v=0.7" />
 	<link rel="stylesheet" type="text/css" href="resources/css/ai-interpret.css?v=1.7" />
@@ -48,7 +48,7 @@
 	<link rel="stylesheet" type="text/css" href="resources/css/network-views.css?v=2.3" />
 	<link rel="stylesheet" type="text/css" href="resources/css/more-network.css?v=0.4" />
 	<link rel="stylesheet" type="text/css" href="resources/css/evidence-overlay.css?v=1.0" />
-	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=1.40" />
+	<link rel="stylesheet" type="text/css" href="resources/css/dark.css?v=1.41" />
 
 	<!-- Theme, resolved before the first paint.
 	     Deliberately inline and here rather than in Util.js: the stylesheets

--- a/PaintomicsClient/public_html/resources/css/dark.css
+++ b/PaintomicsClient/public_html/resources/css/dark.css
@@ -747,21 +747,22 @@
  * dark-mode values (36% resting, 48% hover, 56% pressed) so it still separates
  * from a #2A2C32 band, and the glyph turned light. The glyphs are masks over
  * the img's background colour, so this is colours only; the drawings are not
- * repeated here. */
+ * repeated here.
+ *
+ * The box-shadow spread that used to sit beside each fill is gone for the
+ * reason main.css gives: the header clips it, so it drew a half-moon rather
+ * than a disc. Colours only here, and the shape comes from main.css. */
 [data-theme="dark"] .x-window .x-tool,
 [data-theme="dark"] .x-panel:not(.more-net-panel) > .x-panel-header-default .x-tool {
 	background-color: rgba(120, 120, 128, 0.36);
-	box-shadow: 0 0 0 3.5px rgba(120, 120, 128, 0.36);
 }
 [data-theme="dark"] .x-window .x-tool-over,
 [data-theme="dark"] .x-panel:not(.more-net-panel) > .x-panel-header-default .x-tool-over {
 	background-color: rgba(120, 120, 128, 0.48);
-	box-shadow: 0 0 0 3.5px rgba(120, 120, 128, 0.48);
 }
 [data-theme="dark"] .x-window .x-tool-pressed,
 [data-theme="dark"] .x-panel:not(.more-net-panel) > .x-panel-header-default .x-tool-pressed {
 	background-color: rgba(120, 120, 128, 0.56);
-	box-shadow: 0 0 0 3.5px rgba(120, 120, 128, 0.56);
 }
 [data-theme="dark"] .x-window .x-tool .x-tool-img,
 [data-theme="dark"] .x-panel:not(.more-net-panel) > .x-panel-header-default .x-tool .x-tool-img {

--- a/PaintomicsClient/public_html/resources/css/main.css
+++ b/PaintomicsClient/public_html/resources/css/main.css
@@ -2502,8 +2502,31 @@ body > .x-mask {
    Two elements share the work. The disc is the tool wrapper, `.x-tool`: the
    15px box ExtJS sizes inline (the header's hbox layout reads that size, so it
    is left alone - growing it would grow every window by the same amount),
-   rounded, filled, and brought to 22px by a 3.5px box-shadow spread in the
-   same colour, which follows the radius and takes no layout space.
+   rounded and filled.
+
+   It is drawn WITHIN that 15px box. It used to be brought to 22px by a 3.5px
+   box-shadow spread in the same colour, on the reasoning that a spread follows
+   the radius and takes no layout space. It takes no layout space, but it does
+   need room to paint, and it has none: ExtJS puts the tool inside
+   `.x-header-body` > `.x-box-inner`, both `overflow: hidden` and 17px tall.
+   A 15px tool in a 17px box has 1px of slack, and it sits flush with the right
+   edge, so of the 3.5px the disc needed it lost 2.5px top, 2.5px bottom and
+   the whole 3.5px right. What shipped was not a disc: it was a circle sliced
+   flat on three sides -- a half-moon behind the cross, at every window's close
+   control. Measured in Chrome on paintomics.org, 2026-09-11.
+
+   Lifting the clip is not the fix. Those two elements are what keeps a long
+   window title from spilling out of its header: with `overflow: visible` the
+   title's own box still runs 250px past the header edge (measured on the same
+   page), it is just no longer hidden. So the surface has to fit the box it is
+   given, which means the disc is 15px and there is no spread.
+
+   That leaves it smaller than the 22px `.toolbarOption` discs on the Step 4
+   lateral panels, which are a real 22px element and clip against nothing. The
+   two no longer match in size. Reconciling them means either growing the
+   header row to fit a 22px tool -- which grows every window header -- or
+   taking the panel controls down to 15px; both are design decisions rather
+   than bug fixes, and neither belongs in the same change as this.
 
    The glyph is the <img> inside it, a transparent 1×1 gif that Neptune paints
    with a PNG sprite. The sprite is a raster - soft on Retina - and a white
@@ -2538,18 +2561,15 @@ body > .x-mask {
 .x-panel:not(.more-net-panel) > .x-panel-header-default .x-tool {
 	background-color: rgba(120, 120, 128, 0.16);
 	border-radius: 50%;
-	box-shadow: 0 0 0 3.5px rgba(120, 120, 128, 0.16);
-	transition: background-color var(--pa-transition), box-shadow var(--pa-transition);
+	transition: background-color var(--pa-transition);
 }
 .x-window .x-tool-over,
 .x-panel:not(.more-net-panel) > .x-panel-header-default .x-tool-over {
 	background-color: rgba(120, 120, 128, 0.28);
-	box-shadow: 0 0 0 3.5px rgba(120, 120, 128, 0.28);
 }
 .x-window .x-tool-pressed,
 .x-panel:not(.more-net-panel) > .x-panel-header-default .x-tool-pressed {
 	background-color: rgba(120, 120, 128, 0.36);
-	box-shadow: 0 0 0 3.5px rgba(120, 120, 128, 0.36);
 }
 .x-window .x-tool .x-tool-img,
 .x-panel:not(.more-net-panel) > .x-panel-header-default .x-tool .x-tool-img {


### PR DESCRIPTION
Reported from paintomics.org: the close ✕ renders as a **half-moon** — a circle bulging on the left, sliced flat on the right.

## Cause

The disc is a 15px rounded box brought to 22px by a `box-shadow: 0 0 0 3.5px` spread, on the reasoning that a spread follows the radius and costs no layout space. It costs no layout space — but it still needs room to *paint*, and it has none.

ExtJS puts the tool inside `.x-header-body` > `.x-box-inner`, **both `overflow: hidden`, both 17px tall**. Measured in Chrome against the live `main.css?v=2.26`:

| | available | needed |
|---|---|---|
| top | 1px | 3.5px |
| bottom | 1px | 3.5px |
| right | **0px** | 3.5px |

So the disc loses 2.5px top, 2.5px bottom and its **entire** right-hand spread. Round where it isn't clipped, flat where it is.

Worth noting: layer-for-layer this was never a styling preference — `#140`, which proposes removing the resting disc, keeps the same 3.5px spread, so it would be clipped identically and merely hide the symptom until hover.

## Why not just lift the clip

Because those two elements are the only thing keeping a long window title inside its header. With `overflow: visible` the title's own box still runs **250px past the header edge** on the same page — it is simply no longer hidden. Tested with a deliberately long title.

## Fix

The surface fits the box it is given: the disc is drawn inside the 15px tool, no spread. Removes the `box-shadow` from the three light states in `main.css` and the three dark ones in `dark.css`, and drops `box-shadow` from the transition, which no longer has anything to animate. Cache-busters bumped (`main.css` 2.26→2.27, `dark.css` 1.40→1.41).

## Known consequence, deliberately not addressed here

Window tools are now 15px while the `.toolbarOption` discs on the Step 4 lateral panels are a real 22px element that clips against nothing — so the two no longer match in size. Reconciling them means either growing the header row (which grows every window header) or taking the panel controls down to 15px. Both are design decisions, not bug fixes.

## Testing

- `pytest src/tests/test_versioned_assets_are_bumped.py` — 6 passed (the test that enforces the bump above).
- **Chrome, at 3x, before and after** — clipped half-moon vs clean circle, with a long-title window open to confirm the header still truncates with an ellipsis rather than spilling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)