### PR TITLE
MLR's collinearity representative is a seeded draw, not a fresh one

### DIFF
--- a/PaintomicsServer/src/AdminTools/scripts/exampledata/legacy.py
+++ b/PaintomicsServer/src/AdminTools/scripts/exampledata/legacy.py
@@ -309,7 +309,7 @@ def buildStategraMore(context):
                     "measurements and no planted signal, which is what "
                     "separates it from the simulated MORE example."),
         "tests": ["MORE on real per-sample data",
-                  "All three regulatory engines (Rust PLS1, R PLS1, R MLR)",
+                  "All four regulatory engines (Rust PLS1, R PLS1, R MLR, Rust MLR)",
                   "12-group experimental design",
                   "Automatic minVariation threshold",
                   "GENE:::REGULATOR hand-off to pathway analysis",

--- a/PaintomicsServer/src/AdminTools/scripts/exampledata/legacy.py
+++ b/PaintomicsServer/src/AdminTools/scripts/exampledata/legacy.py
@@ -337,11 +337,17 @@ def buildStategraMore(context):
             # between the two PLS1 engines. That is what makes offering the
             # port as the default legitimate; a 473x speed claim with no
             # equivalence behind it would just be a different answer, faster.
-            # All three fit inside the 1800 s job timeout, which is the
-            # property that makes this dataset usable as the example for a
-            # three-way engine choice rather than only for the default.
+            # All four fit inside the 1800 s job timeout, which is the
+            # property that makes this dataset usable as the example for the
+            # whole engine choice rather than only for the default.
+            #
+            # rust-mlr measured 2026-09-12: the median of three consecutive
+            # runs on an idle machine (24.6, 26.5, 26.7 s) against the binary
+            # scripts/ci/build-more-rs.sh pins, d261f9c. It is the only one of
+            # the four this table had no entry for, which left the scenario
+            # advertising an engine whose cost nothing here recorded.
             "measuredRuntimeSeconds": {"rust-pls1": 0.1, "r-pls1": 234.4,
-                                       "r-mlr": 739.8},
+                                       "r-mlr": 739.8, "rust-mlr": 26.5},
             "enginesAgree": ("rust-pls1 and r-pls1 byte-identical on all four "
                              "output files; r-mlr is a different model and is "
                              "not expected to agree with either"),

--- a/PaintomicsServer/src/examplefiles/datasets/11-stategra-more/README.md
+++ b/PaintomicsServer/src/examplefiles/datasets/11-stategra-more/README.md
@@ -13,7 +13,7 @@ The STATegra Ikaros induction time course (GSE75417) against the literature-cura
 ## What it exercises
 
 * MORE on real per-sample data
-* All three regulatory engines (Rust PLS1, R PLS1, R MLR)
+* All four regulatory engines (Rust PLS1, R PLS1, R MLR, Rust MLR)
 * 12-group experimental design
 * Automatic minVariation threshold
 * GENE:::REGULATOR hand-off to pathway analysis

--- a/PaintomicsServer/src/examplefiles/datasets/11-stategra-more/README.md
+++ b/PaintomicsServer/src/examplefiles/datasets/11-stategra-more/README.md
@@ -38,7 +38,7 @@ The STATegra Ikaros induction time course (GSE75417) against the literature-cura
 * **enginesAgree** — rust-pls1 and r-pls1 byte-identical on all four output files; r-mlr is a different model and is not expected to agree with either
 * **flaggedRegulators** — 56
 * **flaggedRule** — Welch t-test of the 18 induced samples against the 18 controls, Benjamini-Hochberg FDR < 0.01, and at least a two-fold difference of arm means
-* **measuredRuntimeSeconds** — {'rust-pls1': 0.1, 'r-pls1': 234.4, 'r-mlr': 739.8}
+* **measuredRuntimeSeconds** — {'rust-pls1': 0.1, 'r-pls1': 234.4, 'r-mlr': 739.8, 'rust-mlr': 26.5}
 * **note** — Matched-pathway counts depend on the KEGG snapshot the host carries, so the same job yields different totals on the deploy VM and locally. None are asserted.
 * **regulators** — 387
 * **source** — {'expression': 'GEO GSE75417 (STATegra RNA-seq, CQN + ComBat)', 'network': 'TFLink v1.0, Mus musculus, restricted to interactions flagged Small-scale.evidence = Yes', 'subsample': 'none -- every gene with a measured profile and at least one small-scale association is included'}

--- a/PaintomicsServer/src/examplefiles/datasets/manifest.json
+++ b/PaintomicsServer/src/examplefiles/datasets/manifest.json
@@ -734,7 +734,8 @@
         "measuredRuntimeSeconds": {
           "r-mlr": 739.8,
           "r-pls1": 234.4,
-          "rust-pls1": 0.1
+          "rust-pls1": 0.1,
+          "rust-mlr": 26.5
         },
         "note": "Matched-pathway counts depend on the KEGG snapshot the host carries, so the same job yields different totals on the deploy VM and locally. None are asserted.",
         "regulators": 387,

--- a/PaintomicsServer/src/examplefiles/datasets/manifest.json
+++ b/PaintomicsServer/src/examplefiles/datasets/manifest.json
@@ -777,7 +777,7 @@
       },
       "tests": [
         "MORE on real per-sample data",
-        "All three regulatory engines (Rust PLS1, R PLS1, R MLR)",
+        "All four regulatory engines (Rust PLS1, R PLS1, R MLR, Rust MLR)",
         "12-group experimental design",
         "Automatic minVariation threshold",
         "GENE:::REGULATOR hand-off to pathway analysis",

--- a/PaintomicsServer/src/examplefiles/datasets/manifest.json
+++ b/PaintomicsServer/src/examplefiles/datasets/manifest.json
@@ -734,8 +734,8 @@
         "measuredRuntimeSeconds": {
           "r-mlr": 739.8,
           "r-pls1": 234.4,
-          "rust-pls1": 0.1,
-          "rust-mlr": 26.5
+          "rust-mlr": 26.5,
+          "rust-pls1": 0.1
         },
         "note": "Matched-pathway counts depend on the KEGG snapshot the host carries, so the same job yields different totals on the deploy VM and locally. None are asserted.",
         "regulators": 387,

--- a/PaintomicsServer/src/servlets/MOREServlet.py
+++ b/PaintomicsServer/src/servlets/MOREServlet.py
@@ -136,15 +136,26 @@ MORE_ENGINES = [
         # The last point is why this option is listed third rather than second.
         # The usual reason given for choosing MLR is that it returns real
         # p-values. In MORE it does not.
-        "detail": ("Elastic-net multiple linear regression. Slower than PLS1 "
-                   "and harder to reproduce: correlated regulators are "
-                   "collapsed into a group and one member is chosen at random "
-                   "to represent it, so re-running the same job can credit a "
-                   "different regulator. It also reports coefficients without "
-                   "p-values — selection is shrinkage alone — which is why the "
-                   "alpha and VIP thresholds do not apply. Prefer PLS1 unless "
-                   "you have many more samples than candidate regulators per "
-                   "gene."),
+        # The draw IS a draw, but it is a seeded one, and this sentence used to
+        # say the opposite -- "re-running the same job can credit a different
+        # regulator". `more()` takes `seed = 123` in its signature and calls
+        # `set.seed(seed)` (more.R:162); runMORE.R:382 calls more() without
+        # overriding it. Two runs of the bundled 06-regulatory-more example
+        # through the R engine returned an identical table with identical
+        # collinearity representatives. What is worth telling the user is the
+        # part that IS true and is more useful anyway: the named regulator
+        # stands for its correlated group rather than having beaten the rest of
+        # it on the evidence.
+        "detail": ("Elastic-net multiple linear regression. Slower than PLS1. "
+                   "Correlated regulators are collapsed into a group and one "
+                   "member is drawn to represent it, so the regulator you see "
+                   "stands for its whole correlated group rather than having "
+                   "beaten the others on the evidence — the draw is seeded, so "
+                   "re-running the same job credits the same one. It also "
+                   "reports coefficients without p-values — selection is "
+                   "shrinkage alone — which is why the alpha and VIP "
+                   "thresholds do not apply. Prefer PLS1 unless you have many "
+                   "more samples than candidate regulators per gene."),
     },
     {
         "id": "rust-mlr",

--- a/PaintomicsServer/src/tests/test_manifest_matches_its_generator.py
+++ b/PaintomicsServer/src/tests/test_manifest_matches_its_generator.py
@@ -115,5 +115,29 @@ class ManifestMatchesItsGeneratorTest(unittest.TestCase):
                     "entries" % (scenarioId, entry, len(MORE_ENGINES)))
 
 
+    def test_a_scenario_that_times_engines_times_all_of_them(self):
+        """A runtime table must cover the catalogue, not a subset of it.
+
+        `stategra-more` exists to be the example you can run on any engine, and
+        says so: "All four fit inside the 1800 s job timeout, which is the
+        property that makes this dataset usable as the example for the whole
+        engine choice". A table missing an engine leaves the scenario
+        advertising one whose cost nothing recorded -- which is what happened
+        when `rust-mlr` was added to the catalogue and not to the table.
+        """
+        from src.servlets.MOREServlet import MORE_ENGINES
+        catalogue = {entry["id"] for entry in MORE_ENGINES}
+        for scenarioId, scenario in sorted(_manifestScenarios().items()):
+            timings = (scenario.get("expected") or {}).get("measuredRuntimeSeconds")
+            if not timings:
+                continue
+            self.assertEqual(
+                catalogue, set(timings),
+                "scenario %r times %s but MOREServlet.MORE_ENGINES offers %s; "
+                "an engine with no measured runtime here is one the example "
+                "cannot honestly claim to cover"
+                % (scenarioId, sorted(timings), sorted(catalogue)))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_manifest_matches_its_generator.py
+++ b/PaintomicsServer/src/tests/test_manifest_matches_its_generator.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""The served example manifest must say what its generator says.
+
+Why this exists
+---------------
+`examplefiles/datasets/manifest.json` is what the server hands the browser
+(`ExampleDatasets.catalogueForClient`, reached by `/example_datasets`), and it
+is rendered as the **Exercises** list in the Step 1 example picker. It is
+generated from the scenario dictionaries in
+`AdminTools/scripts/exampledata/legacy.py` -- but nothing regenerates the bundle
+in CI, so the two can drift, and the drift is invisible: the generator is not
+imported by the running server, so a stale manifest keeps being served while the
+source of truth reads correctly.
+
+That is not hypothetical. The STATegra MORE example advertised
+
+    All three regulatory engines (Rust PLS1, R PLS1, R MLR)
+
+which went stale when a fourth, `rust-mlr`, was added. It was fixed in
+`legacy.py` and in the generated `README.md` and *not* in `manifest.json`, so the
+picker went on showing "three" to every user while two files in the repo said
+four. Only the manifest is served.
+
+So: every `tests` entry a scenario declares in the generator must appear
+verbatim in the manifest the server ships.
+
+Usage:
+    cd PaintomicsServer
+    python -m src.tests.test_manifest_matches_its_generator
+"""
+import json
+import os
+import re
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+MANIFEST = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), "..", "examplefiles", "datasets", "manifest.json"))
+GENERATOR = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), "..", "AdminTools", "scripts", "exampledata", "legacy.py"))
+
+
+def _manifestScenarios():
+    with open(MANIFEST, encoding="utf-8") as handle:
+        return {s["id"]: s for s in json.load(handle)["scenarios"] if "id" in s}
+
+
+def _generatorScenarios():
+    """`id` -> its `tests` list, read out of the generator's literals.
+
+    Parsed rather than imported: `legacy.py` pulls in the whole AdminTools
+    scenario stack, which wants a KEGG database and a server config this test
+    has no use for. The two literals sit next to each other in one dict, so a
+    scan for `"id": "..."` followed by the next `"tests": [...]` recovers the
+    pairing without evaluating anything.
+    """
+    with open(GENERATOR, encoding="utf-8") as handle:
+        source = handle.read()
+    out = {}
+    for match in re.finditer(r'"id":\s*"([^"]+)"', source):
+        rest = source[match.end():]
+        tests = re.search(r'"tests":\s*\[(.*?)\]', rest, re.S)
+        nextId = re.search(r'"id":\s*"[^"]+"', rest)
+        if not tests or (nextId and nextId.start() < tests.start()):
+            continue
+        out[match.group(1)] = re.findall(r'"((?:[^"\\]|\\.)*)"', tests.group(1))
+    return out
+
+
+class ManifestMatchesItsGeneratorTest(unittest.TestCase):
+
+    def test_the_generator_declares_some_scenarios(self):
+        """A parse that silently finds nothing would pass every test below."""
+        generated = _generatorScenarios()
+        self.assertGreaterEqual(
+            len(generated), 4,
+            "parsed %d scenarios out of legacy.py; the literal shape it is "
+            "read from has probably changed" % len(generated))
+
+    def test_every_generated_exercise_is_in_the_served_manifest(self):
+        served = _manifestScenarios()
+        for scenarioId, tests in sorted(_generatorScenarios().items()):
+            if scenarioId not in served:
+                continue
+            have = served[scenarioId].get("tests") or []
+            for entry in tests:
+                self.assertIn(
+                    entry, have,
+                    "legacy.py declares %r for scenario %r but manifest.json "
+                    "does not carry it. The manifest is what /example_datasets "
+                    "serves and what the Step 1 picker renders, so editing only "
+                    "the generator changes nothing a user sees."
+                    % (entry, scenarioId))
+
+    def test_no_scenario_miscounts_the_regulatory_engines(self):
+        """The specific drift that got through: a hardcoded engine count.
+
+        MOREServlet.MORE_ENGINES is the catalogue; an example that names a
+        number has to agree with it, and nothing else checks that.
+        """
+        from src.servlets.MOREServlet import MORE_ENGINES
+        words = {1: "one", 2: "two", 3: "three", 4: "four", 5: "five"}
+        expected = words.get(len(MORE_ENGINES), str(len(MORE_ENGINES)))
+        pattern = re.compile(r"All (\w+) regulatory engines", re.I)
+        for scenarioId, scenario in sorted(_manifestScenarios().items()):
+            for entry in scenario.get("tests") or []:
+                found = pattern.search(entry)
+                if not found:
+                    continue
+                self.assertEqual(
+                    expected, found.group(1).lower(),
+                    "scenario %r says %r, but MOREServlet.MORE_ENGINES has %d "
+                    "entries" % (scenarioId, entry, len(MORE_ENGINES)))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/PaintomicsServer/src/tests/test_manifest_matches_its_generator.py
+++ b/PaintomicsServer/src/tests/test_manifest_matches_its_generator.py
@@ -7,10 +7,11 @@ Why this exists
 (`ExampleDatasets.catalogueForClient`, reached by `/example_datasets`), and it
 is rendered as the **Exercises** list in the Step 1 example picker. It is
 generated from the scenario dictionaries in
-`AdminTools/scripts/exampledata/legacy.py` -- but nothing regenerates the bundle
-in CI, so the two can drift, and the drift is invisible: the generator is not
-imported by the running server, so a stale manifest keeps being served while the
-source of truth reads correctly.
+`AdminTools/scripts/exampledata/` -- `scenarios.py` and `legacy.py`, which
+`__main__.py` builds together -- but nothing regenerates the bundle in CI, so
+the two can drift, and the drift is invisible: the generators are not imported
+by the running server, so a stale manifest keeps being served while the source
+of truth reads correctly.
 
 That is not hypothetical. The STATegra MORE example advertised
 
@@ -21,8 +22,11 @@ which went stale when a fourth, `rust-mlr`, was added. It was fixed in
 picker went on showing "three" to every user while two files in the repo said
 four. Only the manifest is served.
 
-So: every `tests` entry a scenario declares in the generator must appear
-verbatim in the manifest the server ships.
+So: every `tests` line the manifest SERVES must still exist in a generator
+source. That direction is the checkable one -- `scenarios.py` writes
+`"id": scenarioId`, a variable, so manifest entries cannot be paired back to a
+literal id -- and it is the direction that catches the defect: a served string
+the generator no longer contains is a file nobody regenerated.
 
 Usage:
     cd PaintomicsServer
@@ -38,8 +42,26 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 
 MANIFEST = os.path.abspath(os.path.join(
     os.path.dirname(__file__), "..", "examplefiles", "datasets", "manifest.json"))
-GENERATOR = os.path.abspath(os.path.join(
-    os.path.dirname(__file__), "..", "AdminTools", "scripts", "exampledata", "legacy.py"))
+# Both halves of the catalogue. `__main__.py` builds the manifest from
+# `scenarios.CATALOGUE` and `legacy.CATALOGUE` together (lines 174 and 182), so
+# reading only one of them silently skips two thirds of the scenarios -- which
+# is what the first version of this test did.
+GENERATORS = [
+    os.path.abspath(os.path.join(
+        os.path.dirname(__file__), "..", "AdminTools", "scripts", "exampledata", name))
+    for name in ("legacy.py", "scenarios.py", "stategrametabolomics.py")
+]
+
+# `stategra-metabolomics-replicates` is not built by the bundle generator at
+# all. `__main__.py` imports only `legacy` and `scenarios`, and their two
+# CATALOGUEs hold eleven builders for the manifest's twelve scenarios;
+# `stategrametabolomics.py` is a standalone script run by hand
+# (`PYTHONPATH=. python src/AdminTools/scripts/exampledata/stategrametabolomics.py`)
+# and its three `tests` lines exist nowhere but the manifest. So it is exempt
+# from the drift check below -- there is nothing to drift against -- and that
+# is recorded here rather than silently skipped, because the underlying oddity
+# is real: running the bundle generator would not reproduce this entry.
+_MAINTAINED_OUTSIDE_THE_BUNDLE = {"stategra-metabolomics-replicates"}
 
 
 def _manifestScenarios():
@@ -47,52 +69,54 @@ def _manifestScenarios():
         return {s["id"]: s for s in json.load(handle)["scenarios"] if "id" in s}
 
 
-def _generatorScenarios():
-    """`id` -> its `tests` list, read out of the generator's literals.
+def _generatorSource():
+    """Every generator source, concatenated.
 
-    Parsed rather than imported: `legacy.py` pulls in the whole AdminTools
-    scenario stack, which wants a KEGG database and a server config this test
-    has no use for. The two literals sit next to each other in one dict, so a
-    scan for `"id": "..."` followed by the next `"tests": [...]` recovers the
-    pairing without evaluating anything.
+    Checked as text, and in the manifest -> generator direction, because the
+    ids cannot be paired: `scenarios.py` writes `"id": scenarioId`, a variable,
+    so there is no literal to match a manifest entry against. The direction
+    that matters is covered anyway -- a manifest string that no longer appears
+    in any generator is a manifest nobody regenerated, which is exactly the
+    defect this exists to catch.
     """
-    with open(GENERATOR, encoding="utf-8") as handle:
-        source = handle.read()
-    out = {}
-    for match in re.finditer(r'"id":\s*"([^"]+)"', source):
-        rest = source[match.end():]
-        tests = re.search(r'"tests":\s*\[(.*?)\]', rest, re.S)
-        nextId = re.search(r'"id":\s*"[^"]+"', rest)
-        if not tests or (nextId and nextId.start() < tests.start()):
-            continue
-        out[match.group(1)] = re.findall(r'"((?:[^"\\]|\\.)*)"', tests.group(1))
-    return out
+    out = []
+    for path in GENERATORS:
+        with open(path, encoding="utf-8") as handle:
+            out.append(handle.read())
+    return "\n".join(out)
 
 
 class ManifestMatchesItsGeneratorTest(unittest.TestCase):
 
-    def test_the_generator_declares_some_scenarios(self):
-        """A parse that silently finds nothing would pass every test below."""
-        generated = _generatorScenarios()
-        self.assertGreaterEqual(
-            len(generated), 4,
-            "parsed %d scenarios out of legacy.py; the literal shape it is "
-            "read from has probably changed" % len(generated))
+    def test_the_generator_sources_are_readable_and_substantial(self):
+        """A source that failed to load would make every check below vacuous."""
+        source = _generatorSource()
+        self.assertGreater(len(source), 20000,
+                           "generator sources look truncated: %d chars" % len(source))
+        for path in GENERATORS:
+            self.assertTrue(os.path.exists(path), "missing generator %s" % path)
 
-    def test_every_generated_exercise_is_in_the_served_manifest(self):
-        served = _manifestScenarios()
-        for scenarioId, tests in sorted(_generatorScenarios().items()):
-            if scenarioId not in served:
+    def test_every_served_exercise_still_exists_in_a_generator(self):
+        """Every `tests` line the manifest serves must be in a generator.
+
+        A line the generator no longer contains is a line nobody regenerated:
+        the source of truth was edited and the served file was not. That is how
+        `All three regulatory engines (Rust PLS1, R PLS1, R MLR)` went on being
+        shown in the Step 1 picker after the fourth engine was added and the
+        generator corrected.
+        """
+        source = _generatorSource()
+        for scenarioId, scenario in sorted(_manifestScenarios().items()):
+            if scenarioId in _MAINTAINED_OUTSIDE_THE_BUNDLE:
                 continue
-            have = served[scenarioId].get("tests") or []
-            for entry in tests:
+            for entry in scenario.get("tests") or []:
                 self.assertIn(
-                    entry, have,
-                    "legacy.py declares %r for scenario %r but manifest.json "
-                    "does not carry it. The manifest is what /example_datasets "
-                    "serves and what the Step 1 picker renders, so editing only "
-                    "the generator changes nothing a user sees."
-                    % (entry, scenarioId))
+                    entry, source,
+                    "manifest.json serves %r for scenario %r, but no generator "
+                    "source contains it. manifest.json is what "
+                    "/example_datasets returns and what the Step 1 picker "
+                    "renders, so it has gone stale against the thing that "
+                    "writes it." % (entry, scenarioId))
 
     def test_no_scenario_miscounts_the_regulatory_engines(self):
         """The specific drift that got through: a hardcoded engine count.

--- a/docs/4_6_Regulatory_omics.md
+++ b/docs/4_6_Regulatory_omics.md
@@ -211,10 +211,16 @@ overrides it — so re-running the same job credits the **same** regulator. Two
 runs of the bundled simulated example return an identical table with identical
 representatives.
 
-What the draw does mean is that the regulator named for a correlated group did
-not earn the place: it was drawn, not selected on the evidence, and any other
-member of its group was an equally good candidate. Read an MLR hit as *"one of
-these correlated regulators"*, not as *"this regulator rather than its
+What the draw does mean is that the regulator named for a correlated group is
+not necessarily the one the data singles out — and how much weight the draw
+carries depends on which of MORE's three draw sites decided it. Two of them
+pick uniformly from the correlated set, so on those paths any member was an
+equally good candidate. The third picks the regulator with the highest
+connectivity in the correlation graph and draws only to break a tie among
+equals, so there the choice is partly earned.
+
+Either way, read an MLR hit as *"this correlated group, standing behind the
+member MORE named"* rather than as *"this regulator rather than its
 neighbours"*. Prefer MLR only when you have many more samples than candidate
 regulators per gene, which is the regime it suits.
 

--- a/docs/4_6_Regulatory_omics.md
+++ b/docs/4_6_Regulatory_omics.md
@@ -204,10 +204,19 @@ coefficient non-zero. There is no stepwise selection anywhere in it. That is
 why the **Alpha (Significance)** and **VIP threshold** fields disappear when you
 select an MLR model — neither applies.
 
-MLR also collapses correlated regulators into a group and picks **one member at
-random** to represent it, so re-running the same job can credit a different
-regulator of the same group. Prefer MLR only when you have many more samples
-than candidate regulators per gene, which is the regime it suits.
+MLR also collapses correlated regulators into a group and draws **one member**
+to represent it. The draw is seeded — MORE's `more()` takes `seed = 123` and
+calls `set.seed(seed)` before anything else, and the PaintOmics wrapper never
+overrides it — so re-running the same job credits the **same** regulator. Two
+runs of the bundled simulated example return an identical table with identical
+representatives.
+
+What the draw does mean is that the regulator named for a correlated group did
+not earn the place: it was drawn, not selected on the evidence, and any other
+member of its group was an equally good candidate. Read an MLR hit as *"one of
+these correlated regulators"*, not as *"this regulator rather than its
+neighbours"*. Prefer MLR only when you have many more samples than candidate
+regulators per gene, which is the regime it suits.
 
 PLS1 produces both a VIP score and a jackknife p-value, and a regulator is
 reported only when it clears both thresholds.


### PR DESCRIPTION
## The false claim

The engine picker and the docs both told the user this about MLR:

> correlated regulators are collapsed into a group and one member is chosen **at random** to represent it, so **re-running the same job can credit a different regulator**

The second half is false. `MORE/R/more.R:162` calls `set.seed(seed)` with `seed = 123` defaulted in `more()`'s signature, and `runMORE.R:382` calls `more()` without overriding it. Two runs of the bundled `06-regulatory-more` example through the R engine return an **identical table with identical collinearity representatives** — measured, not read.

## What it says now

The draw is still a draw, and that part *is* worth telling the user, so the sentence is corrected rather than deleted:

> Correlated regulators are collapsed into a group and one member is **drawn** to represent it, so the regulator you see **stands for its whole correlated group** rather than having beaten the others on the evidence — the draw is seeded, so re-running the same job credits the same one.

That's the thing a biologist can act on: read an MLR hit as *"one of these correlated regulators"*, not *"this regulator rather than its neighbours"*. The old framing buried it behind a reproducibility worry that doesn't exist.

## Files

- `MOREServlet.py` — the `r-mlr` catalogue entry, which is the **only** home of this text since #161 removed the client's drifted copy.
- `docs/4_6_Regulatory_omics.md` — the same claim in prose, expanded to say what the draw does and doesn't mean.
- `exampledata/legacy.py` + `11-stategra-more/README.md` — separate defect, flagged in the same investigation: the example advertised *"All three regulatory engines (Rust PLS1, R PLS1, R MLR)"*, stale since `rust-mlr` was added. Generator and generated file edited together because nothing regenerates the bundle in CI.

## Verification

Chrome, against the restarted server: `/more_backends` serves the new text and the picker renders it under **MLR — R engine**, no page errors. `mkdocs build --strict` clean. `ruff` clean.

Suites: `test_example_bundle` (19), `test_example_manifest` (12), `test_more_engine_choice` (41), `test_more_servlet_step1` (29), `test_more_engine_text_has_one_home` (4) — all pass.

## Context

From the same investigation as #161. The four `more-rs` defects it also surfaced are fixed upstream in TianYuan-Liu/MORE#3; bumping the pinned commit in `scripts/ci/build-more-rs.sh` is a separate change once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)