### PR TITLE
Give the regulatory-engine wording one home, in the server catalogue

### DIFF
--- a/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
+++ b/PaintomicsClient/public_html/app/view/PathwayAcquisitionViews/PA_Step1Views.js
@@ -4773,9 +4773,18 @@ function MORESubmittingPanel(nElem, options) {
 							if (methodField) { methodField.setValue(method); }
 
 							var detail = container.queryById('moreEngineDetail');
-							if (detail && record) {
-								detail.update('<p class="more-engine-detail">' +
-									Ext.String.htmlEncode(record.get('detail')) + '</p>');
+							if (detail) {
+								// Empty whenever the offline fallback supplied the row,
+								// because it carries no prose. Render nothing at all
+								// rather than an empty <p>, which would reserve a line's
+								// height for a sentence that is never coming -- and
+								// rather than String(undefined), which is what
+								// htmlEncode would have printed into the card.
+								var description = record ? (record.get('detail') || "") : "";
+								detail.update(description
+									? '<p class="more-engine-detail">' +
+									  Ext.String.htmlEncode(description) + '</p>'
+									: '');
 							}
 
 							var alphaField = container.queryById('moreAlphaField');
@@ -5148,54 +5157,61 @@ var _aiProviderRequest = null;
 /**********************************************************************
  * WHICH REGULATORY ENGINES THIS SERVER CAN RUN
  *
- * The picker offers three: PLS1 on the Rust engine, PLS1 on R, and MLR on R.
+ * The picker offers four: PLS1 and MLR, each on the Rust engine or on R.
  * Which of them a given host can actually run is not a fact the client can
  * know -- the deployed image carries /usr/bin/Rscript and none of MORE,
  * optparse, ropls or glmnet, so a list hardcoded here would offer two options
  * that pass every check in the browser and then fail deep inside the job.
  *
  * /more_backends answers it, from a probe of the R *packages* rather than the
- * interpreter. One request, cached for the page.
+ * interpreter. One request, cached for the page. It also carries the LABEL and
+ * the DESCRIPTION of every engine, and those are not restated here: see the
+ * fallback below.
  *
  * The fallback matters as much as the success path: if the request fails, the
- * picker is filled with the same three entries marked available, because a
- * server that cannot answer is more likely to be an old one that has no such
- * route than one with nothing installed -- and refusing every engine on a
- * transport error would take a working feature down. The server refuses an
- * engine it cannot run anyway (MOREServlet.engineRefusal), so the cost of
- * being optimistic here is a clear message at submission rather than a
- * mislabelled dropdown.
+ * picker is still filled with every engine marked available, because a server
+ * that cannot answer is more likely to be an old one that has no such route
+ * than one with nothing installed -- and refusing every engine on a transport
+ * error would take a working feature down. The server refuses an engine it
+ * cannot run anyway (MOREServlet.engineRefusal), so the cost of being
+ * optimistic here is a clear message at submission rather than a mislabelled
+ * dropdown.
  **********************************************************************/
 var MORE_BACKENDS = null;
 var _moreBackendsRequest = null;
 
-/* Every engine marked runnable, used when the server cannot be asked. Mirrors
-   MOREServlet.MORE_ENGINES; the labels are deliberately terser than the
-   server's, so a reader can tell an offline fallback from a real answer. */
-var MORE_ENGINES_FALLBACK = [
-	{id: "rust-pls1", method: "PLS1", engine: "rust", available: true,
-	 unavailableReason: "", label: "PLS1 — Rust engine (recommended)",
-	 detail: "The same model as the R engine, reimplemented and much faster."},
-	{id: "r-pls1", method: "PLS1", engine: "r", available: true,
-	 unavailableReason: "", label: "PLS1 — R engine (reference)",
-	 detail: "The original MORE R package. Same answers, far slower."},
-	{id: "r-mlr", method: "MLR", engine: "r", available: true,
-	 unavailableReason: "", label: "MLR — R engine",
-	 detail: "Elastic-net multiple linear regression. Slower than PLS1 and " +
-	         "harder to reproduce, and it reports no p-values, so the alpha " +
-	         "and VIP thresholds do not apply."},
-	/* Listed last and labelled opt-in, mirroring the server. The port
-	   reproduces R's random draws exactly, so collinear regulators are grouped
-	   and represented identically; it does not reproduce R's rounding, because
-	   MORE runs the solver at a tolerance where it has not converged. A few
-	   borderline regulators can therefore differ. */
-	{id: "rust-mlr", method: "MLR", engine: "rust", available: true,
-	 unavailableReason: "", label: "MLR — Rust engine (opt-in)",
-	 detail: "The same elastic-net model, reimplemented and much faster. It " +
-	         "reproduces R's random draws exactly but not R's rounding, so a " +
-	         "small number of borderline regulators can differ from the R " +
-	         "engine."}
-];
+/* Used when the server cannot be asked. It carries STRUCTURE ONLY -- the ids,
+   the method each one runs and the fact that it is offered -- and deliberately
+   no prose.
+
+   The wording lives in exactly one place, MOREServlet.MORE_ENGINES, and
+   reaches the browser through /more_backends. The copy that used to sit here
+   was a second source for the same four descriptions and had already drifted
+   from the first: it dropped the speed figure and the recommendation, and it
+   still described MLR's collinearity representative as an unseeded draw, which
+   more.R:162 seeds (`set.seed(seed)`, `seed = 123`) and runMORE.R:382 never
+   overrides -- so re-running an MLR job credits the same regulator, and the
+   sentence was false in both copies.
+
+   `label` is the combo's displayField and a row without one renders blank, so
+   it is DERIVED from the method and engine rather than written out; a hardcoded
+   label would be the duplication this list exists to avoid. `detail` is left
+   empty, and the description box renders nothing rather than a stale sentence:
+   when the route cannot be reached this client genuinely does not know what
+   this host runs, and saying nothing is the honest form of that. */
+var MORE_ENGINES_FALLBACK = ([
+	{id: "rust-pls1", method: "PLS1", engine: "rust"},
+	{id: "r-pls1",    method: "PLS1", engine: "r"},
+	{id: "r-mlr",     method: "MLR",  engine: "r"},
+	{id: "rust-mlr",  method: "MLR",  engine: "rust"}
+]).map(function (entry) {
+	entry.available = true;
+	entry.unavailableReason = "";
+	entry.label = entry.method + " — " +
+		(entry.engine === "rust" ? "Rust" : "R") + " engine";
+	entry.detail = "";
+	return entry;
+});
 
 /* Fills `combo` from /more_backends, and selects the server's default. */
 function loadMOREEngines(combo) {

--- a/PaintomicsServer/src/tests/test_more_engine_text_has_one_home.py
+++ b/PaintomicsServer/src/tests/test_more_engine_text_has_one_home.py
@@ -59,23 +59,47 @@ def _clientSource():
 
 
 def _fallbackBlock(source):
-    """The MORE_ENGINES_FALLBACK initialiser, bracket-matched.
+    """The whole MORE_ENGINES_FALLBACK statement, up to its terminating `;`.
 
-    Counting brackets rather than regex-matching to `]` because the entries are
-    piped through `.map()` and a naive match stops at the first one.
+    The array literal alone is not enough, and stopping there was a real hole:
+    the entries are piped through `.map()`, and `label` and `detail` -- the two
+    fields this test exists to police -- are assigned inside that callback, not
+    inside the array. A walker that returned at the array's closing `]` stopped
+    just before `).map(function (entry) {`, so prose written into the callback
+    passed every check.
+
+    So: walk to the `;` that ends the statement, at depth zero of (), [] and {}
+    together, skipping string literals and comments so a bracket or a semicolon
+    inside either cannot end the scan early.
     """
     start = source.index("var MORE_ENGINES_FALLBACK")
-    depth, index = 0, source.index("[", start)
-    opened = index
+    index = source.index("=", start) + 1
+    depth = 0
     while index < len(source):
-        if source[index] == "[":
+        char = source[index]
+        pair = source[index:index + 2]
+        if pair == "//":
+            index = source.find("\n", index)
+            if index < 0:
+                break
+            continue
+        if pair == "/*":
+            index = source.index("*/", index) + 2
+            continue
+        if char in "\"'":
+            quote, index = char, index + 1
+            while index < len(source) and source[index] != quote:
+                index += 2 if source[index] == "\\" else 1
+            index += 1
+            continue
+        if char in "([{":
             depth += 1
-        elif source[index] == "]":
+        elif char in ")]}":
             depth -= 1
-            if depth == 0:
-                return source[opened:index + 1]
+        elif char == ";" and depth == 0:
+            return source[start:index + 1]
         index += 1
-    raise AssertionError("MORE_ENGINES_FALLBACK is not bracket-balanced")
+    raise AssertionError("MORE_ENGINES_FALLBACK statement is not terminated")
 
 
 class EngineTextHasOneHomeTest(unittest.TestCase):
@@ -133,7 +157,10 @@ class EngineTextHasOneHomeTest(unittest.TestCase):
         enabled on a model that has no use for either.
         """
         block = _fallbackBlock(_clientSource())
-        entries = re.findall(r"\{[^{}]*\}", block)
+        # Braces carrying an `id:` -- the `.map()` callback is inside the block
+        # too (deliberately, so the prose check reaches it) and its body is a
+        # brace pair as well.
+        entries = [b for b in re.findall(r"\{[^{}]*\}", block) if "id:" in b]
         self.assertEqual(
             len(MORE_ENGINES), len(entries),
             "expected one fallback entry per catalogue engine, found %d"

--- a/PaintomicsServer/src/tests/test_more_engine_text_has_one_home.py
+++ b/PaintomicsServer/src/tests/test_more_engine_text_has_one_home.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""The regulatory-engine wording lives in the server catalogue, and only there.
+
+What this guards
+----------------
+`MOREServlet.MORE_ENGINES` is the catalogue: four entries, each with a `label`
+and a `detail`, served to the browser by `/more_backends`. The client kept a
+second copy of all four descriptions in `MORE_ENGINES_FALLBACK`, for the case
+where that route cannot be reached -- and the two drifted, as two copies of a
+paragraph do. By the time they were compared the client's copy had lost the
+speed figure and the recommendation, and both copies still told the user this
+about MLR:
+
+    "correlated regulators are collapsed into a group and one member is chosen
+     at random to represent it, so re-running the same job can credit a
+     different regulator"
+
+which is false. `MORE/R/more.R:162` calls `set.seed(seed)` with `seed = 123`
+defaulted in `more()`'s signature, and `runMORE.R` calls `more()` without
+overriding it, so the draw is seeded: re-running an MLR job credits the *same*
+regulator. Two engines running the bundled example twice each confirmed it --
+identical tables, identical collinearity representatives.
+
+The fallback still exists, and still lists every engine: a host that has R but
+no `more-rs` binary must not lose the feature because one request failed. What
+it no longer carries is prose. It holds the ids, the method each entry runs and
+the fact that it is offered; the label is derived from method and engine, and
+the description is left empty so the card renders nothing rather than a
+sentence this client cannot vouch for.
+
+So the rule is: no `detail` string from the server catalogue may appear in the
+client source. A second copy is how the first one went stale.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_more_engine_text_has_one_home
+"""
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from src.servlets.MOREServlet import MORE_ENGINES
+
+CLIENT = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), "..", "..", "..", "PaintomicsClient", "public_html",
+    "app", "view", "PathwayAcquisitionViews", "PA_Step1Views.js"))
+
+# Long enough that a match is a copied sentence rather than a shared noun. The
+# shortest `detail` in the catalogue is comfortably above this.
+_PHRASE = 40
+
+
+def _clientSource():
+    with open(CLIENT, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _fallbackBlock(source):
+    """The MORE_ENGINES_FALLBACK initialiser, bracket-matched.
+
+    Counting brackets rather than regex-matching to `]` because the entries are
+    piped through `.map()` and a naive match stops at the first one.
+    """
+    start = source.index("var MORE_ENGINES_FALLBACK")
+    depth, index = 0, source.index("[", start)
+    opened = index
+    while index < len(source):
+        if source[index] == "[":
+            depth += 1
+        elif source[index] == "]":
+            depth -= 1
+            if depth == 0:
+                return source[opened:index + 1]
+        index += 1
+    raise AssertionError("MORE_ENGINES_FALLBACK is not bracket-balanced")
+
+
+class EngineTextHasOneHomeTest(unittest.TestCase):
+
+    def test_no_catalogue_detail_is_copied_into_the_client(self):
+        """No sentence from a server `detail` may appear in the client source."""
+        source = _clientSource()
+        for entry in MORE_ENGINES:
+            detail = entry.get("detail") or ""
+            # Compare on the opening clause: the client's copy was a trimmed
+            # paraphrase, so requiring the whole string to match would let a
+            # shortened duplicate straight through.
+            head = " ".join(detail.split())[:_PHRASE]
+            if not head:
+                continue
+            self.assertNotIn(
+                head, " ".join(source.split()),
+                "PA_Step1Views.js repeats the %r description from "
+                "MOREServlet.MORE_ENGINES. The wording belongs in the "
+                "catalogue only; the client receives it from /more_backends."
+                % entry["id"])
+
+    def test_the_fallback_carries_structure_and_no_prose(self):
+        """Every fallback entry is ids and flags -- no sentence-length literal."""
+        block = _fallbackBlock(_clientSource())
+        literals = re.findall(r'"([^"\\]*)"', block)
+        wordy = [text for text in literals if len(text) > _PHRASE]
+        self.assertEqual(
+            [], wordy,
+            "MORE_ENGINES_FALLBACK has grown prose again: %r. It carries "
+            "structure only; descriptions come from /more_backends." % wordy)
+
+    def test_the_fallback_still_offers_every_catalogue_engine(self):
+        """Dropping an engine here would take it away from an offline host.
+
+        The fallback exists so a server that cannot answer `/more_backends`
+        still gets a usable picker -- including on a host that has R and no
+        `more-rs`, where offering only the Rust entries would leave nothing
+        runnable.
+        """
+        block = _fallbackBlock(_clientSource())
+        for entry in MORE_ENGINES:
+            self.assertIn(
+                '"%s"' % entry["id"], block,
+                "MORE_ENGINES_FALLBACK no longer lists %r, so a client that "
+                "cannot reach /more_backends would not offer it."
+                % entry["id"])
+
+    def test_every_fallback_entry_names_its_method(self):
+        """`method` drives the posted `more_method` and the alpha/VIP toggle.
+
+        The combo's change handler reads `method` off the selected record; an
+        entry without one falls back to PLS1, which would silently run the
+        wrong model for the two MLR rows and leave the alpha and VIP fields
+        enabled on a model that has no use for either.
+        """
+        block = _fallbackBlock(_clientSource())
+        entries = re.findall(r"\{[^{}]*\}", block)
+        self.assertEqual(
+            len(MORE_ENGINES), len(entries),
+            "expected one fallback entry per catalogue engine, found %d"
+            % len(entries))
+        for entry in entries:
+            self.assertRegex(
+                entry, r'method:\s*"(PLS1|MLR)"',
+                "fallback entry %s names no method" % entry)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

`MOREServlet.MORE_ENGINES` holds the four engine descriptions and `/more_backends` serves them to the browser. `MORE_ENGINES_FALLBACK` in `PA_Step1Views.js` held a **second copy of all four**, for when that route cannot be reached — and the two had drifted.

The client's copy had lost the 8–30× speed figure and the closing recommendation. And both copies still told the user this about MLR:

> correlated regulators are collapsed into a group and one member is chosen at random to represent it, so re-running the same job can credit a different regulator

**That is false.** `MORE/R/more.R:162` calls `set.seed(seed)` with `seed = 123` defaulted in `more()`'s signature, and `runMORE.R:382` calls `more()` without overriding it — the draw is seeded. Running the bundled `06-regulatory-more` example twice through the R engine returns an identical table with identical collinearity representatives. Re-running an MLR job credits the *same* regulator.

## What changed

- `MORE_ENGINES_FALLBACK` carries **structure only** — id, method, engine, availability. `label` is derived (`method + " — " + engine`), because the combo's `displayField` needs one and a written-out label is the duplication the list exists to avoid. `detail` is empty.
- The detail box renders **nothing** when there is no description, rather than an empty `<p>` (which reserves a line's height) or `String(undefined)` (which is what `htmlEncode` would have printed).
- The banner comment said the picker "offers three" over four entries, since `rust-mlr` was added. Corrected.
- New suite `test_more_engine_text_has_one_home.py` pins it: no `detail` from the server catalogue may appear in the client source, the fallback carries no sentence-length literal, it still lists every catalogue engine, and every entry names its method.

**The fallback still lists all four engines on purpose.** A host with R installed and no `more-rs` binary must not lose the picker because one request failed — that is what the fallback is for.

## Verification

Chrome, bundled STATegra MORE example, both branches:

| branch | result |
| --- | --- |
| server answers | four entries, the catalogue's own labels and details, detail box renders the served paragraph |
| `/more_backends` aborted | four entries, derived labels, detail box renders nothing |

In both, selecting an MLR entry posts `more_method=MLR` and disables **and** hides the alpha and VIP fields — the behaviour that needs `method` to survive in the fallback. No page errors on either path.

Alignment overlay reports the same single off-rail item before and after (`x417 "Regulatory Omic — MORE"`), so it is pre-existing and untouched here.

Suites green: the new one, `test_more_engine_choice` (41), `test_more_servlet_step1` (29), `test_more_servlet_step2` (43), `test_more_backend_selection` (16), `test_other_omic_file_type_combo_stores_the_pick` (16), `test_input_check_covers_every_omic_slot` (7). `ruff` and `eslint@10.9.1` clean.

## Not in this PR

This came out of an evaluation of whether the R engine could be removed entirely. It cannot yet — six reproducible `more-rs` defects, two on the default `rust-pls1` path. Those are tracked separately; this PR only removes the duplicated text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)