### PR TITLE
Show an organism the lists cannot name by its code, instead of failing every install

### DIFF
--- a/PaintomicsServer/src/AdminTools/DBManager.py
+++ b/PaintomicsServer/src/AdminTools/DBManager.py
@@ -1722,12 +1722,19 @@ def generateAvailableSpeciesFile(VALID_SPECIES, species_file, installed_species_
         # (see the note above): the file the dropdown reads must list what
         # is installed, all of it, or the picker offers a half-installed
         # server. Named in the error, so the fix is a lookup, not a hunt.
+        # A code the lists cannot name is shown by its code, and said so. It
+        # used to abort species.json for EVERY installed organism: KEGG adds
+        # organisms between two common downloads (nfo, Naegleria fowleri, on
+        # 2026-09-12), the new species installed into MongoDB, and then every
+        # later install run died here after its species were installed --
+        # 148 species were recorded as failed for one missing display name.
         missing = sorted(code for code in set(codes) if not species.get(code))
         if missing:
-            raise Exception("no display name in organisms_all.list or organisms_custom.list for "
-                            + ", ".join(missing))
-        # By display name, deterministic: the previous loop walked a set, so
-        # the file came out in hash order, different on every run.
+            log("            WARNING: no display name in organisms_all.list or organisms_custom.list for " +
+                ", ".join(missing) + "; shown by code until the common data is refreshed")
+            INSTALL_WARNINGS.append(("species.json", "no display name for " + ", ".join(missing)))
+            for code in missing:
+                species[code] = code
         rows = species_json_rows(codes, species)
     except Exception as ex:
         errorlog("Error while writing species.json: " + str(ex))

--- a/PaintomicsServer/src/tests/test_species_json_is_written_by_name.py
+++ b/PaintomicsServer/src/tests/test_species_json_is_written_by_name.py
@@ -186,15 +186,22 @@ class DBManagerWriter(KeggDataDir):
             self.assertEqual(first, handle.read())
         self.assertEqual(["eco", "hsa", "mmu"], [s["value"] for s in read_species(self.target)["species"]])
 
-    def test_a_species_without_a_display_name_aborts_and_is_named(self):
+    def test_a_species_without_a_display_name_is_shown_by_its_code(self):
         # A code installed in Mongo but absent from both lists used to abort
-        # with "Error while writting specie <code>" for whichever code the
-        # loop reached first; now every missing code is in the message, and
-        # no file is written.
-        with self.assertRaises(Exception) as caught:
-            self.generate(["mmu", "zzz", "yyy"], self.all_list, self.target)
-        self.assertIn("yyy, zzz", str(caught.exception))
-        self.assertFalse(os.path.exists(self.target))
+        # species.json for EVERY organism ("Error while writting specie" for
+        # the first such code, later a message naming them all). KEGG adds
+        # organisms between two common downloads -- nfo, Naegleria fowleri,
+        # installed on 2026-09-12 while the list predated it -- and that abort
+        # ended every later install run after its species were installed. The
+        # file is written, the code stands in for the name, and the run's
+        # warnings say so.
+        self.generate(["mmu", "zzz", "yyy"], self.all_list, self.target)
+        species = read_species(self.target)["species"]
+        self.assertEqual({"mmu", "yyy", "zzz"}, {s["value"] for s in species})
+        byCode = {s["value"]: s["name"] for s in species}
+        self.assertEqual("yyy", byCode["yyy"])
+        self.assertEqual("zzz", byCode["zzz"])
+        self.assertNotEqual("mmu", byCode["mmu"], "a named organism keeps its name")
 
 
 class CustomInstallerWriter(KeggDataDir):

--- a/PaintomicsServer/src/tests/test_species_manifest.py
+++ b/PaintomicsServer/src/tests/test_species_manifest.py
@@ -302,6 +302,24 @@ def test_runner_progress_file_survives_concurrent_writers():
         shutil.rmtree(tmp)
 
 
+def test_runner_reads_per_species_verdicts_when_the_summary_is_missing():
+    """A run that installed its species and then died writing species.json has
+    INSTALL ... SUCCESS lines and no summary block; those species are installed."""
+    r = _load("allspecies_runner")
+    import tempfile
+    path = tempfile.mktemp()
+    with open(path, "w") as handle:
+        handle.write("2026-09-12 10:15:25,994 - INFO - DBManager.py : log -              INSTALL  1 ppy...SUCCESS\n"
+                     "2026-09-12 10:15:25,994 - INFO - DBManager.py : log -              INSTALL  1 xyz...ERROR\n"
+                     "2026-09-12 10:15:26,027 - ERROR - DBManager.py : errorlog -          Error while writing species.json: no display name for nfo\n")
+    try:
+        parsed = r.Runner.parseSummary(r.Runner.__new__(r.Runner), path)
+    finally:
+        os.remove(path)
+    assert parsed["installed"] == {"ppy"} and parsed["failed"] == {"xyz"}, parsed
+    assert parsed["from_verdict_lines"] == {"ppy", "xyz"}, parsed
+
+
 def test_runner_parses_the_install_summary_block():
     r = _load("allspecies_runner")
     import tempfile

--- a/deploy/species/allspecies_runner.py
+++ b/deploy/species/allspecies_runner.py
@@ -80,6 +80,11 @@ ENV_FAILURE = re.compile(r"PermissionError|ModuleNotFoundError|ImportError|No su
 #: The INSTALL SUMMARY block DBManager prints at the end of a run, as it
 #: appears through the logging prefix ("... - DBManager.py : log -   installed : 2  aaf aag").
 SUMMARY_LINE = re.compile(r"\b(installed|failed|skipped)\s+:\s+(\d+)\s+(.*)$")
+#: DBManager's per-species verdict line, printed as each species finishes:
+#: "INSTALL  1 hpy...SUCCESS" / "...ERROR" / "...REFUSED". The summary block
+#: comes after species.json is written, so a run that installs its species
+#: and then dies writing species.json has these lines and no summary.
+VERDICT_LINE = re.compile(r"\bINSTALL\s+\d+\s+(\S+?)\.\.\.(SUCCESS|ERROR|REFUSED)\b")
 
 
 def now():
@@ -460,6 +465,9 @@ class Runner(object):
             rc = rc or rc2
         elapsed = int(time.time() - start)
         summary = self.parseSummary(logPath)
+        if summary.get("from_verdict_lines"):
+            self.log("install run ended without a summary; verdicts read from the per-species lines for %s"
+                     % " ".join(sorted(summary["from_verdict_lines"])))
         if not summary and ENV_FAILURE.search(self.tail(logPath, 4000)):
             # The run died before it looked at any species (root-owned
             # summary.log, a recreated container): not their fault.
@@ -513,14 +521,26 @@ class Runner(object):
         """{installed|failed|skipped: set(codes)} over every summary block in the log.
 
         One log can hold two runs (promote, then --reinstall), so the sets are
-        unioned rather than the last block winning.
+        unioned rather than the last block winning. Without any summary block
+        the per-species verdict lines decide: a run that installed its species
+        and then died writing species.json (it could not name a newer KEGG
+        organism, 2026-09-12) has those and nothing else; the Mongo count in
+        installBatch still guards every SUCCESS.
         """
         out = {}
+        verdicts = {}
         for line in self.tail(logPath, 200000).splitlines():
             match = SUMMARY_LINE.search(line.rstrip())
             if match:
                 key, _, rest = match.groups()
                 out.setdefault(key, set()).update(set(rest.split()) - {"-"})
+            verdict = VERDICT_LINE.search(line)
+            if verdict:
+                verdicts[verdict.group(1)] = verdict.group(2)
+        if not out and verdicts:
+            for code, verdict in verdicts.items():
+                out.setdefault("installed" if verdict == "SUCCESS" else "failed", set()).add(code)
+            out["from_verdict_lines"] = set(verdicts)
         return out
 
     def pathwayCount(self, code, tries=3):


### PR DESCRIPTION
## What happened

KEGG adds organisms between two common downloads. `nfo` (*Naegleria fowleri*) installed into MongoDB on paintomics.org on 2026-09-12 while `current/common/organisms_all.list` predated it. `generateAvailableSpeciesFile` then raised at the end of **every** later install run -- after that run's species were installed, before the INSTALL SUMMARY -- so the species runner (#150) recorded 148 correctly installed species as failed and `species.json` stopped being rewritten for five hours.

## Fix

- `generateAvailableSpeciesFile`: a code without a display name is written under its own code, with a WARNING in the log and in the run's summary, instead of aborting the file for every organism. (The organism list on the VM was regenerated in place from KEGG, with the lineage column, and the 148 states repaired by hand.)
- `allspecies_runner.py`: when a run ends without a summary block, the per-species `INSTALL n <code>...SUCCESS/ERROR` lines are the verdict; the MongoDB pathway count still guards every SUCCESS.

## Tests

`test_species_json_is_written_by_name`: the abort test becomes "shown by its code" (file written, named organisms keep their names). `test_species_manifest`: `test_runner_reads_per_species_verdicts_when_the_summary_is_missing`. Existing organism-list, CLI-parse and identifier-table suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VyrDmcv7ZAhQRoPwTc9Fa