### PR TITLE
Let the anole build the UniProt route it declares, instead of dying on one it does not

### DIFF
--- a/PaintomicsServer/src/AdminTools/scripts/acs_resources/build_database.py
+++ b/PaintomicsServer/src/AdminTools/scripts/acs_resources/build_database.py
@@ -16,6 +16,7 @@ LOG_FILE    = argv[4]
 
 COMMON_BUILD_DB_TOOLS = imp.load_source('common_build_database', ROOT_DIR + "scripts/common_build_database.py")
 COMMON_BUILD_DB_TOOLS.SPECIE= SPECIE
+COMMON_BUILD_DB_TOOLS.ROOT_DIR= ROOT_DIR
 COMMON_BUILD_DB_TOOLS.DATA_DIR= DATA_DIR
 COMMON_BUILD_DB_TOOLS.EXTERNAL_RESOURCES = imp.load_source('download_conf',  ROOT_DIR + "scripts/" + SPECIE + "_resources/download_conf.py").EXTERNAL_RESOURCES
 
@@ -30,7 +31,13 @@ try:
     #**************************************************************************
     COMMON_BUILD_DB_TOOLS.processEnsemblData()
     COMMON_BUILD_DB_TOOLS.processRefSeqData()
-    COMMON_BUILD_DB_TOOLS.processUniProtData()
+    # KEGG's own conversions (kegg_id, ncbi_geneid, uniprot_acc), then the
+    # Ensembl-UniProt join, which can only link into groups that exist.
+    # processUniProtData() stood here: it reads a UniProt id-mapping file
+    # under a "uniprot" resource this species never declared, so every
+    # acs install died before it reached the pathways (2026-09-11).
+    COMMON_BUILD_DB_TOOLS.processKEGGMappingData()
+    COMMON_BUILD_DB_TOOLS.processEnsemblUniProtData()
     COMMON_BUILD_DB_TOOLS.processRefSeqGeneSymbolData()
 
     #**************************************************************************

--- a/PaintomicsServer/src/AdminTools/scripts/acs_resources/download_conf.py
+++ b/PaintomicsServer/src/AdminTools/scripts/acs_resources/download_conf.py
@@ -6,15 +6,24 @@ EXTERNAL_RESOURCES = {
                     "division"      :   "vertebrates",
                     "output"        :   "ensembl_mapping.list",
                     "description"   :   "Source: Ensembl cross-reference TSV dumps. BioMart was retired (martservice answers HTTP 405), so the release/assembly and filename are resolved at run time rather than pinned here."
-                    },
+                    }
+                ],
+                # The UniProt cross-reference dump used to sit as a second entry
+                # under "ensembl", where nothing read it: build_database.py then
+                # called processUniProtData(), which wants a "uniprot" id-mapping
+                # resource this file never declared, and the build died on
+                # `EXTERNAL_RESOURCES.get("uniprot")[0]` (paintomics.org,
+                # 2026-09-11). It is the Ensembl UniProt route every other
+                # species spells "ensembl_uniprot", read by processEnsemblUniProtData.
+                "ensembl_uniprot"   :   [
                     {
                     "url"           :   "https://ftp.ensembl.org/pub/",
                     "species-dir"   :   "anolis_carolinensis",
                     "division"      :   "vertebrates",
                     "xref-type"     :   "uniprot",
-                    "xref-db"       :   ["Uniprot/SWISSPROT", "Uniprot/SPTREMBL"],
-                    "output"        :   "uniprot_mapping.list",
-                    "description"   :   "Source: Ensembl UniProt cross-reference TSV dumps. BioMart was retired (martservice answers HTTP 405), so the release/assembly and filename are resolved at run time rather than pinned here."
+                    "xref-db"       :   ["Uniprot/SWISSPROT", "Uniprot/SPTREMBL", "UniProtKB_all"],
+                    "output"        :   "ensembl_uniprot.list",
+                    "description"   :   "Source: Ensembl UniProt cross-reference TSV dumps. Links the Ensembl identifiers to KEGG through the accessions KEGG maps itself (processEnsemblUniProtData)."
                     }
                 ],
                 "refseq"   :  [

--- a/PaintomicsServer/src/AdminTools/scripts/acs_resources/download_others.py
+++ b/PaintomicsServer/src/AdminTools/scripts/acs_resources/download_others.py
@@ -28,14 +28,10 @@ try:
 
     #**************************************************************************
     #STEP 2.1 GET ENSEMBL GENE ID -> TRANSCRIPT ID -> PEPTIDE ID -> ENTREZ ID
-    resource = COMMON_BUILD_DB_TOOLS.EXTERNAL_RESOURCES.get("ensembl")[0]
-    COMMON_BUILD_DB_TOOLS.downloadEnsemblMapping(resource, DESTINATION + resource.get("output"), SERVER_SETTINGS.DOWNLOAD_DELAY_1, SERVER_SETTINGS.MAX_TRIES_1)
-
-    resource = COMMON_BUILD_DB_TOOLS.EXTERNAL_RESOURCES.get("ensembl")[1]
-    COMMON_BUILD_DB_TOOLS.downloadEnsemblMapping(resource, DESTINATION + resource.get("output"), SERVER_SETTINGS.DOWNLOAD_DELAY_1, SERVER_SETTINGS.MAX_TRIES_1)
-
-    #**************************************************************************
-    #STEP 2.2 GET REFSEQ TRANSCRIPTS, PEPTIDES -> ENTREZ GENES and REFSEQ GENE ID -> GENE SYMBOL
+    # Both Ensembl dumps (EntrezGene rows and UniProt rows) through the shared
+    # helper every other species uses; it resolves release and filename.
+    COMMON_BUILD_DB_TOOLS.downloadEnsemblResources(COMMON_BUILD_DB_TOOLS.EXTERNAL_RESOURCES, DESTINATION,
+                                                   SERVER_SETTINGS.DOWNLOAD_DELAY_1, SERVER_SETTINGS.MAX_TRIES_1)
     resource = COMMON_BUILD_DB_TOOLS.EXTERNAL_RESOURCES.get("refseq")
     for aux in resource:
         COMMON_BUILD_DB_TOOLS.downloadFile(aux.get("url"), aux.get("file"), DESTINATION + aux.get("output"),  SERVER_SETTINGS.DOWNLOAD_DELAY_1, SERVER_SETTINGS.MAX_TRIES_1)

--- a/PaintomicsServer/src/AdminTools/scripts/common_build_database.py
+++ b/PaintomicsServer/src/AdminTools/scripts/common_build_database.py
@@ -1044,7 +1044,15 @@ def processUniProtData():
     FAILED_LINES["UNIPROT"]=[]
     stderr.write("\n\nPROCESSING UniProt MAPPING FILE...\n")
 
-    resource = EXTERNAL_RESOURCES.get("uniprot")[0]
+    resources = (EXTERNAL_RESOURCES or {}).get("uniprot")
+    if not resources:
+        # A build script that calls this without declaring the id-mapping
+        # resource used to die on `None[0]` (acs, 2026-09-11) and lose the
+        # whole species; a missing source is a skipped identifier type.
+        skipSource("UNIPROT", "no \"uniprot\" resource declared for " + str(SPECIE),
+                   "UniProt accessions and identifiers will be absent for this species")
+        return
+    resource = resources[0]
     file_name= DATA_DIR + "mapping/" + resource.get("output")
     if not haveInputFile("UNIPROT", file_name,
                          "UniProt accessions and identifiers will be absent for this species"):

--- a/PaintomicsServer/src/tests/test_species_build_scripts_declare_their_resources.py
+++ b/PaintomicsServer/src/tests/test_species_build_scripts_declare_their_resources.py
@@ -1,0 +1,112 @@
+"""A species build script may only call a processor whose resource its download_conf declares.
+
+Run from `PaintomicsServer/`:
+    python -m src.tests.test_species_build_scripts_declare_their_resources
+
+`acs_resources/build_database.py` called `processUniProtData()`, which reads a
+UniProt id-mapping file declared under the "uniprot" key -- a key acs's
+download_conf.py never had (its UniProt dump sat as a second entry under
+"ensembl", read by nothing). The build died on `EXTERNAL_RESOURCES.get("uniprot")[0]`
+after the mapping had been downloaded, on paintomics.org, 2026-09-11, and the
+species was never installed. The mismatch is visible in the source: this test
+reads every species directory and pairs each live processor call with the
+resource key that processor reads.
+"""
+import os
+import re
+import sys
+import traceback
+
+SCRIPTS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "AdminTools", "scripts")
+sys.path.insert(0, SCRIPTS)
+from common_build_database import declaredResourceKeys  # noqa: E402
+
+#: processor -> the EXTERNAL_RESOURCES key it reads first. Processors that only
+#: consult COMMON_RESOURCES or the registry (KEGG mapping, pathways, Reactome,
+#: the MapMan pathway step) are not listed.
+PROCESSOR_RESOURCE = {
+    "processEnsemblData": "ensembl",
+    "processEnsemblUniProtData": "ensembl_uniprot",
+    "processUniProtData": "uniprot",
+    "processRefSeqData": "refseq",
+    "processRefSeqGeneSymbolData": "refseq",
+    "processMapManMappingData": "mapman_gene",
+    "processVegaData": "vega",
+}
+#: Processors that may run without their resource: they skip, warned.
+FAIL_SOFT = {"processEnsemblUniProtData", "processUniProtData"}
+
+_LIVE_CALL = re.compile(r"^\s*(?:COMMON_BUILD_DB_TOOLS\.)?(process\w+)\(\)")
+
+_PASSED = []
+_FAILED = []
+
+
+def _check(name, fn):
+    try:
+        fn()
+        _PASSED.append(name)
+        print(f"PASS  {name}")
+    except AssertionError as exc:
+        _FAILED.append((name, str(exc)))
+        print(f"FAIL  {name}: {exc}")
+    except Exception:
+        _FAILED.append((name, traceback.format_exc()))
+        print(f"ERROR {name}:\n{traceback.format_exc()}")
+
+
+def liveProcessorCalls(scriptPath):
+    with open(scriptPath, encoding="utf-8") as handle:
+        return [m.group(1) for m in (_LIVE_CALL.match(line) for line in handle) if m]
+
+
+def speciesDirectories():
+    return sorted(name[:-len("_resources")] for name in os.listdir(SCRIPTS)
+                  if name.endswith("_resources") and os.path.isfile(os.path.join(SCRIPTS, name, "build_database.py")))
+
+
+def test_every_processor_a_build_script_calls_has_its_resource_declared():
+    problems = []
+    for code in speciesDirectories():
+        directory = os.path.join(SCRIPTS, code + "_resources")
+        declared = declaredResourceKeys(os.path.join(directory, "download_conf.py"))
+        for call in liveProcessorCalls(os.path.join(directory, "build_database.py")):
+            key = PROCESSOR_RESOURCE.get(call)
+            if key and key not in declared and call not in FAIL_SOFT:
+                problems.append("%s: %s() reads the %r resource, which download_conf.py does not declare" % (code, call, key))
+    assert not problems, "\n  ".join([""] + problems)
+
+
+def test_the_anole_declares_the_ensembl_uniprot_route_it_builds():
+    declared = declaredResourceKeys(os.path.join(SCRIPTS, "acs_resources", "download_conf.py"))
+    calls = liveProcessorCalls(os.path.join(SCRIPTS, "acs_resources", "build_database.py"))
+    assert "ensembl_uniprot" in declared, declared
+    assert "processEnsemblUniProtData" in calls and "processUniProtData" not in calls, calls
+    # The join can only land in groups KEGG's mapping created.
+    assert calls.index("processKEGGMappingData") < calls.index("processEnsemblUniProtData"), calls
+
+
+def test_uniprot_processor_skips_instead_of_dying_without_its_resource():
+    """The processor itself must not raise on None[0] any more."""
+    import importlib.util
+    path = os.path.join(SCRIPTS, "common_build_database.py")
+    spec = importlib.util.spec_from_file_location("cbd_for_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.EXTERNAL_RESOURCES = {}
+    module.SPECIE = "xyz"
+    module.DATA_DIR = "/nonexistent/"
+    result = module.processUniProtData()
+    assert result is None, result
+
+
+def main():
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            _check(name, fn)
+    print(f"\n{len(_PASSED)} passed, {len(_FAILED)} failed")
+    return 1 if _FAILED else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

`acs` (*Anolis carolinensis*) could never install. Its build script called `processUniProtData()`, which reads a UniProt id-mapping file declared under a `uniprot` resource; `acs_resources/download_conf.py` never declared one. Its Ensembl UniProt cross-reference dump sat as a **second entry under `ensembl`**, was downloaded, and was read by nothing. Every install died on `EXTERNAL_RESOURCES.get("uniprot")[0]` after the mapping download (paintomics.org, 2026-09-11, found by the all-species runner from #150).

## Fix

- The dump moves under `ensembl_uniprot`, spelled like every other species; both dumps are fetched through `downloadEnsemblResources`.
- The build runs `processKEGGMappingData()` then `processEnsemblUniProtData()` (the join can only land in groups KEGG's mapping created), then the RefSeq symbols as before. `organismDB.py`'s acs entry (`entrezgene` / `refseq_gene_symbol`) is unchanged and both tables are still produced.
- `processUniProtData` skips, warned, when its resource is undeclared instead of raising `None[0]` -- a missing source is a skipped identifier type, per the fail-soft rule the rest of the builder follows.

## Test

`test_species_build_scripts_declare_their_resources` pairs every live `process*Data()` call in every `*_resources/build_database.py` with the resource key that processor reads and fails on a mismatch; it fails on master's acs and passes here. Existing suites (`test_ensembl_genebuilds_are_installed`, `test_configured_identifier_tables_are_built`, `test_mapman_install_sources`, `test_organism_taxids_are_correct`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VyrDmcv7ZAhQRoPwTc9Fa