### PR TITLE
Pin more-rs at the commit where all six reproduced defects are fixed

### DIFF
--- a/.github/actions/setup-paintomics/action.yml
+++ b/.github/actions/setup-paintomics/action.yml
@@ -80,11 +80,19 @@ runs:
       shell: bash
       run: scripts/ci/restore-data.sh ~/paintomics-ci/data
 
+    # Keyed on the build script's own hash, not on a copy of the commit it
+    # pins. The commit used to be written out here as well, and the two went
+    # out of step the first time the pin moved: the cache restored the old
+    # binary under a key naming it, build-more-rs.sh looked for the new one,
+    # missed, rebuilt it, and then saved it back under the stale key -- so
+    # every run rebuilt from scratch while the key claimed otherwise. Hashing
+    # the script cannot drift from it. The cost is that editing a comment in
+    # that file also busts the cache, which is one rebuild.
     - name: more-rs binary (cache)
       uses: actions/cache@v6
       with:
         path: ~/paintomics-ci/more-rs
-        key: more-rs-d261f9c8ea39aefd371bfb46afc596957a9dd7c5-${{ runner.os }}-${{ runner.arch }}
+        key: more-rs-${{ hashFiles('scripts/ci/build-more-rs.sh') }}-${{ runner.os }}-${{ runner.arch }}
 
     - name: more-rs
       shell: bash

--- a/scripts/ci/build-more-rs.sh
+++ b/scripts/ci/build-more-rs.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CI_HOME="${PAINTOMICS_CI_HOME:-$HOME/paintomics-ci}"
-MORE_RS_COMMIT="${MORE_RS_COMMIT:-d261f9c8ea39aefd371bfb46afc596957a9dd7c5}"
+MORE_RS_COMMIT="${MORE_RS_COMMIT:-8d9ffebb0dc387c81cd1df3dc9ea5958c0d5c1b0}"
 CACHED="$CI_HOME/more-rs/$MORE_RS_COMMIT/more-rs"
 TARGET="$ROOT/PaintomicsServer/src/common/bioscripts/more-rs"
 


### PR DESCRIPTION
`d261f9c8` → `8d9ffebb`, which is MORE [#3](https://github.com/TianYuan-Liu/MORE/pull/3) and [#4](https://github.com/TianYuan-Liu/MORE/pull/4) landed on `main`.

### What the new pin fixes

**#3 — four correctness defects and a quadratic**

| defect | effect before |
|---|---|
| associations oriented on mangled ids | a regulator id that is also a target id, or any id containing `:`, **aborted the job** |
| internal `<omic>-` prefix leaked into all four output files | `MOREServlet` matches on the half of `GENE:::REGULATOR` after the separator, so **every red star for that omic silently disappeared** while the job reported success |
| `--filter_r2` never reached the pairs file | at `0.9` on one fixture: R wrote 4 pairs, the port wrote 217 |
| quadratic in the output path | per-gene cost `0.8 + 0.0008n` ms → flat **0.65 ms**; 20,000 genes **336.5 s → 13.1 s** |

Two of those — the prefix leak and the ignored `--filter_r2` — were live on
`rust-pls1`, the **default** engine.

**#4 — a run that modelled nothing now stops instead of reporting success**

A design with a single condition group (PLS1 wrote an empty table, MLR wrote
887 "regulations per condition" for a condition set of size one), and a run
where no target could be fitted at all.

### Verification

No baseline changes. Run before pushing, on Python 3.11:

- `scripts/regression.sh 06-regulatory-more 11-stategra-more` — the only two baseline datasets that use MORE — **2/2 PASS** against the existing `tests/baseline`.
- more-rs output for both bundled datasets, both methods, **byte-identical** to the binary built from the old pin.

The `fixtures` gate re-runs `06-regulatory-more` through the full pipeline, so
this is checked end-to-end in CI as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)