### PR TITLE
Serialise the runner's progress file: two workers racing on one temp name killed a thread

### DIFF
--- a/PaintomicsServer/src/tests/test_species_manifest.py
+++ b/PaintomicsServer/src/tests/test_species_manifest.py
@@ -273,6 +273,35 @@ def test_runner_priority_order_ignores_the_kingdom():
         shutil.rmtree(tmp)
 
 
+def test_runner_progress_file_survives_concurrent_writers():
+    """Five workers wrote progress.json through one temp name; the loser's os.replace
+    raised FileNotFoundError and killed its thread. Eight threads, 200 writes each, no error."""
+    r = _load("allspecies_runner")
+    import tempfile, threading, argparse, shutil
+    tmp = tempfile.mkdtemp()
+    try:
+        runner = r.Runner.__new__(r.Runner)
+        # The fields writeProgress reads, without running __init__ (which opens logs).
+        runner.__dict__.update(dict(args=argparse.Namespace(state_dir=tmp), stateLock=threading.Lock(),
+                                    progressLock=threading.Lock(), logLock=threading.Lock(), states={},
+                                    installedTimes=[], breakerUntil=0.0, consecutiveNetworkFailures=0))
+        errors = []
+        def hammer():
+            try:
+                for _ in range(200):
+                    runner.writeProgress(10)
+            except Exception as exc:
+                errors.append(exc)
+        threads = [threading.Thread(target=hammer) for _ in range(8)]
+        for t in threads: t.start()
+        for t in threads: t.join()
+        assert not errors, errors[:3]
+        assert os.path.isfile(os.path.join(tmp, "progress.json"))
+        assert not [n for n in os.listdir(tmp) if n.endswith(".tmp")], "temp files left behind"
+    finally:
+        shutil.rmtree(tmp)
+
+
 def test_runner_parses_the_install_summary_block():
     r = _load("allspecies_runner")
     import tempfile

--- a/deploy/species/allspecies_runner.py
+++ b/deploy/species/allspecies_runner.py
@@ -94,6 +94,7 @@ class Runner(object):
         self.logLock = threading.Lock()
         self.stateLock = threading.Lock()
         self.copyLock = threading.Lock()
+        self.progressLock = threading.Lock()
         self.logFile = open(os.path.join(args.log_dir, "runner.log"), "a")
         self.states = {}
         self.breakerUntil = 0.0
@@ -260,6 +261,13 @@ class Runner(object):
                 out[entry["state"]] = out.get(entry["state"], 0) + 1
             return out
 
+    def safeProgress(self, total):
+        """writeProgress for worker threads: a bookkeeping failure is logged, never fatal."""
+        try:
+            self.writeProgress(total)
+        except Exception as exc:
+            self.log("progress file not written: %s" % exc)
+
     def writeProgress(self, total, extra=None):
         counts = self.counts()
         cutoff = time.time() - 3600
@@ -272,10 +280,16 @@ class Runner(object):
                     "breaker_until": self.breakerUntil, "consecutive_network_failures": self.consecutiveNetworkFailures}
         if extra:
             progress.update(extra)
-        tmp = os.path.join(self.args.state_dir, "progress.json.tmp")
-        with open(tmp, "w") as handle:
-            json.dump(progress, handle, indent=1)
-        os.replace(tmp, os.path.join(self.args.state_dir, "progress.json"))
+        # One writer at a time, and a temp name nobody else uses: every worker
+        # called this after each species through the same progress.json.tmp,
+        # and when two overlapped the second os.replace found its temp file
+        # already moved (FileNotFoundError) -- uncaught, it killed the worker
+        # thread. Two of five workers died that way on 2026-09-11.
+        with self.progressLock:
+            tmp = os.path.join(self.args.state_dir, "progress.json.%d.tmp" % threading.get_ident())
+            with open(tmp, "w") as handle:
+                json.dump(progress, handle, indent=1)
+            os.replace(tmp, os.path.join(self.args.state_dir, "progress.json"))
         return progress
 
     # ------------------------------------------------------------ manifest
@@ -424,7 +438,7 @@ class Runner(object):
                 self.setState(row["code"], "retry", reason="worker: " + str(exc)[:300])
             finally:
                 work.task_done()
-            self.writeProgress(total)
+            self.safeProgress(total)
 
     # ------------------------------------------------------------ install
     def installBatch(self, rows, total):
@@ -483,7 +497,7 @@ class Runner(object):
         self.installedTimes.append((time.time(), installedNow))
         self.installedTimes = [(t, n) for t, n in self.installedTimes if t >= time.time() - 7200]
         self.log("install batch of %d: %d installed, %d s (%s)" % (len(codes), installedNow, elapsed, os.path.basename(logPath)))
-        self.writeProgress(total)
+        self.safeProgress(total)
 
     def installFailure(self, code, reason):
         entry = self.getState(code)


### PR DESCRIPTION
## What

`allspecies_runner.py` wrote `progress.json` from every worker thread through one temp file name. When two workers finished a species at the same moment, the second `os.replace` found its temp file already moved, raised `FileNotFoundError`, and -- being outside the worker's try block -- ended the thread. Two of five download workers died that way at the 22:46 UTC container swap on paintomics.org and the ranked run continued at three workers (19/h instead of 27/h).

## Fix

A `progressLock` around the write, a per-thread temp name, and `safeProgress()` so no bookkeeping failure can end a worker. Test: eight threads × 200 writes, no error, no temp files left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VyrDmcv7ZAhQRoPwTc9Fa