### PR TITLE
Bring the deployment config back in line with what production runs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,10 @@ PaintomicsServer/src/conf/serverconf.py
 **/*.pyc
 .DS_Store
 *.log
+
+# The reference GTF library. It is bind-mounted into the container at run time
+# (see the ./gtf mount in deploy/compose.yaml), so it must never enter the
+# image -- and, more urgently, never enter the build context: at 6.6 GB it took
+# the context from ~800 MB to 7.4 GB, and every build after that produced an
+# image whose rootfs was missing /bin/sh while still reporting success.
+deploy/gtf/

--- a/PaintomicsServer/src/resources/example_serverconf.py
+++ b/PaintomicsServer/src/resources/example_serverconf.py
@@ -169,9 +169,15 @@ PAINTOMICS_LOGO_PATH    = os.getenv("PAINTOMICS_LOGO_PATH", "/resources/images/p
 PAINTOMICS_LOGO_URL     = f"{PAINTOMICS_BASE_URL}{PAINTOMICS_LOGO_PATH}"
 PAINTOMICS_LOGIN_URL    = os.getenv("PAINTOMICS_LOGIN_URL", f"{PAINTOMICS_BASE_URL}/")
 PAINTOMICS_DOCS_URL     = os.getenv("PAINTOMICS_DOCS_URL", "https://conesalab.github.io/PaintOmics/")
-PAINTOMICS_EMAIL_DOMAIN = os.getenv(
-    "PAINTOMICS_EMAIL_DOMAIN",
-    urlparse(PAINTOMICS_BASE_URL).netloc or "example.org"
+# `or`, not os.getenv's default, because deploy/compose.yaml passes this as
+# ${PAINTOMICS_EMAIL_DOMAIN:-}: absent from .env, the container still gets the
+# variable SET to "". os.getenv returns that empty string rather than the
+# default, so the fallback below never ran and guest accounts were mailed as
+# "guest1234@" -- a domainless address, with nothing logged either side.
+PAINTOMICS_EMAIL_DOMAIN = (
+    os.getenv("PAINTOMICS_EMAIL_DOMAIN", "").strip()
+    or urlparse(PAINTOMICS_BASE_URL).netloc
+    or "example.org"
 )
 EMAIL_REPORT_RECIPIENTS = [
     email.strip()

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -26,7 +26,7 @@ $EDITOR deploy/.env               # see "Configuration" below
 # Two host directories are bind-mounted into the stack. Create them yourself:
 # left to Docker they are created owned by root, and the reference GTF library
 # then rejects every admin upload, because the container runs as uid 1001.
-install -d -m 755 -o 1001 -g 1000 deploy/gtf     # reference GTF library
+sudo install -d -m 755 -o 1001 -g 1000 deploy/gtf  # reference GTF library
 install -d -m 755 deploy/certbot-webroot         # http-01 challenge webroot
 
 # Build with the script, not `up --build`. The Dockerfile copies a single

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -23,7 +23,20 @@ $EDITOR deploy/.env               # see "Configuration" below
 
 ./deploy/make-cert.sh <your-hostname-or-ip>
 
-docker compose -f deploy/compose.yaml up -d --build
+# Two host directories are bind-mounted into the stack. Create them yourself:
+# left to Docker they are created owned by root, and the reference GTF library
+# then rejects every admin upload, because the container runs as uid 1001.
+install -d -m 755 -o 1001 -g 1000 deploy/gtf     # reference GTF library
+install -d -m 755 deploy/certbot-webroot         # http-01 challenge webroot
+
+# Build with the script, not `up --build`. The Dockerfile copies a single
+# deploy/app.tar, which build-image.sh packs from the working tree -- it is
+# gitignored, so a fresh clone has no app.tar and `--build` fails on that COPY.
+# The script also refuses to ship an image it cannot start. See the comments in
+# it for the two failure modes that earned those checks.
+./deploy/build-image.sh
+
+docker compose -f deploy/compose.yaml up -d
 ```
 
 The first build takes 15–30 minutes; most of it is R packages.
@@ -124,10 +137,42 @@ It downloads Ensembl GRCm38 (mm10 — the assembly the example BED was called
 against), trims it to the feature types RGMatch reads, and installs it. Takes a
 few minutes and lands ~566 MB.
 
-**Re-run this after every image rebuild.** `examplefiles/` is baked into the
-image rather than mounted from the `paintomics-data` volume, so a rebuilt image
-loses the GTF. The script is idempotent: it exits immediately if the file is
-already in place.
+The script is idempotent: it exits immediately if the file is already in place.
+
+### The reference GTF library survives rebuilds (since 2026-09-10)
+
+`examplefiles/GTF/` is now a bind mount (`deploy/gtf` on the host), so nothing
+here is lost on an image rebuild and `fetch-example-gtf.sh` no longer has to be
+re-run after one. Before this it was on the image's writable layer: a rebuild
+dropped every file in it while the `fileCollection` rows advertising them
+survived in MongoDB, which is how paintomics.org came to list five reference
+files that were not on disk at all (four dead bacterial FASTAs, since removed,
+plus the mouse GRCm39 GTF, since restored and md5-verified).
+
+Because the picker lists from MongoDB and never from the directory
+(`dataManagementGetMyFiles` calls `FileDAO().findAll({"userID": "-1"})` and
+touches the disk only for a size total), a file needs BOTH halves: the bytes in
+`deploy/gtf/` and a row. Add one the way the admin endpoint does, via
+`registerFile`, which stats the file itself and is idempotent:
+
+```bash
+sudo install -o 1001 -g 1000 -m 644 my.gtf deploy/gtf/     # container is uid 1001
+docker compose -f deploy/compose.yaml exec -T app python3 - <<'PY'
+import os, sys; sys.path.insert(0, "/app/PaintomicsServer/src")
+os.chdir("/app/PaintomicsServer/src")
+from servlets.DataManagementServlet import registerFile
+GTF = "/app/PaintomicsServer/src/examplefiles/GTF"
+registerFile("-1", "my.gtf", {"dataType": "Reference file", "omicType": "GTF",
+                              "specie": "...", "version": "...", "source": "...",
+                              "description": "..."}, GTF)
+PY
+```
+
+Currently hosted: human GRCh38 (Ensembl 116), mouse GRCm39 (Ensembl 113, full
+untrimmed) and GRCm38/mm10 (`sorted_mmu.gtf`, which also backs the example),
+Arabidopsis TAIR10 and tomato SL4.0 (both Ensembl Plants 63) -- 4.2 GB in all.
+Use Ensembl rather than GENCODE so chromosome names stay bare (`1`, `X`, `MT`)
+and match both `sorted_mmu.gtf` and the BED files users upload.
 
 ## Everyday operations
 

--- a/deploy/build-image.sh
+++ b/deploy/build-image.sh
@@ -33,9 +33,11 @@ tar -cf "${ARCHIVE}" \
     --exclude='*.pyc' \
     --exclude='*.pyo' \
     --exclude='.DS_Store' \
+    --exclude='._*' \
     --exclude='PaintomicsServer/src/conf/serverconf.py' \
     --exclude='PaintomicsServer/src/conf/local_serverconf.py' \
     --exclude='node_modules' \
+    --exclude='PaintomicsServer/src/log' \
     PaintomicsServer PaintomicsClient
 
 echo "  $(du -h "${ARCHIVE}" | cut -f1), $(tar -tf "${ARCHIVE}" | wc -l | tr -d ' ') entries"
@@ -114,7 +116,39 @@ for link in PaintomicsServer/src/src \
 done
 [ "${missing}" -eq 0 ] && echo "  symlinks preserved"
 
+# Build through a `docker-container` buildkit rather than the one embedded in
+# dockerd. On this host (Docker 29.7.1 / buildx 0.36.1 / overlay2) the embedded
+# builder writes an image whose rootfs is missing /bin/sh while still reporting
+# success: 3/3 builds on 2026-09-10 produced a 1.4 GB image that could not be
+# started ("exec: /bin/sh: no such file or directory"), against 2.8 GB for the
+# image the same tree produced on 2026-09-08. Layers 1-7 of the bad image --
+# including the base layer that carries /bin/sh -- were byte-identical to the
+# good one, so the damage is in how the later diffs are generated and exported,
+# not in anything the Dockerfile does. Ruled out: daemon restart, provenance and
+# SBOM attestations, build-context size, base-image corruption, and COPY
+# ordering (the constraint the Dockerfile documents is intact).
+#
+# The docker-container driver runs its own buildkit with its own snapshotter and
+# hands dockerd a finished tarball, which comes out sound.
+BUILDER_NAME="paintomics-isolated"
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    echo "creating isolated builder ${BUILDER_NAME}"
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container >/dev/null
+fi
+
 echo "building image"
-docker compose -f deploy/compose.yaml build "$@"
+docker buildx build --builder "${BUILDER_NAME}" --load --provenance=false \
+    -f deploy/Dockerfile -t paintomics-app:latest "$@" .
+
+# A build that exits 0 is not evidence the image can run -- that is exactly the
+# failure above. Probe it before anything recreates a container from it.
+echo "probing the built image"
+if ! docker run --rm --entrypoint /bin/sh paintomics-app:latest \
+        -c 'ls /bin/sh /usr/bin/ls /usr/local/bin/entrypoint.sh >/dev/null' 2>/dev/null; then
+    echo "REFUSING TO SHIP: the built image has no usable rootfs." >&2
+    echo "Do not recreate the container -- the running one is still on the old image." >&2
+    exit 1
+fi
+echo "  rootfs OK"
 
 echo "done"

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -43,6 +43,13 @@ services:
       # churn alone was 97.7% of the log bytes, burning the 100 MB budget every
       # ~40 hours at zero traffic and evicting the real startup diagnostics.
       interval: 60s
+      # ...but `interval` is also what Docker probes at DURING start_period, and
+      # app gates on `condition: service_healthy`. At 60s alone the whole stack
+      # would wait a minute before the first probe, and a genuinely dead mongod
+      # would take retries x interval = 5 min to be called unhealthy instead of
+      # 75 s. start_interval keeps startup and failure detection fast while the
+      # steady-state probe stays cheap.
+      start_interval: 5s
       timeout: 10s
       retries: 5
       start_period: 30s
@@ -75,9 +82,12 @@ services:
       # Embedded in activation emails: must be the externally reachable URL.
       PAINTOMICS_BASE_URL: ${PAINTOMICS_BASE_URL:?set PAINTOMICS_BASE_URL in deploy/.env}
       # Guest accounts are stored as "guest<n>@<this>", and the client shows the
-      # user the same address from a hardcoded constant in ServerConfiguration.js.
-      # Left unset it is derived from PAINTOMICS_BASE_URL, so changing the base URL
-      # alone silently splits the stored address from the displayed one.
+      # user the same address from a hardcoded constant in ServerConfiguration.js,
+      # so changing the base URL alone splits the stored address from the
+      # displayed one. Note `:-` yields "" rather than leaving the variable unset,
+      # and os.getenv returns a set-but-empty value as-is -- so example_serverconf
+      # treats blank as absent before falling back to PAINTOMICS_BASE_URL's host.
+      # Without that, an unconfigured deployment mails "guest1234@".
       PAINTOMICS_EMAIL_DOMAIN: ${PAINTOMICS_EMAIL_DOMAIN:-}
 
       # The mark every outgoing email shows, relative to PAINTOMICS_BASE_URL.
@@ -119,9 +129,11 @@ services:
       # "AI file conversion is not enabled on this server" after the sandbox
       # has already read their file.
       AI_INPUT_CONVERTER: ${AI_INPUT_CONVERTER:-false}
-      # Production runs the agent arm (median 450 s) rather than the cluster
-      # baseline (627-813 s). The code defaults all three to "0", so omitting
-      # them here quietly ships the slower, differently-worded interpretation.
+      # The code defaults all three OFF (clusters.py and agent_loop.py read them
+      # as os.getenv(..., "0") == "1"), and paintomics.org turns all three ON in
+      # its .env. This block is an allowlist, so leaving them out does not mean
+      # "use the default" -- it means the operator's own 1s never reach the
+      # container and production silently runs the arm it did not choose.
       AI_CLUSTER_MODE: ${AI_CLUSTER_MODE:-0}
       AI_FULL_AGENT: ${AI_FULL_AGENT:-0}
       AI_AGENT_RESULTS_SECTION: ${AI_AGENT_RESULTS_SECTION:-0}

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -23,9 +23,26 @@ services:
       - mongo-data:/data/db
       - mongo-config:/data/configdb
     command: ["--bind_ip_all", "--wiredTigerCacheSizeGB", "4"]
+    # MongoDB's own startup check asks for at least 64000 open files; Docker
+    # hands a container 1024. That is survivable with a handful of databases
+    # and fatal with a full pathway install: PaintOmics keeps one database per
+    # species, so a 133-species server holds well over a thousand WiredTiger
+    # file handles at once. On the first full restore mongod hit EMFILE
+    # (WiredTiger "error 24") midway through, failed the fassert at
+    # wiredtiger_util.cpp:741 and aborted with signal 6, leaving 65 species
+    # short of their `versions` collection. The restart policy then brought it
+    # back cleanly, so `docker inspect` reported ExitCode=0 and nothing looked
+    # wrong from the outside.
+    ulimits:
+      nofile:
+        soft: 64000
+        hard: 64000
     healthcheck:
       test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
-      interval: 15s
+      # 60s, not 15s: each probe is a fresh mongosh connection, and at 15s that
+      # churn alone was 97.7% of the log bytes, burning the 100 MB budget every
+      # ~40 hours at zero traffic and evicting the real startup diagnostics.
+      interval: 60s
       timeout: 10s
       retries: 5
       start_period: 30s
@@ -57,6 +74,11 @@ services:
 
       # Embedded in activation emails: must be the externally reachable URL.
       PAINTOMICS_BASE_URL: ${PAINTOMICS_BASE_URL:?set PAINTOMICS_BASE_URL in deploy/.env}
+      # Guest accounts are stored as "guest<n>@<this>", and the client shows the
+      # user the same address from a hardcoded constant in ServerConfiguration.js.
+      # Left unset it is derived from PAINTOMICS_BASE_URL, so changing the base URL
+      # alone silently splits the stored address from the displayed one.
+      PAINTOMICS_EMAIL_DOMAIN: ${PAINTOMICS_EMAIL_DOMAIN:-}
 
       # The mark every outgoing email shows, relative to PAINTOMICS_BASE_URL.
       # serverconf.py has read this from the environment for a while, but the
@@ -72,6 +94,11 @@ services:
       SMTP_PORT: ${SMTP_PORT:-587}
       SMTP_USERNAME: ${SMTP_USERNAME:-apikey}
       SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      # Where admin error reports and organism requests go. Setting this in
+      # .env alone does nothing -- this environment block is an explicit
+      # allowlist, so an unlisted key is silently dropped and the only symptom
+      # is mail that never arrives.
+      EMAIL_REPORT_RECIPIENTS: ${EMAIL_REPORT_RECIPIENTS:-}
 
       AI_INTERPRETATION_ENABLED: ${AI_INTERPRETATION_ENABLED:-true}
       AI_LLM_PROVIDER: ${AI_LLM_PROVIDER:-csic}
@@ -92,11 +119,37 @@ services:
       # "AI file conversion is not enabled on this server" after the sandbox
       # has already read their file.
       AI_INPUT_CONVERTER: ${AI_INPUT_CONVERTER:-false}
+      # Production runs the agent arm (median 450 s) rather than the cluster
+      # baseline (627-813 s). The code defaults all three to "0", so omitting
+      # them here quietly ships the slower, differently-worded interpretation.
+      AI_CLUSTER_MODE: ${AI_CLUSTER_MODE:-0}
+      AI_FULL_AGENT: ${AI_FULL_AGENT:-0}
+      AI_AGENT_RESULTS_SECTION: ${AI_AGENT_RESULTS_SECTION:-0}
     volumes:
       # Single volume for both trees. On the Drago VM the Docker root lives on
-      # the 600 GiB Cinder volume mounted at /var/lib/docker, so this is backed
+      # the 1 TiB Cinder volume mounted at /var/lib/docker, so this is backed
       # by that disk rather than the 80 GB instance root.
       - paintomics-data:/data
+      # Without this the rotated application.log.1..16 -- about a fortnight of
+      # diagnostics -- sits in the writable layer and dies on every recreate.
+      - paintomics-logs:/app/PaintomicsServer/src/log
+      # Reference GTFs for the admin-hosted file picker (dm_get_gtffiles).
+      # These MUST NOT live in the image: examplefiles/ is on the writable
+      # layer, so a rebuild silently drops every file here while the
+      # fileCollection rows that advertise them survive in MongoDB. That is
+      # exactly how the migrated .org registry ended up listing five reference
+      # files that were not on disk. DataManagementServlet appends "GTF/" for
+      # every isReference upload/list/delete, so this directory is also where
+      # new admin uploads land -- hence a bind mount rather than a named
+      # volume, so they are visible and rsync-able from the host.
+      - ./gtf:/app/PaintomicsServer/src/examplefiles/GTF
+    # Same reasoning as mongo above: the app opens KGML and Reactome graph
+    # files per species, and 1024 is the container default, not a considered
+    # limit.
+    ulimits:
+      nofile:
+        soft: 64000
+        hard: 64000
     logging: *default-logging
 
   nginx:
@@ -112,6 +165,9 @@ services:
     volumes:
       - ./nginx/paintomics.conf:/etc/nginx/conf.d/default.conf:ro
       - ./nginx/certs:/etc/nginx/certs:ro
+      # Webroot for certbot http-01. certbot runs on the host and writes here;
+      # nginx serves it from the :80 block before the redirect to https.
+      - ./certbot-webroot:/var/www/certbot:ro
       - nginx-cache:/var/cache/nginx
     healthcheck:
       # 127.0.0.1, not localhost. In this image localhost resolves to ::1, while
@@ -152,6 +208,7 @@ networks:
 
 volumes:
   paintomics-data:
+  paintomics-logs:
   mongo-data:
   mongo-config:
   nginx-cache:

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -72,10 +72,11 @@ AI_CSIC_FALLBACK_MODELS=default/llm
 # user picks ends in "AI file conversion is not enabled on this server".
 AI_INPUT_CONVERTER=true
 
-# Which interpretation arm runs. All three default to "0" in the code, which is
-# the agent arm (median 450 s); "1" selects the cluster baseline (627-813 s),
-# which also words its output differently. They are listed here because the
-# default is a deliberate choice, not an absence of one.
+# Which interpretation arm runs. All three are OFF in the code's own defaults,
+# and this file ships them off. paintomics.org sets all three to 1: clustered
+# interpretation, the full agent loop, and the Results-section view. Set them
+# here rather than only in compose -- compose's environment block is an
+# allowlist, so a value this file does not name never reaches the container.
 AI_CLUSTER_MODE=0
 AI_FULL_AGENT=0
 AI_AGENT_RESULTS_SECTION=0

--- a/deploy/env.example
+++ b/deploy/env.example
@@ -19,6 +19,13 @@ PAINTOMICS_BASE_URL=https://203.0.113.10
 # raster -- Gmail and every Outlook build refuse an <img> whose source is SVG.
 #PAINTOMICS_LOGO_PATH=/resources/images/paintomics-mark-email.png
 
+# The domain guest accounts are named under: they are stored as
+# "guest<n>@<this>". Left unset it is derived from PAINTOMICS_BASE_URL, while
+# the client shows the user the address from a hardcoded constant in
+# ServerConfiguration.js -- so changing the base URL alone splits the stored
+# address from the displayed one, with no error either side.
+#PAINTOMICS_EMAIL_DOMAIN=paintomics.org
+
 # ---------------------------------------------------------------------------
 # Email (SendGrid SMTP)
 # ---------------------------------------------------------------------------
@@ -29,6 +36,10 @@ SMTP_HOST=smtp.sendgrid.net
 SMTP_PORT=587
 SMTP_USERNAME=apikey
 SMTP_PASSWORD=
+
+# Where admin error reports and "please add this organism" requests are sent.
+# Unset means they are generated and then delivered nowhere.
+EMAIL_REPORT_RECIPIENTS=
 
 # ---------------------------------------------------------------------------
 # AI interpretation
@@ -60,6 +71,14 @@ AI_CSIC_FALLBACK_MODELS=default/llm
 # interpretation; a deployment that has a key wants it on, or every workbook a
 # user picks ends in "AI file conversion is not enabled on this server".
 AI_INPUT_CONVERTER=true
+
+# Which interpretation arm runs. All three default to "0" in the code, which is
+# the agent arm (median 450 s); "1" selects the cluster baseline (627-813 s),
+# which also words its output differently. They are listed here because the
+# default is a deliberate choice, not an absence of one.
+AI_CLUSTER_MODE=0
+AI_FULL_AGENT=0
+AI_AGENT_RESULTS_SECTION=0
 
 # ---------------------------------------------------------------------------
 # PubMed (NCBI E-utilities)

--- a/deploy/fetch-example-gtf.sh
+++ b/deploy/fetch-example-gtf.sh
@@ -23,8 +23,11 @@
 # Usage:
 #   deploy/fetch-example-gtf.sh [container-name]
 #
-# Re-run this after any image rebuild: examplefiles/ is baked into the image
-# (only /data is a volume), so a rebuilt image loses the GTF again.
+# Since 2026-09-10 examplefiles/GTF is a bind mount (deploy/gtf on the host), so
+# this no longer has to be re-run after an image rebuild -- the docker cp below
+# lands on the host directory and persists. Registering the file in MongoDB is a
+# separate step; see "The reference GTF library survives rebuilds" in
+# deploy/README.md. The example itself reads the path directly and needs no row.
 
 set -euo pipefail
 


### PR DESCRIPTION
The Drago VM's `deploy/` tree has drifted ahead of this repository for about a month. Everything here was learned by running paintomics.org and currently exists only on that host — so a fresh clone deploys a server that is wrong in ways that do not announce themselves.

Found while deploying #146, when the VM tree turned out to be five files ahead of master.

## `compose.yaml`

| Change | What it prevents |
|---|---|
| `nofile 64000` on mongo and app | Docker's default 1024 survives a handful of databases and dies on a full pathway install. PaintOmics keeps one database per species; mongod hit `EMFILE` mid-restore, failed its WiredTiger fassert and aborted on signal 6. The restart policy then brought it back so cleanly that `docker inspect` reported `ExitCode=0` — 65 species were quietly short of their `versions` collection. |
| mongo healthcheck `15s` → `60s` | Each probe is a fresh `mongosh` connection. That churn alone was **97.7% of the log bytes**, burning the 100 MB budget every ~40 hours at idle and evicting exactly the startup diagnostics you'd want after a crash like the one above. |
| `PAINTOMICS_EMAIL_DOMAIN`, `EMAIL_REPORT_RECIPIENTS`, `AI_CLUSTER_MODE`, `AI_FULL_AGENT`, `AI_AGENT_RESULTS_SECTION` passed through | This `environment:` block is an explicit allowlist, so setting any of them in `.env` alone does nothing. The only symptom is mail that never arrives, or the slower interpretation arm (627–813 s) shipping under the faster one's name (450 s). |
| `paintomics-logs` volume | The rotated `application.log.1..16` — about a fortnight of diagnostics — was on the writable layer and died on every recreate. |
| `examplefiles/GTF` as a bind mount | **This one has already bitten.** The directory was on the writable layer, so a rebuild dropped every reference GTF while the `fileCollection` rows advertising them survived in MongoDB. That is how .org came to list five reference files that were not on disk. Bind mount rather than named volume because admin uploads land here too and want to be visible from the host. |
| certbot webroot on nginx | It has been serving the http-01 challenge from a path the repo never mentioned. |

## `build-image.sh`

Builds through a `docker-container` buildkit, then **probes the image it just produced**.

On this host the buildkit embedded in dockerd writes an image whose rootfs has no `/bin/sh` while still exiting 0 — 3/3 builds on 2026-09-10, 1.4 GB against 2.8 GB for the same tree two days earlier. Layers 1–7, including the base layer carrying `/bin/sh`, were byte-identical to the good image, so the damage is in how the later diffs are exported. Ruled out: daemon restart, provenance/SBOM attestations, build-context size, base-image corruption, and COPY ordering.

Trusting the exit code took paintomics.org down. A build exiting 0 is not evidence the image can start, so now it has to prove it before anything recreates a container.

The tar also stops packing macOS AppleDouble stubs (`._*`), which had been riding into the image from a laptop copy — 12 of them were in the last build.

## `README.md`

The documented install could not have worked. It says `docker compose up -d --build`, but the Dockerfile copies `deploy/app.tar`, which is gitignored and only `build-image.sh` creates — a fresh clone fails on that COPY. It now builds with the script, and creates the two bind-mount directories itself, because Docker would create them owned by root while the container runs as uid 1001.

## Verification

Deployed and running on paintomics.org as of this PR: `deploy/smoke-test.sh` passes 16/16, and the GTF library survived a container recreate for the first time — 24 files / 6.6 GB still present, registry and disk consistent in both directions.

`test_input_converter_survives_deploy.py::EverySettingReachesTheContainer` passes (3/3); the 3 failures in that file are a pre-existing missing `serverconf.py` in a bare checkout, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)