### PR TITLE
Read verdict lines per species, and keep the environment guard when some species have one

### DIFF
--- a/PaintomicsServer/src/tests/test_species_manifest.py
+++ b/PaintomicsServer/src/tests/test_species_manifest.py
@@ -317,7 +317,23 @@ def test_runner_reads_per_species_verdicts_when_the_summary_is_missing():
     finally:
         os.remove(path)
     assert parsed["installed"] == {"ppy"} and parsed["failed"] == {"xyz"}, parsed
-    assert parsed["from_verdict_lines"] == {"ppy", "xyz"}, parsed
+    assert parsed["from_verdict_lines"] == {"ppy", "xyz"} and parsed["has_block"] is False, parsed
+    # Two legs in one log: the promote leg wrote its summary, the --reinstall
+    # leg died after its species' verdict line. Per species, not per log.
+    path = tempfile.mktemp()
+    with open(path, "w") as handle:
+        handle.write("... - INFO - DBManager.py : log -              INSTALL  1 aaa...SUCCESS\n"
+                     "... - INFO - DBManager.py : log -   installed : 1  aaa\n"
+                     "... - INFO - DBManager.py : log -   failed    : 0  -\n"
+                     "... - INFO - DBManager.py : log -   skipped   : 0  -\n"
+                     "... - INFO - DBManager.py : log -              INSTALL  1 bvu...SUCCESS\n"
+                     "Exception: Error while writing species.json: no display name for nfo\n")
+    try:
+        parsed = r.Runner.parseSummary(r.Runner.__new__(r.Runner), path)
+    finally:
+        os.remove(path)
+    assert parsed["installed"] == {"aaa", "bvu"} and parsed["from_verdict_lines"] == {"bvu"}, parsed
+    assert parsed["has_block"] is True, parsed
 
 
 def test_runner_parses_the_install_summary_block():
@@ -336,6 +352,7 @@ def test_runner_parses_the_install_summary_block():
     assert parsed["installed"] == {"aaf", "aag"}, parsed
     assert parsed["failed"] == {"aalb"}, parsed
     assert parsed["skipped"] == set(), parsed
+    assert parsed["has_block"] is True and parsed["from_verdict_lines"] == set(), parsed
 
 
 def main():

--- a/deploy/species/allspecies_runner.py
+++ b/deploy/species/allspecies_runner.py
@@ -468,17 +468,22 @@ class Runner(object):
         if summary.get("from_verdict_lines"):
             self.log("install run ended without a summary; verdicts read from the per-species lines for %s"
                      % " ".join(sorted(summary["from_verdict_lines"])))
-        if not summary and ENV_FAILURE.search(self.tail(logPath, 4000)):
-            # The run died before it looked at any species (root-owned
-            # summary.log, a recreated container): not their fault.
-            for code in codes:
+        if not summary.get("has_block") and ENV_FAILURE.search(self.tail(logPath, 4000)):
+            # The run died on the environment (root-owned summary.log, a
+            # recreated container), not on its species. A species that had
+            # already logged a verdict keeps it (checked against MongoDB
+            # below); the rest are kept as downloaded and the batch pauses.
+            verdictless = [code for code in codes if code not in summary.get("from_verdict_lines", set())]
+            for code in verdictless:
                 self.setState(code, "downloaded", reason="environment: " + self.reasonFrom(self.tail(logPath, 4000)))
             with self.breakerLock:
                 self.breakerUntil = max(self.breakerUntil, time.time() + self.args.env_pause)
-            self.log("ENVIRONMENT FAILURE in install batch (%s); species kept as downloaded, pausing %d s"
-                     % (self.reasonFrom(self.tail(logPath, 4000)), self.args.env_pause))
-            time.sleep(self.args.env_pause)
-            return
+            self.log("ENVIRONMENT FAILURE in install batch (%s); %d species kept as downloaded, pausing %d s"
+                     % (self.reasonFrom(self.tail(logPath, 4000)), len(verdictless), self.args.env_pause))
+            codes = [code for code in codes if code not in verdictless]
+            if not codes:
+                time.sleep(self.args.env_pause)
+                return
         installedNow = 0
         for code in codes:
             if code in summary.get("installed", set()):
@@ -537,10 +542,16 @@ class Runner(object):
             verdict = VERDICT_LINE.search(line)
             if verdict:
                 verdicts[verdict.group(1)] = verdict.group(2)
-        if not out and verdicts:
-            for code, verdict in verdicts.items():
-                out.setdefault("installed" if verdict == "SUCCESS" else "failed", set()).add(code)
-            out["from_verdict_lines"] = set(verdicts)
+        out["has_block"] = bool(out)
+        # A species with a verdict line but in no summary block: its run died
+        # after it finished (species.json could not name a newer KEGG organism,
+        # 2026-09-12). Per species, not per log -- one log can hold a promote
+        # leg WITH a summary and a --reinstall leg that died without one.
+        inBlocks = set().union(*(out.get(k, set()) for k in ("installed", "failed", "skipped")))
+        fromLines = {code for code in verdicts if code not in inBlocks}
+        for code in fromLines:
+            out.setdefault("installed" if verdicts[code] == "SUCCESS" else "failed", set()).add(code)
+        out["from_verdict_lines"] = fromLines
         return out
 
     def pathwayCount(self, code, tries=3):


### PR DESCRIPTION
## What

Two findings the review posted on #158 alongside its pass, both valid:

1. `parseSummary`'s verdict-line fallback was gated on the **whole log** having no summary block. `installBatch` appends a promote leg and a `--reinstall` leg to the same log; if the first wrote its summary and the second died after its species' `INSTALL … SUCCESS` line, that verdict was lost. The fallback is now per species: any code with a verdict line that appears in no summary block gets that verdict (`from_verdict_lines`), and `has_block` says whether any summary block existed.
2. With a verdict line present the summary dict was truthy, so `if not summary and ENV_FAILURE…` never fired and an environment failure (container recreated mid-batch, permission error) consumed the species' install attempts. The guard now keys on `has_block`: species without a verdict are kept as downloaded and the batch pauses; species with one are checked against MongoDB as before.

## Tests

`test_runner_reads_per_species_verdicts_when_the_summary_is_missing` gains the two-leg case (promote summary + reinstall verdict line → both installed, `from_verdict_lines == {bvu}`, `has_block` true); the summary-block test asserts `has_block` and an empty `from_verdict_lines`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VyrDmcv7ZAhQRoPwTc9Fa